### PR TITLE
Small changes in templates and add links to contributors in each material

### DIFF
--- a/_includes/main_footer.html
+++ b/_includes/main_footer.html
@@ -1,5 +1,5 @@
 <footer>
-    <p>This project is maintained by <a href="https://wiki.galaxyproject.org/Teach/GTN">Galaxy Training Network</a></p>
+    <p>This project is maintained by the <a href="https://wiki.galaxyproject.org/Teach/GTN">Galaxy Training Network</a></p>
 
     <p><small>Hosted on GitHub Pages &mdash; Theme by <a href="https://github.com/orderedlist">orderedlist</a></small></p>
 </footer>

--- a/_includes/main_header.html
+++ b/_includes/main_header.html
@@ -6,5 +6,5 @@
 
     <p><a href="https://gitter.im/Galaxy-Training-Network/Lobby?utm_source=badge&amp;utm_medium=badge&amp;utm_campaign=pr-badge&amp;utm_content=badge"><img src="https://camo.githubusercontent.com/66dbecf63f6c9c68127a18afaca4790a7eb6f1c1/68747470733a2f2f6261646765732e6769747465722e696d2f47616c6178792d547261696e696e672d4e6574776f726b2f747261696e696e672d6d6174657269616c2e737667" alt="Gitter" data-canonical-src="https://badges.gitter.im/Galaxy-Training-Network/training-material.svg" style="max-width:100%;"></a> </p>
 
-    <p class="view"><a href="{{ site.github_repository }}">View the Project on GitHub <small>{{ site.github_repository }}</small></a></p>
+    <p class="view">View the Project on GitHub: <small><a href="{{ site.github_repository }}">{{ site.github_repository }}</small></a></p>
 </header>

--- a/_layouts/base_slides.html
+++ b/_layouts/base_slides.html
@@ -35,16 +35,13 @@ class: center, middle, inverse
 
 ## Welcome!
 
+This material is the result of a collaborative work. <br/>Thanks to [all the contributors]({{ site.url }}/{{ topic.name }}#contributors) and the [Galaxy Training Network](https://wiki.galaxyproject.org/Teach/GTN)!
+
 {% if page.logo == "GTN" %}
-<img src="{{ site.url }}{{ site.logo }}" style="height: 40px;"/>
+<img src="{{ site.url }}{{ site.logo }}" style="height: 100px;"/>
 {% else %}
 <img src="{{ page.logo }}" style="height: 40px;"/>
 {% endif %}
-
-The easiest way to **navigate** this slide deck
-is <br>**by hitting `[space]` on your keyboard**
-
-You can also navigate with arrow keys.
 
 ---
 

--- a/_layouts/base_slides.html
+++ b/_layouts/base_slides.html
@@ -78,6 +78,8 @@ Before diving into this slide deck, we recommend you to have a look at:
 
 {{ content | xml_escape }}
 
+.footnote[Found a typo? Something is wrong in this tutorial? <br/>Edit it on [GitHub]({{ site.github_repository }}/tree/master/{{ topic.name }}/slides/{{ page.name }})]
+
     </textarea>
     <script src="https://gnab.github.io/remark/downloads/remark-latest.min.js" type="text/javascript">
     </script>

--- a/_layouts/home.html
+++ b/_layouts/home.html
@@ -7,7 +7,6 @@ layout: base
     <p style="text-align:center;"><script src="https://embed.github.com/view/geojson/bgruening/galaxy-maps/master/server.geojson?height=300&width=400">
     </script>
     </p>
-    <p><em>This repository will be moved to the <a href="https://github.com/galaxyproject">https://github.com/galaxyproject</a> as soon as we are confident about our guidelines and our initial training material.</em></p>
 
     <h1>Training material</h1>
 

--- a/_layouts/tutorial_hands_on.html
+++ b/_layouts/tutorial_hands_on.html
@@ -121,8 +121,8 @@ layout: base
 
     <h3>:clap: Congratulations on successfully completing this tutorial!</h3>
 
-
     <hr>
 
-    <i>Found a typo ? Something is wrong in this tutorial? Edit it on <a href="{{ site.github_repository }}/tree/master/{{ topic.name }}/tutorials/{{ tutorial.name }}.md">GitHub</a>!</i>
+    <i>This material is the result of a collaborative work. Thanks to <a href="{{ site.url }}/{{ topic.name }}#contributors">all the contributors</a> and the <a href="https://wiki.galaxyproject.org/Teach/GTN">Galaxy Training Network</a>!<br/>
+    Found a typo ? Something is wrong in this tutorial? Edit it on <a href="{{ site.github_repository }}/tree/master/{{ topic.name }}/tutorials/{{ tutorial.name }}.md">GitHub</a>.</i>
 </section>

--- a/_layouts/tutorial_slides.html
+++ b/_layouts/tutorial_slides.html
@@ -40,5 +40,3 @@ layout: base_slides
 ---
 
 ## :clap: Congratulations <br>on successfully completing this tutorial!
-
-.footnote[Found a typo? Something is wrong in this tutorial? <br/>Edit it on [GitHub]({{ site.github_repository }}/tree/master/{{ topic.name }}/tutorials/{{ tutorial.name }}.md)]


### PR DESCRIPTION
Hi,

I made some small changes in templates
- In home page to remove mention of repository moving
- Add link to material file on GitHub in all material to fix typos

I also add on all training material a mention of a collaborative work and a link to the contributors of the topics.

Bérénice

