### PR TITLE
Add a link out to Planemo's tool development tutorial.

### DIFF
--- a/_layouts/topic.html
+++ b/_layouts/topic.html
@@ -61,7 +61,9 @@ layout: base
 
                 {% elsif material.type == "tutorial" %}
                     <td>
-                        {% if material.hands_on == "yes" %}
+                        {% if material.hands_on == "external" %}
+                        <a href="{{ material.hands_on_url }}">:link:</a>
+                        {% elsif material.hands_on == "yes" %}
                         <a href="{{ site.url }}{{ page.url }}tutorials/{{ material.name }}">:book:</a>
                         {% elsif material.hands_on == "github" %}
                         <a href="{{ site.github_repository }}/tree/master/{{ topic.name }}/tutorials/{{ material.name }}.md">:book:</a>

--- a/metadata/Dev-Corner.yml
+++ b/metadata/Dev-Corner.yml
@@ -46,7 +46,8 @@ material:
     name: "tool_integration"
     zenodo_link: ""
     galaxy_tour: ""
-    hands_on: "no"
+    hands_on: "external"
+    hands_on_url: "http://planemo.readthedocs.io/en/latest/writing_standalone.html"
     slides: "yes"
 
     questions:


### PR DESCRIPTION
I love this project and support what it is trying to do - but I see Planemo's docs as the canonical tutorial for tool development and I'd hope we don't have to compete I guess on this one tutorial? I'm happy to take suggestions and PRs to improve the docs.

xref #75 

I'd like to build out slides in this repository for Conda ( #231 ) and Dockerizing tools ( #232 ) - but I guess only if y'all let me link to the Planemo docs as the canonical walkthrough tutorial. Similar to what I am doing in this PR.