### PR TITLE
non-dip variant calling zenodo

### DIFF
--- a/topics/variant-analysis/metadata.yaml
+++ b/topics/variant-analysis/metadata.yaml
@@ -135,7 +135,7 @@ material:
     title: "Calling variants in non-diploid systems"
     type: "tutorial"
     name: "non-dip"
-    zenodo_link: ""
+    zenodo_link: "https://doi.org/10.5281/zenodo.1251112"
     workflows: no
     galaxy_tour: no
     hands_on: yes

--- a/topics/variant-analysis/tutorials/non-dip/tutorial.md
+++ b/topics/variant-analysis/tutorials/non-dip/tutorial.md
@@ -28,7 +28,7 @@ In this tutorials we will take the *first* path is which we map reads against an
 
 The goal of this example is to detect heteroplasmies (variants within mitochondrial DNA). Mitochondria is transmitted maternally and heteroplasmy frequencies may change dramatically and unpredictably during the transmission, due to a germ-line bottleneck [Cree:2008](https://www.nature.com/ng/journal/v40/n2/abs/ng.2007.63.html). As we mentioned above the procedure for finding variants in bacterial or viral genomes will be essentially the same.
 
-[A Galaxy Library](https://usegalaxy.org/library/list#folders/Fe4842bd0c37b03a7) contains datasets representing a child and a mother. These datasets are obtained by paired-end Illumina sequencing of human genomic DNA enriched for mitochondria. The enrichment was performed using long-range PCR with two primer pairs that amplify the entire mitochondrial genome. This means that these samples still contain a lot of DNA from the nuclear genome, which, in this case, is a contaminant.
+Zenodo contains [datasets representing a child and a mother](https://doi.org/10.5281/zenodo.1251112). These datasets are obtained by paired-end Illumina sequencing of human genomic DNA enriched for mitochondria. The enrichment was performed using long-range PCR with two primer pairs that amplify the entire mitochondrial genome. This means that these samples still contain a lot of DNA from the nuclear genome, which, in this case, is a contaminant.
 
 # Importing example datasets
 


### PR DESCRIPTION
Move dataset to zenodo for non-dip variant calling.
https://github.com/galaxyproject/training-material/issues/672