### PR TITLE
Fix missing link to Introduction slides for metagenomics

### DIFF
--- a/topics/metagenomics/metadata.yaml
+++ b/topics/metagenomics/metadata.yaml
@@ -16,6 +16,7 @@ material:
   -
     title: "Introduction"
     type: "introduction"
+    slides: "yes"
     contributors:
       -
         name: "Saskia Hiltemann"


### PR DESCRIPTION
At https://galaxyproject.github.io/training-material/topics/metagenomics/