### PR TITLE
Align remarkjs CSS with Galaxy Architecture slides from galaxyproject/galaxy

### DIFF
--- a/assets/css/slides.css
+++ b/assets/css/slides.css
@@ -3,9 +3,11 @@
 @import url(https://fonts.googleapis.com/css?family=Ubuntu+Mono:400,700,400italic);
 
 body { font-family: 'Droid Serif'; }
+
 h1, h2, h3 {
     font-family: 'Yanone Kaffeesatz';
     font-weight: normal;
+    text-align: center;
 }
 
 h3{
@@ -130,14 +132,42 @@ td, th {
     float: right;
 }
 
-.reduce70 {
-    font-size: 70%;
-}
-      
 .reduce90 {
     font-size: 90%;
 }
 
+.reduce90 .remark-code{
+    font-size: 16px;
+}
+
+.reduce70 {
+    font-size: 70%;
+}
+
+.reduce70 .remark-code{
+    font-size: 12px;
+}
+
 .enlarge120 {
     font-size: 120%;
+}
+
+.enlarge120 .remark-code{
+    font-size: 22px;
+}
+
+.strike {
+    text-decoration: line-through;
+}
+
+.pull-left {
+    float: left;
+    width: 47%;
+}
+.pull-right {
+    float: right;
+    width: 47%;
+}
+.pull-right ~ p {
+    clear: both;
 }


### PR DESCRIPTION
- Make sure title is always centered even if an individual slide is marked as ``class: left``.
- If ``code`` tags appear in ``reduced90``, ``reduced70``, or ``enlarge120`` - modify fixed font size accordingly.
- Add a couple new styles for separating slides into left and right content down the middle as well as a strike through style.

I updated the Galaxy Architecture slides to use this modified template in galaxyproject/galaxy#3594.