### PR TITLE
fix travis testing on PRs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -42,11 +42,11 @@ script:
     then
       timeout 120s htmlproofer --http-status-ignore 405,999 --url-ignore "/.*localhost.*/","/.*vimeo\.com.*/" --file-ignore "/.*\/files\/.*/"
     else
-      if [ "$TRAVIS_BRANCH" != "master" ]
+      if [ "$TRAVIS_PULL_REQUEST" == "false" -a "$TRAVIS_BRANCH" == "master" ]
       then
-        make check
-      else
         make build
+      else
+        make check
       fi
     fi
 


### PR DESCRIPTION
I just realized we are not running htmlproofer/yamllint on PRs from other forks, this should fix that.

see for example #553, the **push** job fails, but the **pr** job succeeds because `$TRAVIS_BRANCH` then gets the value of `master` and only `make build` is run. (and for PRs from other forks this is the only test that is run)

ping @bebatut