### PR TITLE
Add constraints on travis-ci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,6 +20,7 @@ env:
     - secure: AVbwBaVtCtTQCR4KC4gqnVeYSuE+gKFy5KgVWfKmog/eSJ60nQGLgCSJEwzzA5Q80vZkh9WFn5TmVHiSnSikMCQkUXPrux7vnwxSPkeLV23Vy3gOXDqyJQKHzVzuSsw2X7ikX9EAOaD8cn4McL1TwQqQK440gS1gudwFHZDCfdnqjMAVRW9eNVxq2kOfFMm7iUOd0uHl94fPxGQzAK7H8mGLwpphoWPgwsWO/JuIKWXE0gp6yTTZ1OuK2SrB9ZC2rURWeDHN5Q7NMHIeLjfD42NuAFAN5igZ+2CtzQKRCsO9C5vnuuvfby/yMmxrBKEkbWw0GWPanyNcKZ6j8kICIWwhSUt0Hc25gBE6BOn7aijqBCeJlwMKvVgUBASdg2P23Q2jOqy2o4n9iNAHmRKZtvrpBRhzdCu7lDVn4s7VVBfUwBj/e0+E9x1g0jbwofHo8j/BTjK0iDiHnC4O/IBneATeEcFx4bG6xg5+3uBt8/mLqG1BRUAZMz6SpBGi1PlL527t2Z3w5DNyKBzLDC3rborADdaxgjYH989vHakItq3RhiT8ZRGGfpULTnVO2gmFLCHGoVxKQX2RbTm5xiQ2aj5pnnhtYwKqPGSutdyUfJyxz/Av03NnEN65mv9TioA+sWLMKUL6KeJTT1+HcO5D01ZC7cpYc/M/S+gmff6O5eg=
 
 matrix:
+  fast_finish: true
   include:
     - env: CHECK=yamllint
       if: branch != gh-pages
@@ -29,7 +30,7 @@ matrix:
       if: branch != gh-pages
     - env: CHECK=htmlproofer
   allow_failures:
-    env: CHECK=htmlproofer
+    - env: CHECK=htmlproofer
   
 install:
   - sudo apt-get update

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,9 +22,13 @@ env:
 matrix:
   include:
     - env: CHECK=yamllint
+      if: branch != gh-pages
     - env: CHECK=htmlproofer
+      if: branch = gh-pages
     - env: CHECK=slides
+      if: branch != gh-pages
     - env: CHECK=site-build
+      if: branch != gh-pages
 
 install:
   - sudo apt-get update

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,13 +23,14 @@ matrix:
   include:
     - env: CHECK=yamllint
       if: branch != gh-pages
-    - env: CHECK=htmlproofer
-      if: branch = gh-pages
     - env: CHECK=slides
       if: branch != gh-pages
     - env: CHECK=site-build
       if: branch != gh-pages
-
+    - env: CHECK=htmlproofer
+  allow_failures:
+    env: CHECK=htmlproofer
+  
 install:
   - sudo apt-get update
   - sudo update-ca-certificates


### PR DESCRIPTION
This should reduce the number of jobs per build, especially for the `gh-pages` branch. ~~It also skips `htmlproofer` for PRs since no one really cares (I mean PRs get still merged while it is red and it is red all the time, which is very frustrating) and we can still have the report on `gh-pages` builds.~~

It allows `htmlproofer` to fail since this tool is not reliable and generates various random false positives. It is still run, but does not determine the status of the build anymore (🎉 welcome back green statuses).