### PR TITLE
Make sure the Travis build fails when website cannot be built

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,13 +34,15 @@ install:
 - make install
 
 script:
-- set -e
 # Check website
 - |
+  set -e
   if [ "$TRAVIS_BRANCH" == "gh-pages" ]
   then
     htmlproofer --http-status-ignore 405,999 --url-ignore "/.*localhost.*/","/.*vimeo\.com.*/" --file-ignore "/.*\/files\/.*/"
   else
+    make build
+    # TODO: remove `|| return 0` when htmlproofer passes for the first time
     make check || return 0
   fi
 

--- a/Makefile
+++ b/Makefile
@@ -24,11 +24,11 @@ serve: ## run a local server
 
 detached-serve: ## run a local server in detached mode
 	${JEKYLL} serve --detach
-.PHONY: detached_serve
+.PHONY: detached-serve
 
 build: ## build files but do not run a server
 	${JEKYLL} build
-.PHONY: site
+.PHONY: build
 
 check: build ## validate HTML
 	bundle exec htmlproofer --http-status-ignore 405,999 --url-ignore "/.*localhost.*/","/.*vimeo\.com.*/" --file-ignore "/.*\/files\/.*/" ./_site

--- a/bin/publish
+++ b/bin/publish
@@ -20,6 +20,12 @@ git checkout origin/master .travis.yml Makefile Gemfile
 
 cp -R /tmp/site/* .
 
+# this file must be there, if it is not, it is likely a bug during build
+if [ ! -f "index.html" ]; then
+    echo "index.html file is missing, aborting"
+    exit 1
+fi
+
 find * -type f -exec chmod 644 "{}" ";"
 find * -type d -exec chmod 755 "{}" ";"
 


### PR DESCRIPTION
Hi,

This PR prevents the website to be broken by ensuring that an error at build time is caught by Travis. I have also added a check to the `publish` script to avoid publishing an empty website. Both changes should avoid yesterday's situation.

Note: the `|| return 0` should be removed as soon as all htmlproofer errors are fixed.