### PR TITLE
Site proofing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,8 +29,13 @@ before_script:
 script:
 - set -e
 # Check links
-- find .  \( -name "*.md" -o -name "*.html" \) -not -path "./assets/reveal.js/*" | xargs -L 1 -I '{}' sh -c "echo {}; vl -d -t 15 -s 1000 --allow-codes 405 --whitelist localhost,127.0.0.1,fqdn,publish.twitter.com,linkedin.com,vimeo.com {}" || return 0
+- |
+  if [ "$TRAVIS_PULL_REQUEST" == "true" ]
+  then
+    find .  \( -name "*.md" -o -name "*.html" \) -not -path "./assets/reveal.js/*" | xargs -L 1 -I '{}' sh -c "echo {}; vl -d -t 15 -s 1000 --allow-codes 405 --whitelist localhost,127.0.0.1,fqdn,publish.twitter.com,linkedin.com,vimeo.com {}" || return 0
+  fi
 - make site
+- htmlproofer --http-status-ignore 405,999 --url-ignore "/.*localhost.*/"
 after_success:
 - |
   if [ "$TRAVIS_PULL_REQUEST" == "false" -a "$TRAVIS_BRANCH" == "site-proofing" ]

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,9 +8,9 @@ branches:
 services:
 - docker
 
-#env:
-#  global:
-#  - secure: AVbwBaVtCtTQCR4KC4gqnVeYSuE+gKFy5KgVWfKmog/eSJ60nQGLgCSJEwzzA5Q80vZkh9WFn5TmVHiSnSikMCQkUXPrux7vnwxSPkeLV23Vy3gOXDqyJQKHzVzuSsw2X7ikX9EAOaD8cn4McL1TwQqQK440gS1gudwFHZDCfdnqjMAVRW9eNVxq2kOfFMm7iUOd0uHl94fPxGQzAK7H8mGLwpphoWPgwsWO/JuIKWXE0gp6yTTZ1OuK2SrB9ZC2rURWeDHN5Q7NMHIeLjfD42NuAFAN5igZ+2CtzQKRCsO9C5vnuuvfby/yMmxrBKEkbWw0GWPanyNcKZ6j8kICIWwhSUt0Hc25gBE6BOn7aijqBCeJlwMKvVgUBASdg2P23Q2jOqy2o4n9iNAHmRKZtvrpBRhzdCu7lDVn4s7VVBfUwBj/e0+E9x1g0jbwofHo8j/BTjK0iDiHnC4O/IBneATeEcFx4bG6xg5+3uBt8/mLqG1BRUAZMz6SpBGi1PlL527t2Z3w5DNyKBzLDC3rborADdaxgjYH989vHakItq3RhiT8ZRGGfpULTnVO2gmFLCHGoVxKQX2RbTm5xiQ2aj5pnnhtYwKqPGSutdyUfJyxz/Av03NnEN65mv9TioA+sWLMKUL6KeJTT1+HcO5D01ZC7cpYc/M/S+gmff6O5eg=
+env:
+  global:
+  - secure: AVbwBaVtCtTQCR4KC4gqnVeYSuE+gKFy5KgVWfKmog/eSJ60nQGLgCSJEwzzA5Q80vZkh9WFn5TmVHiSnSikMCQkUXPrux7vnwxSPkeLV23Vy3gOXDqyJQKHzVzuSsw2X7ikX9EAOaD8cn4McL1TwQqQK440gS1gudwFHZDCfdnqjMAVRW9eNVxq2kOfFMm7iUOd0uHl94fPxGQzAK7H8mGLwpphoWPgwsWO/JuIKWXE0gp6yTTZ1OuK2SrB9ZC2rURWeDHN5Q7NMHIeLjfD42NuAFAN5igZ+2CtzQKRCsO9C5vnuuvfby/yMmxrBKEkbWw0GWPanyNcKZ6j8kICIWwhSUt0Hc25gBE6BOn7aijqBCeJlwMKvVgUBASdg2P23Q2jOqy2o4n9iNAHmRKZtvrpBRhzdCu7lDVn4s7VVBfUwBj/e0+E9x1g0jbwofHo8j/BTjK0iDiHnC4O/IBneATeEcFx4bG6xg5+3uBt8/mLqG1BRUAZMz6SpBGi1PlL527t2Z3w5DNyKBzLDC3rborADdaxgjYH989vHakItq3RhiT8ZRGGfpULTnVO2gmFLCHGoVxKQX2RbTm5xiQ2aj5pnnhtYwKqPGSutdyUfJyxz/Av03NnEN65mv9TioA+sWLMKUL6KeJTT1+HcO5D01ZC7cpYc/M/S+gmff6O5eg=
 
 install:
 - sudo apt-get update
