### PR TITLE
Typo fix and clarified an input as a collection

### DIFF
--- a/topics/metagenomics/tutorials/mothur-miseq-sop/tutorial.md
+++ b/topics/metagenomics/tutorials/mothur-miseq-sop/tutorial.md
@@ -848,7 +848,7 @@ animal) followed by a D and a three digit number (number of days post weaning).
 > >  What would you exect the result of `count.groups` on this new shared output collection to be? Check if you are correct.
 > > <details>
 > >   <summary> Click to view answer</summary>
-> >   all groups (samples) should now have 2440 sequences. Run count.groups again on the shared file output by the sub.sample
+> >   all groups (samples) should now have 2440 sequences. Run count.groups again on the shared output collection by the sub.sample
 > >   tool to confirm that this is indeed what happened.
 > >  </details>
 > {: .question}

--- a/topics/metagenomics/tutorials/mothur-miseq-sop/tutorial.md
+++ b/topics/metagenomics/tutorials/mothur-miseq-sop/tutorial.md
@@ -845,7 +845,7 @@ animal) followed by a D and a three digit number (number of days post weaning).
 >
 > > ### {% icon question %} Question
 > >
-> >  What would you exect the result of `count.groups` on this new shared file output to be? Check if you are correct.
+> >  What would you exect the result of `count.groups` on this new shared output collection to be? Check if you are correct.
 > > <details>
 > >   <summary> Click to view answer</summary>
 > >   all groups (samples) should now have 2440 sequences. Run count.groups again on the shared file output by the sub.sample
@@ -1352,7 +1352,7 @@ F3D9     9
 > community types
 >
 > <!-- TODO: add this tool to mothur suite -->
-> - **Get.communitype** {% icon tool %} with the following parameters
+> - **Get.communitytype** {% icon tool %} with the following parameters
 >   - "shared" to Subsample.shared file
 >
 {: .hands_on}


### PR DESCRIPTION
 - Section "Hands-on: Subsampling": count.groups input clarified as a collection in final "check" step
 - Section "Hands-on: Correlation": Fix tool name from Get.communitype to Get.communitytype in last hands-on step