### PR TITLE
Update RNA-based tutorial tool

### DIFF
--- a/topics/transcriptomics/tutorials/ref-based/tools.yaml
+++ b/topics/transcriptomics/tutorials/ref-based/tools.yaml
@@ -55,7 +55,6 @@ tools:
     tool_shed_url: https://testtoolshed.g2.bx.psu.edu/
     tool_panel_section_label: 'Graph/Display Data'
 
-
   - name: collection_column_join
     owner: iuc
     tool_panel_section_label: 'Collection Operations'
@@ -94,8 +93,8 @@ tools:
     owner: devteam
     tool_panel_section_label: 'Text Manipulation'
 
-  - name: trimgalore
-    owner: iuc
+  - name: trim_galore
+    owner: bgruening
     tool_panel_section_label: 'NGS: QC and manipulation'
 
   - name: dexseq


### PR DESCRIPTION
`trimgalore` (particularly from `iuc`) does not exist in the Tool Shed so update to an existing tool.