### PR TITLE
Add link to workflows in the topic page

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -73,6 +73,7 @@ icon-tag:
   tutorial: fa-laptop
   slides: fa-slideshare
   interactive_tour: fa-magic
+  workflow: fa-share-alt
   topic: fa-folder-o
   docker_image: fa-ship
   galaxy_instance: fa-external-link

--- a/_layouts/topic.html
+++ b/_layouts/topic.html
@@ -96,12 +96,12 @@ layout: base
                                 <td>
                                     {% if material.workflows and material.workflows != "" %}
                                         <a href="#" class="btn btn-default dropdown-toggle" data-toggle="dropdown" aria-expanded="false" title="Workflows">
-                                        {% icon workflow %}
+                                            {% icon workflow %}
                                         </a>
                                         <ul class="dropdown-menu">
-                                        {% for wf in material.workflows %}
-                                            <a class="dropdown-item" href="{{ site.github_repository  }}/tree/master/topics/{{ topic.name }}/tutorials/{{ material.name }}/workflows/{{ wf.name }}.ga" title="{{ wf.title }}">
-                                                {{ wf.title }}
+                                        {% for workflow in material.workflows %}
+                                            <a class="dropdown-item" href="{{ site.github_repository  }}/tree/master/topics/{{ topic.name }}/tutorials/{{ material.name }}/workflows/{{ workflow.name }}.ga" title="{{ workflow.title }}">
+                                                {{ workflow.title }}
                                             </a>
                                         {% endfor %}
                                         </ul>

--- a/_layouts/topic.html
+++ b/_layouts/topic.html
@@ -38,6 +38,7 @@ layout: base
 
                 {% if topic.type != "admin-dev" %}
                 <th>Input dataset</th>
+                <th>Workflows</th>
                 <th>Galaxy tour</th>
                 {% endif %}
             </tr>
@@ -46,7 +47,6 @@ layout: base
                 {% if material.enable != "false" %}
                     <tr>
                         <td>{{ material.title }}</td>
-
                         {% if material.type == "introduction" %}
                             <td>
                                 {% if material.slides %}
@@ -91,6 +91,20 @@ layout: base
                                     <a href="{{ material.zenodo_link }}">
                                       {% icon zenodo_link %}
                                     </a>
+                                    {% endif %}
+                                </td>
+                                <td>
+                                    {% if material.workflows and material.workflows != "" %}
+                                        <a href="#" class="btn btn-default dropdown-toggle" data-toggle="dropdown" aria-expanded="false" title="Workflows">
+                                        {% icon workflow %}
+                                        </a>
+                                        <ul class="dropdown-menu">
+                                        {% for wf in material.workflows %}
+                                            <a class="dropdown-item" href="{{ site.github_repository  }}/tree/master/topics/{{ topic.name }}/tutorials/{{ material.name }}/workflows/{{ wf.name }}.ga" title="{{ wf.title }}">
+                                                {{ wf.title }}
+                                            </a>
+                                        {% endfor %}
+                                        </ul>
                                     {% endif %}
                                 </td>
                                 <td>

--- a/_layouts/topic.html
+++ b/_layouts/topic.html
@@ -94,17 +94,10 @@ layout: base
                                     {% endif %}
                                 </td>
                                 <td>
-                                    {% if material.workflows and material.workflows != "" %}
-                                        <a href="#" class="btn btn-default dropdown-toggle" data-toggle="dropdown" aria-expanded="false" title="Workflows">
+                                    {% if material.workflows %}
+                                        <a href="{{ site.github_repository  }}/tree/master/topics/{{ topic.name }}/tutorials/{{ material.name }}/workflows/" title="{{ workflow.title }}" alt="{{ material.title }} workflows">
                                             {% icon workflow %}
                                         </a>
-                                        <ul class="dropdown-menu">
-                                        {% for workflow in material.workflows %}
-                                            <a class="dropdown-item" href="{{ site.github_repository  }}/tree/master/topics/{{ topic.name }}/tutorials/{{ material.name }}/workflows/{{ workflow.name }}.ga" title="{{ workflow.title }}">
-                                                {{ workflow.title }}
-                                            </a>
-                                        {% endfor %}
-                                        </ul>
                                     {% endif %}
                                 </td>
                                 <td>

--- a/topics/assembly/metadata.yaml
+++ b/topics/assembly/metadata.yaml
@@ -30,6 +30,7 @@ material:
     galaxy_tour: ""
     slides: yes
     hands_on: yes
+    workflows: yes
     questions:
       - "How do we perform a very basic genome assembly from short read data?"
     objectives:
@@ -50,6 +51,7 @@ material:
     galaxy_tour: ""
     hands_on: yes
     slides: yes