@@ -40,7 +40,7 @@ script:
 
 after_success:
 - |
-  if [ "$TRAVIS_PULL_REQUEST" == "false" -a "$TRAVIS_BRANCH" == "site-proofing" ]
+  if [ "$TRAVIS_PULL_REQUEST" == "false" -a "$TRAVIS_BRANCH" == "master" ]
   then
     bin/publish
   fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,9 +3,11 @@ language: python
 python: 3.6
 services:
 - docker
-env:
-  global:
-  - secure: AVbwBaVtCtTQCR4KC4gqnVeYSuE+gKFy5KgVWfKmog/eSJ60nQGLgCSJEwzzA5Q80vZkh9WFn5TmVHiSnSikMCQkUXPrux7vnwxSPkeLV23Vy3gOXDqyJQKHzVzuSsw2X7ikX9EAOaD8cn4McL1TwQqQK440gS1gudwFHZDCfdnqjMAVRW9eNVxq2kOfFMm7iUOd0uHl94fPxGQzAK7H8mGLwpphoWPgwsWO/JuIKWXE0gp6yTTZ1OuK2SrB9ZC2rURWeDHN5Q7NMHIeLjfD42NuAFAN5igZ+2CtzQKRCsO9C5vnuuvfby/yMmxrBKEkbWw0GWPanyNcKZ6j8kICIWwhSUt0Hc25gBE6BOn7aijqBCeJlwMKvVgUBASdg2P23Q2jOqy2o4n9iNAHmRKZtvrpBRhzdCu7lDVn4s7VVBfUwBj/e0+E9x1g0jbwofHo8j/BTjK0iDiHnC4O/IBneATeEcFx4bG6xg5+3uBt8/mLqG1BRUAZMz6SpBGi1PlL527t2Z3w5DNyKBzLDC3rborADdaxgjYH989vHakItq3RhiT8ZRGGfpULTnVO2gmFLCHGoVxKQX2RbTm5xiQ2aj5pnnhtYwKqPGSutdyUfJyxz/Av03NnEN65mv9TioA+sWLMKUL6KeJTT1+HcO5D01ZC7cpYc/M/S+gmff6O5eg=
+
+#env:
+#  global:
+#  - secure: AVbwBaVtCtTQCR4KC4gqnVeYSuE+gKFy5KgVWfKmog/eSJ60nQGLgCSJEwzzA5Q80vZkh9WFn5TmVHiSnSikMCQkUXPrux7vnwxSPkeLV23Vy3gOXDqyJQKHzVzuSsw2X7ikX9EAOaD8cn4McL1TwQqQK440gS1gudwFHZDCfdnqjMAVRW9eNVxq2kOfFMm7iUOd0uHl94fPxGQzAK7H8mGLwpphoWPgwsWO/JuIKWXE0gp6yTTZ1OuK2SrB9ZC2rURWeDHN5Q7NMHIeLjfD42NuAFAN5igZ+2CtzQKRCsO9C5vnuuvfby/yMmxrBKEkbWw0GWPanyNcKZ6j8kICIWwhSUt0Hc25gBE6BOn7aijqBCeJlwMKvVgUBASdg2P23Q2jOqy2o4n9iNAHmRKZtvrpBRhzdCu7lDVn4s7VVBfUwBj/e0+E9x1g0jbwofHo8j/BTjK0iDiHnC4O/IBneATeEcFx4bG6xg5+3uBt8/mLqG1BRUAZMz6SpBGi1PlL527t2Z3w5DNyKBzLDC3rborADdaxgjYH989vHakItq3RhiT8ZRGGfpULTnVO2gmFLCHGoVxKQX2RbTm5xiQ2aj5pnnhtYwKqPGSutdyUfJyxz/Av03NnEN65mv9TioA+sWLMKUL6KeJTT1+HcO5D01ZC7cpYc/M/S+gmff6O5eg=
+
 install:
 - sudo apt-get update
 - wget https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O miniconda.sh
