### PR TITLE
add --url-swap to htmlproofer

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -40,8 +40,9 @@ install:
   - conda env create -f environment.yml
   - source activate galaxy_training_material
   - make install
-  - if [[ $TRAVIS_EVENT_TYPE == "pull_request" ]]; then export BRANCH=$TRAVIS_PULL_REQUEST_BRANCH; else export BRANCH=$TRAVIS_BRANCH; fi
-  - if [[ $TRAVIS_EVENT_TYPE == "pull_request" ]]; then export REPO=$TRAVIS_PULL_REQUEST_SLUG; else export REPO=$TRAVIS_REPO_SLUG;
+  - if [[ $TRAVIS_EVENT_TYPE == "pull_request" ]]; then export ORIGIN_BRANCH=$TRAVIS_PULL_REQUEST_BRANCH; else export ORIGIN_BRANCH=$TRAVIS_BRANCH; fi
+  - if [[ $TRAVIS_EVENT_TYPE == "pull_request" ]]; then export ORIGIN_REPO=$TRAVIS_PULL_REQUEST_SLUG; else export ORIGIN_REPO=$TRAVIS_REPO_SLUG;
+  - echo $ORIGIN_REPO $ORIGIN_BRANCH
 
 script:
   # Check website

--- a/.travis.yml
+++ b/.travis.yml
@@ -41,7 +41,7 @@ install:
   - source activate galaxy_training_material
   - make install
   - if [[ $TRAVIS_EVENT_TYPE == "pull_request" ]]; then export ORIGIN_BRANCH=$TRAVIS_PULL_REQUEST_BRANCH; else export ORIGIN_BRANCH=$TRAVIS_BRANCH; fi
-  - if [[ $TRAVIS_EVENT_TYPE == "pull_request" ]]; then export ORIGIN_REPO=$TRAVIS_PULL_REQUEST_SLUG; else export ORIGIN_REPO=$TRAVIS_REPO_SLUG;
+  - if [[ $TRAVIS_EVENT_TYPE == "pull_request" ]]; then export ORIGIN_REPO=$TRAVIS_PULL_REQUEST_SLUG; else export ORIGIN_REPO=$TRAVIS_REPO_SLUG; fi
   - echo $ORIGIN_REPO $ORIGIN_BRANCH
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -40,6 +40,8 @@ install:
   - conda env create -f environment.yml
   - source activate galaxy_training_material
   - make install
+  - if [[ $TRAVIS_EVENT_TYPE == "pull_request" ]]; then export BRANCH=$TRAVIS_PULL_REQUEST_BRANCH; else export BRANCH=$TRAVIS_BRANCH; fi
+  - if [[ $TRAVIS_EVENT_TYPE == "pull_request" ]]; then export REPO=$TRAVIS_PULL_REQUEST_SLUG; else export REPO=$TRAVIS_REPO_SLUG;
 
 script:
   # Check website

--- a/Makefile
+++ b/Makefile
@@ -26,24 +26,54 @@ build: clean ## build files but do not run a server
 .PHONY: build
 
 check-html: build ## validate HTML
-	bundle exec htmlproofer --assume-extension --http-status-ignore 405,503,999 --url-ignore "/.*localhost.*/","/.*vimeo\.com.*/","/.*gitter\.im.*/","/.*drmaa\.org.*/" --file-ignore "/.*\/files\/.*/","/.*\/node_modules\/.*/" --allow-hash-href ./_site
+	bundle exec htmlproofer \
+          --assume-extension \
+          --http-status-ignore 405,503,999 \
+          --url-ignore "/.*localhost.*/","/.*vimeo\.com.*/","/.*gitter\.im.*/","/.*drmaa\.org.*/" \
+          --file-ignore "/.*\/files\/.*/","/.*\/node_modules\/.*/" \
+          --allow-hash-href \
+        ./_site
 .PHONY: check-html
 
