### PR TITLE
Update decktape installation

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -13,3 +13,4 @@ dependencies:
   - yaml=0.1.6
   - zlib=1.2.8
   - yamllint=1.2.1
+  - nodejs=8.8.1


### PR DESCRIPTION
- Add npm as dependency
- Use npm to install decktape
- Update decktape command to create PDF for the slides