@@ -20,22 +22,20 @@ install:
 - source activate galaxy_training_material
 - make install
 - pip install vl pyyaml
-before_script:
-- vl --version
-- which vl
-# patch vl to send user-agent header (some links give error if not set)
-- |
-  sed  -i 's|requests = (grequests.head(u, timeout=timeout, verify=False)|requests = (grequests.head(u, timeout=timeout, verify=False, headers={\x27User-Agent\x27: \x27Mozilla\x27})|' /home/travis/miniconda/lib/python*/site-packages/vl/cli.py
+
 script:
 - set -e
-# Check links
+# Check website
 - |
-  if [ "$TRAVIS_PULL_REQUEST" == "true" ]
+  if [ "$TRAVIS_BRANCH" == "gh-pages" ]
   then
-    find .  \( -name "*.md" -o -name "*.html" \) -not -path "./assets/reveal.js/*" | xargs -L 1 -I '{}' sh -c "echo {}; vl -d -t 15 -s 1000 --allow-codes 405 --whitelist localhost,127.0.0.1,fqdn,publish.twitter.com,linkedin.com,vimeo.com {}" || return 0
+    make install
+    htmlproofer --http-status-ignore 405,999 --url-ignore "/.*localhost.*/"
+  else
+    make site
+    htmlproofer --http-status-ignore 405,999 --url-ignore "/.*localhost.*/" ./_site || return 0
   fi
-- make site
-- htmlproofer --http-status-ignore 405,999 --url-ignore "/.*localhost.*/"
+
 after_success:
 - |
   if [ "$TRAVIS_PULL_REQUEST" == "false" -a "$TRAVIS_BRANCH" == "site-proofing" ]

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,7 +25,6 @@ install:
 - conda env create -f environment.yml
 - source activate galaxy_training_material
 - make install
-- pip install vl pyyaml
 
 script:
 - set -e
@@ -33,7 +32,6 @@ script:
 - |
   if [ "$TRAVIS_BRANCH" == "gh-pages" ]
   then
-    make install
     htmlproofer --http-status-ignore 405,999 --url-ignore "/.*localhost.*/"
   else
     make site

--- a/.travis.yml
+++ b/.travis.yml
@@ -33,7 +33,7 @@ script:
 - make site
 after_success:
 - |
-  if [ "$TRAVIS_PULL_REQUEST" == "false" -a "$TRAVIS_BRANCH" == "master" ]
+  if [ "$TRAVIS_PULL_REQUEST" == "false" -a "$TRAVIS_BRANCH" == "site-proofing" ]
   then
     bin/publish
   fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,10 @@
 sudo: required
 language: python
 python: 3.6