-check-links-gh-pages:  ## validate HTML on gh-pages branch (for daily cron job)
-	bundle exec htmlproofer --assume-extension --http-status-ignore 405,503,999 --url-ignore "/.*localhost.*/","/.*vimeo\.com.*/","/.*gitter\.im.*/","/.*drmaa\.org.*/" --file-ignore "/.*\/files\/.*/" --allow-hash-href .
-	find . -path "**/slides*.html" | xargs -L 1 -I '{}' sh -c "awesome_bot --allow 405 --allow-redirect --white-list localhost,127.0.0.1,fqdn,vimeo.com,drmaa.com --allow-ssl --allow-dupe --skip-save-results -f {}"
-.PHONY: check-links-gh-pages
+check-slides: build  ## check the markdown-formatted links in slides
+	find _site -path "**/slides*.html" \
+        | xargs -L 1 -I '{}' sh -c \
+        "awesome_bot \
+           --allow 405 \
+           --allow-redirect \
+           --white-list localhost,127.0.0.1,fqdn,vimeo.com,drmaa.com \
+           --allow-ssl \
+           --allow-dupe \
+           --skip-save-results \
+         -f {}"
+.PHONY: check-slides
 
 check-yaml: ## lint yaml files
 	find . -path "**/*.yaml" | xargs -L 1 -I '{}' sh -c "yamllint {}"
 .PHONY: check-yaml
 
-check-slides: build  ## check the markdown-formatted links in slides
-	find _site -path "**/slides*.html" | xargs -L 1 -I '{}' sh -c "awesome_bot --allow 405 --allow-redirect --white-list localhost,127.0.0.1,fqdn,vimeo.com,drmaa.com --allow-ssl --allow-dupe --skip-save-results -f {}"
-.PHONY: check-slides
-
 check: check-yaml check-html check-slides  ## run all checks
 .PHONY: check
+
+check-links-gh-pages:  ## validate HTML on gh-pages branch (for daily cron job)
+	bundle exec htmlproofer \
+          --assume-extension \
+          --http-status-ignore 405,503,999 \
+          --url-ignore "/.*localhost.*/","/.*vimeo\.com.*/","/.*gitter\.im.*/","/.*drmaa\.org.*/" \
+          --file-ignore "/.*\/files\/.*/" \
+          --allow-hash-href \
+        .
+	find . -path "**/slides*.html" \
+        | xargs -L 1 -I '{}' sh -c \
+        "awesome_bot \
+           --allow 405 \
+           --allow-redirect \
+           --white-list localhost,127.0.0.1,fqdn,vimeo.com,drmaa.com \
+           --allow-ssl \
+           --allow-dupe \
+           --skip-save-results \
+       -f {}"
+.PHONY: check-links-gh-pages
 
 clean: ## clean up junk files
 	@rm -rf _site

--- a/Makefile
+++ b/Makefile
@@ -30,6 +30,7 @@ check-html: build ## validate HTML
           --assume-extension \
           --http-status-ignore 405,503,999 \
           --url-ignore "/.*localhost.*/","/.*vimeo\.com.*/","/.*gitter\.im.*/","/.*drmaa\.org.*/" \
+          --url-swap "github.com/galaxyproject/training-material/tree/master:github.com/${REPO}/tree/${BRANCH}" \
           --file-ignore "/.*\/files\/.*/","/.*\/node_modules\/.*/" \
           --allow-hash-href \
         ./_site

--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,8 @@ SLIDES=$(shell find _site/training-material -name 'slides.html' | sed 's/_site\/
 SLIDES+=$(shell find _site/training-material/*/*/slides/* | sed 's/_site\/training-material\///')
 SITE_URL=http://localhost:4000/training-material
 PDF_DIR=_pdf
+REPO=$(shell echo "$${ORIGIN_REPO:-galaxyproject/training-material}")
+BRANCH=$(shell echo "$${ORIGIN_BRANCH:-master}")
 
 ifeq ($(shell uname -s),Darwin)
 	CHROME=/Applications/Google\ Chrome.app/Contents/MacOS/Google\ Chrome


### PR DESCRIPTION
html proofer currently fails on links to the github repo (e.g. "edit on github" links or links to tours etc)  for PRs that create new tutorials/topics/files because these files do not yet exist in the master branch of this repo. Using the `--url-swap` option in htmlproofer we can rewrite those links on the fly to point to the repo and branch of origin of the PR

so for instance, for this PR it should rewrite links like `github.com/galaxyproject/training-material/tree/master/<etc>` to `github.com/shiltemann/training-material/tree/linkchecking/<etc>`

could use some testing

ping @bebatut 