### PR TITLE
change to user galaxy

### DIFF
--- a/topics/admin/tutorials/database-schema/tutorial.md
+++ b/topics/admin/tutorials/database-schema/tutorial.md
@@ -119,9 +119,10 @@ There is nothing in the database that results from direct manipulation of the ta
 
 > ### {% icon hands_on %} ***Hands on!***
 >
->   1. Connect to the PostgreSQL database
+>   1. Connect to the PostgreSQL database (change to user galaxy first)
 >
->    ```sh
+>    ```sh 
+>        su galaxy
 >        psql -d galaxy -U galaxy
 >    ```
 >
@@ -303,9 +304,10 @@ The following example is from the development server at the FMI
 >       \q
 >   ```
 >
->   Quit the interactive docker
+>   Quit the interactive docker (change back to root first)
 >
 >   ```sh
+>       exit
 >       exit
 >   ```
 


### PR DESCRIPTION
in order to access the PostgreSQL database on the command line. This has become necessary due to a (security) fix within the docker container.
I will update the tutorial to use 'pgadmin' in time for GCC1018 (as discussed with @bgruening yesterday)