### PR TITLE
Use of conda to simplify Jekyll and module installation

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -20,11 +20,6 @@ If you have any questions, you can reach us using the [Gitter chat](https://gitt
     - [`slides` directory](#slides-directory)
     - [`docker` directory](#docker-directory)
 - [How do I add new content?](#how-do-i-add-new-content)
-    - [How do I add a new topic?](#how-do-i-add-a-new-topic)
-    - [How do I add a new tutorial?](#how-do-i-add-a-new-tutorial)
-    - [How do I fill a tutorial hands-on?](#how-do-i-fill-a-tutorial-hands-on)
-    - [How do I fill introduction slides?](#how-do-i-fill-introduction-slides)
-    - [How do I fill tutorial slides?](#how-do-i-fill-tutorial-slides)
 - [How is the training material maintained?](#how-is-the-training-material-maintained)
     - [Maintainers](#maintainers)
     - [Labels](#labels)
@@ -81,7 +76,6 @@ Each training material is related to a topic. All training materials (slides, tu
 │   ├── tutorial1
 │   │   ├── tutorial.md
 │   │   ├── slides.html
-│   │   ├── metadata.yaml
 │   │   ├── tools.yaml
 │   │   ├── data-library.yaml
 │   │   ├── workflows
@@ -90,7 +84,7 @@ Each training material is related to a topic. All training materials (slides, tu
 │   │   │   ├── tour.yaml
 ```
 
-> Want to add a new topic? Check out [how to add a new topic](#how-do-i-add-a-new-topic).
+> Want to add a new topic? Please contact us before: open an issue on this GitHub repository to discuss and we will help you in this process
 
 ## `images` directory
 
@@ -104,8 +98,6 @@ All images for the slides must be in `images` directory. The images must be in g
 
 A slide deck is expected for every topic: the one with a general introduction of the topic. The slides are rendered using `remark.js` but written in Markdown to facilitate collaboration.
 
-> [Check out how to fill introduction slides](#how-do-i-fill-introduction-slides).
-
 ## `tutorials` directory
 
 This directory collects the tutorials related to the topic, one per subdirectory. The tutorials are hands-on built for workshop and self-training, with description of the whole infrastructure needed to run the tutorial on any Galaxy instance (tools, data library, etc).
@@ -114,9 +106,7 @@ The templates for the tutorials are different from the other pages to help users
 
 The content of each tutorial is generated with [Jekyll](https://jekyllrb.com/) from a Markdown file and some metadata (e.g. the requirements, the Zenodo link, the questions) defined inside the metadata of the related topic.
 
-> Want to contribute to a tutorial?
-> - [Check out how to add a new tutorial?](#how-do-i-add-a-new-tutorial)
-> - [Check out how to fill a new tutorial?](#how-do-i-fill-a-tutorial-hands-on)
+> Want to contribute to a tutorial? [Check out our training content about that](http://galaxyproject.github.io/training-material/topics/training/)
 
 Sometimes, an hands-on tutorial is not the most appropriate format for a tutorial and slides are better. The content must be then added in the `slides` directory.
 
@@ -126,265 +116,21 @@ For each topic, a flavored Docker image must integrate the tools needed for
 the tutorials. The corresponding image must be based on official Galaxy Docker
 images. We recommend to use the content of [`templates/docker`](templates/docker) as a template.
 
-The `docker` image must also integrate a Galaxy tour from the [`galaxy-tours` repository](https://github.com/galaxyproject/galaxy-tours)
+The `docker` image must also integrate a Galaxy tour from the [`tours` repository](https://github.com/galaxyproject/galaxy-tours)
+
+> Want to learn more to a tutorial? [Check out our tutorial to build a Docker flavor for a tutorial](https://galaxyproject.github.io/training-material//topics/training/tutorials/create-new-tutorial-docker/tutorial.html)
 
 # How do I add new content?
 
-Most of the content is written in Markdown with some metadata (or variables) stored in YAML. To generate the website, we are using [Jekyll](https://jekyllrb.com/) and its templating system.
-
-So if you want to visualise locally how the website will look like, you need to run a local Jekyll server. So, Jekyll must be installed using [RubyGems](https://rubygems.org/pages/download):
-
-```
-$ make install
-```
-
-If you encounter any errors make sure `ruby` and it's corresponding developer packages (e.g. `ruby-dev`, `ruby2.3-dev`) are installed.
-
-If you are installing it on Mac OSX, you need to install it this way as `/usr/bin/` is not writable:
-
-```
-sudo gem update —system
-sudo gem install -n /usr/local/bin/ gem name
-sudo gem install -n /usr/local/bin/ jemoji
-sudo gem install -n /usr/local/bin/ jekyll
-sudo gem install -n /usr/local/bin/ jekyll-feed
-sudo gem install -n /usr/local/bin/ bundler
-```
-
-To run a local Jekyll server and visualize the changes, launch using the [Makefile](Makefile):
-
-```
-$ make serve
-```
-
-You can then visualize locally ([http://localhost:4000/](http://localhost:4000/)) the website before pushing your changes.
-
-## How do I add a new topic?
-
-1. Copy the [`templates`](templates) directory, rename it and move it to the [`topics`](topics)
-2. Fill the meta information about the topic in the `metadata.yaml` file
-    - `name`: name of the topic (same name as the `yml` file and the directory)
-    - `title`: title of the topic
-    - `type`: targeted users (`"use"` or `""`)
-    - `summary`: summary of the content of the topic
-    - `docker_image`: name of the [Docker image](#docker-directory) with the tools for this topic
-    - `requirements`: list of requirements general for this topic, with a `title`, a `link` (relative for internal (inside training material) requirement or full for external requirement) and the type of link (`internal` or `external`)
-    - `maintainers`: the two maintainers of the topic with their `name`, `github_username`, `email`
-    - `contributors`: list of people who contributed to the topic with `name`, `github_username`, `email`
-
-    This information is used with [Jekyll](https://jekyllrb.com/) to generate the webpage related to the topic
-
-3. Fill the introduction slides
-
-    > Check out [how to fill introduction slides](#how-do-i-fill-introduction-slides)
-
-4. Fill tutorials
-
-    > Check out [how to add a new tutorial](#how-do-i-add-a-new-tutorial)  
-
-
-## How do I add a new tutorial?
-
-1. Add a new directory in the `tutorials` directory of the topic
-2. Add a `metadata.yaml` file and fill it
-    - `title`: title of the tutorial
-    - `type: "tutorial"`
-    - `name`: name of the tutorial (name of the subdirectory where the files related to the tutorial will be stored)
-    - `zenodo_link`: link on Zenodo to the input data for the tutorial (not ideal but it can be empty)
-    - `galaxy_tour`: name of the galaxy tour
-    - `hands_on`(`"yes"` or `"no"`): tell if an hands on is available for this material
-    - `slides` (`"yes"` or `"no"`): tell if slides are available for this material
-    - `questions`: list of questions that are addressed in the tutorial
-    - `objectives`: list of objectives of the tutorial
-    - `requirements`: list of requirements specific to this tutorial (in addition to the one of the topic), with a `title`, a `link` (relative for internal (inside training material) requirement or full for external requirement) and the type of link (`internal` or `external`)
-    - `time_estimation`: estimation of the time needed to complete the hands-on
-    - `key_points`: take home messages
-
-    This information will appear in the top and bottom of the online hands-on generated using [Jekyll](https://jekyllrb.com/)
-
-    ![](shared/images/tutorial_header.png)
-
-2. Add and fill the `tutorial.md` hands-on
-
-    > Check out [how to fill it](#how-do-i-fill-a-tutorial-hands-on)
-
-3. (Not mandatory) Add and fill the `slides.html`
-4. Add and fill the `tools.yaml` file with the neeed tools (from the ToolShed) to run the tutorial
-5. Add and fill the `data-library.yaml` file with the input data linked to Zenodo
-6. Generate and export a `workflow.ga` file with a workflow generated from the tutorial in the `workflows` directory
-7. Add and fill the `tour.yaml` file with a Galaxy Interactive Tour running the tutorial in the `tours` directory
-8. (Not mandatory) Add and fill the `data-manager.yaml`
-
-## How do I fill a tutorial hands-on?
-
-1. Check that the metadata about the tutorial in the `metadata.yaml` file are filled and correct
-
-    They are used to automatically generate the header and the footer of the tutorials.
-
-2. Fill the `tutorial.md` with the tutorial
-
-The content of a tutorial hands-on is written in Markdown. They are rendered by [Jekyll](https://jekyllrb.com/) into the webpage for the tutorial.
-
-    The header of the file must be something like:
-
-    ```
-    ---
-    layout: tutorial_slides
-    topic_name: "dev"
-    tutorial_name: tool_integration
-    logo: "GTN"
-    ---
-    ```
-
-To improve the learning experience, we strongly recommend you to:
-- Add boxes to highlight:
-    - Hands-on parts
-
-        ```
-        > ### :pencil2: Hands-on:
-        >
-        > 1. **Sort BAM dataset** :wrench:: Sort the paired-end BAM file by "Read names" with **Sort BAM dataset**
-        {: .hands_on}
-        ```
-
-        ![](shared/images/tutorial_hand_on_box.png)
-
-    - Questions (to make the learners think about what they are doing) and the collapsing and expanding answers
-
-        ```
-        > ### :question: Questions
-        >
-        > 1. Why are some tests filtered?
-        > 2. Does it improve the *p*-value distribution?
-        >
-        >    <details>
-        >    <summary>Click to view answers</summary>
-        >    Content goes here.
-        >    </details>
-        {: .question}
-        ```
-
-        ![](shared/images/tutorial_question_box.png)
-
-    - Tips
-
-        ```
-        > ### :bulb: Tip: Importing data via links
-        >
-        > * Copy the link location
-        > * Open the Galaxy Upload Manager
-        > * Select **Paste/Fetch Data**
-        > * Paste the link into the text field
-        > * Press **Start**
-        {: .tip}
-        ```
-
-        ![](shared/images/tutorial_tip_box.png)
-
-    - Comments
-
-        ```
-        > ### :nut_and_bolt: Comments
-        > - Edit the "Database/Build" to select "dm3"
-        > - Rename the datasets according to the samples
-        {: .comment}
-        ```
-
-        ![](shared/images/tutorial_comment_box.png)
-
-    To render the boxes correctly, the previous syntaxes have to be followed. The boxes can be nested, e.g. for having tips inside hands-on.
-
-- Add an agenda at the end of the introduction to indicate the plan of the tutorial
-
-    ```
-    > ### Agenda
-    >
-    > In this tutorial, we will analyze the data with:
-    >
-    > 1. [Pretreatments](#pretreatments)
-    > 2. [Mapping](#mapping)
-    > 3. [Analysis of the differential expression](#analysis-of-the-differential-expression)
-    {: .agenda}
-    ```
-
-    ![](shared/images/tutorial_agenda_box.png)
-
-- Add pictures of the expected results
-- Add at least one scheme or diagram to sum up the pipeline used at the end.
-
-The input data required for the tutorials must be upload on [Zenodo](https://zenodo.org/) to obtain a dedicated DOI (in the [Galaxy training network community](https://zenodo.org/communities/galaxy-training/?page=1&size=20)).
-
-You can also add yourself as contributor for the topic in the `yml` file of the related topic that is in `metadata` directory.
-
-> Sometimes, an hands-on tutorial is not the most appropriate format for a tutorial and slides are better. [Check out how to fill tutorial slides?](#how-do-i-fill-tutorial-slides).
-
-## How do I fill introduction slides?
-
-Before starting filling the slides, you have to add the metadata about the tutorial in `material` section in the `yml` file of the related topic that is in `metadata` directory:
-
-- `title`
-- `type: "introduction"`
-- `slides` (`"yes"` or `"no"`): tell if slides are available for this material
-
-The introduction slides must be in the `index.html` file in `slides` directory for each topic. Even if the extension is `html`, slides are written in Markdown. `---` is used to separate the slides.
-
-```
----
-layout: introduction_slides
-topic_name: RNA-Seq
-logo: "GTN"
----
-
-# What is RNA sequencing?
-
----
-
-### Where my data comes from?
-
-![](../images/ecker_2012.jpg)
-
-<!-- add a resized image in percentage: 10%, 25%, 50%, or 75% -->
-.image-25[![](../images/ecker_2012.jpg)]
-
-<small>[*Ecker et al, Nature, 2012*](https://www.ncbi.nlm.nih.gov/pubmed/22955614)</small>
-
-???
-
-Slide notes
--> Pressing **P** will toggle presenter mode.
-
----
-```
-
-The first slides (with the title, the requirements,...) are automatically generated using the metadata of the topic. Then the content to fill starts with the introduction.
-
-They are then rendered with [`Remark`](https://remarkjs.com/). Template for the `html` files can be found in
-[`templates/slides/`](templates/slides/). Once the slides are on the `master` branch, they will be available at `https://galaxyproject.github.io/training-material/<topic>/slides/<slide_name>.html`
-
-You can also add yourself as contributor for the topic in the `yml` file of the related topic that is in `metadata` directory
-
-## How do I fill tutorial slides?
-
-Filling tutorial slides are similar a combination of filling introduction slides and filling an hands-on tutorial:
-
-1. Filling the metadata file with useful information about the tutorial and its format (`slides: "yes"`)
-2. Filling an `html` file in the `slides` directory
-
-    The name of the file must be the same as the name of the tutorial
-
-    The header of the file must be something like:
-
-    ```
-    ---
-    layout: tutorial_slides
-    topic_name: "dev"
-    tutorial_name: tool_integration
-    logo: "GTN"
-    ---
-    ```
-
-    Filling the content is then similar to filling the content of [introduction slides](#how-do-i-fill-introduction-slides). The first slides (with the title, the requirements, the questions, the objectives) are automatically generated using the metadata of the topic and the tutorial.
-
+Most of the content is written in Markdown with some metadata (or variables) stored in YAML. To learn how to add new content, check out our [series of tutorials to create a new tutorial](http://galaxyproject.github.io/training-material/topics/training/):
+
+- [Writing content in markdown to create a new tutorial](https://galaxyproject.github.io/training-material//topics/training/tutorials/create-new-tutorial-content/tutorial.html)
+- [Defining metadata](https://galaxyproject.github.io/training-material//topics/training/tutorials/create-new-tutorial-metadata/tutorial.html)
+- [Setting up the infrastructure](https://galaxyproject.github.io/training-material//topics/training/tutorials/create-new-tutorial-jekyll/tutorial.html) to run Jekyll and check the website generation
+- [Creating Interactive Galaxy Tours](https://galaxyproject.github.io/training-material//topics/training/tutorials/create-new-tutorial-tours/tutorial.html)
+- [Building a Docker flavor for a tutorial](https://galaxyproject.github.io/training-material//topics/training/tutorials/create-new-tutorial-docker/tutorial.html)
+
+If you want to add a new topic, please contact us before: open an issue on this GitHub repository to discuss!
 
 # How is the training material maintained?
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -118,7 +118,7 @@ images. We recommend to use the content of [`templates/docker`](templates/docker
 
 The `docker` image must also integrate a Galaxy tour from the [`tours` repository](https://github.com/galaxyproject/galaxy-tours)
 
-> Want to learn more to a tutorial? [Check out our tutorial to build a Docker flavor for a tutorial](https://galaxyproject.github.io/training-material//topics/training/tutorials/create-new-tutorial-docker/tutorial.html)
+> Want to learn more? [Check out our tutorial to build a Docker flavor for a tutorial](https://galaxyproject.github.io/training-material//topics/training/tutorials/create-new-tutorial-docker/tutorial.html)
 
 # How do I add new content?
 

--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,5 @@
 source 'https://rubygems.org' do
-  gem 'jemoji'
-  gem 'jekyll-feed'
+    gem 'jekyll'
+    gem 'jemoji'
+    gem 'jekyll-feed'
 end

--- a/Makefile
+++ b/Makefile
@@ -33,13 +33,9 @@ clean :
 
 ## install          : install dependencies
 install:
-	$(if $(shell uname -s) == "Darwin", \
-		sudo gem update —-system; \
-		sudo gem install -n /usr/local/bin/ bundler; \
-		sudo gem install -n /usr/local/bin/ nokogiri,  \
-		gem install bundler; \
-		gem install nokogiri);
-	bundle install;
-	bundle update;
+	gem install bundler
+	gem install nokogiri
+	bundle install
+	bundle update
 
 

--- a/Makefile
+++ b/Makefile
@@ -35,16 +35,11 @@ clean :
 install:
 	$(if $(shell uname -s) == "Darwin", \
 		sudo gem update —-system; \
-		sudo gem install -n /usr/local/bin/ jekyll; \
-		sudo gem install -n /usr/local/bin/ jemoji; \
-		sudo gem install -n /usr/local/bin/ jekyll-feed; \
 		sudo gem install -n /usr/local/bin/ bundler; \
-		sudo gem install -n /usr/local/bin/ nokogiri -v '1.6.8.1'; \
-		bundle install,  \
-		gem install jekyll; \
-		gem install jemoji; \
-		gem install jekyll-feed; \
-		gem install bundler \)
-
+		sudo gem install -n /usr/local/bin/ nokogiri,  \
+		gem install bundler; \
+		gem install nokogiri);
+	bundle install;
+	bundle update;
 
 

--- a/README.md
+++ b/README.md
@@ -1,30 +1,18 @@
 [![Gitter](https://badges.gitter.im/Galaxy-Training-Network/training-material.svg)](https://gitter.im/Galaxy-Training-Network/Lobby?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
 
 
-Training material
+Galaxy training material
 =================
 
+This repository collect tutorials and slides developed and maintained by the worldwide Galaxy community.
 
-| topic | features |
-| :-- | :--: |
-| [Galaxy Introduction](topics/introduction) | [:whale:](topics/introduction/docker/)[:book:](topics/introduction/tutorials/) |
-| [Transcriptomics](topics/transcriptomics/) | [:whale:](topics/transcriptomics/docker/) [:movie_camera:](https://vimeo.com/128268401) [:page_facing_up:](https://usegalaxy.org/u/jeremy/p/galaxy-rna-seq-analysis-exercise) [:book:](RNA-Seq/tutorials/ref_based.md) [:mortar_board:](RNA-Seq/slides/index.html) |
-| [ChIP-seq](topics/chip-seq/) | [:whale:](topics/chip-seq/docker/) [:book:](topis/chip-seq/) [:mortar_board:](topics/chip-seq/slides/index.html) |
-| [Variant Analysis](topics/variant-analysis/) | [:whale:](topics/variant-analysis/docker) [:book:](topics/variant-analysis/tutorials) [:mortar_board:](topics/variant-analysis/slides/index.html/) |
-| [Epigenetics](topics/epigenetics/) | [:book:](topics/epigenetics//tutorials/methylation-seq.md) |
-| [Data Sources](topics/dev/tutorials/data-source-integration/tutorial.md) | :book: |
-| [Galaxy Tool Development](topics/dev/) | [:book:](topics/dev/readme.md) |
-| [Galaxy Docker Project](https://slides.com/bgruening/the-galaxy-docker-project/) | [:book:](https://slides.com/bgruening/the-galaxy-docker-project/) |
+# Usage
 
+The content of the material is developed in Markdown and a templating system ([Jekyll](http://jekyllrb.com/)) is used to format the tutorials and generate a website ([http://training.galaxyproject.org](http://training.galaxyproject.org)).
 
-The Galaxy community offers many different ways of training. The table above lists all available training features of a specific topic to give you a fast and comprehensive overview.
+If you want to generate website locally, please have a look at our [dedicated tutorial](https://galaxyproject.github.io/training-material//topics/training/tutorials/create-new-tutorial-jekyll/tutorial.html).
 
- - :whale: The training course and material is available as Docker container.
- - :movie_camera: The training course is available as video on our [vimeo page](https://vimeo.com/galaxyproject).
- - :eyes: The training course is available as [Galaxy tour](https://github.com/galaxyproject/galaxy-tours)
- - :page_facing_up: The training course and material is available as Galaxy page (:thumbsup: hands-on training).
- - :book: The training course and material is available as annotated text (:thumbsup: hands-on training).
- - :mortar_board: Slides as Introduction
+> You want to help us on this project? Please have a look at our [`CONTRIBUTING`](CONTRIBUTING.md) file
 
 # License
 
@@ -37,6 +25,3 @@ We would like to thank all contributors to our Galaxy courses, especially those 
 <a href="https://www.denbi.de/"><img src="https://raw.githubusercontent.com/bgruening/rbc_docs/master/logo/deNBI_Logo_rgb.png" width="15%"></a> 	&emsp;<a href="http://www.sfb992.uni-freiburg.de/"><img src="https://raw.githubusercontent.com/bgruening/presentations/bce348bb606c312d531c479e63a66efc2bc38d44/shared/resources/img/MEDEP.jpg" width="15%"></a> 	&emsp;<a href="http://www.ie-freiburg.mpg.de"><img src="https://raw.githubusercontent.com/bgruening/presentations/master/shared/resources/img/14_MPI_IE_logo_mit_180.gif" width="15%"></a> 	&emsp;<a href="https://www.uni-freiburg.de/"><img src="https://raw.githubusercontent.com/bgruening/presentations/a2e38e4b007994af798320db3a0131c4bb891c0e/shared/resources/img/logo_freiburg.jpg" width="15%"></a>
 <a href="https://wiki.galaxyproject.org/Teach/GTN"><img src="./shared/images/GTNLogo1000.png" width="15%"></a>
 <a href="http://www.france-bioinformatique.fr/"><img src="http://www.france-bioinformatique.fr/sites/default/files/ifb-logo_1.png" width="15%"></a> &emsp;
----
-
-You want to help us on this project? Please, see the [`CONTRIBUTING`](CONTRIBUTING.md) file.

--- a/environment.yml
+++ b/environment.yml
@@ -1,0 +1,14 @@
+name: galaxy_training_material
+channels:
+- bioconda
+- r
+- defaults
+- conda-forge
+dependencies:
+- ruby=2.2.3=1
+- jemalloc=4.4.0=0
+- gmp=6.1.0=0
+- openssl=1.0.2l=0
+- readline=6.2=2
+- yaml=0.1.6=0
+- zlib=1.2.8=3

--- a/environment.yml
+++ b/environment.yml
@@ -1,9 +1,7 @@
 name: galaxy_training_material
 channels:
-- bioconda
-- r
-- defaults
 - conda-forge
+- defaults
 dependencies:
 - ruby=2.2.3=1
 - jemalloc=4.4.0=0

--- a/topics/training/tutorials/create-new-tutorial-jekyll/tutorial.md
+++ b/topics/training/tutorials/create-new-tutorial-jekyll/tutorial.md
@@ -19,40 +19,42 @@ In 2016, the Galaxy Training Network decide to set up a new infrastructure for d
 We took inspiration from [Software Carpentry](https://software-carpentry.org) and collected everything on a GitHub repository: [https://github.com/galaxyproject/training-material ](https://github.com/galaxyproject/training-material).
 We decided on a structure based on tutorials with hands-on, fitting both for online self-training but also for workshops, grouped in topics. Each tutorial follows the same structure and comes with a virtualised isntance to run the training everywhere.
 
-In this tutorial, you will learn how to run a local instance of the GTN webiste with all materials to test and develop new training sessions.
+If you want to run the entire GTN website locally or test your new training material you can do this! 
+
+Currently, the website is generated from the metadata and the tutorials using Jekyll, a simple static site builder.
+We can use Jekyll to run a server to check if the tutorial is correctly added and rendered.
+
 
 > ### Agenda
 >
-> In this tutorial, we will deal with:
+> In this tutorial, you will learn how to run a local instance of the GTN website:
 >
 > 1. TOC
 > {:toc}
 >
 {: .agenda}
 
-> ### Devloping GTN training material
+# Installation of the requirements
+
+The first step is to install the requirements inside a conda environment. This step has to be done once.
+
+> ### :pencil2: Hands-on: Install the requirements
 >
-> This tutorial is part of a series to develop GTN training material, feel free to also look at:
->
-> 1. [Writing content in markdown](../create-new-tutorial-content/tutorial.html)
-> 1. [Defining metadata](../create-new-tutorial-metadata/tutorial.html)
-> 1. [Setting up the infrastructure](../create-new-tutorial-jekyll/tutorial.html)
-> 1. [Creating Interactive Galaxy Tours](../create-new-tutorial-tours/tutorial.html)
-> 1. [Building a Docker flavor](../create-new-tutorial-docker/tutorial.html)
-> 1. [Submitting the new tutorial to the GitHub repository](../../../dev/tutorials/github-contribution/slides.html)
-{: .agenda}
+> 1. Install [conda](https://conda.io/miniconda.html)
+> 2. Create the conda environment: `conda env create -f environment.yml`
+> 3. Activate the conda environment: `source activate galaxy_training_material`
+> 4. Install Jekyll and related modules using [RubyGems](https://rubygems.org/pages/download): `make install`
+{: .hands_on}
 
 # Checking the website generation
 
-If you want to run the entire GTN website locally or test your new training material we can do this! Currently, the website is generated from the metadata and the tutorials using Jekyll, a simple static site builder.
-We can use Jekyll to run a server to check if the tutorial is correctly added and rendered.
+Once Jekyll and its modules are installed in our conda environment, we can check the generation of the website locally:
 
 > ### :pencil2: Hands-on: Checking the website generation locally
->
-> 1. Install Jekyll using [RubyGems](https://rubygems.org/pages/download): `make install`
->
-> 2. Run a local Jekyll server: `make serve`
-> 3. Visualize at [http://localhost:4000/ ](http://localhost:4000/)
+> 
+> 1. (If not done) Activate the conda environment: `source activate galaxy_training_material`
+> 1. Run a local Jekyll server with `make serve`
+> 2. Visualize at [http://localhost:4000/ ](http://localhost:4000/)
 >
 >    > ### :question: Questions
 >    >
@@ -64,6 +66,10 @@ We can use Jekyll to run a server to check if the tutorial is correctly added an
 >    >    </details>
 >    {: .question}
 {: .hands_on}
+
+With `make serve`, a local Jekyll server will run in background. It will check the changes and regenerate the website accordingly. You may need to reload the page to see the changes (and sometimes to wait 1-2 minutes)
+
+Once you are done, you can stop the server with `ctrl-c` and deactivate your conda environment with `source deactivate`.
 
 # Conclusion
 {:.no_toc}


### PR DESCRIPTION
Hi,

On the advise of @bgruening, we can use conda to manage the installation Jekyll and its modules.
It can then simplified the Makefile. 

I documented that in the dedicated tutorial. In the same time, I simplified the CONTRIBUTING.md and the README.md to link to the "Train the trainers" tutorials where everything needed to develop a tutorial is explained.

Bérénice