+branches:
+  only:
+  - gh-pages
+  - /.*/
 services:
 - docker
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Gitter](https://badges.gitter.im/Galaxy-Training-Network/training-material.svg)](https://gitter.im/Galaxy-Training-Network/Lobby?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge) [![Build Status](https://travis-ci.org/galaxyproject/training-material.svg?branch=master)](https://travis-ci.org/galaxyproject/training-material)
+[![Gitter](https://badges.gitter.im/Galaxy-Training-Network/training-material.svg)](https://gitter.im/Galaxy-Training-Network/Lobby?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge) [![Build Status](https://travis-ci.org/galaxyproject/training-material.svg?branch=gh-pages)](https://travis-ci.org/galaxyproject/training-material)
 
 
 Galaxy training material

--- a/bin/publish
+++ b/bin/publish
@@ -17,7 +17,7 @@ git clean -fdx
 git rm -r .
 
 # keep the travis file
-git checkout origin/master .travis.yml
+git checkout origin/site-proofing .travis.yml
 
 cp -R /tmp/site/* .
 

--- a/bin/publish
+++ b/bin/publish
@@ -16,6 +16,9 @@ git checkout gh-pages
 git clean -fdx
 git rm -r .
 
+# keep the travis file
+git checkout master .travis.yml
+
 cp -R /tmp/site/* .
 
 find * -type f -exec chmod 644 "{}" ";"

--- a/bin/publish
+++ b/bin/publish
@@ -3,7 +3,8 @@
 git config user.name "Travis-CI"
 git config user.email "noreply@travis-ci.org"
 git remote rm origin
-git remote add origin "https://bebatut:$GH_TOKEN@github.com/galaxyproject/training-material"
+#git remote add origin "https://bebatut:$GH_TOKEN@github.com/galaxyproject/training-material"
+git remote add origin "https://shiltemann:$GH_TOKEN@github.com/shiltemann/training-material"
 
 rm -rf /tmp/site
 mv _site /tmp/site

--- a/bin/publish
+++ b/bin/publish
@@ -25,5 +25,5 @@ find * -type f -exec chmod 644 "{}" ";"
 find * -type d -exec chmod 755 "{}" ";"
 
 git add -A .
-git commit -m "[ci skip] Update on: `date`"
+git commit -m "Update on: `date`"
 git push origin gh-pages

--- a/bin/publish
+++ b/bin/publish
@@ -17,7 +17,7 @@ git clean -fdx
 git rm -r .
 
 # keep the travis file
-git checkout origin/site-proofing .travis.yml
+git checkout origin/site-proofing .travis.yml Makefile Gemfile
 
 cp -R /tmp/site/* .
 

--- a/bin/publish
+++ b/bin/publish
@@ -3,8 +3,7 @@
 git config user.name "Travis-CI"
 git config user.email "noreply@travis-ci.org"
 git remote rm origin
-#git remote add origin "https://bebatut:$GH_TOKEN@github.com/galaxyproject/training-material"
-git remote add origin "https://shiltemann:$GH_TOKEN@github.com/shiltemann/training-material"
+git remote add origin "https://bebatut:$GH_TOKEN@github.com/galaxyproject/training-material"
 
 rm -rf /tmp/site
 mv _site /tmp/site
@@ -16,8 +15,8 @@ git checkout gh-pages
 git clean -fdx
 git rm -r .
 
-# keep the travis file
-git checkout origin/site-proofing .travis.yml Makefile Gemfile
+# keep files needed for travis testing
+git checkout origin/master .travis.yml Makefile Gemfile
 
 cp -R /tmp/site/* .
 

--- a/bin/publish
+++ b/bin/publish
@@ -17,7 +17,7 @@ git clean -fdx
 git rm -r .
 
 # keep the travis file
-git checkout master .travis.yml
+git checkout origin/master .travis.yml
 
 cp -R /tmp/site/* .
 

--- a/topics/assembly/tutorials/debruijn-graph-assembly/tutorial.md
+++ b/topics/assembly/tutorials/debruijn-graph-assembly/tutorial.md
@@ -18,7 +18,7 @@ SPAdes is a de novo genome assembler written by Pavel Pevzner's group in St. Pet
 > In this tutorial, we will deal with:
 >
 > 1. [Get the data](#get-the-data)
-> 2. [Assemble with the Velvet Optimiser](#assemble-with-the-velvet-optimiser)
+> 2. [Assemble with the Velvet Optimiser](#assembly-with-the-velvet-optimiser)
 > 3. [Assemble with SPAdes](#assemble-with-spades)
 {: .agenda}
 


### PR DESCRIPTION
- Replaces vl check with htmlproofer
- Enables travis testing on the gh-pages branch so that we can set up a daily travis cron job on the served site to continually test links
- Badge on readme now reflects build status of gh-pages branch (this will fail for a while until we go back and add alt-texts for images in existing materials, but maybe this will be good encouragement to do this sooner rather than later :) )

there are also some more broken links reported by htmlproofer, will fix those in a later PR

ping @bebatut 