+    workflows: no
     questions:
       - "What are the factors that affect genome assembly?"
       - "How does Genome assembly work?"
@@ -73,6 +75,7 @@ material:
     galaxy_tour: ""
     hands_on: yes
     slides: yes
+    workflows: yes
     questions:
       - "How to perform an hybrid bacterial assembly with Unicycler"
     objectives:

--- a/topics/chip-seq/metadata.yaml
+++ b/topics/chip-seq/metadata.yaml
@@ -36,6 +36,7 @@ material:
     galaxy_tour: ""
     hands_on: yes
     slides: no
+    workflows: no
     edam_ontology: "topic_3169"
     questions:
       - How is raw ChIP-seq data processed and analyzed?
@@ -75,6 +76,7 @@ material:
     galaxy_tour: ""
     hands_on: yes
     slides: no
+    workflows: yes
     questions:
       - How is raw ChIP-seq data processed and analyzed?
       - What are the binding sites of the Estrogen receptor?

--- a/topics/epigenetics/metadata.yaml
+++ b/topics/epigenetics/metadata.yaml
@@ -37,6 +37,7 @@ material:
     galaxy_tour: ""
     hands_on: yes
     slides: no
+    workflows: yes
     edam_ontology: "topic_3173"
     questions:
       - "What is methylation and why it cannot be recognised by a normal NGS procedure?"

--- a/topics/introduction/metadata.yaml
+++ b/topics/introduction/metadata.yaml
@@ -27,6 +27,7 @@ material:
     galaxy_tour: ""
     hands_on: yes
     slides: no
+    workflows: no
     questions:
       - "Which coding exon has the highest number of single nucleotide polymorphisms (SNPs) on human chromosome 22?"
     objectives:
@@ -58,6 +59,7 @@ material:
     galaxy_tour: ""
     hands_on: yes
     slides: no
+    workflows: no
     questions:
       - "How to use Galaxy?"
       - "How to get from peak regions to a list of gene names?"
@@ -87,6 +89,7 @@ material:
     type: "tutorial"
     name: "galaxy-intro-strands"
     zenodo_link: ""
+    workflows: no
     galaxy_tour: ""
     hands_on: yes
     slides: no
@@ -109,6 +112,7 @@ material:
     type: "tutorial"
     name: "galaxy-intro-history-to-workflow"
     zenodo_link: ""
+    workflows: no
     galaxy_tour: ""
     hands_on: yes
     slides: no
@@ -133,6 +137,7 @@ material:
     type: "tutorial"
     name: "processing-many-samples-at-once"
     zenodo_link: ""
+    workflows: no
     galaxy_tour: ""
     hands_on: yes
     slides: no
@@ -155,6 +160,7 @@ material:
     type: "tutorial"
     name: "options-for-using-galaxy"
     zenodo_link: ""
+    workflows: no
     galaxy_tour: ""
     hands_on: no
     slides: yes
@@ -173,6 +179,7 @@ material:
     type: "tutorial"
     name: "igv-introduction"
     zenodo_link: ""
+    workflows: no
     galaxy_tour: ""
     hands_on: yes
     slides: no
@@ -200,6 +207,7 @@ material:
     galaxy_tour: ""
     hands_on: yes
     slides: no
+    workflows: no
     questions:
     objectives:
     time_estimation:
@@ -214,6 +222,7 @@ material:
     galaxy_tour: ""
     hands_on: no
     slides: yes
+    workflows: no
     questions:
     objectives:
     time_estimation:
@@ -227,6 +236,7 @@ material:
     name: "galaxy-intro-collections"
     enable: "false"
     zenodo_link: ""
+    workflows: no
     galaxy_tour: ""
     hands_on: yes
     slides: no

--- a/topics/metagenomics/metadata.yaml
+++ b/topics/metagenomics/metadata.yaml
@@ -29,6 +29,7 @@ material:
     galaxy_tour:
     hands_on: yes
     slides: no
+    workflows: yes
     questions:
       - "What is the effect of normal variation in the gut microbiome on host health?"
     objectives:
@@ -50,6 +51,7 @@ material:
     galaxy_tour:
     hands_on: yes
     slides: no
+    workflows: yes
     questions:
       - "How to analyze metagenomics data?"
       - "What information can be extracted of metagenomics data?"

--- a/topics/proteomics/metadata.yaml
+++ b/topics/proteomics/metadata.yaml
@@ -22,6 +22,7 @@ material:
     galaxy_tour: ""
     hands_on: yes
     slides: no
+    workflows: yes
     questions:
       - "How to download protein FASTA databases of a certain organism?"
       - "How to download a contaminant database?"
