### PR TITLE
update config file to jekyll 3.5

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -38,10 +38,11 @@ kramdown:
 
 # Handling Reading
 exclude:
+  - shared/font-awesome/src/
   - Gemfile
   - Gemfile.lock
 
 # Plugins
-gems:
+plugins:
   - jekyll-feed
   - jemoji


### PR DESCRIPTION
I tried jekyll on a fresh VM and since there was a new release (3.5) I got this latest release. Unfortunately, this means I needed to patch the config file as outlined in this PR.

People, that want to try this next week, probably needs this. Old installation will probably not work out of the box and either needs to upgrade or revert this change.

What do you think? Merge or not?