### PR TITLE
Automatic table of content generation in tutorials

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -35,6 +35,8 @@ highlighter: rouge
 kramdown:
   input: GFM
   syntax_highlighter: rouge
+  auto_ids: true
+  toc_levels: 1..2
 
 # Handling Reading
 exclude:

--- a/templates/tutorials/tutorial1/tutorial.md
+++ b/templates/tutorials/tutorial1/tutorial.md
@@ -5,6 +5,7 @@ tutorial_name: your_tutorial_name
 ---
 
 # Introduction
+{:.no_toc}
 
 General introduction about the topic and then an introduction of the tutorial (the questions and the objectives). It is nice also to have a scheme to sum up the pipeline used during the tutorial. The idea is to give to trainees insight into the content of the tutorial and the (theoretical and technical) key concepts they will learn.
 
@@ -12,9 +13,9 @@ General introduction about the topic and then an introduction of the tutorial (t
 >
 > In this tutorial, we will deal with:
 >
-> 1. [Pretreatments](#pretreatments)
-> 2. [Mapping](#mapping)
-> 3. [Analysis of the differential expression](#analysis-of-the-differential-expression)
+> 1. TOC
+> {:toc}
+>
 {: .agenda}
 
 # Part 1
@@ -94,5 +95,6 @@ Short introduction about this subpart.
 > {: .comment}
 
 # Conclusion
+{:.no_toc}
 
 Conclusion about the technical key points. And then relation between the technics and the biological question to end with a global view.

--- a/topics/assembly/tutorials/general-introduction/tutorial.md
+++ b/topics/assembly/tutorials/general-introduction/tutorial.md
@@ -5,6 +5,8 @@ tutorial_name: general-introduction
 ---
 
 # Genome assembly with Velvet: Background
+{:.no_toc}
+
 Velvet is one of a number of *de novo* assemblers that use short read sets as input (e.g. Illumina Reads), and the assembly method is based on de Bruijn graphs. For information about Velvet see this [link](https://en.wikipedia.org/wiki/Velvet_assembler).
 
 
@@ -14,11 +16,9 @@ In this activity, we will perform a *de novo* assembly of a short read set using
 >
 > In this tutorial, we will deal with:
 >
-> 1. [Get the data](#get-the-data)
-> 2. [Evaluate the input reads](#evaluate-the-input-reads)
-> 3. [Assemble reads with Velvet](#assemble-reads-with-velvet)
-> 4. [Collect some statistics on the contigs](#collect-some-statistics-on-the-contigs)
-> 5. [Discussion](#discussion)
+> 1. TOC
+> {:toc}
+>
 {: .agenda}
 
 # Get the data

--- a/topics/chip-seq/tutorials/tal1-binding-site-identification/tutorial.md
+++ b/topics/chip-seq/tutorials/tal1-binding-site-identification/tutorial.md
@@ -5,6 +5,7 @@ tutorial_name: tal1-binding-site-identification
 ---
 
 # Introduction
+{:.no_toc}
 
 This tutorial uses ChIP-seq datasets from a study published by [Wu *et al.* (2014)](https://genome.cshlp.org/content/24/12/1945.full.pdf+html). The goal of this study was to investigate "the dynamics of occupancy and the role in gene regulation of the transcription factor Tal1, a critical regulator of hematopoiesis, at multiple stages of hematopoietic differentiation."
 
@@ -32,15 +33,9 @@ Because of the long processing time for the large original files, we have downsa
 >
 > In this tutorial, we will deal with:
 >
-> 1. [Step 1: Quality control](#step-1-quality-control)
-> 2. [Step 2: Trimming/clipping reads](#step-2-trimming-and-clipping-reads)
-> 3. [Step 3: Aligning reads to a genome](#step-3-aligning-reads-to-a-reference-genome)
-> 4. [Step 4: Assessing correlation between samples](#step-4-assessing-correlation-between-samples)
-> 5. [Step 5: Assessing IP strength](#step-5-assessing-ip-strength)
-> 6. [Step 6: Determining Tal1 binding sites](#step-6-determining-tal1-binding-sites)
-> 7. [Step 7: Inspection of Tal1 peaks](#step-7-inspection-of-peaks-and-aligned-data)
-> 8. [Step 8: Identifying unique/common Tal1 peaks](#step-8-identifying-unique-and-common-tal1-peaks-between-states)
-> 9. [Additional optional analyses](#additional-optional-analyses)
+> 1. TOC
+> {:toc}
+>
 {: .agenda}
 
 # Step 1: Quality control
@@ -442,5 +437,6 @@ For additional informaton on how to interpret **computeGCbias** plots, read the 
 
 
 # Conclusion
+{:.no_toc}
 
 In this exercise you imported raw Illumina sequencing data, evaluated the quality before and after you trimmed reads with low confidence scores, algined the trimmed reads, identified Tal1 peaks relative to the negative control (background), and visualized the aligned reads and Tal1 peaks relative to gene structures and positions. Additional, you assessed the "goodness" of the experiments by looking at metrics such as GC bias and IP enrichment.

--- a/topics/dev/tutorials/visualization-charts/tutorial.md
+++ b/topics/dev/tutorials/visualization-charts/tutorial.md
@@ -5,6 +5,7 @@ tutorial_name: visualization-charts
 ---
 
 ## Introduction
+{:.no_toc}
 
 In this tutorial we are going to demonstrate how to add a 3rd-party visualization to *Charts* and what the benefits are. The plugin we select for this purpose is the [*PV-Javascript Protein Viewer*](https://biasmv.github.io/pv/). It is an open source, protein structure viewer for `PDB`-files. There are many other popular protein structure viewers available for the visualization of `PDB`-files such as e.g. [NGL](https://arose.github.io/ngl/) (also available in *Charts*) and [JSMol](https://chemapps.stolaf.edu/jmol/jsmol/jsmol.htm).
 
@@ -63,6 +64,16 @@ As mentioned above we will be focusing on the *PV-Javascript Protein Viewer* in 
 > 3. Can you find the minified code file of this plugin?
 >
 {: .hands_on}
+
+> ### Agenda
+>
+> In this tutorial, we will deal with:
+>
+> 1. TOC
+> {:toc}
+>
+{: .agenda}
+
 
 ## Section 1 - Basic plugin setup
 ### 1.1 Directory and plugin preparations
@@ -372,5 +383,6 @@ From the *PV-Viewer* documentation we can see that there are more settings avail
 {: .hands_on}
 
 ## Conclusion
+{:.no_toc}
 
 First of all, thank you for completing this tutorial. We have learned how to add visualizations to the *Charts* framework and how to build a custom visualization form.

--- a/topics/dev/tutorials/visualization-generic/tutorial.md
+++ b/topics/dev/tutorials/visualization-generic/tutorial.md
@@ -5,6 +5,7 @@ tutorial_name: visualization-generic
 ---
 
 # Introduction
+{:.no_toc}
 
 Visualizations may be very helpful in understanding data better. There is a whole
 range of visualizations, from rather simple scatter and barplots up to projections
@@ -33,6 +34,15 @@ Additional documentation about Galaxy visualizations can be found here:
 - [DataProviders](https://galaxyproject.org/data-providers)
 - [DataProviders/Cookbook](https://galaxyproject.org/data-providers/cookbook)
 - [Develop/Visualizations](https://galaxyproject.org/develop/visualizations)
+
+> ### Agenda
+>
+> In this tutorial, we will deal with:
+>
+> 1. TOC
+> {:toc}
+>
+{: .agenda}
 
 # Part 1
 
@@ -565,6 +575,7 @@ For more examples of visualization plugins, you can browse this
 [GitHub repo](https://github.com/bgruening/galaxytools/tree/master/visualisations)
 
 # Conclusion
+{:.no_toc}
 
 We have just created a visualization plugin in Galaxy to visualize the number of alignments
 per `RNAME` (chromosome) in a BAM file.

--- a/topics/epigenetics/tutorials/methylation-seq/tutorial.md
+++ b/topics/epigenetics/tutorials/methylation-seq/tutorial.md
@@ -6,20 +6,16 @@ tutorial_name: methylation-seq
 
 > ### Agenda
 >
-> In this tutorial we will:
+> In this tutorial, we will deal with:
 >
-> 1. [Load data and quality control](#load-data-and-quality-control)
-> 2. [Align the data](#alignment)
-> 3. [Methylation bias and metric extraction](#methylation-bias-and-metric-extraction)
-> 4. [Visualize the mapped data](#visualization)
-> 5. [Metilene](#metilene)
->
->
-> This tutorial is based on [I-Hsuan Lin et al.: 'Hierarchical Clustering of Breast Cancer Methylomes Revealed Differentially Methylated and Expressed Breast Cancer Genes'](https://dx.doi.org/10.1371/journal.pone.0118453).
->
-> The data we use in this tutorial is available at [Zenodo](https://zenodo.org/record/557099).
+> 1. TOC
+> {:toc}
 >
 {: .agenda}
+
+This tutorial is based on [I-Hsuan Lin et al.: 'Hierarchical Clustering of Breast Cancer Methylomes Revealed Differentially Methylated and Expressed Breast Cancer Genes'](https://dx.doi.org/10.1371/journal.pone.0118453).
+
+The data we use in this tutorial is available at [Zenodo](https://zenodo.org/record/557099).
 
 
 # Load data and quality control

--- a/topics/introduction/tutorials/galaxy-intro-101/tutorial.md
+++ b/topics/introduction/tutorials/galaxy-intro-101/tutorial.md
@@ -5,6 +5,7 @@ tutorial_name: galaxy-intro-101
 ---
 
 # 101 Introduction
+{:.no_toc}
 
 This practical aims to familiarize you with the Galaxy user interface. It will teach you how to perform basic tasks such as importing data, running tools, working with histories, creating workflows, and sharing your work.
 
@@ -12,10 +13,9 @@ This practical aims to familiarize you with the Galaxy user interface. It will t
 >
 > In this tutorial, we will:
 >
-> 1. [Obtain data from external sources](#data-upload)
-> 2. [Analyze the data](#analysis)
-> 3. [Manage histories and workflows](#galaxy-management)
-> 4. [Share your work](#share-your-work)
+> 1. TOC
+> {:toc}
+>
 {: .agenda}
 
 # Pretreatments
@@ -436,5 +436,6 @@ To share a history, click on the gear symbol in the history pane and select `Sha
 {: .hands_on}
 
 # Conclusion
+{:.no_toc}
 
 :tada: Well done! :clap: You have just performed your first analysis in Galaxy. You also created a workflow from your analysis so you can easily repeat the exact same analysis on other datasets. Additionally you shared your results and methods with others.

--- a/topics/introduction/tutorials/galaxy-intro-peaks2genes/tutorial.md
+++ b/topics/introduction/tutorials/galaxy-intro-peaks2genes/tutorial.md
@@ -4,14 +4,23 @@ topic_name: introduction
 tutorial_name: galaxy-intro-peaks2genes
 ---
 
-# From peaks to genes
-
 # Introduction
+{:.no_toc}
+
 We stumbled upon a paper [Li et al., Cell Stem Cell 2012](https://www.ncbi.nlm.nih.gov/pubmed/22862943) that contains the analysis of possible target genes of an interesting protein in mice. The targets were obtained by ChIP-seq and the raw data is available through [GEO](https://www.ncbi.nlm.nih.gov/geo/query/acc.cgi?acc=GSE37268).
 The list of genes however is neither in the supplement of the paper nor part of the GEO submission.
 The closest thing we can find is a list of the regions where the signal is
 significantly enriched (so called *peaks*).
 The goal of this exercise is to **turn this list of genomic regions into a list of possible target genes**.
+
+> ### Agenda
+>
+> In this tutorial, we will deal with:
+>
+> 1. TOC
+> {:toc}
+>
+{: .agenda}
 
 # Pretreatments
 
@@ -475,5 +484,6 @@ To share a history, click on the gear symbol in the history pane and select `Sha
 {: .hands_on}
 
 # Conclusion
+{:.no_toc}
 
 :tada: Well done! :clap: You have just performed your first analysis in Galaxy. You also created a workflow from your analysis so you can easily repeat the exact same analysis on other datasets. Additionally you shared your results and methods with others.

--- a/topics/introduction/tutorials/processing-many-samples-at-once/tutorial.md
+++ b/topics/introduction/tutorials/processing-many-samples-at-once/tutorial.md
@@ -4,6 +4,15 @@ topic_name: introduction
 tutorial_name: Processing-many-samples-at-once
 ---
 
+> ### Agenda
+>
+> In this tutorial, we will deal with:
+>
+> 1. TOC
+> {:toc}
+>
+{: .agenda}
+
 # Processing many samples at once
 
 Here we will show Galaxy features designed to help with the analysis of large numbers of samples. When you have just a few samples - clicking through them is easy. But once you've got hundreds - it becomes very annoying. In Galaxy we have introduced **Dataset collections** that allow you to combine numerous datasets in a single entity that can be easily manipulated.

--- a/topics/metagenomics/tutorials/general-tutorial/tutorial.md
+++ b/topics/metagenomics/tutorials/general-tutorial/tutorial.md
@@ -5,6 +5,7 @@ tutorial_name: general-tutorial
 ---
 
 # Introduction
+{:.no_toc}
 
 In metagenomics, information about micro-organisms in an environment can be extracted with two main techniques:
 
@@ -19,8 +20,9 @@ For that, we will use two datasets (one amplicon and one shotgun) from the same 
 >
 > In this tutorial, we will deal with:
 >
-> 1. [Amplicon data](#amplicon-data)
-> 2. [Shotgun data](#shotgun-data)
+> 1. TOC
+> {:toc}
+>
 {: .agenda}
 
 # Amplicon data
@@ -671,6 +673,7 @@ With the HUMAnN2 output, we have access to UniRef50 gene families. However, the 
 With the previous analyses, we investigate "Which micro-organims are present in my sample?" and "What function are done by the micro-organisms in my sample?". We can go further in these analyses (for example with combination of functional and taxonomic results). We did not detail that in this tutorial but you can found more analyses in our tutorials on shotgun metagenomic data analyses.
 
 # Conclusion
+{:.no_toc}
 
 We can summarize the analyses with amplicon and shotgun metagenomic data:
 

--- a/topics/metagenomics/tutorials/mothur-miseq-sop/tutorial.md
+++ b/topics/metagenomics/tutorials/mothur-miseq-sop/tutorial.md
@@ -1,10 +1,12 @@
----
+topics/proteomics/tutorials/database-handling/tutorial.md---
 layout: tutorial_hands_on
 topic_name: metagenomics
 tutorial_name: mothur-miseq-sop
 ---
 
 # Overview
+{:.no_toc}
+
 In this tutorial we will perform the
 [Standard Operating Procedure (SOP) for MiSeq data](https://www.mothur.org/wiki/MiSeq_SOP), developed by the
 creators of the Mothur software package, the [Schloss lab](https://www.schlosslab.org/), within Galaxy.
@@ -13,23 +15,9 @@ creators of the Mothur software package, the [Schloss lab](https://www.schlossla
 >
 > In this tutorial, we will:
 >
-> 1. [Obtain and prepare our input data](#obtaining-and-preparing-data)
->   - [Understand our experimental setup](#understanding-our-input-data)
->   - [Import the data into Galaxy](#importing-the-data-into-galaxy)
-> 2. [Perform Quality Control](#quality-control)
->   - [Reduce sequencing and PCR errors](#reducing-sequencing-and-pcr-errors)
->   - [Align sequence to a reference](#sequence-alignment)
->   - [Chimera Removal](#chimera-removal)
->   - [Remove contamination](#removal-of-non-bacterial-sequences)
->   - [Assess error rate by sequencing a mock community](#assessing-error-rates-based-n-our-mock-community)
->   - [Prepare for analysis](#preparing-for-analysis)  
-> 3. [Perform OTU-based analysis](#otu-based-analysis)
->   - [Alpha diversity](#alpha-diversity)
->   - [Beta diversity](#beta-diversity)
->   - [Population-level analysis](#population-level-analysis)
-> 4. [Visualizing our data](#visualizations)
->   - [Phinch](#phinch)
->   - [Krona](#krona)
+> 1. TOC
+> {:toc}
+>
 {: .agenda}
 
 
@@ -1569,6 +1557,7 @@ innermost ring labeled "Bacteria"
 {: .question}
 
 # Conclusion
+{:.no_toc}
 
 You have now seen how to perform the Schloss lab's Standard Operating Procedure (SOP) for MiSeq data.
 You have worked your way through the following pipeline:

--- a/topics/metagenomics/tutorials/mothur-miseq-sop/tutorial.md
+++ b/topics/metagenomics/tutorials/mothur-miseq-sop/tutorial.md
@@ -1,4 +1,4 @@
-topics/proteomics/tutorials/database-handling/tutorial.md---
+---
 layout: tutorial_hands_on
 topic_name: metagenomics
 tutorial_name: mothur-miseq-sop

--- a/topics/proteomics/tutorials/database-handling/tutorial.md
+++ b/topics/proteomics/tutorials/database-handling/tutorial.md
@@ -5,6 +5,7 @@ tutorial_name: database-handling
 ---
 
 # Introduction
+{:.no_toc}
 
 Identifying peptides in proteomic datasets is commonly done by using search engines that compare the MS2 spectra of peptides to theoretical spectra. These theoretical spectra are generated from a FASTA database containing proteins that are expected in the measured sample. Typically, those FASTA databases will contain all proteins of the organism the sample derived from.
 
@@ -12,10 +13,9 @@ Identifying peptides in proteomic datasets is commonly done by using search engi
 >
 > In this tutorial, we will deal with:
 >
-> 1. [Loading a Search Database](#loading-a-search-database)
-> 2. [Contaminant Databases](#contaminant-databases)
-> 3. [Merging Databases](#merging-databases)
-> 4. [Creating Decoy Databases](#creating-decoy-databases)
+> 1. TOC
+> {:toc}
+>
 {: .agenda}
 
 
@@ -138,6 +138,8 @@ The most common method of peptide and protein FDR calculation is by adding known
 
 
 # Concluding remarks
+{:.no_toc}
+
 To keep your databases up-to-date, or if you need several databases for different organisms, it would make sense to create a workflow out of the Hands-On sections (to learn about workflows see [this tutorial](../../Introduction/tutorials/workflows.md)). You might also want to combine the mycoplasma databases to a single file, which you then easily can add to each of your main databases.
 
 Often you may not want to use the most recent database for reasons of reproducibility. If so, you can transfer the final database of this tutorial into other histories to work with it.

--- a/topics/proteomics/tutorials/labelfree-vs-labelled/tutorial.md
+++ b/topics/proteomics/tutorials/labelfree-vs-labelled/tutorial.md
@@ -5,6 +5,8 @@ tutorial_name: labelfree-vs-labelled
 ---
 
 # Purpose
+{:.no_toc}
+
 A basic question when planning any quantitative proteomic experiment is the choice between label-free versus labelled quantitation. Here, we want to explain and discuss benefits and drawbacks of each method.
 Finally, we will give a guideline what points may be vital for the decision in our opinion. We will not discuss different labelling methods here in detail, but focus on our basic question.
 
@@ -16,8 +18,9 @@ A basic overview of different quantitation techniques is shown below ([original 
 >
 > In this tutorial, we will deal with:
 >
-> 1. [Drawbacks and Benefits of Labelled Quantitation](#drawbacks-and-benefits-of-labelled-quantitation)
-> 2. [Guideline: How to Choose Your Technique](#guideline-how-to-choose-your-technique)
+> 1. TOC
+> {:toc}
+>
 {: .agenda}
 
 

--- a/topics/proteomics/tutorials/metaproteomics/tutorial.md
+++ b/topics/proteomics/tutorials/metaproteomics/tutorial.md
@@ -5,6 +5,7 @@ tutorial_name: metaproteomics
 ---
 
 # Introduction
+{:.no_toc}
 
 In this metaproteomics tutorial we will identify expressed proteins from a complex bacterial community sample.
 For this MS/MS data will be matched to peptide sequences provided through a FASTA file.
@@ -15,10 +16,11 @@ the host / environment by analyzing the functional dynamics of the microbiome.
 
 > ### Agenda
 >
-> 1. [Pretreatments](#pretreatments)
-> 2. [Match peptide sequences](#match-peptide-sequences)
-> 3. [Unipept metaproteomic analysis](#unipept-metaproteomic-analysis)
-> 4. [Summarizing the results](#genus-taxonomy-level-summary)
+> In this tutorial, we will deal with:
+>
+> 1. TOC
+> {:toc}
+>
 {: .agenda}
 
 # Pretreatments

--- a/topics/proteomics/tutorials/protein-id-sg-ps/tutorial.md
+++ b/topics/proteomics/tutorials/protein-id-sg-ps/tutorial.md
@@ -5,6 +5,7 @@ tutorial_name: protein-id-sg-ps
 ---
 
 # Introduction
+{:.no_toc}
 
 Identifying the proteins contained in a sample is an important step in any proteomic experiment. However, in most settings, proteins are digested to peptides before the LC-MS/MS analysis. In this so-called "bottom-up" procedure, only peptide masses are measured. Therefore, protein identification cannot be performed directly from raw data, but is a multi-step process:
 
@@ -31,10 +32,9 @@ you can use the constructed database before the **DecoyDatabase** :wrench: step.
 >
 > In this tutorial, we will deal with:
 >
-> 1. [Preparing raw data](#preparing-raw-data)
-> 2. [Peptide and Protein Identification](#peptide-and-protein-identification)
-> 4. [Analysis of Contaminants](#analysis-of-contaminants)
-> 5. [Peptide and Protein Evaluation](#evaluation-of-peptide-and-protein-ids)
+> 1. TOC
+> {:toc}
+>
 {: .agenda}
 
 

--- a/topics/proteomics/tutorials/protein-quant-sil/tutorial.md
+++ b/topics/proteomics/tutorials/protein-quant-sil/tutorial.md
@@ -5,6 +5,8 @@ tutorial_name: protein-quant-sil
 ---
 
 # Introduction
+{:.no_toc}
+
 To compare protein amounts in different samples from MS/MS data, two different experiment setups exist. Firstly, unmodified proteins can be measured in separate runs at one sample per MS-run. Secondly, proteins of samples to compare can be labelled with small chemical tags, mixed, and measured side-by-side in a single MS-run.
 There are two types of chemical tags: isobaric tags display the same mass on first hand, but fragment during the generation of the MS/MS spectra to yield reporter ions of different mass. The intensity of those reporter ions can be compared in MS/MS spectra. There are two types of isobaric tags commercially available: tandem mass tags (TMT) and isobaric tags for relative and absolute quantitation (iTRAQ).
 The second type of chemical tags are isotopic. They are chemically identical, but differ in their mass due to incorporated stable isotopes. Examples of different isotopic tags for stable isotope labelling (SIL) are ICAT, SILAC, dimethylation, or heavy oxygen (<sup>18</sup>O).
@@ -26,10 +28,9 @@ If you still are in the planning phase of your quantitative proteomics experimen
 >
 > In this tutorial, we will deal with:
 >
-> 1. [MS1 Feature Detection](#ms1-feature-detection)
-> 2. [Importing and Converting Peptide and Protein IDs](#importing-and-converting-peptide-and-protein-ids)
-> 3. [Quant to ID matching](#quant-to-id-matching)
-> 4. [Expert level: Evaluation and Optimization of Quantitation Results](#expert-level-evaluation-and-optimization-of-quantitation-results)
+> 1. TOC
+> {:toc}
+>
 {: .agenda}
 
 # MS1 Feature Detection

--- a/topics/sequence-analysis/tutorials/de-novo-rad-seq/tutorial.md
+++ b/topics/sequence-analysis/tutorials/de-novo-rad-seq/tutorial.md
@@ -5,6 +5,7 @@ tutorial_name: de-novo-rad-seq
 ---
 
 # Introduction
+{:.no_toc}
 
 In the study of [Hohenlohe *et al.* 2010](https://journals.plos.org/plosgenetics/article?id=10.1371/journal.pgen.1000862), a genome scan of nucleotide diversity and differentiation in natural populations of threespine stickleback *Gasterosteus aculeatus* was conducted. Authors used Illumina-sequenced RAD tags to identify and type over 45,000 single nucleotide polymorphisms (SNPs) in each of 100 individuals from two oceanic and three freshwater populations.
 
@@ -17,9 +18,10 @@ We here proposed to re-analyze these data at least until the population genomics
 >
 > In this tutorial, we will deal with:
 >
-> 1. [Pretreatments](#pretreatments)
-> 2. [Building loci using STACKS](#building-loci-using-stacks)
-> 3. [Calculate population genomics statistics](#calculate-population-genomics-statistics)
+> 1. TOC
+> {:toc}
+>
+{: .agenda}
 
 # Pretreatments
 
@@ -202,6 +204,7 @@ Run `Stacks: De novo map` Galaxy tool. This program will run ustacks, cstacks, a
 >    >    </details>
 
 # Conclusion
+{:.no_toc}
 
 In this tutorial, we have analyzed real RAD sequencing data to extract useful information, such as which loci are candidate regarding the genetic differentiation between freshwater and oceanic Stickelback populations. To answer these questions, we analyzed RAD sequence datasets using a de novo RAD-seq data analysis approach. This approach can be sum up with the following scheme:
 

--- a/topics/sequence-analysis/tutorials/genetic-map-rad-seq/tutorial.md
+++ b/topics/sequence-analysis/tutorials/genetic-map-rad-seq/tutorial.md
@@ -5,19 +5,20 @@ tutorial_name: genetic-map-rad-seq
 ---
 
 # Introduction
+{:.no_toc}
 
 Original description is reachable on a [dedicated page of the official STACKS website](https://catchenlab.life.illinois.edu/stacks/tut_gar.php). Writers describe that they developed a genetic map in the spotted gar and present here data from a single linkage group. The gar genetic map is an F1 pseudotest cross between two parents and 94 of their F1 progeny. They took the markers that appeared in one of the linkage groups and worked backwards to provide the raw reads from all of the stacks contributing to that linkage group.
 
 We here proposed to re-analyze these data at least until genotypes determination. Data are already clean so you don't have to demultiplex it using barcode information through `Process Radtags tool`.
 
-
 > ### Agenda
 >
 > In this tutorial, we will deal with:
 >
-> 1. [Pretreatments](#pretreatments)
-> 2. [Building loci using STACKS](#snp-calling-from-radtags)
-> 3. [Genotypes determination](#genotypes-determination)
+> 1. TOC
+> {:toc}
+>
+{: .agenda}
 
 # Pretreatments
 
@@ -214,6 +215,7 @@ Run `Stacks: De novo map` Galaxy tool. This program will run `ustacks`, `cstacks
 >    >    </details>
 
 # Conclusion
+{:.no_toc}
 
 In this tutorial, we have analyzed real RAD sequencing data to extract useful information, such as genotypes and haplotypes to generate input files for downstream genetic map creation. This approach can be sum up with the following scheme:
 

--- a/topics/sequence-analysis/tutorials/genome-annotation/tutorial.md
+++ b/topics/sequence-analysis/tutorials/genome-annotation/tutorial.md
@@ -5,6 +5,7 @@ tutorial_name: genome-anotation
 ---
 
 # Introduction
+{:.no_toc}
 
 Genome annotation is the process of attaching biological information to sequences.
 It consists of three main steps:
@@ -17,9 +18,9 @@ It consists of three main steps:
 >
 > In this tutorial, we will deal with:
 >
-> 1. [Introduction into File Formats](#introduction-into-file-formats)
-> 2. [Structural Annotation](#structural-annotation)
-> 3. [Functional Annotation](#functional-annotation)
+> 1. TOC
+> {:toc}
+>
 {: .agenda}
 
 # Introduction into File Formats

--- a/topics/sequence-analysis/tutorials/mapping/tutorial.md
+++ b/topics/sequence-analysis/tutorials/mapping/tutorial.md
@@ -5,15 +5,18 @@ tutorial_name: mapping
 ---
 
 # Introduction to next generation sequencing data mapping
+{:.no_toc}
+
 To map DNA/RNA reads of an experiment to a reference genome is a key step in modern genomic data analysis. With the mapping the reads are assigned to a specific location in the genome and insights like the expression level of genes can be gained.
 In the following we will process a dataset with a mapper, 'Bowtie2', and we will visualize the data with the software 'IGV'.
 
 > ### Agenda
 >
-> In this tutorial we will:
+> In this tutorial, we will deal with:
 >
-> 1. [Map the data](#mapping)
-> 3. [Visualize the mapped data](#visualization)
+> 1. TOC
+> {:toc}
+>
 {: .agenda}
 
 # Mapping

--- a/topics/sequence-analysis/tutorials/quality-control/tutorial.md
+++ b/topics/sequence-analysis/tutorials/quality-control/tutorial.md
@@ -5,6 +5,7 @@ tutorial_name: quality-control
 ---
 
 # Introduction
+{:.no_toc}
 
 During the sequencing process, some errors may be introduced like incorporation of ambiguous nucleotides. Analyzing poor data wastes CPU and people time.
 
@@ -14,9 +15,9 @@ The quality control of the sequences right after sequencing is then an essential
 >
 > In this tutorial, we will deal with:
 >
-> 1. [Sequence dataset importing](#sequence-dataset-importing)
-> 2. [Quality checking of the sequences](#quality-checking-of-the-sequences)
-> 3. [Improvement of the quality of the sequences](#improvement-of-the-quality-of-the-sequences)
+> 1. TOC
+> {:toc}
+>
 {: .agenda}
 
 # Sequence dataset importing
@@ -204,6 +205,7 @@ Now, we would like to see the impact to quality control and treatment on a bad d
 {: .hands_on}
 
 # Conclusion
+{:.no_toc}
 
 In this tutorial, we have controlled the quality of two datasets to ensure that the raw data looks good before analysing them with tools to extract RNA-Seq, ChIP-Seq or any other type of information. The approach of quality control is similar for any type of sequencing data:
 

--- a/topics/sequence-analysis/tutorials/ref-based-rad-seq/tutorial.md
+++ b/topics/sequence-analysis/tutorials/ref-based-rad-seq/tutorial.md
@@ -5,6 +5,7 @@ tutorial_name: ref-based-rad-seq
 ---
 
 # Introduction
+{:.no_toc}
 
 In the study of [Hohenlohe *et al.* 2010](https://journals.plos.org/plosgenetics/article?id=10.1371/journal.pgen.1000862), a genome scan of nucleotide diversity and differentiation in natural populations of threespine stickleback *Gasterosteus aculeatus* was conducted. Authors used Illumina-sequenced RAD tags to identify and type over 45,000 single nucleotide polymorphisms (SNPs) in each of 100 individuals from two oceanic and three freshwater populations.
 
@@ -17,10 +18,10 @@ We here proposed to re-analyze these data at least until the population genomics
 >
 > In this tutorial, we will deal with:
 >
-> 1. [Pretreatments](#pretreatments)
-> 2. [Mapping](#mapping)
-> 3. [SNP calling using STACKS](#snp-calling-from-radtags)
-> 4. [Calculate population genomics statistics](#calculate-population-genomics-statistics)
+> 1. TOC
+> {:toc}
+>
+{: .agenda}
 
 # Pretreatments
 
@@ -229,6 +230,7 @@ Run `Stacks: Reference map` Galaxy tool. This program will run pstacks, cstacks,
 >    >    </details>
 
 # Conclusion
+{:.no_toc}
 
 In this tutorial, we have analyzed real RAD sequencing data to extract useful information, such as which loci are candidate regarding the genetic differentiation between freshwater and oceanic Stickelback populations. To answer these questions, we analyzed RAD sequence datasets using a reference-based RAD-seq data analysis approach. This approach can be sum up with the following scheme:
 

--- a/topics/training/tutorials/create-new-tutorial-content/tutorial.md
+++ b/topics/training/tutorials/create-new-tutorial-content/tutorial.md
@@ -5,6 +5,7 @@ tutorial_name: create-new-tutorial-content
 ---
 
 # Introduction
+{:.no_toc}
 
 Galaxy is a great solution to train the bioinformatics concepts:
 
@@ -20,17 +21,13 @@ We decided on a structure based on tutorials with hands-on, fitting both for onl
 
 In this tutorial, you will learn how to write your first tutorial in markdown and contribute it to the Galaxy Training Network.
 
-
-> ### Devloping GTN training material
+> ### Agenda
 >
-> This tutorial is part of a series to develop GTN training material, feel free to also look at:
+> In this tutorial, we will deal with:
 >
-> 1. [Writing content in markdown](../create-new-tutorial-content/tutorial.html)
-> 1. [Defining metadata](../create-new-tutorial-metadata/tutorial.html)
-> 1. [Setting up the infrastructure](../create-new-tutorial-jekyll/tutorial.html)
-> 1. [Creating Interactive Galaxy Tours](../create-new-tutorial-tours/tutorial.html)
-> 1. [Building a Docker flavor](../create-new-tutorial-docker/tutorial.html)
-> 1. [Submitting the new tutorial to the GitHub repository](../../../dev/tutorials/github-contribution/slides.html)
+> 1. TOC
+> {:toc}
+>
 {: .agenda}
 
 # Setting up a new tutorial
@@ -135,6 +132,7 @@ topic_name: training
 tutorial_name: create-new-tutorial
 ---
 # Introduction
+{:.no_toc}
 
 blabla
 
@@ -155,6 +153,7 @@ blabla
 blabla
 
 # Conclusion
+{:.no_toc}
 
 blabla
 ```
@@ -240,12 +239,16 @@ This structure needs to be respected otherwise it would not be interpreted corre
 
         > ### Agenda
         >
-        > In this tutorial, we will analyze the data with:
+        > In this tutorial, we will deal with:
         >
-        > 1. [Pretreatments](#pretreatments)
-        > 2. [Mapping](#mapping)
-        > 3. [Analysis of the differential expression](#analysis-of-the-differential-expression)
+        > 1. TOC
+        > {:toc}
+        >
         {: .agenda}
+
+    No need to fill the list: it will be done automatically based on the title of the sections.
+
+    To avoid to add the "Introduction" and "Conclusion", we add `{:.no_toc}` below the section name.
 
     ![](../../../../shared/images/tutorial_agenda_box.png)
 
@@ -399,3 +402,16 @@ After, each new slide is introduced by `---`, and the content of each slide is w
 {: .hands_on}
 
 # Conclusion
+{:.no_toc}
+
+> ### Developing GTN training material
+>
+> This tutorial is part of a series to develop GTN training material, feel free to also look at:
+>
+> 1. [Writing content in markdown](../create-new-tutorial-content/tutorial.html)
+> 1. [Defining metadata](../create-new-tutorial-metadata/tutorial.html)
+> 1. [Setting up the infrastructure](../create-new-tutorial-jekyll/tutorial.html)
+> 1. [Creating Interactive Galaxy Tours](../create-new-tutorial-tours/tutorial.html)
+> 1. [Building a Docker flavor](../create-new-tutorial-docker/tutorial.html)
+> 1. [Submitting the new tutorial to the GitHub repository](../../../dev/tutorials/github-contribution/slides.html)
+{: .agenda}

--- a/topics/training/tutorials/create-new-tutorial-docker/tutorial.md
+++ b/topics/training/tutorials/create-new-tutorial-docker/tutorial.md
@@ -5,6 +5,7 @@ tutorial_name: create-new-tutorial-docker
 ---
 
 # Introduction
+{:.no_toc}
 
 Galaxy is a great solution to train the bioinformatics concepts:
 
@@ -19,6 +20,15 @@ We took inspiration from [Software Carpentry](https://software-carpentry.org) an
 We decided on a structure based on tutorials with hands-on, fitting both for online self-training but also for workshops, grouped in topics. Each tutorial follows the same structure and comes with a virtualised isntance to run the training everywhere.
 
 In this tutorial, you will learn how to create a virtualised Galaxy instance, based on Docker, to run your training - either on normal computers or cloud environments.
+
+> ### Agenda
+>
+> In this tutorial, we will deal with:
+>
+> 1. TOC
+> {:toc}
+>
+{: .agenda}
 
 > ### Devloping GTN training material
 >
@@ -161,3 +171,16 @@ Every topic will come with a Docker image containing the tools, data, workflows 
 {: .hands_on}
 
 # Conclusion
+{:.no_toc}
+
+> ### Developing GTN training material
+>
+> This tutorial is part of a series to develop GTN training material, feel free to also look at:
+>
+> 1. [Writing content in markdown](../create-new-tutorial-content/tutorial.html)
+> 1. [Defining metadata](../create-new-tutorial-metadata/tutorial.html)
+> 1. [Setting up the infrastructure](../create-new-tutorial-jekyll/tutorial.html)
+> 1. [Creating Interactive Galaxy Tours](../create-new-tutorial-tours/tutorial.html)
+> 1. [Building a Docker flavor](../create-new-tutorial-docker/tutorial.html)
+> 1. [Submitting the new tutorial to the GitHub repository](../../../dev/tutorials/github-contribution/slides.html)
+{: .agenda}

--- a/topics/training/tutorials/create-new-tutorial-jekyll/tutorial.md
+++ b/topics/training/tutorials/create-new-tutorial-jekyll/tutorial.md
@@ -5,6 +5,7 @@ tutorial_name: create-new-tutorial-jekyll
 ---
 
 # Introduction
+{:.no_toc}
 
 Galaxy is a great solution to train the bioinformatics concepts:
 
@@ -20,6 +21,14 @@ We decided on a structure based on tutorials with hands-on, fitting both for onl
 
 In this tutorial, you will learn how to run a local instance of the GTN webiste with all materials to test and develop new training sessions.
 
+> ### Agenda
+>
+> In this tutorial, we will deal with:
+>
+> 1. TOC
+> {:toc}
+>
+{: .agenda}
 
 > ### Devloping GTN training material
 >
@@ -57,3 +66,16 @@ We can use Jekyll to run a server to check if the tutorial is correctly added an
 {: .hands_on}
 
 # Conclusion
+{:.no_toc}
+
+> ### Developing GTN training material
+>
+> This tutorial is part of a series to develop GTN training material, feel free to also look at:
+>
+> 1. [Writing content in markdown](../create-new-tutorial-content/tutorial.html)
+> 1. [Defining metadata](../create-new-tutorial-metadata/tutorial.html)
+> 1. [Setting up the infrastructure](../create-new-tutorial-jekyll/tutorial.html)
+> 1. [Creating Interactive Galaxy Tours](../create-new-tutorial-tours/tutorial.html)
+> 1. [Building a Docker flavor](../create-new-tutorial-docker/tutorial.html)
+> 1. [Submitting the new tutorial to the GitHub repository](../../../dev/tutorials/github-contribution/slides.html)
+{: .agenda}

--- a/topics/training/tutorials/create-new-tutorial-metadata/tutorial.md
+++ b/topics/training/tutorials/create-new-tutorial-metadata/tutorial.md
@@ -5,6 +5,7 @@ tutorial_name: create-new-tutorial-metadata
 ---
 
 # Introduction
+{:.no_toc}
 
 Galaxy is a great solution to train the bioinformatics concepts:
 
@@ -19,6 +20,15 @@ We took inspiration from [Software Carpentry](https://software-carpentry.org) an
 We decided on a structure based on tutorials with hands-on, fitting both for online self-training but also for workshops, grouped in topics. Each tutorial follows the same structure and comes with a virtualised isntance to run the training everywhere.
 
 In this tutorial, you will learn how to annotate your training material with a lot of metadata, so that it can be reused and empower other services.
+
+> ### Agenda
+>
+> In this tutorial, we will deal with:
+>
+> 1. TOC
+> {:toc}
+>
+{: .agenda}
 
 > ### Devloping GTN training material
 >
@@ -90,3 +100,16 @@ We recommend you to fill the questions and the learning objectives before starti
 For the take-home messages, it is easier to define them once the tutorial is written and you identified the issues.
 
 # Conclusion
+{:.no_toc}
+
+> ### Developing GTN training material
+>
+> This tutorial is part of a series to develop GTN training material, feel free to also look at:
+>
+> 1. [Writing content in markdown](../create-new-tutorial-content/tutorial.html)
+> 1. [Defining metadata](../create-new-tutorial-metadata/tutorial.html)
+> 1. [Setting up the infrastructure](../create-new-tutorial-jekyll/tutorial.html)
+> 1. [Creating Interactive Galaxy Tours](../create-new-tutorial-tours/tutorial.html)
+> 1. [Building a Docker flavor](../create-new-tutorial-docker/tutorial.html)
+> 1. [Submitting the new tutorial to the GitHub repository](../../../dev/tutorials/github-contribution/slides.html)
+{: .agenda}

--- a/topics/training/tutorials/create-new-tutorial-tours/tutorial.md
+++ b/topics/training/tutorials/create-new-tutorial-tours/tutorial.md
@@ -5,6 +5,7 @@ tutorial_name: create-new-tutorial-tours
 ---
 
 # Introduction
+{:.no_toc}
 
 Galaxy is a great solution to train the bioinformatics concepts:
 
@@ -19,16 +20,13 @@ We take inspiration from [Software Carpentry](https://software-carpentry.org). W
 
 In this tutorial, you will understand how to design and develop a new tutorial fitting in this training material repository. As doing helps to understand, we will develop a small tutorial to explain BLAST with the full infrastructure to be able to run this tutorial anywhere.
 
-> ### Devloping GTN training material
+> ### Agenda
 >
-> This tutorial is part of a series to develop GTN training material, feel free to also look at:
+> In this tutorial, we will deal with:
 >
-> 1. [Writing content in markdown](../create-new-tutorial-content/tutorial.html)
-> 1. [Defining metadata](../create-new-tutorial-metadata/tutorial.html)
-> 1. [Setting up the infrastructure](../create-new-tutorial-jekyll/tutorial.html)
-> 1. [Creating Interactive Galaxy Tours](../create-new-tutorial-tours/tutorial.html)
-> 1. [Building a Docker flavor](../create-new-tutorial-docker/tutorial.html)
-> 1. [Submitting the new tutorial to the GitHub repository](../../../dev/tutorials/github-contribution/slides.html)
+> 1. TOC
+> {:toc}
+>
 {: .agenda}
 
 # A Galaxy Interactive Tour
@@ -120,3 +118,16 @@ We can now create easily a Galaxy Interactive Tour and test it on the fly.
 {: .hands_on}
 
 # Conclusion
+{:.no_toc}
+
+> ### Developing GTN training material
+>
+> This tutorial is part of a series to develop GTN training material, feel free to also look at:
+>
+> 1. [Writing content in markdown](../create-new-tutorial-content/tutorial.html)
+> 1. [Defining metadata](../create-new-tutorial-metadata/tutorial.html)
+> 1. [Setting up the infrastructure](../create-new-tutorial-jekyll/tutorial.html)
+> 1. [Creating Interactive Galaxy Tours](../create-new-tutorial-tours/tutorial.html)
+> 1. [Building a Docker flavor](../create-new-tutorial-docker/tutorial.html)
+> 1. [Submitting the new tutorial to the GitHub repository](../../../dev/tutorials/github-contribution/slides.html)
+{: .agenda}

--- a/topics/transcriptomics/tutorials/de-novo/tutorial.md
+++ b/topics/transcriptomics/tutorials/de-novo/tutorial.md
@@ -5,6 +5,7 @@ tutorial_name: de-novo
 ---
 
 # Introduction
+{:.no_toc}
 
 The data provided here are part of a Galaxy tutorial that analyzes RNA-seq data from a study published by *Wu et al.* in 2014 [DOI:10.1101/gr.164830.113](https://genome.cshlp.org/content/early/2014/10/12/gr.164830.113.abstract). The goal of this study was to investigate "the dynamics of occupancy and the role in gene regulation of the transcription factor Tal1, a critical regulator of hematopoiesis, at multiple stages of hematopoietic differentiation." To this end, RNA-seq libraries were constructed from multiple mouse cell types including G1E - a GATA-null immortalized cell line derived from targeted disruption of GATA-1 in mouse embryonic stem cells - and megakaryocytes. This RNA-seq data was used to determine differential gene expression between G1E and megakaryocytes and later correlated with Tal1 occupancy. This dataset (GEO Accession: GSE51338) consists of biological replicate, paired-end, poly(A) selected RNA-seq libraries. Because of the long processing time for the large original files, we have downsampled the original raw data files to include only reads that align to chromosome 19 and a subset of interesting genomic loci identified by Wu *et al*.
 
@@ -14,15 +15,11 @@ The goal of this exercise is to identify what transcripts are present in the G1E
 
 > ### Agenda
 >
-> In this tutorial, we will address:
+> In this tutorial, we will deal with:
 >
-> 1. Data upload
-> 2. Read trimming
-> 3. Read mapping
-> 4. *De novo* transcript reconstruction
-> 5. Transcriptome assembly
-> 6. Read counting and differential expression analysis
-> 7. Visualization
+> 1. TOC
+> {:toc}
+>
 {: .agenda}
 
 ## Data upload
@@ -395,6 +392,7 @@ In this last section, we will convert our aligned read data from BAM format to b
 {: .hands_on}
 
 # Conclusion
+{:.no_toc}
 
 In this tutorial, we have analyzed real RNA sequencing data to extract useful information, such as which genes are up- or down-regulated by depletion of the Pasilla gene and which genes are regulated by the Pasilla gene. To answer these questions, we analyzed RNA sequence datasets using a reference-based RNA-seq data analysis approach. This approach can be sum up with the following scheme:
 

--- a/topics/transcriptomics/tutorials/ref-based/tutorial.md
+++ b/topics/transcriptomics/tutorials/ref-based/tutorial.md
@@ -5,6 +5,7 @@ tutorial_name: ref-based
 ---
 
 # Introduction
+{:.no_toc}
 
 In the study of [Brooks *et al.* 2011](https://genome.cshlp.org/content/21/2/193.long), the Pasilla (PS) gene, *Drosophila* homologue of the Human splicing regulators Nova-1 and Nova-2 Proteins, was depleted in *Drosophila melanogaster* by RNAi. The authors wanted to identify exons that are regulated by Pasilla gene using RNA sequencing data.
 
@@ -16,10 +17,9 @@ The genome of *Drosophila melanogaster* is known and assembled. It can be used a
 >
 > In this tutorial, we will deal with:
 >
-> 1. [Pretreatments](#pretreatments)
-> 2. [Mapping](#mapping)
-> 3. [Analysis of the differential expression](#analysis-of-the-differential-expression)
-> 4. [Inference of the differential exon usage](#inference-of-the-differential-exon-usage)
+> 1. TOC
+> {:toc}
+>
 {: .agenda}
 
 # Pretreatments
@@ -741,6 +741,7 @@ Unfortunately, in the process of counting, we loose all the information of the g
 {: .hands_on}
 
 # Conclusion
+{:.no_toc}
 
 In this tutorial, we have analyzed real RNA sequencing data to extract useful information, such as which genes are up- or downregulated by depletion of the Pasilla gene and which genes are regulated by the Pasilla gene. To answer these questions, we analyzed RNA sequence datasets using a reference-based RNA-seq data analysis approach. This approach can be sum up with the following scheme:
 

--- a/topics/transcriptomics/tutorials/srna/tutorial.md
+++ b/topics/transcriptomics/tutorials/srna/tutorial.md
@@ -5,6 +5,7 @@ tutorial_name: srna
 ---
 
 # Introduction
+{:.no_toc}
 
 Small, noncoding RNA (sRNA) molecules, typically 18-40nt in length, are key features of post-transcriptional regulatory mechanisms governing gene expression. Through interactions with protein cofactors, these tiny sRNAs typically function by perfectly or imperfectly basepairing with substrate RNA molecules, and then eliciting downstream effects such as translation inhibition or RNA degradation. Different subclasses of sRNAs - *e.g.* microRNAs (miRNAs), Piwi-interaction RNAs (piRNAs), and endogenous short interferring RNAs (siRNAs) - exhibit unique characteristics, and their relative abundances in biological contexts can indicate whether they are active or not. In this tutorial, we will examine expression of the piRNA subclass of sRNAs and their targets in *Drosophila melanogaster*.
 
@@ -18,18 +19,11 @@ It is of note that this tutorial uses datasets that have been de-multiplexed so 
 
 > ### Agenda
 >
-> In this tutorial, we will address:
+> In this tutorial, we will deal with:
 >
-> 1. Data upload and organization
-> 1. Read quality checking
-> 1. Adaptor trimming
-> 1. Hierarchical read alignment to remove rRNA/miRNA reads
-> 1. Small RNA subclass distinction
-> 1. piRNA abundance estimation
-> 1. piRNA differential abundance testing
-> 1. Small RNA and mRNA integration
-> 1. Visualization
-> 1. Conclusion
+> 1. TOC
+> {:toc}
+>
 {: .agenda}
 
 ## Data upload and organization
@@ -330,6 +324,7 @@ For more information about `DESeq2` and its outputs, have a look at [`DESeq2` do
 Coming soon!
 
 ## Conclusion
+{:.no_toc}
 
 Analysis of small RNAs is a complicated and intricate process due to the diversity in characteristics, functionality, and nuances of small RNA subclasses. The goal of this tutorial is to introduce you to a common small RNA workflow that specifically identifies changes in endogenous siRNA abundances that target protein-coding mRNAs and transposable elements. The steps presented here can be rearranged and modified based on small RNA features of specific systems and the needs of the user.
 

--- a/topics/variant-analysis/tutorials/diploid-variant-calling/tutorial.md
+++ b/topics/variant-analysis/tutorials/diploid-variant-calling/tutorial.md
@@ -7,6 +7,7 @@ tutorial_name: diploid-variant-calling
 > Much of Galaxy-related features described in this section have been developed by Björn Grüning (@bgruening) and configured by Dave Bouvier (@davebx).
 
 # Introduction
+{:.no_toc}
 
 Variant calling is a complex field that was significantly propelled by advances in DNA sequencing and efforts of large scientific consortia such as the [1000 Genomes](https://www.1000genomes.org). Here we summarize basic ideas central to Genotype and Variant calling. First, let's contrast the two things although they often go together:
 
@@ -29,10 +30,9 @@ However, continuing evolution of variant detection methods has made some of thes
 >
 > In this tutorial, we will deal with:
 >
-> 1. [How does SNP calling and genotyping work?](#how-does-SNP-calling-and-genotyping-work)
-> 2. [Calling with FreeBayes](#calling-with-freebayes)
-> 3. [Let's try it](#lets-try-it)
-> 4. [Going further](#going-further)
+> 1. TOC
+> {:toc}
+>
 {: .agenda}
 
 # How does SNP calling and genotyping work?
@@ -306,6 +306,7 @@ Wildcards simply writing SQL expressions when searching across multiple terms. T
 {: .question}
 
 # Going further
+{:.no_toc}
 
 This short tutorial should give you an overall idea on how generate variant data in Galaxy and process it with GEMINI. Yet there is much more to learn. Below we list GEMINI tutorials and links to Galaxy libraries with relevant data.
 


### PR DESCRIPTION
Hi,

I found how to automatically generate the Table of Content based on the section title using Jekyll
I added this functionality and change the tutorials so they can use it.
It will make easier the writing and maintenance of tutorial: no need to check the links and the title...

So information, I excluded the Introduction and Conclusion sections of the TOC.

Bérénice