### PR TITLE
docker: switch to galaxy user for install

### DIFF
--- a/bin/docker-install-tutorials.sh
+++ b/bin/docker-install-tutorials.sh
@@ -10,6 +10,9 @@ startup_lite
 # wait until galaxy has started
 galaxy-wait -g $galaxy_instance
 
+# run tutorial install as user galaxy
+su - galaxy
+
 # install other tutorial materials
 for dir in /tutorials/*
 do

--- a/bin/docker-install-tutorials.sh
+++ b/bin/docker-install-tutorials.sh
@@ -11,7 +11,7 @@ startup_lite
 galaxy-wait -g $galaxy_instance
 
 # run tutorial install as user galaxy
-su - galaxy
+su - $GALAXY_USER
 
 # install other tutorial materials
 for dir in /tutorials/*


### PR DESCRIPTION
run the installation of tutorials as user `galaxy` to prevent problems when some files in conda are owned by root (as mentioned by @nekrut on Gitter)