### PR TITLE
Add CODEOWNERS file for automatic PR review requests

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,24 @@
+# Templates
+*   @bebatut @shiltemann
+_*    @bebatut @shiltemann @willdurand
+assets/*    @bebatut @shiltemann @willdurand
+bin/*   @bebatut @shiltemann @bgruening
+metadata/*  @bebatut @shiltemann
+
+# Maintainers of the topics
+topics  @bebatut @shiltemann
+topics/admin/*    @bgruening @martenson @hrhotz @erasche
+topics/assembly/*    @Slugger70
+topics/chip-seq/*    @malloryfreeberg
+topics/dev/*    @lecorguille @bebatut @shiltemann
+topics/epigenetics/*    @joachimwolff @dpryan79
+topics/introduction/*    @tnabtaf
+topics/metagenomics/*    @bebatut @shiltemann
+topics/proteomics/*    @Stortebecker @bgruening @blankclemens
+topics/sequence-analysis/*    @yvanlebras @bebatut @joachimwolff
+topics/training/*    @bebatut @bgruening
+topics/transcriptomics/*    @bebatut @malloryfreeberg
+topics/variant-analysis/*    @TorHou
+
+# Lines starting with '#' are comments.
+# Order is important. The last matching pattern has the most precedence.


### PR DESCRIPTION
As suggested by @erasche in #489, this PR add a `CODEOWNERS` to have automatic PR review requests of the maintainers of each topic

Can you check if it is ok with you?