### PR TITLE
Try to clarify maintainer role and add link to training tutorials

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -136,7 +136,9 @@ If you want to add a new topic, please contact us before: open an issue on this 
 
 ## Maintainers
 
-Each training topic and tutorial has one or two maintainers who act as editors. They are responsible for making sure issues and change requests are looked at. They have the final say over what is included in the training material. But they are not responsible for writing training material content or deciding what lessons ought to exist, both will be coming from the community.
+Each training topic and tutorial has one or two maintainers who act as editors.
+
+They are responsible for making sure issues and change requests are looked at. They have the final say over what is included in the training material. But they are not responsible for writing/keeping up-to-date training material content or deciding what lessons ought to exist, both will be coming from the community.
 
 ## Labels
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ This repository collects tutorials, slides, and exercises developed and maintain
 
 The content of the material is developed in Markdown and a templating system ([Jekyll](http://jekyllrb.com/)) is used to format the tutorials and generate a website ([http://training.galaxyproject.org ](http://training.galaxyproject.org)).
 
-Do you want to help with this project? Please have a look at the [`CONTRIBUTING`](CONTRIBUTING.md) file
+Do you want to help with this project? Have a question? Please have a look at the [`CONTRIBUTING`](CONTRIBUTING.md) file and our [tutorials dedicating to training material development](https://galaxyproject.github.io/training-material//topics/training).
 
 If you want to build the website locally, please have a look at the [tutorial](https://galaxyproject.github.io/training-material//topics/training/tutorials/create-new-tutorial-jekyll/tutorial.html).
 


### PR DESCRIPTION
As spotted by @joachimwolff in #447, the role of a maintainer is not clear. I tried to clarify it a bit.
I also had link to the "Train the trainers" tutorials in the README file (it was missing)