@@ -46,6 +47,7 @@ material:
     galaxy_tour: ""
     hands_on: yes
     slides: no
+    workflows: yes
     zenodo_link: "https://doi.org/10.5281/zenodo.839701"
     questions:
       - "How can I match metaproteomic mass spectrometry data to peptide sequences derived from shotgun metagenomic data?"
@@ -71,6 +73,7 @@ material:
     galaxy_tour: ""
     hands_on: yes
     slides: no
+    workflows: no
     questions:
       - "What are benefits and drawbacks of different quantitation methods?"
       - "How to choose which quantitation method bests suits my need?"
@@ -94,6 +97,7 @@ material:
     galaxy_tour: ""
     hands_on: yes
     slides: no
+    workflows: yes
     questions:
       - "What is the N-TAILS technique?"
       - "How can N-TAILS datasets be analyzed using Galaxy?"
@@ -114,6 +118,7 @@ material:
     galaxy_tour: "yes"
     hands_on: yes
     slides: no
+    workflows: yes
     questions:
       - "How to convert LC-MS/MS raw files?"
       - "How to identify peptides?"
@@ -137,6 +142,7 @@ material:
     galaxy_tour: "no"
     hands_on: yes
     slides: no
+    workflows: yes
     questions:
       - "How to convert LC-MS/MS raw files?"
       - "How to identify peptides?"
@@ -160,6 +166,7 @@ material:
     galaxy_tour: ""
     hands_on: yes
     slides: no
+    workflows: yes
     questions:
       - "How to combine two different methods for localization prediction?"
     objectives:
@@ -181,6 +188,7 @@ material:
     galaxy_tour: ""
     hands_on: yes
     slides: no
+    workflows: no
     questions:
       - "What are MS1 features?"
       - "How to quantify based on MS1 features?"

--- a/topics/sequence-analysis/metadata.yaml
+++ b/topics/sequence-analysis/metadata.yaml
@@ -18,6 +18,7 @@ material:
     galaxy_tour: ""
     hands_on: yes
     slides: yes
+    workflows: yes
     questions:
       - How to control quality of NGS data?
       - What are the quality parameters to check for each dataset?
@@ -44,6 +45,7 @@ material:
     galaxy_tour: ""
     hands_on: yes
     slides: yes
+    workflows: yes
     questions:
       - What two things are crucial for a correct mapping?
       - What is BAM?
@@ -65,6 +67,7 @@ material:
     galaxy_tour: ""
     hands_on: yes
     slides: no
+    workflows: no
     questions:
       - "First question addressed during the tutorial"
       - "Second question addressed during the tutorial"
@@ -86,6 +89,7 @@ material:
     galaxy_tour: "ref-based-rad-seq"
     hands_on: yes
     slides: no
+    workflows: no
     questions:
       - "How to analyze RAD sequencing data using a reference genome for a population genomics study?"
     objectives:
@@ -105,6 +109,7 @@ material:
     galaxy_tour: "de-novo-rad-seq"
     hands_on: yes
     slides: no
+    workflows: no
     questions:
       - "How to analyze RAD sequencing data without a reference genome for a population genomics study?"
     objectives:
@@ -124,6 +129,7 @@ material:
     galaxy_tour: "genetic-map-rad-seq"
     hands_on: yes
     slides: no
+    workflows: no
     questions:
       - "How to analyze RAD sequencing data for a genetic map study?"
     objectives:

--- a/topics/training/tutorials/create-new-tutorial-metadata/tutorial.md
+++ b/topics/training/tutorials/create-new-tutorial-metadata/tutorial.md
@@ -53,9 +53,7 @@ The first file we will fill is the `metadata.yaml` file describing the metadata 
 - `name`: name of the tutorial (name of the subdirectory where the files related to the tutorial will be stored)
 - `zenodo_link`: link on Zenodo to the input data for the tutorial (not ideal but it can be empty)
 - `galaxy_tour`: name of the galaxy tour
-- `workflows`: list of the related workflows with for each workflow:
-    - `name`: the name of the workflow file in the `workflows` subdirectory of the tutorial
-    - `title`: title of the workflow, as it will appear in the topic page
+- `workflows` (`yes` or `no`): tell if a workflow is available for this material
 - `hands_on`(`yes` or `no`): tell if an hands on is available for this material
 - `slides` (`yes` or `no`): tell if slides are available for this material its title, its type, ...
 - `requirements`: list of requirements specific to this tutorial (in addition to the one of the topic), with:

