### PR TITLE
metaproteomics minor improvements

### DIFF
--- a/topics/proteomics/tutorials/metaproteomics/tools.yaml
+++ b/topics/proteomics/tutorials/metaproteomics/tools.yaml
@@ -1,0 +1,13 @@
+---
+api_key: admin
+galaxy_instance: http://localhost:8080
+tools:
+- name: peptideshaker
+  owner: galaxyp
+  tool_panel_section_label: "Proteomics"
+- name: unipept
+  owner: galaxyp
+  tool_panel_section_label: "Proteomics"
+- name: suite_query_tabular
+  owner: iuc
+  tool_panel_section_label: "Text Manipulation"

--- a/topics/proteomics/tutorials/metaproteomics/tools.yaml
+++ b/topics/proteomics/tutorials/metaproteomics/tools.yaml
@@ -17,7 +17,4 @@ tools:
 - name: suite_query_tabular
   owner: iuc
   tool_panel_section_label: "Text Manipulation"
-- name: sqlite_to_tabular
-  owner: iuc
-  tool_panel_section_label: Text Manipulation
 

--- a/topics/proteomics/tutorials/metaproteomics/tools.yaml
+++ b/topics/proteomics/tutorials/metaproteomics/tools.yaml
@@ -8,6 +8,16 @@ tools:
 - name: unipept
   owner: galaxyp
   tool_panel_section_label: "Proteomics"
+- name: searchgui
+  owner: galaxyp
+  tool_panel_section_label: Proteomics
+- name: split_tabular_columns
+  owner: jjohnson
+  tool_panel_section_label: 'Text Manipulation'
 - name: suite_query_tabular
   owner: iuc
   tool_panel_section_label: "Text Manipulation"
+- name: sqlite_to_tabular
+  owner: iuc
+  tool_panel_section_label: Text Manipulation
+

--- a/topics/proteomics/tutorials/metaproteomics/tutorial.md
+++ b/topics/proteomics/tutorials/metaproteomics/tutorial.md
@@ -315,7 +315,7 @@ As a tabular file is being read, line filters may be applied and an SQL query ca
 >    >    </details>
 >    {: .question}
 >
->    - **Omit column headers from tabular output**: `Yes`
+>    - **include query result column headers**: `No`
 >
 > 2. Click **Execute** and inspect the query results file after it turned green. If everything went well, it should look similiar:
 >
@@ -546,6 +546,7 @@ The UniPept result file can contain multiple GO IDs in a single row. In order to
 >
 >    - **Tabular Dataset to normalize**: The latest UniPept `tabluar`/`tsv` output
 >    - **Columns to split**: Select `Column: 6`, the one containing the GO IDs
+>    - **List delimiter in column**: Insert a single space in the input field
 >
 > 2. Click **Execute**.
 >
@@ -639,7 +640,7 @@ As a final step we will use **Query Tabular** in a more sophisticated way to com
 >
 >          ORDER BY  bering_peptides desc,bering_psms desc
 >
->    - **Omit column headers from tabular output**: `No`
+>    - **include query result column headers**: `Yes`
 >
 > 4. Click **Execute** and inspect the three query result files.
 >


### PR DESCRIPTION
Added a tools file for the metaproteomics tutorial. 

Missing is still the entry for "Split Tabular Columns" - I did not know which tool the corresponds to. 

I was wondering if there is way to specify visualizations that need to be installed/configured. For this tutorial the required Unipept Tree viewer seems not to work by default. 
