### PR TITLE
Add category tags for tutorials

### DIFF
--- a/_layouts/topic.html
+++ b/_layouts/topic.html
@@ -46,7 +46,16 @@ layout: base
             {% for material in topic.material %}
                 {% if material.enable != "false" %}
                     <tr>
-                        <td>{{ material.title }}</td>
+                        <td>
+                            {{ material.title }}
+                            {% if material.tags %}
+                                <div class="">
+                                    {% for tag in material.tags %}
+                                        <span class="label label-default">{{ tag }}</span>
+                                    {% endfor %}
+                                </div>
+                            {% endif %}
+                        </td>
                         {% if material.type == "introduction" %}
                             <td>
                                 {% if material.slides %}

--- a/assets/css/main.scss
+++ b/assets/css/main.scss
@@ -292,3 +292,20 @@ footer {
         display: none;
     }
 }
+
+.label {
+    display: inline;
+    padding: .2em .6em .3em;
+    font-size: 75%;
+    font-weight: bold;
+    line-height: 1;
+    color: #fff;
+    text-align: center;
+    white-space: nowrap;
+    vertical-align: baseline;
+    border-radius: .25em;
+}
+
+.label-default {
+    background-color: #999999;
+}

--- a/topics/assembly/metadata.yaml
+++ b/topics/assembly/metadata.yaml
@@ -76,6 +76,8 @@ material:
     hands_on: yes
     slides: yes
     workflows: yes
+    tags:
+      - prokaryote
     questions:
       - "How to perform an hybrid bacterial assembly with Unicycler"
     objectives:

--- a/topics/sequence-analysis/metadata.yaml
+++ b/topics/sequence-analysis/metadata.yaml
@@ -68,6 +68,8 @@ material:
     hands_on: yes
     slides: no
     workflows: no
+    tags:
+      - prokaryote
     questions:
       - "First question addressed during the tutorial"
       - "Second question addressed during the tutorial"

--- a/topics/sequence-analysis/metadata.yaml
+++ b/topics/sequence-analysis/metadata.yaml
@@ -153,6 +153,8 @@ material:
     hands_on: yes
     slides: yes
     workflows: yes
+    tags:
+      - prokaryote
     questions:
       - "How to annotate a bacterial genome?"
       - "How to visualize annoted genomic features?"

--- a/topics/transcriptomics/metadata.yaml
+++ b/topics/transcriptomics/metadata.yaml
@@ -57,8 +57,6 @@ material:
     hands_on: yes
     slides: no
     workflows: yes
-    tags:
-      - eukaryote
     questions:
       - "What are the effects of Pasilla (PS) gene depletion on splicing events?"
       - "How to analyze RNA sequencing data using a reference genome?"

--- a/topics/transcriptomics/metadata.yaml
+++ b/topics/transcriptomics/metadata.yaml
@@ -57,6 +57,8 @@ material:
     hands_on: yes
     slides: no
     workflows: yes
+    tags:
+      - eukaryote
     questions:
       - "What are the effects of Pasilla (PS) gene depletion on splicing events?"
       - "How to analyze RNA sequencing data using a reference genome?"

--- a/topics/variant-analysis/metadata.yaml
+++ b/topics/variant-analysis/metadata.yaml
@@ -112,6 +112,8 @@ material:
     hands_on: yes
     slides: no
     workflows: yes
+    tags:
+      - prokaryote
     questions:
       - "How do we detect differences between a set of reads from a microorganism and a reference genome"
     objectives:
@@ -138,6 +140,8 @@ material:
     galaxy_tour: no
     hands_on: yes
     slides: no
+    tags:
+      - prokaryote
     questions:
       - "How does frequency of mitochondrial polymorphisms change from mother to child?"
     objectives:


### PR DESCRIPTION
As asked in #349, this PR should add the possibility to have tags for the tutorials in the metadata files that will be display below the tutorial name on the topic page: 

![screen shot 2018-01-30 at 15 15 10](https://user-images.githubusercontent.com/1842467/35570820-96872b06-05d0-11e8-9181-c402b2c2acdf.png)

Several tags can be added for a tutorial as a list:

![screen shot 2018-01-30 at 15 19 57](https://user-images.githubusercontent.com/1842467/35570983-1c53791a-05d1-11e8-89c1-cb29b7b3d23e.png)

PS: Currently the labels are not links. But we could think (in the future) to extend this feature to list all the tutorials with the same tag. But I am not sure if it will be easy...