--- a/topics/training/tutorials/create-new-tutorial-metadata/tutorial.md
+++ b/topics/training/tutorials/create-new-tutorial-metadata/tutorial.md
@@ -53,6 +53,9 @@ The first file we will fill is the `metadata.yaml` file describing the metadata 
 - `name`: name of the tutorial (name of the subdirectory where the files related to the tutorial will be stored)
 - `zenodo_link`: link on Zenodo to the input data for the tutorial (not ideal but it can be empty)
 - `galaxy_tour`: name of the galaxy tour
+- `workflows`: list of the related workflows with for each workflow:
+    - `name`: the name of the workflow file in the `workflows` subdirectory of the tutorial
+    - `title`: title of the workflow, as it will appear in the topic page
 - `hands_on`(`yes` or `no`): tell if an hands on is available for this material
 - `slides` (`yes` or `no`): tell if slides are available for this material its title, its type, ...
 - `requirements`: list of requirements specific to this tutorial (in addition to the one of the topic), with:

--- a/topics/transcriptomics/metadata.yaml
+++ b/topics/transcriptomics/metadata.yaml
@@ -30,12 +30,9 @@ material:
     name: "de-novo"
     zenodo_link: "https://zenodo.org/record/254485#.WKODmRIrKRu"
     galaxy_tour: ""
-    workflows:
-      -
-        name: rnaseq-denovo-transcriptome-reconstruction
-        title: "Full"
     hands_on: yes
     slides: no
+    workflows: yes
     questions:
       - "What genes are differentially expressed between G1E cells and megakaryocytes?"
       - "How can we generate a transcriptome de novo from RNA sequencing data?"
@@ -59,6 +56,7 @@ material:
     galaxy_tour: "ref_based_rna_seq"
     hands_on: yes
     slides: no
+    workflows: no
     questions:
       - "What are the effects of Pasilla (PS) gene depletion on splicing events?"
       - "How to analyze RNA sequencing data using a reference genome?"
@@ -86,6 +84,7 @@ material:
     galaxy_tour: ""
     hands_on: yes
     slides: no
+    workflows: yes
     questions:
       - "What small RNAs are expressed?"
       - "What RNA features have significantly different numbers of small RNAs targeting them between two conditions?"
@@ -108,6 +107,7 @@ material:
     galaxy_tour: ""
     hands_on: yes
     slides: yes
+    workflows: no
     questions:
       - "How are RNA-Seq results stored?"
       - "Why are visualization techniques needed?"

--- a/topics/transcriptomics/metadata.yaml
+++ b/topics/transcriptomics/metadata.yaml
@@ -30,6 +30,10 @@ material:
     name: "de-novo"
     zenodo_link: "https://zenodo.org/record/254485#.WKODmRIrKRu"
     galaxy_tour: ""
+    workflows:
+      -
+          name: rnaseq-denovo-transcriptome-reconstruction
+          title: "Full"
     hands_on: yes
     slides: no
     questions:

--- a/topics/transcriptomics/metadata.yaml
+++ b/topics/transcriptomics/metadata.yaml
@@ -32,8 +32,8 @@ material:
     galaxy_tour: ""
     workflows:
       -
-          name: rnaseq-denovo-transcriptome-reconstruction
-          title: "Full"
+        name: rnaseq-denovo-transcriptome-reconstruction
+        title: "Full"
     hands_on: yes
     slides: no
     questions:

--- a/topics/variant-analysis/metadata.yaml
+++ b/topics/variant-analysis/metadata.yaml
@@ -37,6 +37,7 @@ material:
     galaxy_tour: ""
     hands_on: yes
     slides: no
+    workflows: no
     questions:
       - "What is the pipeline of the processes for variant calling and processing it?"
     objectives:
@@ -60,6 +61,7 @@ material:
     galaxy_tour: ""
     hands_on: yes
     slides: no
+    workflows: no
     questions:
       - "How to identify the genetic variation with the use of exome sequencing?"
       - "What is the pipeline of the process of finding genetic variation which caused the disease?"


### PR DESCRIPTION
To fix #287

On the topic page:
![screen shot 2017-12-03 at 12 34 04](https://user-images.githubusercontent.com/1842467/33524973-4a9524a0-d826-11e7-83c2-223e8502ca35.png)

It links to the workflow on GitHub

To add that, some metadata are added for the tutorials

```
-
    title: "De novo transcriptome reconstruction with RNA-Seq"
    type: "tutorial"
    name: "de-novo"
    zenodo_link: "https://zenodo.org/record/254485#.WKODmRIrKRu"
    galaxy_tour: ""
    workflows:
      -
          name: rnaseq-denovo-transcriptome-reconstruction
          title: "Full"
     ....
```

We can then have several workflows for a tutorial and link them from the topic page.

The training tutorial on metadata is updated