### PR TITLE
Add base_slides to the list of excluded layouts

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -44,6 +44,7 @@ figurify:
   skip_layouts:
     - introduction_slides
     - tutorial_slides
+    - base_slides
   skip_titles:
     - This is my super caption
 


### PR DESCRIPTION
Thanks to #432, we can now see diffs of what has changed on the deployed website.

I have looked at [the first diff after the figurify plugin has been merged](https://github.com/galaxyproject/training-material/commit/a93aaa185162435412f0f685c93533cad4c94c96), and a slide deck has been figurified 😝 This PR excludes the `base_slides` layout to avoid that.

Cheers,
W.