### PR TITLE
Activate correct Travis check

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -41,9 +41,7 @@ script:
     then
       htmlproofer --http-status-ignore 405,999 --url-ignore "/.*localhost.*/","/.*vimeo\.com.*/" --file-ignore "/.*\/files\/.*/"
     else
-      make build
-      # TODO: remove `|| return 0` when htmlproofer passes for the first time
-      make check || return 0
+      make check
     fi
 
 after_success:


### PR DESCRIPTION
⚠️  Not merging before YAML linting and #493 
---
I removed the `|| return 0` in Travis, to make sure that Travis tests can fail