### PR TITLE
stop using suites in tool.yaml files

### DIFF
--- a/badges/Huttenhower Lab/assembly.svg
+++ b/badges/Huttenhower Lab/assembly.svg
@@ -1,0 +1,1 @@
+../cache/Assembly-3%2f3-green.svg

--- a/badges/Huttenhower Lab/assembly/debruijn-graph-assembly.svg
+++ b/badges/Huttenhower Lab/assembly/debruijn-graph-assembly.svg
@@ -1,0 +1,1 @@
+../../cache/De%20Bruijn%20Graph%20Assembly-Supported-green.svg

--- a/badges/Huttenhower Lab/assembly/general-introduction.svg
+++ b/badges/Huttenhower Lab/assembly/general-introduction.svg
@@ -1,0 +1,1 @@
+../../cache/Introduction%20to%20Genome%20Assembly-Supported-green.svg

--- a/badges/Huttenhower Lab/assembly/unicycler-assembly.svg
+++ b/badges/Huttenhower Lab/assembly/unicycler-assembly.svg
@@ -1,0 +1,1 @@
+../../cache/Unicycler%20Assembly-Supported-green.svg

--- a/badges/Huttenhower Lab/chip-seq.svg
+++ b/badges/Huttenhower Lab/chip-seq.svg
@@ -1,0 +1,1 @@
+../cache/ChIP--Seq%20data%20analysis-2%2f3-orange.svg

--- a/badges/Huttenhower Lab/chip-seq/estrogen-receptor-binding-site-identification.svg
+++ b/badges/Huttenhower Lab/chip-seq/estrogen-receptor-binding-site-identification.svg
@@ -1,0 +1,1 @@
+../../cache/Identification%20of%20the%20binding%20sites%20of%20the%20Estrogen%20receptor-Supported-green.svg

--- a/badges/Huttenhower Lab/chip-seq/tal1-binding-site-identification.svg
+++ b/badges/Huttenhower Lab/chip-seq/tal1-binding-site-identification.svg
@@ -1,0 +1,1 @@
+../../cache/Identification%20of%20the%20binding%20sites%20of%20the%20T--cell%20acute%20lymphocytic%20leukemia%20protein%201%20(TAL1)-Supported-green.svg

--- a/badges/Huttenhower Lab/epigenetics.svg
+++ b/badges/Huttenhower Lab/epigenetics.svg
@@ -1,0 +1,1 @@
+../cache/Epigenetics-2%2f3-orange.svg

--- a/badges/Huttenhower Lab/epigenetics/hicexplorer.svg
+++ b/badges/Huttenhower Lab/epigenetics/hicexplorer.svg
@@ -1,0 +1,1 @@
+../../cache/Hi--C%20analysis%20of%20Drosophila%20melanogaster%20cells%20using%20HiCExplorer-Supported-green.svg

--- a/badges/Huttenhower Lab/epigenetics/methylation-seq.svg
+++ b/badges/Huttenhower Lab/epigenetics/methylation-seq.svg
@@ -1,0 +1,1 @@
+../../cache/DNA%20Methylation%20data%20analysis-Supported-green.svg

--- a/badges/Huttenhower Lab/introduction.svg
+++ b/badges/Huttenhower Lab/introduction.svg
@@ -1,0 +1,1 @@
+../cache/Introduction%20to%20Galaxy-8%2f14-orange.svg

--- a/badges/Huttenhower Lab/introduction/galaxy-intro-101.svg
+++ b/badges/Huttenhower Lab/introduction/galaxy-intro-101.svg
@@ -1,0 +1,1 @@
+../../cache/Galaxy%20101-Supported-green.svg

--- a/badges/Huttenhower Lab/introduction/galaxy-intro-collections.svg
+++ b/badges/Huttenhower Lab/introduction/galaxy-intro-collections.svg
@@ -1,0 +1,1 @@
+../../cache/Using%20dataset%20collection-Supported-green.svg

--- a/badges/Huttenhower Lab/introduction/galaxy-intro-get-data.svg
+++ b/badges/Huttenhower Lab/introduction/galaxy-intro-get-data.svg
@@ -1,0 +1,1 @@
+../../cache/Getting%20data%20into%20Galaxy-Supported-green.svg

--- a/badges/Huttenhower Lab/introduction/galaxy-intro-peaks2genes.svg
+++ b/badges/Huttenhower Lab/introduction/galaxy-intro-peaks2genes.svg
@@ -1,0 +1,1 @@
+../../cache/From%20peaks%20to%20genes-Supported-green.svg

--- a/badges/Huttenhower Lab/introduction/galaxy-intro-vis.svg
+++ b/badges/Huttenhower Lab/introduction/galaxy-intro-vis.svg
@@ -1,0 +1,1 @@
+../../cache/Visualization-Supported-green.svg

--- a/badges/Huttenhower Lab/introduction/igv-introduction.svg
+++ b/badges/Huttenhower Lab/introduction/igv-introduction.svg
@@ -1,0 +1,1 @@
+../../cache/IGV%20Introduction-Supported-green.svg

--- a/badges/Huttenhower Lab/introduction/options-for-using-galaxy.svg
+++ b/badges/Huttenhower Lab/introduction/options-for-using-galaxy.svg
@@ -1,0 +1,1 @@
+../../cache/Options%20for%20using%20Galaxy-Supported-green.svg

--- a/badges/Huttenhower Lab/introduction/processing-many-samples-at-once.svg
+++ b/badges/Huttenhower Lab/introduction/processing-many-samples-at-once.svg
@@ -1,0 +1,1 @@
+../../cache/Multisample%20Analysis-Supported-green.svg

--- a/badges/Huttenhower Lab/metagenomics.svg
+++ b/badges/Huttenhower Lab/metagenomics.svg
@@ -1,0 +1,1 @@
+../cache/Metagenomics-2%2f3-orange.svg

--- a/badges/Huttenhower Lab/metagenomics/general-tutorial.svg
+++ b/badges/Huttenhower Lab/metagenomics/general-tutorial.svg
@@ -1,0 +1,1 @@
+../../cache/Analyses%20of%20metagenomics%20data%20--%20The%20global%20picture-Supported-green.svg

--- a/badges/Huttenhower Lab/metagenomics/mothur-miseq-sop.svg
+++ b/badges/Huttenhower Lab/metagenomics/mothur-miseq-sop.svg
@@ -1,0 +1,1 @@
+../../cache/16S%20Microbial%20Analysis%20with%20Mothur-Supported-green.svg

--- a/badges/Huttenhower Lab/proteomics.svg
+++ b/badges/Huttenhower Lab/proteomics.svg
@@ -1,0 +1,1 @@
+../cache/Proteomics-8%2f8-green.svg

--- a/badges/Huttenhower Lab/proteomics/database-handling.svg
+++ b/badges/Huttenhower Lab/proteomics/database-handling.svg
@@ -1,0 +1,1 @@
+../../cache/Protein%20FASTA%20Database%20Handling-Supported-green.svg

--- a/badges/Huttenhower Lab/proteomics/labelfree-vs-labelled.svg
+++ b/badges/Huttenhower Lab/proteomics/labelfree-vs-labelled.svg
@@ -1,0 +1,1 @@
+../../cache/Label--free%20versus%20Labelled%20--%20How%20to%20Choose%20Your%20Quantitation%20Method-Supported-green.svg

--- a/badges/Huttenhower Lab/proteomics/metaproteomics.svg
+++ b/badges/Huttenhower Lab/proteomics/metaproteomics.svg
@@ -1,0 +1,1 @@
+../../cache/Metaproteomics%20tutorial-Supported-green.svg

--- a/badges/Huttenhower Lab/proteomics/ntails.svg
+++ b/badges/Huttenhower Lab/proteomics/ntails.svg
@@ -1,0 +1,1 @@
+../../cache/Detection%20and%20quantitation%20of%20N--termini%20(degradomics)%20via%20N--TAILS-Supported-green.svg

--- a/badges/Huttenhower Lab/proteomics/protein-id-oms.svg
+++ b/badges/Huttenhower Lab/proteomics/protein-id-oms.svg
@@ -1,0 +1,1 @@
+../../cache/Peptide%20and%20Protein%20ID%20using%20OpenMS%20tools-Supported-green.svg

--- a/badges/Huttenhower Lab/proteomics/protein-id-sg-ps.svg
+++ b/badges/Huttenhower Lab/proteomics/protein-id-sg-ps.svg
@@ -1,0 +1,1 @@
+../../cache/Peptide%20and%20Protein%20ID%20using%20SearchGUI%20and%20PeptideShaker-Supported-green.svg

--- a/badges/Huttenhower Lab/proteomics/protein-quant-sil.svg
+++ b/badges/Huttenhower Lab/proteomics/protein-quant-sil.svg
@@ -1,0 +1,1 @@
+../../cache/Peptide%20and%20Protein%20Quantification%20via%20Stable%20Isotope%20Labelling%20(SIL)-Supported-green.svg

--- a/badges/Huttenhower Lab/proteomics/secretome-prediction.svg
+++ b/badges/Huttenhower Lab/proteomics/secretome-prediction.svg
@@ -1,0 +1,1 @@
+../../cache/Secretome%20Prediction-Supported-green.svg

--- a/badges/Huttenhower Lab/sequence-analysis.svg
+++ b/badges/Huttenhower Lab/sequence-analysis.svg
@@ -1,0 +1,1 @@
+../cache/Sequence%20analysis-7%2f7-green.svg

--- a/badges/Huttenhower Lab/sequence-analysis/annotation-with-prokka.svg
+++ b/badges/Huttenhower Lab/sequence-analysis/annotation-with-prokka.svg
@@ -1,0 +1,1 @@
+../../cache/Genome%20annotation%20with%20Prokka-Supported-green.svg

--- a/badges/Huttenhower Lab/sequence-analysis/de-novo-rad-seq.svg
+++ b/badges/Huttenhower Lab/sequence-analysis/de-novo-rad-seq.svg
@@ -1,0 +1,1 @@
+../../cache/RAD--Seq%20de--novo%20data%20analysis-Supported-green.svg

--- a/badges/Huttenhower Lab/sequence-analysis/genetic-map-rad-seq.svg
+++ b/badges/Huttenhower Lab/sequence-analysis/genetic-map-rad-seq.svg
@@ -1,0 +1,1 @@
+../../cache/RAD--Seq%20to%20construct%20genetic%20maps-Supported-green.svg

--- a/badges/Huttenhower Lab/sequence-analysis/genome-annotation.svg
+++ b/badges/Huttenhower Lab/sequence-analysis/genome-annotation.svg
@@ -1,0 +1,1 @@
+../../cache/Genome%20Annotation-Supported-green.svg

--- a/badges/Huttenhower Lab/sequence-analysis/mapping.svg
+++ b/badges/Huttenhower Lab/sequence-analysis/mapping.svg
@@ -1,0 +1,1 @@
+../../cache/Mapping-Supported-green.svg

--- a/badges/Huttenhower Lab/sequence-analysis/quality-control.svg
+++ b/badges/Huttenhower Lab/sequence-analysis/quality-control.svg
@@ -1,0 +1,1 @@
+../../cache/Quality%20Control-Supported-green.svg

--- a/badges/Huttenhower Lab/sequence-analysis/ref-based-rad-seq.svg
+++ b/badges/Huttenhower Lab/sequence-analysis/ref-based-rad-seq.svg
@@ -1,0 +1,1 @@
+../../cache/RAD--Seq%20Reference--based%20data%20analysis-Supported-green.svg

--- a/badges/Huttenhower Lab/training.svg
+++ b/badges/Huttenhower Lab/training.svg
@@ -1,0 +1,1 @@
+../cache/Train%20the%20trainers-5%2f7-orange.svg

--- a/badges/Huttenhower Lab/training/create-new-tutorial-content.svg
+++ b/badges/Huttenhower Lab/training/create-new-tutorial-content.svg
@@ -1,0 +1,1 @@
+../../cache/Creating%20a%20new%20tutorial%20--%20Writing%20content%20in%20Markdown-Supported-green.svg

--- a/badges/Huttenhower Lab/training/create-new-tutorial-docker.svg
+++ b/badges/Huttenhower Lab/training/create-new-tutorial-docker.svg
@@ -1,0 +1,1 @@
+../../cache/Creating%20a%20new%20tutorial%20--%20Building%20a%20Docker%20flavor%20for%20a%20tutorial-Supported-green.svg

--- a/badges/Huttenhower Lab/training/create-new-tutorial-jekyll.svg
+++ b/badges/Huttenhower Lab/training/create-new-tutorial-jekyll.svg
@@ -1,0 +1,1 @@
+../../cache/Creating%20a%20new%20tutorial%20--%20Setting%20up%20the%20infrastructure-Supported-green.svg

--- a/badges/Huttenhower Lab/training/create-new-tutorial-metadata.svg
+++ b/badges/Huttenhower Lab/training/create-new-tutorial-metadata.svg
@@ -1,0 +1,1 @@
+../../cache/Creating%20a%20new%20tutorial%20--%20Defining%20metadata-Supported-green.svg

--- a/badges/Huttenhower Lab/training/create-new-tutorial-tours.svg
+++ b/badges/Huttenhower Lab/training/create-new-tutorial-tours.svg
@@ -1,0 +1,1 @@
+../../cache/Creating%20a%20new%20tutorial%20--%20Creating%20Interactive%20Galaxy%20Tours-Supported-green.svg

--- a/badges/Huttenhower Lab/transcriptomics.svg
+++ b/badges/Huttenhower Lab/transcriptomics.svg
@@ -1,0 +1,1 @@
+../cache/Transcriptomics-4%2f6-orange.svg

--- a/badges/Huttenhower Lab/transcriptomics/de-novo.svg
+++ b/badges/Huttenhower Lab/transcriptomics/de-novo.svg
@@ -1,0 +1,1 @@
+../../cache/De%20novo%20transcriptome%20reconstruction%20with%20RNA--Seq-Supported-green.svg

--- a/badges/Huttenhower Lab/transcriptomics/ref-based.svg
+++ b/badges/Huttenhower Lab/transcriptomics/ref-based.svg
@@ -1,0 +1,1 @@
+../../cache/Reference--based%20RNA--Seq%20data%20analysis-Supported-green.svg

--- a/badges/Huttenhower Lab/transcriptomics/rna-seq-viz-with-cummerbund.svg
+++ b/badges/Huttenhower Lab/transcriptomics/rna-seq-viz-with-cummerbund.svg
@@ -1,0 +1,1 @@
+../../cache/Visualization%20of%20RNA--Seq%20results%20with%20CummeRbund-Supported-green.svg

--- a/badges/Huttenhower Lab/transcriptomics/srna.svg
+++ b/badges/Huttenhower Lab/transcriptomics/srna.svg
@@ -1,0 +1,1 @@
+../../cache/Differential%20abundance%20testing%20of%20small%20RNAs-Supported-green.svg

--- a/badges/Huttenhower Lab/variant-analysis.svg
+++ b/badges/Huttenhower Lab/variant-analysis.svg
@@ -1,0 +1,1 @@
+../cache/Variant%20Analysis-4%2f8-orange.svg

--- a/badges/Huttenhower Lab/variant-analysis/diploid-variant-calling.svg
+++ b/badges/Huttenhower Lab/variant-analysis/diploid-variant-calling.svg
@@ -1,0 +1,1 @@
+../../cache/Variant%20calling:%20Diploid%20case-Supported-green.svg

--- a/badges/Huttenhower Lab/variant-analysis/exome-seq.svg
+++ b/badges/Huttenhower Lab/variant-analysis/exome-seq.svg
@@ -1,0 +1,1 @@
+../../cache/Exome%20sequencing%20data%20analysis-Supported-green.svg

--- a/badges/Huttenhower Lab/variant-analysis/mapping-by-sequencing.svg
+++ b/badges/Huttenhower Lab/variant-analysis/mapping-by-sequencing.svg
@@ -1,0 +1,1 @@
+../../cache/Mapping%20and%20molecular%20identification%20of%20phenotype--causing%20mutations-Supported-green.svg

--- a/badges/Huttenhower Lab/variant-analysis/microbial-variants.svg
+++ b/badges/Huttenhower Lab/variant-analysis/microbial-variants.svg
@@ -1,0 +1,1 @@
+../../cache/Microbial%20Variant%20Calling-Supported-green.svg

--- a/metadata/instances.yaml
+++ b/metadata/instances.yaml
@@ -54,6 +54,9 @@ assembly:
         GVL Melbourne:
           supported: true
           url: http://galaxy-mel.genome.edu.au/galaxy/
+        GVL Queensland:
+          supported: true
+          url: https://galaxy-qld.genome.edu.au/
         GVL-Tutorial:
           supported: false
           url: http://galaxy-tut.genome.edu.au/galaxy/
@@ -192,6 +195,9 @@ assembly:
         GVL Melbourne:
           supported: false
           url: http://galaxy-mel.genome.edu.au/galaxy/
+        GVL Queensland:
+          supported: false
+          url: https://galaxy-qld.genome.edu.au/
         GVL-Tutorial:
           supported: false
           url: http://galaxy-tut.genome.edu.au/galaxy/
@@ -330,6 +336,9 @@ assembly:
         GVL Melbourne:
           supported: false
           url: http://galaxy-mel.genome.edu.au/galaxy/
+        GVL Queensland:
+          supported: true
+          url: https://galaxy-qld.genome.edu.au/
         GVL-Tutorial:
           supported: false
           url: http://galaxy-tut.genome.edu.au/galaxy/
@@ -471,6 +480,9 @@ chip-seq:
         GVL Melbourne:
           supported: false
           url: http://galaxy-mel.genome.edu.au/galaxy/
+        GVL Queensland:
+          supported: true
+          url: https://galaxy-qld.genome.edu.au/
         GVL-Tutorial:
           supported: false
           url: http://galaxy-tut.genome.edu.au/galaxy/
@@ -609,6 +621,9 @@ chip-seq:
         GVL Melbourne:
           supported: false
           url: http://galaxy-mel.genome.edu.au/galaxy/
+        GVL Queensland:
+          supported: true
+          url: https://galaxy-qld.genome.edu.au/
         GVL-Tutorial:
           supported: false
           url: http://galaxy-tut.genome.edu.au/galaxy/
@@ -753,6 +768,9 @@ epigenetics:
         GVL Melbourne:
           supported: false
           url: http://galaxy-mel.genome.edu.au/galaxy/
+        GVL Queensland:
+          supported: false
+          url: https://galaxy-qld.genome.edu.au/
         GVL-Tutorial:
           supported: false
           url: http://galaxy-tut.genome.edu.au/galaxy/
@@ -891,6 +909,9 @@ epigenetics:
         GVL Melbourne:
           supported: false
           url: http://galaxy-mel.genome.edu.au/galaxy/
+        GVL Queensland:
+          supported: false
+          url: https://galaxy-qld.genome.edu.au/
         GVL-Tutorial:
           supported: false
           url: http://galaxy-tut.genome.edu.au/galaxy/
@@ -1032,6 +1053,9 @@ introduction:
         GVL Melbourne:
           supported: true
           url: http://galaxy-mel.genome.edu.au/galaxy/
+        GVL Queensland:
+          supported: true
+          url: https://galaxy-qld.genome.edu.au/
         GVL-Tutorial:
           supported: true
           url: http://galaxy-tut.genome.edu.au/galaxy/
@@ -1170,6 +1194,9 @@ introduction:
         GVL Melbourne:
           supported: false
           url: http://galaxy-mel.genome.edu.au/galaxy/
+        GVL Queensland:
+          supported: false
+          url: https://galaxy-qld.genome.edu.au/
         GVL-Tutorial:
           supported: false
           url: http://galaxy-tut.genome.edu.au/galaxy/
@@ -1308,6 +1335,9 @@ introduction:
         GVL Melbourne:
           supported: false
           url: http://galaxy-mel.genome.edu.au/galaxy/
+        GVL Queensland:
+          supported: false
+          url: https://galaxy-qld.genome.edu.au/
         GVL-Tutorial:
           supported: false
           url: http://galaxy-tut.genome.edu.au/galaxy/
@@ -1446,6 +1476,9 @@ introduction:
         GVL Melbourne:
           supported: false
           url: http://galaxy-mel.genome.edu.au/galaxy/
+        GVL Queensland:
+          supported: false
+          url: https://galaxy-qld.genome.edu.au/
         GVL-Tutorial:
           supported: false
           url: http://galaxy-tut.genome.edu.au/galaxy/
@@ -1584,6 +1617,9 @@ introduction:
         GVL Melbourne:
           supported: false
           url: http://galaxy-mel.genome.edu.au/galaxy/
+        GVL Queensland:
+          supported: false
+          url: https://galaxy-qld.genome.edu.au/
         GVL-Tutorial:
           supported: false
           url: http://galaxy-tut.genome.edu.au/galaxy/
@@ -1722,6 +1758,9 @@ introduction:
         GVL Melbourne:
           supported: false
           url: http://galaxy-mel.genome.edu.au/galaxy/
+        GVL Queensland:
+          supported: false
+          url: https://galaxy-qld.genome.edu.au/
         GVL-Tutorial:
           supported: false
           url: http://galaxy-tut.genome.edu.au/galaxy/
@@ -1860,6 +1899,9 @@ introduction:
         GVL Melbourne:
           supported: false
           url: http://galaxy-mel.genome.edu.au/galaxy/
+        GVL Queensland:
+          supported: false
+          url: https://galaxy-qld.genome.edu.au/
         GVL-Tutorial:
           supported: false
           url: http://galaxy-tut.genome.edu.au/galaxy/
@@ -1998,6 +2040,9 @@ introduction:
         GVL Melbourne:
           supported: false
           url: http://galaxy-mel.genome.edu.au/galaxy/
+        GVL Queensland:
+          supported: false
+          url: https://galaxy-qld.genome.edu.au/
         GVL-Tutorial:
           supported: false
           url: http://galaxy-tut.genome.edu.au/galaxy/
@@ -2139,6 +2184,9 @@ metagenomics:
         GVL Melbourne:
           supported: false
           url: http://galaxy-mel.genome.edu.au/galaxy/
+        GVL Queensland:
+          supported: false
+          url: https://galaxy-qld.genome.edu.au/
         GVL-Tutorial:
           supported: false
           url: http://galaxy-tut.genome.edu.au/galaxy/
@@ -2277,6 +2325,9 @@ metagenomics:
         GVL Melbourne:
           supported: false
           url: http://galaxy-mel.genome.edu.au/galaxy/
+        GVL Queensland:
+          supported: false
+          url: https://galaxy-qld.genome.edu.au/
         GVL-Tutorial:
           supported: false
           url: http://galaxy-tut.genome.edu.au/galaxy/
@@ -2418,6 +2469,9 @@ proteomics:
         GVL Melbourne:
           supported: false
           url: http://galaxy-mel.genome.edu.au/galaxy/
+        GVL Queensland:
+          supported: false
+          url: https://galaxy-qld.genome.edu.au/
         GVL-Tutorial:
           supported: false
           url: http://galaxy-tut.genome.edu.au/galaxy/
@@ -2556,6 +2610,9 @@ proteomics:
         GVL Melbourne:
           supported: false
           url: http://galaxy-mel.genome.edu.au/galaxy/
+        GVL Queensland:
+          supported: false
+          url: https://galaxy-qld.genome.edu.au/
         GVL-Tutorial:
           supported: false
           url: http://galaxy-tut.genome.edu.au/galaxy/
@@ -2694,6 +2751,9 @@ proteomics:
         GVL Melbourne:
           supported: false
           url: http://galaxy-mel.genome.edu.au/galaxy/
+        GVL Queensland:
+          supported: false
+          url: https://galaxy-qld.genome.edu.au/
         GVL-Tutorial:
           supported: false
           url: http://galaxy-tut.genome.edu.au/galaxy/
@@ -2832,6 +2892,9 @@ proteomics:
         GVL Melbourne:
           supported: false
           url: http://galaxy-mel.genome.edu.au/galaxy/
+        GVL Queensland:
+          supported: false
+          url: https://galaxy-qld.genome.edu.au/
         GVL-Tutorial:
           supported: false
           url: http://galaxy-tut.genome.edu.au/galaxy/
@@ -2970,6 +3033,9 @@ proteomics:
         GVL Melbourne:
           supported: false
           url: http://galaxy-mel.genome.edu.au/galaxy/
+        GVL Queensland:
+          supported: false
+          url: https://galaxy-qld.genome.edu.au/
         GVL-Tutorial:
           supported: false
           url: http://galaxy-tut.genome.edu.au/galaxy/
@@ -3108,6 +3174,9 @@ proteomics:
         GVL Melbourne:
           supported: false
           url: http://galaxy-mel.genome.edu.au/galaxy/
+        GVL Queensland:
+          supported: false
+          url: https://galaxy-qld.genome.edu.au/
         GVL-Tutorial:
           supported: false
           url: http://galaxy-tut.genome.edu.au/galaxy/
@@ -3246,6 +3315,9 @@ proteomics:
         GVL Melbourne:
           supported: false
           url: http://galaxy-mel.genome.edu.au/galaxy/
+        GVL Queensland:
+          supported: false
+          url: https://galaxy-qld.genome.edu.au/
         GVL-Tutorial:
           supported: false
           url: http://galaxy-tut.genome.edu.au/galaxy/
@@ -3384,6 +3456,9 @@ proteomics:
         GVL Melbourne:
           supported: false
           url: http://galaxy-mel.genome.edu.au/galaxy/
+        GVL Queensland:
+          supported: false
+          url: https://galaxy-qld.genome.edu.au/
         GVL-Tutorial:
           supported: false
           url: http://galaxy-tut.genome.edu.au/galaxy/
@@ -3525,6 +3600,9 @@ sequence-analysis:
         GVL Melbourne:
           supported: true
           url: http://galaxy-mel.genome.edu.au/galaxy/
+        GVL Queensland:
+          supported: true
+          url: https://galaxy-qld.genome.edu.au/
         GVL-Tutorial:
           supported: false
           url: http://galaxy-tut.genome.edu.au/galaxy/
@@ -3663,6 +3741,9 @@ sequence-analysis:
         GVL Melbourne:
           supported: false
           url: http://galaxy-mel.genome.edu.au/galaxy/
+        GVL Queensland:
+          supported: false
+          url: https://galaxy-qld.genome.edu.au/
         GVL-Tutorial:
           supported: false
           url: http://galaxy-tut.genome.edu.au/galaxy/
@@ -3801,6 +3882,9 @@ sequence-analysis:
         GVL Melbourne:
           supported: true
           url: http://galaxy-mel.genome.edu.au/galaxy/
+        GVL Queensland:
+          supported: false
+          url: https://galaxy-qld.genome.edu.au/
         GVL-Tutorial:
           supported: false
           url: http://galaxy-tut.genome.edu.au/galaxy/
@@ -3939,6 +4023,9 @@ sequence-analysis:
         GVL Melbourne:
           supported: false
           url: http://galaxy-mel.genome.edu.au/galaxy/
+        GVL Queensland:
+          supported: false
+          url: https://galaxy-qld.genome.edu.au/
         GVL-Tutorial:
           supported: false
           url: http://galaxy-tut.genome.edu.au/galaxy/
@@ -4077,6 +4164,9 @@ sequence-analysis:
         GVL Melbourne:
           supported: true
           url: http://galaxy-mel.genome.edu.au/galaxy/
+        GVL Queensland:
+          supported: true
+          url: https://galaxy-qld.genome.edu.au/
         GVL-Tutorial:
           supported: false
           url: http://galaxy-tut.genome.edu.au/galaxy/
@@ -4215,6 +4305,9 @@ sequence-analysis:
         GVL Melbourne:
           supported: true
           url: http://galaxy-mel.genome.edu.au/galaxy/
+        GVL Queensland:
+          supported: true
+          url: https://galaxy-qld.genome.edu.au/
         GVL-Tutorial:
           supported: false
           url: http://galaxy-tut.genome.edu.au/galaxy/
@@ -4353,6 +4446,9 @@ sequence-analysis:
         GVL Melbourne:
           supported: false
           url: http://galaxy-mel.genome.edu.au/galaxy/
+        GVL Queensland:
+          supported: false
+          url: https://galaxy-qld.genome.edu.au/
         GVL-Tutorial:
           supported: false
           url: http://galaxy-tut.genome.edu.au/galaxy/
@@ -4494,6 +4590,9 @@ training:
         GVL Melbourne:
           supported: true
           url: http://galaxy-mel.genome.edu.au/galaxy/
+        GVL Queensland:
+          supported: true
+          url: https://galaxy-qld.genome.edu.au/
         GVL-Tutorial:
           supported: true
           url: http://galaxy-tut.genome.edu.au/galaxy/
@@ -4632,6 +4731,9 @@ training:
         GVL Melbourne:
           supported: true
           url: http://galaxy-mel.genome.edu.au/galaxy/
+        GVL Queensland:
+          supported: true
+          url: https://galaxy-qld.genome.edu.au/
         GVL-Tutorial:
           supported: true
           url: http://galaxy-tut.genome.edu.au/galaxy/
@@ -4770,6 +4872,9 @@ training:
         GVL Melbourne:
           supported: true
           url: http://galaxy-mel.genome.edu.au/galaxy/
+        GVL Queensland:
+          supported: true
+          url: https://galaxy-qld.genome.edu.au/
         GVL-Tutorial:
           supported: true
           url: http://galaxy-tut.genome.edu.au/galaxy/
@@ -4908,6 +5013,9 @@ training:
         GVL Melbourne:
           supported: true
           url: http://galaxy-mel.genome.edu.au/galaxy/
+        GVL Queensland:
+          supported: true
+          url: https://galaxy-qld.genome.edu.au/
         GVL-Tutorial:
           supported: true
           url: http://galaxy-tut.genome.edu.au/galaxy/
@@ -5046,6 +5154,9 @@ training:
         GVL Melbourne:
           supported: true
           url: http://galaxy-mel.genome.edu.au/galaxy/
+        GVL Queensland:
+          supported: true
+          url: https://galaxy-qld.genome.edu.au/
         GVL-Tutorial:
           supported: true
           url: http://galaxy-tut.genome.edu.au/galaxy/
@@ -5187,6 +5298,9 @@ transcriptomics:
         GVL Melbourne:
           supported: false
           url: http://galaxy-mel.genome.edu.au/galaxy/
+        GVL Queensland:
+          supported: false
+          url: https://galaxy-qld.genome.edu.au/
         GVL-Tutorial:
           supported: false
           url: http://galaxy-tut.genome.edu.au/galaxy/
@@ -5325,6 +5439,9 @@ transcriptomics:
         GVL Melbourne:
           supported: false
           url: http://galaxy-mel.genome.edu.au/galaxy/
+        GVL Queensland:
+          supported: false
+          url: https://galaxy-qld.genome.edu.au/
         GVL-Tutorial:
           supported: false
           url: http://galaxy-tut.genome.edu.au/galaxy/
@@ -5463,6 +5580,9 @@ transcriptomics:
         GVL Melbourne:
           supported: false
           url: http://galaxy-mel.genome.edu.au/galaxy/
+        GVL Queensland:
+          supported: false
+          url: https://galaxy-qld.genome.edu.au/
         GVL-Tutorial:
           supported: false
           url: http://galaxy-tut.genome.edu.au/galaxy/
@@ -5601,6 +5721,9 @@ transcriptomics:
         GVL Melbourne:
           supported: false
           url: http://galaxy-mel.genome.edu.au/galaxy/
+        GVL Queensland:
+          supported: true
+          url: https://galaxy-qld.genome.edu.au/
         GVL-Tutorial:
           supported: false
           url: http://galaxy-tut.genome.edu.au/galaxy/
@@ -5742,6 +5865,9 @@ variant-analysis:
         GVL Melbourne:
           supported: false
           url: http://galaxy-mel.genome.edu.au/galaxy/
+        GVL Queensland:
+          supported: false
+          url: https://galaxy-qld.genome.edu.au/
         GVL-Tutorial:
           supported: false
           url: http://galaxy-tut.genome.edu.au/galaxy/
@@ -5880,6 +6006,9 @@ variant-analysis:
         GVL Melbourne:
           supported: false
           url: http://galaxy-mel.genome.edu.au/galaxy/
+        GVL Queensland:
+          supported: false
+          url: https://galaxy-qld.genome.edu.au/
         GVL-Tutorial:
           supported: false
           url: http://galaxy-tut.genome.edu.au/galaxy/
@@ -6018,6 +6147,9 @@ variant-analysis:
         GVL Melbourne:
           supported: false
           url: http://galaxy-mel.genome.edu.au/galaxy/
+        GVL Queensland:
+          supported: false
+          url: https://galaxy-qld.genome.edu.au/
         GVL-Tutorial:
           supported: false
           url: http://galaxy-tut.genome.edu.au/galaxy/
@@ -6156,6 +6288,9 @@ variant-analysis:
         GVL Melbourne:
           supported: true
           url: http://galaxy-mel.genome.edu.au/galaxy/
+        GVL Queensland:
+          supported: false
+          url: https://galaxy-qld.genome.edu.au/
         GVL-Tutorial:
           supported: false
           url: http://galaxy-tut.genome.edu.au/galaxy/

--- a/metadata/instances.yaml
+++ b/metadata/instances.yaml
@@ -12,9 +12,6 @@ assembly:
         ABiMS Tools:
           supported: false
           url: http://webtools.sb-roscoff.fr
-        AGEseq Galaxy @ AspenDB:
-          supported: false
-          url: http://aspendb.uga.edu:8085/
         APOSTL Galaxy:
           supported: false
           url: http://apostl.moffitt.org/
@@ -57,12 +54,6 @@ assembly:
         GVL Melbourne:
           supported: true
           url: http://galaxy-mel.genome.edu.au/galaxy/
-        GVL Queensland:
-          supported: false
-          url: https://galaxy-qld.genome.edu.au/galaxy/
-        GVL-QLD:
-          supported: false
-          url: https://galaxy-qld.genome.edu.au/galaxy
         GVL-Tutorial:
           supported: false
           url: http://galaxy-tut.genome.edu.au/galaxy/
@@ -93,9 +84,9 @@ assembly:
         GrAPPA:
           supported: false
           url: https://grappa.eecs.utk.edu/grappa/
-        Halogen Bonding Galaxy:
+        Huttenhower Lab:
           supported: false
-          url: http://134.2.17.68:8081/
+          url: http://huttenhower.sph.harvard.edu/galaxy/
         Koslicki Lab Galaxy:
           supported: false
           url: http://math-galaxy.cgrb.oregonstate.edu:8080/
@@ -132,9 +123,6 @@ assembly:
         Pitagora-Galaxy:
           supported: false
           url: http://try.pitagora-galaxy.org/galaxy/
-        RNA-Seq Portal:
-          supported: false
-          url: http://weizhongli-lab.org:8088
         South Green Galaxy:
           supported: false
           url: http://galaxy.southgreen.fr/galaxy/
@@ -162,9 +150,6 @@ assembly:
         ABiMS Tools:
           supported: false
           url: http://webtools.sb-roscoff.fr
-        AGEseq Galaxy @ AspenDB:
-          supported: false
-          url: http://aspendb.uga.edu:8085/
         APOSTL Galaxy:
           supported: false
           url: http://apostl.moffitt.org/
@@ -207,12 +192,6 @@ assembly:
         GVL Melbourne:
           supported: false
           url: http://galaxy-mel.genome.edu.au/galaxy/
-        GVL Queensland:
-          supported: false
-          url: https://galaxy-qld.genome.edu.au/galaxy/
-        GVL-QLD:
-          supported: false
-          url: https://galaxy-qld.genome.edu.au/galaxy
         GVL-Tutorial:
           supported: false
           url: http://galaxy-tut.genome.edu.au/galaxy/
@@ -243,9 +222,9 @@ assembly:
         GrAPPA:
           supported: false
           url: https://grappa.eecs.utk.edu/grappa/
-        Halogen Bonding Galaxy:
+        Huttenhower Lab:
           supported: false
-          url: http://134.2.17.68:8081/
+          url: http://huttenhower.sph.harvard.edu/galaxy/
         Koslicki Lab Galaxy:
           supported: false
           url: http://math-galaxy.cgrb.oregonstate.edu:8080/
@@ -282,9 +261,6 @@ assembly:
         Pitagora-Galaxy:
           supported: false
           url: http://try.pitagora-galaxy.org/galaxy/
-        RNA-Seq Portal:
-          supported: false
-          url: http://weizhongli-lab.org:8088
         South Green Galaxy:
           supported: false
           url: http://galaxy.southgreen.fr/galaxy/
@@ -312,9 +288,6 @@ assembly:
         ABiMS Tools:
           supported: false
           url: http://webtools.sb-roscoff.fr
-        AGEseq Galaxy @ AspenDB:
-          supported: false
-          url: http://aspendb.uga.edu:8085/
         APOSTL Galaxy:
           supported: false
           url: http://apostl.moffitt.org/
@@ -357,12 +330,6 @@ assembly:
         GVL Melbourne:
           supported: false
           url: http://galaxy-mel.genome.edu.au/galaxy/
-        GVL Queensland:
-          supported: false
-          url: https://galaxy-qld.genome.edu.au/galaxy/
-        GVL-QLD:
-          supported: false
-          url: https://galaxy-qld.genome.edu.au/galaxy
         GVL-Tutorial:
           supported: false
           url: http://galaxy-tut.genome.edu.au/galaxy/
@@ -393,9 +360,9 @@ assembly:
         GrAPPA:
           supported: false
           url: https://grappa.eecs.utk.edu/grappa/
-        Halogen Bonding Galaxy:
+        Huttenhower Lab:
           supported: false
-          url: http://134.2.17.68:8081/
+          url: http://huttenhower.sph.harvard.edu/galaxy/
         Koslicki Lab Galaxy:
           supported: false
           url: http://math-galaxy.cgrb.oregonstate.edu:8080/
@@ -432,9 +399,6 @@ assembly:
         Pitagora-Galaxy:
           supported: false
           url: http://try.pitagora-galaxy.org/galaxy/
-        RNA-Seq Portal:
-          supported: false
-          url: http://weizhongli-lab.org:8088
         South Green Galaxy:
           supported: false
           url: http://galaxy.southgreen.fr/galaxy/
@@ -465,9 +429,6 @@ chip-seq:
         ABiMS Tools:
           supported: false
           url: http://webtools.sb-roscoff.fr
-        AGEseq Galaxy @ AspenDB:
-          supported: false
-          url: http://aspendb.uga.edu:8085/
         APOSTL Galaxy:
           supported: false
           url: http://apostl.moffitt.org/
@@ -510,12 +471,6 @@ chip-seq:
         GVL Melbourne:
           supported: false
           url: http://galaxy-mel.genome.edu.au/galaxy/
-        GVL Queensland:
-          supported: false
-          url: https://galaxy-qld.genome.edu.au/galaxy/
-        GVL-QLD:
-          supported: false
-          url: https://galaxy-qld.genome.edu.au/galaxy
         GVL-Tutorial:
           supported: false
           url: http://galaxy-tut.genome.edu.au/galaxy/
@@ -546,9 +501,9 @@ chip-seq:
         GrAPPA:
           supported: false
           url: https://grappa.eecs.utk.edu/grappa/
-        Halogen Bonding Galaxy:
+        Huttenhower Lab:
           supported: false
-          url: http://134.2.17.68:8081/
+          url: http://huttenhower.sph.harvard.edu/galaxy/
         Koslicki Lab Galaxy:
           supported: false
           url: http://math-galaxy.cgrb.oregonstate.edu:8080/
@@ -585,9 +540,6 @@ chip-seq:
         Pitagora-Galaxy:
           supported: false
           url: http://try.pitagora-galaxy.org/galaxy/
-        RNA-Seq Portal:
-          supported: false
-          url: http://weizhongli-lab.org:8088
         South Green Galaxy:
           supported: false
           url: http://galaxy.southgreen.fr/galaxy/
@@ -610,14 +562,11 @@ chip-seq:
     tal1-binding-site-identification:
       instances:
         ABiMS:
-          supported: false
+          supported: true
           url: http://galaxy3.sb-roscoff.fr/
         ABiMS Tools:
           supported: false
           url: http://webtools.sb-roscoff.fr
-        AGEseq Galaxy @ AspenDB:
-          supported: false
-          url: http://aspendb.uga.edu:8085/
         APOSTL Galaxy:
           supported: false
           url: http://apostl.moffitt.org/
@@ -660,12 +609,6 @@ chip-seq:
         GVL Melbourne:
           supported: false
           url: http://galaxy-mel.genome.edu.au/galaxy/
-        GVL Queensland:
-          supported: false
-          url: https://galaxy-qld.genome.edu.au/galaxy/
-        GVL-QLD:
-          supported: false
-          url: https://galaxy-qld.genome.edu.au/galaxy
         GVL-Tutorial:
           supported: false
           url: http://galaxy-tut.genome.edu.au/galaxy/
@@ -673,7 +616,7 @@ chip-seq:
           supported: false
           url: http://use.galaxeast.fr/
         Galaxy Europe:
-          supported: false
+          supported: true
           url: https://usegalaxy.eu
         Galaxy Palfinder:
           supported: false
@@ -696,9 +639,9 @@ chip-seq:
         GrAPPA:
           supported: false
           url: https://grappa.eecs.utk.edu/grappa/
-        Halogen Bonding Galaxy:
+        Huttenhower Lab:
           supported: false
-          url: http://134.2.17.68:8081/
+          url: http://huttenhower.sph.harvard.edu/galaxy/
         Koslicki Lab Galaxy:
           supported: false
           url: http://math-galaxy.cgrb.oregonstate.edu:8080/
@@ -712,7 +655,7 @@ chip-seq:
           supported: false
           url: http://mississippi.fr/
         Main:
-          supported: false
+          supported: true
           url: https://usegalaxy.org
         Majewski Lab ExomeAI:
           supported: false
@@ -735,9 +678,6 @@ chip-seq:
         Pitagora-Galaxy:
           supported: false
           url: http://try.pitagora-galaxy.org/galaxy/
-        RNA-Seq Portal:
-          supported: false
-          url: http://weizhongli-lab.org:8088
         South Green Galaxy:
           supported: false
           url: http://galaxy.southgreen.fr/galaxy/
@@ -756,7 +696,7 @@ chip-seq:
         workflow4metabolomics:
           supported: false
           url: http://galaxy.workflow4metabolomics.org
-      supported: false
+      supported: true
 dev:
   supported: false
   tutorials: {}
@@ -771,9 +711,6 @@ epigenetics:
         ABiMS Tools:
           supported: false
           url: http://webtools.sb-roscoff.fr
-        AGEseq Galaxy @ AspenDB:
-          supported: false
-          url: http://aspendb.uga.edu:8085/
         APOSTL Galaxy:
           supported: false
           url: http://apostl.moffitt.org/
@@ -816,12 +753,6 @@ epigenetics:
         GVL Melbourne:
           supported: false
           url: http://galaxy-mel.genome.edu.au/galaxy/
-        GVL Queensland:
-          supported: false
-          url: https://galaxy-qld.genome.edu.au/galaxy/
-        GVL-QLD:
-          supported: false
-          url: https://galaxy-qld.genome.edu.au/galaxy
         GVL-Tutorial:
           supported: false
           url: http://galaxy-tut.genome.edu.au/galaxy/
@@ -852,9 +783,9 @@ epigenetics:
         GrAPPA:
           supported: false
           url: https://grappa.eecs.utk.edu/grappa/
-        Halogen Bonding Galaxy:
+        Huttenhower Lab:
           supported: false
-          url: http://134.2.17.68:8081/
+          url: http://huttenhower.sph.harvard.edu/galaxy/
         Koslicki Lab Galaxy:
           supported: false
           url: http://math-galaxy.cgrb.oregonstate.edu:8080/
@@ -891,9 +822,6 @@ epigenetics:
         Pitagora-Galaxy:
           supported: false
           url: http://try.pitagora-galaxy.org/galaxy/
-        RNA-Seq Portal:
-          supported: false
-          url: http://weizhongli-lab.org:8088
         South Green Galaxy:
           supported: false
           url: http://galaxy.southgreen.fr/galaxy/
@@ -921,9 +849,6 @@ epigenetics:
         ABiMS Tools:
           supported: false
           url: http://webtools.sb-roscoff.fr
-        AGEseq Galaxy @ AspenDB:
-          supported: false
-          url: http://aspendb.uga.edu:8085/
         APOSTL Galaxy:
           supported: false
           url: http://apostl.moffitt.org/
@@ -966,12 +891,6 @@ epigenetics:
         GVL Melbourne:
           supported: false
           url: http://galaxy-mel.genome.edu.au/galaxy/
-        GVL Queensland:
-          supported: false
-          url: https://galaxy-qld.genome.edu.au/galaxy/
-        GVL-QLD:
-          supported: false
-          url: https://galaxy-qld.genome.edu.au/galaxy
         GVL-Tutorial:
           supported: false
           url: http://galaxy-tut.genome.edu.au/galaxy/
@@ -1002,9 +921,9 @@ epigenetics:
         GrAPPA:
           supported: false
           url: https://grappa.eecs.utk.edu/grappa/
-        Halogen Bonding Galaxy:
+        Huttenhower Lab:
           supported: false
-          url: http://134.2.17.68:8081/
+          url: http://huttenhower.sph.harvard.edu/galaxy/
         Koslicki Lab Galaxy:
           supported: false
           url: http://math-galaxy.cgrb.oregonstate.edu:8080/
@@ -1041,9 +960,6 @@ epigenetics:
         Pitagora-Galaxy:
           supported: false
           url: http://try.pitagora-galaxy.org/galaxy/
-        RNA-Seq Portal:
-          supported: false
-          url: http://weizhongli-lab.org:8088
         South Green Galaxy:
           supported: false
           url: http://galaxy.southgreen.fr/galaxy/
@@ -1074,9 +990,6 @@ introduction:
         ABiMS Tools:
           supported: false
           url: http://webtools.sb-roscoff.fr
-        AGEseq Galaxy @ AspenDB:
-          supported: false
-          url: http://aspendb.uga.edu:8085/
         APOSTL Galaxy:
           supported: false
           url: http://apostl.moffitt.org/
@@ -1119,12 +1032,6 @@ introduction:
         GVL Melbourne:
           supported: true
           url: http://galaxy-mel.genome.edu.au/galaxy/
-        GVL Queensland:
-          supported: true
-          url: https://galaxy-qld.genome.edu.au/galaxy/
-        GVL-QLD:
-          supported: true
-          url: https://galaxy-qld.genome.edu.au/galaxy
         GVL-Tutorial:
           supported: true
           url: http://galaxy-tut.genome.edu.au/galaxy/
@@ -1155,9 +1062,9 @@ introduction:
         GrAPPA:
           supported: false
           url: https://grappa.eecs.utk.edu/grappa/
-        Halogen Bonding Galaxy:
+        Huttenhower Lab:
           supported: false
-          url: http://134.2.17.68:8081/
+          url: http://huttenhower.sph.harvard.edu/galaxy/
         Koslicki Lab Galaxy:
           supported: false
           url: http://math-galaxy.cgrb.oregonstate.edu:8080/
@@ -1194,9 +1101,6 @@ introduction:
         Pitagora-Galaxy:
           supported: true
           url: http://try.pitagora-galaxy.org/galaxy/
-        RNA-Seq Portal:
-          supported: false
-          url: http://weizhongli-lab.org:8088
         South Green Galaxy:
           supported: true
           url: http://galaxy.southgreen.fr/galaxy/
@@ -1224,9 +1128,6 @@ introduction:
         ABiMS Tools:
           supported: false
           url: http://webtools.sb-roscoff.fr
-        AGEseq Galaxy @ AspenDB:
-          supported: false
-          url: http://aspendb.uga.edu:8085/
         APOSTL Galaxy:
           supported: false
           url: http://apostl.moffitt.org/
@@ -1269,12 +1170,6 @@ introduction:
         GVL Melbourne:
           supported: false
           url: http://galaxy-mel.genome.edu.au/galaxy/
-        GVL Queensland:
-          supported: false
-          url: https://galaxy-qld.genome.edu.au/galaxy/
-        GVL-QLD:
-          supported: false
-          url: https://galaxy-qld.genome.edu.au/galaxy
         GVL-Tutorial:
           supported: false
           url: http://galaxy-tut.genome.edu.au/galaxy/
@@ -1305,9 +1200,9 @@ introduction:
         GrAPPA:
           supported: false
           url: https://grappa.eecs.utk.edu/grappa/
-        Halogen Bonding Galaxy:
+        Huttenhower Lab:
           supported: false
-          url: http://134.2.17.68:8081/
+          url: http://huttenhower.sph.harvard.edu/galaxy/
         Koslicki Lab Galaxy:
           supported: false
           url: http://math-galaxy.cgrb.oregonstate.edu:8080/
@@ -1344,9 +1239,6 @@ introduction:
         Pitagora-Galaxy:
           supported: false
           url: http://try.pitagora-galaxy.org/galaxy/
-        RNA-Seq Portal:
-          supported: false
-          url: http://weizhongli-lab.org:8088
         South Green Galaxy:
           supported: false
           url: http://galaxy.southgreen.fr/galaxy/
@@ -1374,9 +1266,6 @@ introduction:
         ABiMS Tools:
           supported: false
           url: http://webtools.sb-roscoff.fr
-        AGEseq Galaxy @ AspenDB:
-          supported: false
-          url: http://aspendb.uga.edu:8085/
         APOSTL Galaxy:
           supported: false
           url: http://apostl.moffitt.org/
@@ -1419,12 +1308,6 @@ introduction:
         GVL Melbourne:
           supported: false
           url: http://galaxy-mel.genome.edu.au/galaxy/
-        GVL Queensland:
-          supported: false
-          url: https://galaxy-qld.genome.edu.au/galaxy/
-        GVL-QLD:
-          supported: false
-          url: https://galaxy-qld.genome.edu.au/galaxy
         GVL-Tutorial:
           supported: false
           url: http://galaxy-tut.genome.edu.au/galaxy/
@@ -1455,9 +1338,9 @@ introduction:
         GrAPPA:
           supported: false
           url: https://grappa.eecs.utk.edu/grappa/
-        Halogen Bonding Galaxy:
+        Huttenhower Lab:
           supported: false
-          url: http://134.2.17.68:8081/
+          url: http://huttenhower.sph.harvard.edu/galaxy/
         Koslicki Lab Galaxy:
           supported: false
           url: http://math-galaxy.cgrb.oregonstate.edu:8080/
@@ -1494,9 +1377,6 @@ introduction:
         Pitagora-Galaxy:
           supported: false
           url: http://try.pitagora-galaxy.org/galaxy/
-        RNA-Seq Portal:
-          supported: false
-          url: http://weizhongli-lab.org:8088
         South Green Galaxy:
           supported: false
           url: http://galaxy.southgreen.fr/galaxy/
@@ -1524,9 +1404,6 @@ introduction:
         ABiMS Tools:
           supported: false
           url: http://webtools.sb-roscoff.fr
-        AGEseq Galaxy @ AspenDB:
-          supported: false
-          url: http://aspendb.uga.edu:8085/
         APOSTL Galaxy:
           supported: false
           url: http://apostl.moffitt.org/
@@ -1569,12 +1446,6 @@ introduction:
         GVL Melbourne:
           supported: false
           url: http://galaxy-mel.genome.edu.au/galaxy/
-        GVL Queensland:
-          supported: false
-          url: https://galaxy-qld.genome.edu.au/galaxy/
-        GVL-QLD:
-          supported: false
-          url: https://galaxy-qld.genome.edu.au/galaxy
         GVL-Tutorial:
           supported: false
           url: http://galaxy-tut.genome.edu.au/galaxy/
@@ -1605,9 +1476,9 @@ introduction:
         GrAPPA:
           supported: false
           url: https://grappa.eecs.utk.edu/grappa/
-        Halogen Bonding Galaxy:
+        Huttenhower Lab:
           supported: false
-          url: http://134.2.17.68:8081/
+          url: http://huttenhower.sph.harvard.edu/galaxy/
         Koslicki Lab Galaxy:
           supported: false
           url: http://math-galaxy.cgrb.oregonstate.edu:8080/
@@ -1644,9 +1515,6 @@ introduction:
         Pitagora-Galaxy:
           supported: false
           url: http://try.pitagora-galaxy.org/galaxy/
-        RNA-Seq Portal:
-          supported: false
-          url: http://weizhongli-lab.org:8088
         South Green Galaxy:
           supported: false
           url: http://galaxy.southgreen.fr/galaxy/
@@ -1674,9 +1542,6 @@ introduction:
         ABiMS Tools:
           supported: false
           url: http://webtools.sb-roscoff.fr
-        AGEseq Galaxy @ AspenDB:
-          supported: false
-          url: http://aspendb.uga.edu:8085/
         APOSTL Galaxy:
           supported: false
           url: http://apostl.moffitt.org/
@@ -1719,12 +1584,6 @@ introduction:
         GVL Melbourne:
           supported: false
           url: http://galaxy-mel.genome.edu.au/galaxy/
-        GVL Queensland:
-          supported: false
-          url: https://galaxy-qld.genome.edu.au/galaxy/
-        GVL-QLD:
-          supported: false
-          url: https://galaxy-qld.genome.edu.au/galaxy
         GVL-Tutorial:
           supported: false
           url: http://galaxy-tut.genome.edu.au/galaxy/
@@ -1755,9 +1614,9 @@ introduction:
         GrAPPA:
           supported: false
           url: https://grappa.eecs.utk.edu/grappa/
-        Halogen Bonding Galaxy:
+        Huttenhower Lab:
           supported: false
-          url: http://134.2.17.68:8081/
+          url: http://huttenhower.sph.harvard.edu/galaxy/
         Koslicki Lab Galaxy:
           supported: false
           url: http://math-galaxy.cgrb.oregonstate.edu:8080/
@@ -1794,9 +1653,6 @@ introduction:
         Pitagora-Galaxy:
           supported: false
           url: http://try.pitagora-galaxy.org/galaxy/
-        RNA-Seq Portal:
-          supported: false
-          url: http://weizhongli-lab.org:8088
         South Green Galaxy:
           supported: false
           url: http://galaxy.southgreen.fr/galaxy/
@@ -1824,9 +1680,6 @@ introduction:
         ABiMS Tools:
           supported: false
           url: http://webtools.sb-roscoff.fr
-        AGEseq Galaxy @ AspenDB:
-          supported: false
-          url: http://aspendb.uga.edu:8085/
         APOSTL Galaxy:
           supported: false
           url: http://apostl.moffitt.org/
@@ -1869,12 +1722,6 @@ introduction:
         GVL Melbourne:
           supported: false
           url: http://galaxy-mel.genome.edu.au/galaxy/
-        GVL Queensland:
-          supported: false
-          url: https://galaxy-qld.genome.edu.au/galaxy/
-        GVL-QLD:
-          supported: false
-          url: https://galaxy-qld.genome.edu.au/galaxy
         GVL-Tutorial:
           supported: false
           url: http://galaxy-tut.genome.edu.au/galaxy/
@@ -1905,9 +1752,9 @@ introduction:
         GrAPPA:
           supported: false
           url: https://grappa.eecs.utk.edu/grappa/
-        Halogen Bonding Galaxy:
+        Huttenhower Lab:
           supported: false
-          url: http://134.2.17.68:8081/
+          url: http://huttenhower.sph.harvard.edu/galaxy/
         Koslicki Lab Galaxy:
           supported: false
           url: http://math-galaxy.cgrb.oregonstate.edu:8080/
@@ -1944,9 +1791,6 @@ introduction:
         Pitagora-Galaxy:
           supported: false
           url: http://try.pitagora-galaxy.org/galaxy/
-        RNA-Seq Portal:
-          supported: false
-          url: http://weizhongli-lab.org:8088
         South Green Galaxy:
           supported: false
           url: http://galaxy.southgreen.fr/galaxy/
@@ -1974,9 +1818,6 @@ introduction:
         ABiMS Tools:
           supported: false
           url: http://webtools.sb-roscoff.fr
-        AGEseq Galaxy @ AspenDB:
-          supported: false
-          url: http://aspendb.uga.edu:8085/
         APOSTL Galaxy:
           supported: false
           url: http://apostl.moffitt.org/
@@ -2019,12 +1860,6 @@ introduction:
         GVL Melbourne:
           supported: false
           url: http://galaxy-mel.genome.edu.au/galaxy/
-        GVL Queensland:
-          supported: false
-          url: https://galaxy-qld.genome.edu.au/galaxy/
-        GVL-QLD:
-          supported: false
-          url: https://galaxy-qld.genome.edu.au/galaxy
         GVL-Tutorial:
           supported: false
           url: http://galaxy-tut.genome.edu.au/galaxy/
@@ -2055,9 +1890,9 @@ introduction:
         GrAPPA:
           supported: false
           url: https://grappa.eecs.utk.edu/grappa/
-        Halogen Bonding Galaxy:
+        Huttenhower Lab:
           supported: false
-          url: http://134.2.17.68:8081/
+          url: http://huttenhower.sph.harvard.edu/galaxy/
         Koslicki Lab Galaxy:
           supported: false
           url: http://math-galaxy.cgrb.oregonstate.edu:8080/
@@ -2094,9 +1929,6 @@ introduction:
         Pitagora-Galaxy:
           supported: false
           url: http://try.pitagora-galaxy.org/galaxy/
-        RNA-Seq Portal:
-          supported: false
-          url: http://weizhongli-lab.org:8088
         South Green Galaxy:
           supported: false
           url: http://galaxy.southgreen.fr/galaxy/
@@ -2124,9 +1956,6 @@ introduction:
         ABiMS Tools:
           supported: false
           url: http://webtools.sb-roscoff.fr
-        AGEseq Galaxy @ AspenDB:
-          supported: false
-          url: http://aspendb.uga.edu:8085/
         APOSTL Galaxy:
           supported: false
           url: http://apostl.moffitt.org/
@@ -2169,12 +1998,6 @@ introduction:
         GVL Melbourne:
           supported: false
           url: http://galaxy-mel.genome.edu.au/galaxy/
-        GVL Queensland:
-          supported: false
-          url: https://galaxy-qld.genome.edu.au/galaxy/
-        GVL-QLD:
-          supported: false
-          url: https://galaxy-qld.genome.edu.au/galaxy
         GVL-Tutorial:
           supported: false
           url: http://galaxy-tut.genome.edu.au/galaxy/
@@ -2205,9 +2028,9 @@ introduction:
         GrAPPA:
           supported: false
           url: https://grappa.eecs.utk.edu/grappa/
-        Halogen Bonding Galaxy:
+        Huttenhower Lab:
           supported: false
-          url: http://134.2.17.68:8081/
+          url: http://huttenhower.sph.harvard.edu/galaxy/
         Koslicki Lab Galaxy:
           supported: false
           url: http://math-galaxy.cgrb.oregonstate.edu:8080/
@@ -2244,9 +2067,6 @@ introduction:
         Pitagora-Galaxy:
           supported: false
           url: http://try.pitagora-galaxy.org/galaxy/
-        RNA-Seq Portal:
-          supported: false
-          url: http://weizhongli-lab.org:8088
         South Green Galaxy:
           supported: false
           url: http://galaxy.southgreen.fr/galaxy/
@@ -2267,7 +2087,7 @@ introduction:
           url: http://galaxy.workflow4metabolomics.org
       supported: true
 metagenomics:
-  supported: false
+  supported: true
   tutorials:
     general-tutorial:
       instances:
@@ -2277,9 +2097,6 @@ metagenomics:
         ABiMS Tools:
           supported: false
           url: http://webtools.sb-roscoff.fr
-        AGEseq Galaxy @ AspenDB:
-          supported: false
-          url: http://aspendb.uga.edu:8085/
         APOSTL Galaxy:
           supported: false
           url: http://apostl.moffitt.org/
@@ -2322,12 +2139,6 @@ metagenomics:
         GVL Melbourne:
           supported: false
           url: http://galaxy-mel.genome.edu.au/galaxy/
-        GVL Queensland:
-          supported: false
-          url: https://galaxy-qld.genome.edu.au/galaxy/
-        GVL-QLD:
-          supported: false
-          url: https://galaxy-qld.genome.edu.au/galaxy
         GVL-Tutorial:
           supported: false
           url: http://galaxy-tut.genome.edu.au/galaxy/
@@ -2335,7 +2146,7 @@ metagenomics:
           supported: false
           url: http://use.galaxeast.fr/
         Galaxy Europe:
-          supported: false
+          supported: true
           url: https://usegalaxy.eu
         Galaxy Palfinder:
           supported: false
@@ -2358,9 +2169,9 @@ metagenomics:
         GrAPPA:
           supported: false
           url: https://grappa.eecs.utk.edu/grappa/
-        Halogen Bonding Galaxy:
+        Huttenhower Lab:
           supported: false
-          url: http://134.2.17.68:8081/
+          url: http://huttenhower.sph.harvard.edu/galaxy/
         Koslicki Lab Galaxy:
           supported: false
           url: http://math-galaxy.cgrb.oregonstate.edu:8080/
@@ -2397,9 +2208,6 @@ metagenomics:
         Pitagora-Galaxy:
           supported: false
           url: http://try.pitagora-galaxy.org/galaxy/
-        RNA-Seq Portal:
-          supported: false
-          url: http://weizhongli-lab.org:8088
         South Green Galaxy:
           supported: false
           url: http://galaxy.southgreen.fr/galaxy/
@@ -2418,7 +2226,7 @@ metagenomics:
         workflow4metabolomics:
           supported: false
           url: http://galaxy.workflow4metabolomics.org
-      supported: false
+      supported: true
     mothur-miseq-sop:
       instances:
         ABiMS:
@@ -2427,9 +2235,6 @@ metagenomics:
         ABiMS Tools:
           supported: false
           url: http://webtools.sb-roscoff.fr
-        AGEseq Galaxy @ AspenDB:
-          supported: false
-          url: http://aspendb.uga.edu:8085/
         APOSTL Galaxy:
           supported: false
           url: http://apostl.moffitt.org/
@@ -2464,7 +2269,7 @@ metagenomics:
           supported: false
           url: http://dintor.eurac.edu/
         Erasmus MC:
-          supported: false
+          supported: true
           url: https://bioinf-galaxian.erasmusmc.nl/galaxy/
         GIO:
           supported: false
@@ -2472,12 +2277,6 @@ metagenomics:
         GVL Melbourne:
           supported: false
           url: http://galaxy-mel.genome.edu.au/galaxy/
-        GVL Queensland:
-          supported: false
-          url: https://galaxy-qld.genome.edu.au/galaxy/
-        GVL-QLD:
-          supported: false
-          url: https://galaxy-qld.genome.edu.au/galaxy
         GVL-Tutorial:
           supported: false
           url: http://galaxy-tut.genome.edu.au/galaxy/
@@ -2508,9 +2307,9 @@ metagenomics:
         GrAPPA:
           supported: false
           url: https://grappa.eecs.utk.edu/grappa/
-        Halogen Bonding Galaxy:
+        Huttenhower Lab:
           supported: false
-          url: http://134.2.17.68:8081/
+          url: http://huttenhower.sph.harvard.edu/galaxy/
         Koslicki Lab Galaxy:
           supported: false
           url: http://math-galaxy.cgrb.oregonstate.edu:8080/
@@ -2547,9 +2346,6 @@ metagenomics:
         Pitagora-Galaxy:
           supported: false
           url: http://try.pitagora-galaxy.org/galaxy/
-        RNA-Seq Portal:
-          supported: false
-          url: http://weizhongli-lab.org:8088
         South Green Galaxy:
           supported: false
           url: http://galaxy.southgreen.fr/galaxy/
@@ -2568,7 +2364,7 @@ metagenomics:
         workflow4metabolomics:
           supported: false
           url: http://galaxy.workflow4metabolomics.org
-      supported: false
+      supported: true
 proteomics:
   supported: true
   tutorials:
@@ -2580,9 +2376,6 @@ proteomics:
         ABiMS Tools:
           supported: false
           url: http://webtools.sb-roscoff.fr
-        AGEseq Galaxy @ AspenDB:
-          supported: false
-          url: http://aspendb.uga.edu:8085/
         APOSTL Galaxy:
           supported: false
           url: http://apostl.moffitt.org/
@@ -2625,12 +2418,6 @@ proteomics:
         GVL Melbourne:
           supported: false
           url: http://galaxy-mel.genome.edu.au/galaxy/
-        GVL Queensland:
-          supported: false
-          url: https://galaxy-qld.genome.edu.au/galaxy/
-        GVL-QLD:
-          supported: false
-          url: https://galaxy-qld.genome.edu.au/galaxy
         GVL-Tutorial:
           supported: false
           url: http://galaxy-tut.genome.edu.au/galaxy/
@@ -2661,9 +2448,9 @@ proteomics:
         GrAPPA:
           supported: false
           url: https://grappa.eecs.utk.edu/grappa/
-        Halogen Bonding Galaxy:
+        Huttenhower Lab:
           supported: false
-          url: http://134.2.17.68:8081/
+          url: http://huttenhower.sph.harvard.edu/galaxy/
         Koslicki Lab Galaxy:
           supported: false
           url: http://math-galaxy.cgrb.oregonstate.edu:8080/
@@ -2700,9 +2487,6 @@ proteomics:
         Pitagora-Galaxy:
           supported: false
           url: http://try.pitagora-galaxy.org/galaxy/
-        RNA-Seq Portal:
-          supported: false
-          url: http://weizhongli-lab.org:8088
         South Green Galaxy:
           supported: false
           url: http://galaxy.southgreen.fr/galaxy/
@@ -2730,9 +2514,6 @@ proteomics:
         ABiMS Tools:
           supported: false
           url: http://webtools.sb-roscoff.fr
-        AGEseq Galaxy @ AspenDB:
-          supported: false
-          url: http://aspendb.uga.edu:8085/
         APOSTL Galaxy:
           supported: false
           url: http://apostl.moffitt.org/
@@ -2775,12 +2556,6 @@ proteomics:
         GVL Melbourne:
           supported: false
           url: http://galaxy-mel.genome.edu.au/galaxy/
-        GVL Queensland:
-          supported: false
-          url: https://galaxy-qld.genome.edu.au/galaxy/
-        GVL-QLD:
-          supported: false
-          url: https://galaxy-qld.genome.edu.au/galaxy
         GVL-Tutorial:
           supported: false
           url: http://galaxy-tut.genome.edu.au/galaxy/
@@ -2811,9 +2586,9 @@ proteomics:
         GrAPPA:
           supported: false
           url: https://grappa.eecs.utk.edu/grappa/
-        Halogen Bonding Galaxy:
+        Huttenhower Lab:
           supported: false
-          url: http://134.2.17.68:8081/
+          url: http://huttenhower.sph.harvard.edu/galaxy/
         Koslicki Lab Galaxy:
           supported: false
           url: http://math-galaxy.cgrb.oregonstate.edu:8080/
@@ -2850,9 +2625,6 @@ proteomics:
         Pitagora-Galaxy:
           supported: false
           url: http://try.pitagora-galaxy.org/galaxy/
-        RNA-Seq Portal:
-          supported: false
-          url: http://weizhongli-lab.org:8088
         South Green Galaxy:
           supported: false
           url: http://galaxy.southgreen.fr/galaxy/
@@ -2880,9 +2652,6 @@ proteomics:
         ABiMS Tools:
           supported: false
           url: http://webtools.sb-roscoff.fr
-        AGEseq Galaxy @ AspenDB:
-          supported: false
-          url: http://aspendb.uga.edu:8085/
         APOSTL Galaxy:
           supported: false
           url: http://apostl.moffitt.org/
@@ -2925,12 +2694,6 @@ proteomics:
         GVL Melbourne:
           supported: false
           url: http://galaxy-mel.genome.edu.au/galaxy/
-        GVL Queensland:
-          supported: false
-          url: https://galaxy-qld.genome.edu.au/galaxy/
-        GVL-QLD:
-          supported: false
-          url: https://galaxy-qld.genome.edu.au/galaxy
         GVL-Tutorial:
           supported: false
           url: http://galaxy-tut.genome.edu.au/galaxy/
@@ -2961,9 +2724,9 @@ proteomics:
         GrAPPA:
           supported: false
           url: https://grappa.eecs.utk.edu/grappa/
-        Halogen Bonding Galaxy:
+        Huttenhower Lab:
           supported: false
-          url: http://134.2.17.68:8081/
+          url: http://huttenhower.sph.harvard.edu/galaxy/
         Koslicki Lab Galaxy:
           supported: false
           url: http://math-galaxy.cgrb.oregonstate.edu:8080/
@@ -3000,9 +2763,6 @@ proteomics:
         Pitagora-Galaxy:
           supported: false
           url: http://try.pitagora-galaxy.org/galaxy/
-        RNA-Seq Portal:
-          supported: false
-          url: http://weizhongli-lab.org:8088
         South Green Galaxy:
           supported: false
           url: http://galaxy.southgreen.fr/galaxy/
@@ -3030,9 +2790,6 @@ proteomics:
         ABiMS Tools:
           supported: false
           url: http://webtools.sb-roscoff.fr
-        AGEseq Galaxy @ AspenDB:
-          supported: false
-          url: http://aspendb.uga.edu:8085/
         APOSTL Galaxy:
           supported: false
           url: http://apostl.moffitt.org/
@@ -3075,12 +2832,6 @@ proteomics:
         GVL Melbourne:
           supported: false
           url: http://galaxy-mel.genome.edu.au/galaxy/
-        GVL Queensland:
-          supported: false
-          url: https://galaxy-qld.genome.edu.au/galaxy/
-        GVL-QLD:
-          supported: false
-          url: https://galaxy-qld.genome.edu.au/galaxy
         GVL-Tutorial:
           supported: false
           url: http://galaxy-tut.genome.edu.au/galaxy/
@@ -3111,9 +2862,9 @@ proteomics:
         GrAPPA:
           supported: false
           url: https://grappa.eecs.utk.edu/grappa/
-        Halogen Bonding Galaxy:
+        Huttenhower Lab:
           supported: false
-          url: http://134.2.17.68:8081/
+          url: http://huttenhower.sph.harvard.edu/galaxy/
         Koslicki Lab Galaxy:
           supported: false
           url: http://math-galaxy.cgrb.oregonstate.edu:8080/
@@ -3150,9 +2901,6 @@ proteomics:
         Pitagora-Galaxy:
           supported: false
           url: http://try.pitagora-galaxy.org/galaxy/
-        RNA-Seq Portal:
-          supported: false
-          url: http://weizhongli-lab.org:8088
         South Green Galaxy:
           supported: false
           url: http://galaxy.southgreen.fr/galaxy/
@@ -3180,9 +2928,6 @@ proteomics:
         ABiMS Tools:
           supported: false
           url: http://webtools.sb-roscoff.fr
-        AGEseq Galaxy @ AspenDB:
-          supported: false
-          url: http://aspendb.uga.edu:8085/
         APOSTL Galaxy:
           supported: false
           url: http://apostl.moffitt.org/
@@ -3225,12 +2970,6 @@ proteomics:
         GVL Melbourne:
           supported: false
           url: http://galaxy-mel.genome.edu.au/galaxy/
-        GVL Queensland:
-          supported: false
-          url: https://galaxy-qld.genome.edu.au/galaxy/
-        GVL-QLD:
-          supported: false
-          url: https://galaxy-qld.genome.edu.au/galaxy
         GVL-Tutorial:
           supported: false
           url: http://galaxy-tut.genome.edu.au/galaxy/
@@ -3261,9 +3000,9 @@ proteomics:
         GrAPPA:
           supported: false
           url: https://grappa.eecs.utk.edu/grappa/
-        Halogen Bonding Galaxy:
+        Huttenhower Lab:
           supported: false
-          url: http://134.2.17.68:8081/
+          url: http://huttenhower.sph.harvard.edu/galaxy/
         Koslicki Lab Galaxy:
           supported: false
           url: http://math-galaxy.cgrb.oregonstate.edu:8080/
@@ -3300,9 +3039,6 @@ proteomics:
         Pitagora-Galaxy:
           supported: false
           url: http://try.pitagora-galaxy.org/galaxy/
-        RNA-Seq Portal:
-          supported: false
-          url: http://weizhongli-lab.org:8088
         South Green Galaxy:
           supported: false
           url: http://galaxy.southgreen.fr/galaxy/
@@ -3330,9 +3066,6 @@ proteomics:
         ABiMS Tools:
           supported: false
           url: http://webtools.sb-roscoff.fr
-        AGEseq Galaxy @ AspenDB:
-          supported: false
-          url: http://aspendb.uga.edu:8085/
         APOSTL Galaxy:
           supported: false
           url: http://apostl.moffitt.org/
@@ -3375,12 +3108,6 @@ proteomics:
         GVL Melbourne:
           supported: false
           url: http://galaxy-mel.genome.edu.au/galaxy/
-        GVL Queensland:
-          supported: false
-          url: https://galaxy-qld.genome.edu.au/galaxy/
-        GVL-QLD:
-          supported: false
-          url: https://galaxy-qld.genome.edu.au/galaxy
         GVL-Tutorial:
           supported: false
           url: http://galaxy-tut.genome.edu.au/galaxy/
@@ -3411,9 +3138,9 @@ proteomics:
         GrAPPA:
           supported: false
           url: https://grappa.eecs.utk.edu/grappa/
-        Halogen Bonding Galaxy:
+        Huttenhower Lab:
           supported: false
-          url: http://134.2.17.68:8081/
+          url: http://huttenhower.sph.harvard.edu/galaxy/
         Koslicki Lab Galaxy:
           supported: false
           url: http://math-galaxy.cgrb.oregonstate.edu:8080/
@@ -3450,9 +3177,6 @@ proteomics:
         Pitagora-Galaxy:
           supported: false
           url: http://try.pitagora-galaxy.org/galaxy/
-        RNA-Seq Portal:
-          supported: false
-          url: http://weizhongli-lab.org:8088
         South Green Galaxy:
           supported: false
           url: http://galaxy.southgreen.fr/galaxy/
@@ -3480,9 +3204,6 @@ proteomics:
         ABiMS Tools:
           supported: false
           url: http://webtools.sb-roscoff.fr
-        AGEseq Galaxy @ AspenDB:
-          supported: false
-          url: http://aspendb.uga.edu:8085/
         APOSTL Galaxy:
           supported: false
           url: http://apostl.moffitt.org/
@@ -3525,12 +3246,6 @@ proteomics:
         GVL Melbourne:
           supported: false
           url: http://galaxy-mel.genome.edu.au/galaxy/
-        GVL Queensland:
-          supported: false
-          url: https://galaxy-qld.genome.edu.au/galaxy/
-        GVL-QLD:
-          supported: false
-          url: https://galaxy-qld.genome.edu.au/galaxy
         GVL-Tutorial:
           supported: false
           url: http://galaxy-tut.genome.edu.au/galaxy/
@@ -3561,9 +3276,9 @@ proteomics:
         GrAPPA:
           supported: false
           url: https://grappa.eecs.utk.edu/grappa/
-        Halogen Bonding Galaxy:
+        Huttenhower Lab:
           supported: false
-          url: http://134.2.17.68:8081/
+          url: http://huttenhower.sph.harvard.edu/galaxy/
         Koslicki Lab Galaxy:
           supported: false
           url: http://math-galaxy.cgrb.oregonstate.edu:8080/
@@ -3600,9 +3315,6 @@ proteomics:
         Pitagora-Galaxy:
           supported: false
           url: http://try.pitagora-galaxy.org/galaxy/
-        RNA-Seq Portal:
-          supported: false
-          url: http://weizhongli-lab.org:8088
         South Green Galaxy:
           supported: false
           url: http://galaxy.southgreen.fr/galaxy/
@@ -3630,9 +3342,6 @@ proteomics:
         ABiMS Tools:
           supported: false
           url: http://webtools.sb-roscoff.fr
-        AGEseq Galaxy @ AspenDB:
-          supported: false
-          url: http://aspendb.uga.edu:8085/
         APOSTL Galaxy:
           supported: false
           url: http://apostl.moffitt.org/
@@ -3675,12 +3384,6 @@ proteomics:
         GVL Melbourne:
           supported: false
           url: http://galaxy-mel.genome.edu.au/galaxy/
-        GVL Queensland:
-          supported: false
-          url: https://galaxy-qld.genome.edu.au/galaxy/
-        GVL-QLD:
-          supported: false
-          url: https://galaxy-qld.genome.edu.au/galaxy
         GVL-Tutorial:
           supported: false
           url: http://galaxy-tut.genome.edu.au/galaxy/
@@ -3711,9 +3414,9 @@ proteomics:
         GrAPPA:
           supported: false
           url: https://grappa.eecs.utk.edu/grappa/
-        Halogen Bonding Galaxy:
+        Huttenhower Lab:
           supported: false
-          url: http://134.2.17.68:8081/
+          url: http://huttenhower.sph.harvard.edu/galaxy/
         Koslicki Lab Galaxy:
           supported: false
           url: http://math-galaxy.cgrb.oregonstate.edu:8080/
@@ -3750,9 +3453,6 @@ proteomics:
         Pitagora-Galaxy:
           supported: false
           url: http://try.pitagora-galaxy.org/galaxy/
-        RNA-Seq Portal:
-          supported: false
-          url: http://weizhongli-lab.org:8088
         South Green Galaxy:
           supported: false
           url: http://galaxy.southgreen.fr/galaxy/
@@ -3783,9 +3483,6 @@ sequence-analysis:
         ABiMS Tools:
           supported: false
           url: http://webtools.sb-roscoff.fr
-        AGEseq Galaxy @ AspenDB:
-          supported: false
-          url: http://aspendb.uga.edu:8085/
         APOSTL Galaxy:
           supported: false
           url: http://apostl.moffitt.org/
@@ -3828,12 +3525,6 @@ sequence-analysis:
         GVL Melbourne:
           supported: true
           url: http://galaxy-mel.genome.edu.au/galaxy/
-        GVL Queensland:
-          supported: true
-          url: https://galaxy-qld.genome.edu.au/galaxy/
-        GVL-QLD:
-          supported: true
-          url: https://galaxy-qld.genome.edu.au/galaxy
         GVL-Tutorial:
           supported: false
           url: http://galaxy-tut.genome.edu.au/galaxy/
@@ -3864,9 +3555,9 @@ sequence-analysis:
         GrAPPA:
           supported: false
           url: https://grappa.eecs.utk.edu/grappa/
-        Halogen Bonding Galaxy:
+        Huttenhower Lab:
           supported: false
-          url: http://134.2.17.68:8081/
+          url: http://huttenhower.sph.harvard.edu/galaxy/
         Koslicki Lab Galaxy:
           supported: false
           url: http://math-galaxy.cgrb.oregonstate.edu:8080/
@@ -3903,9 +3594,6 @@ sequence-analysis:
         Pitagora-Galaxy:
           supported: false
           url: http://try.pitagora-galaxy.org/galaxy/
-        RNA-Seq Portal:
-          supported: false
-          url: http://weizhongli-lab.org:8088
         South Green Galaxy:
           supported: false
           url: http://galaxy.southgreen.fr/galaxy/
@@ -3933,9 +3621,6 @@ sequence-analysis:
         ABiMS Tools:
           supported: false
           url: http://webtools.sb-roscoff.fr
-        AGEseq Galaxy @ AspenDB:
-          supported: false
-          url: http://aspendb.uga.edu:8085/
         APOSTL Galaxy:
           supported: false
           url: http://apostl.moffitt.org/
@@ -3978,12 +3663,6 @@ sequence-analysis:
         GVL Melbourne:
           supported: false
           url: http://galaxy-mel.genome.edu.au/galaxy/
-        GVL Queensland:
-          supported: false
-          url: https://galaxy-qld.genome.edu.au/galaxy/
-        GVL-QLD:
-          supported: false
-          url: https://galaxy-qld.genome.edu.au/galaxy
         GVL-Tutorial:
           supported: false
           url: http://galaxy-tut.genome.edu.au/galaxy/
@@ -4014,9 +3693,9 @@ sequence-analysis:
         GrAPPA:
           supported: false
           url: https://grappa.eecs.utk.edu/grappa/
-        Halogen Bonding Galaxy:
+        Huttenhower Lab:
           supported: false
-          url: http://134.2.17.68:8081/
+          url: http://huttenhower.sph.harvard.edu/galaxy/
         Koslicki Lab Galaxy:
           supported: false
           url: http://math-galaxy.cgrb.oregonstate.edu:8080/
@@ -4053,9 +3732,6 @@ sequence-analysis:
         Pitagora-Galaxy:
           supported: false
           url: http://try.pitagora-galaxy.org/galaxy/
-        RNA-Seq Portal:
-          supported: false
-          url: http://weizhongli-lab.org:8088
         South Green Galaxy:
           supported: false
           url: http://galaxy.southgreen.fr/galaxy/
@@ -4078,14 +3754,11 @@ sequence-analysis:
     genetic-map-rad-seq:
       instances:
         ABiMS:
-          supported: false
+          supported: true
           url: http://galaxy3.sb-roscoff.fr/
         ABiMS Tools:
           supported: false
           url: http://webtools.sb-roscoff.fr
-        AGEseq Galaxy @ AspenDB:
-          supported: false
-          url: http://aspendb.uga.edu:8085/
         APOSTL Galaxy:
           supported: false
           url: http://apostl.moffitt.org/
@@ -4096,7 +3769,7 @@ sequence-analysis:
           supported: false
           url: https://bioinf-galaxian.erasmusmc.nl/argalaxy/
         BIPAA:
-          supported: false
+          supported: true
           url: https://bipaa-galaxy.genouest.org
         BioMaS Galaxy:
           supported: false
@@ -4126,14 +3799,8 @@ sequence-analysis:
           supported: false
           url: http://gio.sbcs.qmul.ac.uk/
         GVL Melbourne:
-          supported: false
+          supported: true
           url: http://galaxy-mel.genome.edu.au/galaxy/
-        GVL Queensland:
-          supported: false
-          url: https://galaxy-qld.genome.edu.au/galaxy/
-        GVL-QLD:
-          supported: false
-          url: https://galaxy-qld.genome.edu.au/galaxy
         GVL-Tutorial:
           supported: false
           url: http://galaxy-tut.genome.edu.au/galaxy/
@@ -4141,7 +3808,7 @@ sequence-analysis:
           supported: false
           url: http://use.galaxeast.fr/
         Galaxy Europe:
-          supported: false
+          supported: true
           url: https://usegalaxy.eu
         Galaxy Palfinder:
           supported: false
@@ -4150,7 +3817,7 @@ sequence-analysis:
           supported: false
           url: http://cefap.icb.usp.br/galaxy
         Galaxy@GenOuest:
-          supported: false
+          supported: true
           url: https://galaxy.genouest.org
         Galaxy@PRABI:
           supported: false
@@ -4164,9 +3831,9 @@ sequence-analysis:
         GrAPPA:
           supported: false
           url: https://grappa.eecs.utk.edu/grappa/
-        Halogen Bonding Galaxy:
+        Huttenhower Lab:
           supported: false
-          url: http://134.2.17.68:8081/
+          url: http://huttenhower.sph.harvard.edu/galaxy/
         Koslicki Lab Galaxy:
           supported: false
           url: http://math-galaxy.cgrb.oregonstate.edu:8080/
@@ -4203,9 +3870,6 @@ sequence-analysis:
         Pitagora-Galaxy:
           supported: false
           url: http://try.pitagora-galaxy.org/galaxy/
-        RNA-Seq Portal:
-          supported: false
-          url: http://weizhongli-lab.org:8088
         South Green Galaxy:
           supported: false
           url: http://galaxy.southgreen.fr/galaxy/
@@ -4224,7 +3888,7 @@ sequence-analysis:
         workflow4metabolomics:
           supported: false
           url: http://galaxy.workflow4metabolomics.org
-      supported: false
+      supported: true
     genome-annotation:
       instances:
         ABiMS:
@@ -4233,9 +3897,6 @@ sequence-analysis:
         ABiMS Tools:
           supported: false
           url: http://webtools.sb-roscoff.fr
-        AGEseq Galaxy @ AspenDB:
-          supported: false
-          url: http://aspendb.uga.edu:8085/
         APOSTL Galaxy:
           supported: false
           url: http://apostl.moffitt.org/
@@ -4278,12 +3939,6 @@ sequence-analysis:
         GVL Melbourne:
           supported: false
           url: http://galaxy-mel.genome.edu.au/galaxy/
-        GVL Queensland:
-          supported: false
-          url: https://galaxy-qld.genome.edu.au/galaxy/
-        GVL-QLD:
-          supported: false
-          url: https://galaxy-qld.genome.edu.au/galaxy
         GVL-Tutorial:
           supported: false
           url: http://galaxy-tut.genome.edu.au/galaxy/
@@ -4314,9 +3969,9 @@ sequence-analysis:
         GrAPPA:
           supported: false
           url: https://grappa.eecs.utk.edu/grappa/
-        Halogen Bonding Galaxy:
+        Huttenhower Lab:
           supported: false
-          url: http://134.2.17.68:8081/
+          url: http://huttenhower.sph.harvard.edu/galaxy/
         Koslicki Lab Galaxy:
           supported: false
           url: http://math-galaxy.cgrb.oregonstate.edu:8080/
@@ -4353,9 +4008,6 @@ sequence-analysis:
         Pitagora-Galaxy:
           supported: false
           url: http://try.pitagora-galaxy.org/galaxy/
-        RNA-Seq Portal:
-          supported: false
-          url: http://weizhongli-lab.org:8088
         South Green Galaxy:
           supported: false
           url: http://galaxy.southgreen.fr/galaxy/
@@ -4383,9 +4035,6 @@ sequence-analysis:
         ABiMS Tools:
           supported: false
           url: http://webtools.sb-roscoff.fr
-        AGEseq Galaxy @ AspenDB:
-          supported: false
-          url: http://aspendb.uga.edu:8085/
         APOSTL Galaxy:
           supported: false
           url: http://apostl.moffitt.org/
@@ -4428,12 +4077,6 @@ sequence-analysis:
         GVL Melbourne:
           supported: true
           url: http://galaxy-mel.genome.edu.au/galaxy/
-        GVL Queensland:
-          supported: false
-          url: https://galaxy-qld.genome.edu.au/galaxy/
-        GVL-QLD:
-          supported: false
-          url: https://galaxy-qld.genome.edu.au/galaxy
         GVL-Tutorial:
           supported: false
           url: http://galaxy-tut.genome.edu.au/galaxy/
@@ -4464,9 +4107,9 @@ sequence-analysis:
         GrAPPA:
           supported: false
           url: https://grappa.eecs.utk.edu/grappa/
-        Halogen Bonding Galaxy:
+        Huttenhower Lab:
           supported: false
-          url: http://134.2.17.68:8081/
+          url: http://huttenhower.sph.harvard.edu/galaxy/
         Koslicki Lab Galaxy:
           supported: false
           url: http://math-galaxy.cgrb.oregonstate.edu:8080/
@@ -4503,9 +4146,6 @@ sequence-analysis:
         Pitagora-Galaxy:
           supported: false
           url: http://try.pitagora-galaxy.org/galaxy/
-        RNA-Seq Portal:
-          supported: false
-          url: http://weizhongli-lab.org:8088
         South Green Galaxy:
           supported: false
           url: http://galaxy.southgreen.fr/galaxy/
@@ -4533,9 +4173,6 @@ sequence-analysis:
         ABiMS Tools:
           supported: false
           url: http://webtools.sb-roscoff.fr
-        AGEseq Galaxy @ AspenDB:
-          supported: false
-          url: http://aspendb.uga.edu:8085/
         APOSTL Galaxy:
           supported: false
           url: http://apostl.moffitt.org/
@@ -4578,12 +4215,6 @@ sequence-analysis:
         GVL Melbourne:
           supported: true
           url: http://galaxy-mel.genome.edu.au/galaxy/
-        GVL Queensland:
-          supported: false
-          url: https://galaxy-qld.genome.edu.au/galaxy/
-        GVL-QLD:
-          supported: false
-          url: https://galaxy-qld.genome.edu.au/galaxy
         GVL-Tutorial:
           supported: false
           url: http://galaxy-tut.genome.edu.au/galaxy/
@@ -4614,9 +4245,9 @@ sequence-analysis:
         GrAPPA:
           supported: false
           url: https://grappa.eecs.utk.edu/grappa/
-        Halogen Bonding Galaxy:
+        Huttenhower Lab:
           supported: false
-          url: http://134.2.17.68:8081/
+          url: http://huttenhower.sph.harvard.edu/galaxy/
         Koslicki Lab Galaxy:
           supported: false
           url: http://math-galaxy.cgrb.oregonstate.edu:8080/
@@ -4653,9 +4284,6 @@ sequence-analysis:
         Pitagora-Galaxy:
           supported: false
           url: http://try.pitagora-galaxy.org/galaxy/
-        RNA-Seq Portal:
-          supported: false
-          url: http://weizhongli-lab.org:8088
         South Green Galaxy:
           supported: false
           url: http://galaxy.southgreen.fr/galaxy/
@@ -4683,9 +4311,6 @@ sequence-analysis:
         ABiMS Tools:
           supported: false
           url: http://webtools.sb-roscoff.fr
-        AGEseq Galaxy @ AspenDB:
-          supported: false
-          url: http://aspendb.uga.edu:8085/
         APOSTL Galaxy:
           supported: false
           url: http://apostl.moffitt.org/
@@ -4728,12 +4353,6 @@ sequence-analysis:
         GVL Melbourne:
           supported: false
           url: http://galaxy-mel.genome.edu.au/galaxy/
-        GVL Queensland:
-          supported: false
-          url: https://galaxy-qld.genome.edu.au/galaxy/
-        GVL-QLD:
-          supported: false
-          url: https://galaxy-qld.genome.edu.au/galaxy
         GVL-Tutorial:
           supported: false
           url: http://galaxy-tut.genome.edu.au/galaxy/
@@ -4764,9 +4383,9 @@ sequence-analysis:
         GrAPPA:
           supported: false
           url: https://grappa.eecs.utk.edu/grappa/
-        Halogen Bonding Galaxy:
+        Huttenhower Lab:
           supported: false
-          url: http://134.2.17.68:8081/
+          url: http://huttenhower.sph.harvard.edu/galaxy/
         Koslicki Lab Galaxy:
           supported: false
           url: http://math-galaxy.cgrb.oregonstate.edu:8080/
@@ -4803,9 +4422,6 @@ sequence-analysis:
         Pitagora-Galaxy:
           supported: false
           url: http://try.pitagora-galaxy.org/galaxy/
-        RNA-Seq Portal:
-          supported: false
-          url: http://weizhongli-lab.org:8088
         South Green Galaxy:
           supported: false
           url: http://galaxy.southgreen.fr/galaxy/
@@ -4836,9 +4452,6 @@ training:
         ABiMS Tools:
           supported: true
           url: http://webtools.sb-roscoff.fr
-        AGEseq Galaxy @ AspenDB:
-          supported: false
-          url: http://aspendb.uga.edu:8085/
         APOSTL Galaxy:
           supported: false
           url: http://apostl.moffitt.org/
@@ -4881,12 +4494,6 @@ training:
         GVL Melbourne:
           supported: true
           url: http://galaxy-mel.genome.edu.au/galaxy/
-        GVL Queensland:
-          supported: true
-          url: https://galaxy-qld.genome.edu.au/galaxy/
-        GVL-QLD:
-          supported: true
-          url: https://galaxy-qld.genome.edu.au/galaxy
         GVL-Tutorial:
           supported: true
           url: http://galaxy-tut.genome.edu.au/galaxy/
@@ -4917,9 +4524,9 @@ training:
         GrAPPA:
           supported: false
           url: https://grappa.eecs.utk.edu/grappa/
-        Halogen Bonding Galaxy:
+        Huttenhower Lab:
           supported: false
-          url: http://134.2.17.68:8081/
+          url: http://huttenhower.sph.harvard.edu/galaxy/
         Koslicki Lab Galaxy:
           supported: false
           url: http://math-galaxy.cgrb.oregonstate.edu:8080/
@@ -4956,9 +4563,6 @@ training:
         Pitagora-Galaxy:
           supported: false
           url: http://try.pitagora-galaxy.org/galaxy/
-        RNA-Seq Portal:
-          supported: false
-          url: http://weizhongli-lab.org:8088
         South Green Galaxy:
           supported: true
           url: http://galaxy.southgreen.fr/galaxy/
@@ -4986,9 +4590,6 @@ training:
         ABiMS Tools:
           supported: true
           url: http://webtools.sb-roscoff.fr
-        AGEseq Galaxy @ AspenDB:
-          supported: false
-          url: http://aspendb.uga.edu:8085/
         APOSTL Galaxy:
           supported: false
           url: http://apostl.moffitt.org/
@@ -5031,12 +4632,6 @@ training:
         GVL Melbourne:
           supported: true
           url: http://galaxy-mel.genome.edu.au/galaxy/
-        GVL Queensland:
-          supported: true
-          url: https://galaxy-qld.genome.edu.au/galaxy/
-        GVL-QLD:
-          supported: true
-          url: https://galaxy-qld.genome.edu.au/galaxy
         GVL-Tutorial:
           supported: true
           url: http://galaxy-tut.genome.edu.au/galaxy/
@@ -5067,9 +4662,9 @@ training:
         GrAPPA:
           supported: false
           url: https://grappa.eecs.utk.edu/grappa/
-        Halogen Bonding Galaxy:
+        Huttenhower Lab:
           supported: false
-          url: http://134.2.17.68:8081/
+          url: http://huttenhower.sph.harvard.edu/galaxy/
         Koslicki Lab Galaxy:
           supported: false
           url: http://math-galaxy.cgrb.oregonstate.edu:8080/
@@ -5106,9 +4701,6 @@ training:
         Pitagora-Galaxy:
           supported: false
           url: http://try.pitagora-galaxy.org/galaxy/
-        RNA-Seq Portal:
-          supported: false
-          url: http://weizhongli-lab.org:8088
         South Green Galaxy:
           supported: true
           url: http://galaxy.southgreen.fr/galaxy/
@@ -5136,9 +4728,6 @@ training:
         ABiMS Tools:
           supported: true
           url: http://webtools.sb-roscoff.fr
-        AGEseq Galaxy @ AspenDB:
-          supported: false
-          url: http://aspendb.uga.edu:8085/
         APOSTL Galaxy:
           supported: false
           url: http://apostl.moffitt.org/
@@ -5181,12 +4770,6 @@ training:
         GVL Melbourne:
           supported: true
           url: http://galaxy-mel.genome.edu.au/galaxy/
-        GVL Queensland:
-          supported: true
-          url: https://galaxy-qld.genome.edu.au/galaxy/
-        GVL-QLD:
-          supported: true
-          url: https://galaxy-qld.genome.edu.au/galaxy
         GVL-Tutorial:
           supported: true
           url: http://galaxy-tut.genome.edu.au/galaxy/
@@ -5217,9 +4800,9 @@ training:
         GrAPPA:
           supported: false
           url: https://grappa.eecs.utk.edu/grappa/
-        Halogen Bonding Galaxy:
+        Huttenhower Lab:
           supported: false
-          url: http://134.2.17.68:8081/
+          url: http://huttenhower.sph.harvard.edu/galaxy/
         Koslicki Lab Galaxy:
           supported: false
           url: http://math-galaxy.cgrb.oregonstate.edu:8080/
@@ -5256,9 +4839,6 @@ training:
         Pitagora-Galaxy:
           supported: false
           url: http://try.pitagora-galaxy.org/galaxy/
-        RNA-Seq Portal:
-          supported: false
-          url: http://weizhongli-lab.org:8088
         South Green Galaxy:
           supported: true
           url: http://galaxy.southgreen.fr/galaxy/
@@ -5286,9 +4866,6 @@ training:
         ABiMS Tools:
           supported: true
           url: http://webtools.sb-roscoff.fr
-        AGEseq Galaxy @ AspenDB:
-          supported: false
-          url: http://aspendb.uga.edu:8085/
         APOSTL Galaxy:
           supported: false
           url: http://apostl.moffitt.org/
@@ -5331,12 +4908,6 @@ training:
         GVL Melbourne:
           supported: true
           url: http://galaxy-mel.genome.edu.au/galaxy/
-        GVL Queensland:
-          supported: true
-          url: https://galaxy-qld.genome.edu.au/galaxy/
-        GVL-QLD:
-          supported: true
-          url: https://galaxy-qld.genome.edu.au/galaxy
         GVL-Tutorial:
           supported: true
           url: http://galaxy-tut.genome.edu.au/galaxy/
@@ -5367,9 +4938,9 @@ training:
         GrAPPA:
           supported: false
           url: https://grappa.eecs.utk.edu/grappa/
-        Halogen Bonding Galaxy:
+        Huttenhower Lab:
           supported: false
-          url: http://134.2.17.68:8081/
+          url: http://huttenhower.sph.harvard.edu/galaxy/
         Koslicki Lab Galaxy:
           supported: false
           url: http://math-galaxy.cgrb.oregonstate.edu:8080/
@@ -5406,9 +4977,6 @@ training:
         Pitagora-Galaxy:
           supported: false
           url: http://try.pitagora-galaxy.org/galaxy/
-        RNA-Seq Portal:
-          supported: false
-          url: http://weizhongli-lab.org:8088
         South Green Galaxy:
           supported: true
           url: http://galaxy.southgreen.fr/galaxy/
@@ -5436,9 +5004,6 @@ training:
         ABiMS Tools:
           supported: true
           url: http://webtools.sb-roscoff.fr
-        AGEseq Galaxy @ AspenDB:
-          supported: false
-          url: http://aspendb.uga.edu:8085/
         APOSTL Galaxy:
           supported: false
           url: http://apostl.moffitt.org/
@@ -5481,12 +5046,6 @@ training:
         GVL Melbourne:
           supported: true
           url: http://galaxy-mel.genome.edu.au/galaxy/
-        GVL Queensland:
-          supported: true
-          url: https://galaxy-qld.genome.edu.au/galaxy/
-        GVL-QLD:
-          supported: true
-          url: https://galaxy-qld.genome.edu.au/galaxy
         GVL-Tutorial:
           supported: true
           url: http://galaxy-tut.genome.edu.au/galaxy/
@@ -5517,9 +5076,9 @@ training:
         GrAPPA:
           supported: false
           url: https://grappa.eecs.utk.edu/grappa/
-        Halogen Bonding Galaxy:
+        Huttenhower Lab:
           supported: false
-          url: http://134.2.17.68:8081/
+          url: http://huttenhower.sph.harvard.edu/galaxy/
         Koslicki Lab Galaxy:
           supported: false
           url: http://math-galaxy.cgrb.oregonstate.edu:8080/
@@ -5556,9 +5115,6 @@ training:
         Pitagora-Galaxy:
           supported: false
           url: http://try.pitagora-galaxy.org/galaxy/
-        RNA-Seq Portal:
-          supported: false
-          url: http://weizhongli-lab.org:8088
         South Green Galaxy:
           supported: true
           url: http://galaxy.southgreen.fr/galaxy/
@@ -5589,9 +5145,6 @@ transcriptomics:
         ABiMS Tools:
           supported: false
           url: http://webtools.sb-roscoff.fr
-        AGEseq Galaxy @ AspenDB:
-          supported: false
-          url: http://aspendb.uga.edu:8085/
         APOSTL Galaxy:
           supported: false
           url: http://apostl.moffitt.org/
@@ -5634,12 +5187,6 @@ transcriptomics:
         GVL Melbourne:
           supported: false
           url: http://galaxy-mel.genome.edu.au/galaxy/
-        GVL Queensland:
-          supported: false
-          url: https://galaxy-qld.genome.edu.au/galaxy/
-        GVL-QLD:
-          supported: false
-          url: https://galaxy-qld.genome.edu.au/galaxy
         GVL-Tutorial:
           supported: false
           url: http://galaxy-tut.genome.edu.au/galaxy/
@@ -5670,9 +5217,9 @@ transcriptomics:
         GrAPPA:
           supported: false
           url: https://grappa.eecs.utk.edu/grappa/
-        Halogen Bonding Galaxy:
+        Huttenhower Lab:
           supported: false
-          url: http://134.2.17.68:8081/
+          url: http://huttenhower.sph.harvard.edu/galaxy/
         Koslicki Lab Galaxy:
           supported: false
           url: http://math-galaxy.cgrb.oregonstate.edu:8080/
@@ -5709,9 +5256,6 @@ transcriptomics:
         Pitagora-Galaxy:
           supported: false
           url: http://try.pitagora-galaxy.org/galaxy/
-        RNA-Seq Portal:
-          supported: false
-          url: http://weizhongli-lab.org:8088
         South Green Galaxy:
           supported: false
           url: http://galaxy.southgreen.fr/galaxy/
@@ -5739,9 +5283,6 @@ transcriptomics:
         ABiMS Tools:
           supported: false
           url: http://webtools.sb-roscoff.fr
-        AGEseq Galaxy @ AspenDB:
-          supported: false
-          url: http://aspendb.uga.edu:8085/
         APOSTL Galaxy:
           supported: false
           url: http://apostl.moffitt.org/
@@ -5784,12 +5325,6 @@ transcriptomics:
         GVL Melbourne:
           supported: false
           url: http://galaxy-mel.genome.edu.au/galaxy/
-        GVL Queensland:
-          supported: false
-          url: https://galaxy-qld.genome.edu.au/galaxy/
-        GVL-QLD:
-          supported: false
-          url: https://galaxy-qld.genome.edu.au/galaxy
         GVL-Tutorial:
           supported: false
           url: http://galaxy-tut.genome.edu.au/galaxy/
@@ -5820,9 +5355,9 @@ transcriptomics:
         GrAPPA:
           supported: false
           url: https://grappa.eecs.utk.edu/grappa/
-        Halogen Bonding Galaxy:
+        Huttenhower Lab:
           supported: false
-          url: http://134.2.17.68:8081/
+          url: http://huttenhower.sph.harvard.edu/galaxy/
         Koslicki Lab Galaxy:
           supported: false
           url: http://math-galaxy.cgrb.oregonstate.edu:8080/
@@ -5859,9 +5394,6 @@ transcriptomics:
         Pitagora-Galaxy:
           supported: false
           url: http://try.pitagora-galaxy.org/galaxy/
-        RNA-Seq Portal:
-          supported: false
-          url: http://weizhongli-lab.org:8088
         South Green Galaxy:
           supported: false
           url: http://galaxy.southgreen.fr/galaxy/
@@ -5889,9 +5421,6 @@ transcriptomics:
         ABiMS Tools:
           supported: false
           url: http://webtools.sb-roscoff.fr
-        AGEseq Galaxy @ AspenDB:
-          supported: false
-          url: http://aspendb.uga.edu:8085/
         APOSTL Galaxy:
           supported: false
           url: http://apostl.moffitt.org/
@@ -5934,12 +5463,6 @@ transcriptomics:
         GVL Melbourne:
           supported: false
           url: http://galaxy-mel.genome.edu.au/galaxy/
-        GVL Queensland:
-          supported: false
-          url: https://galaxy-qld.genome.edu.au/galaxy/
-        GVL-QLD:
-          supported: false
-          url: https://galaxy-qld.genome.edu.au/galaxy
         GVL-Tutorial:
           supported: false
           url: http://galaxy-tut.genome.edu.au/galaxy/
@@ -5970,9 +5493,9 @@ transcriptomics:
         GrAPPA:
           supported: false
           url: https://grappa.eecs.utk.edu/grappa/
-        Halogen Bonding Galaxy:
+        Huttenhower Lab:
           supported: false
-          url: http://134.2.17.68:8081/
+          url: http://huttenhower.sph.harvard.edu/galaxy/
         Koslicki Lab Galaxy:
           supported: false
           url: http://math-galaxy.cgrb.oregonstate.edu:8080/
@@ -6009,9 +5532,6 @@ transcriptomics:
         Pitagora-Galaxy:
           supported: false
           url: http://try.pitagora-galaxy.org/galaxy/
-        RNA-Seq Portal:
-          supported: false
-          url: http://weizhongli-lab.org:8088
         South Green Galaxy:
           supported: false
           url: http://galaxy.southgreen.fr/galaxy/
@@ -6039,9 +5559,6 @@ transcriptomics:
         ABiMS Tools:
           supported: false
           url: http://webtools.sb-roscoff.fr
-        AGEseq Galaxy @ AspenDB:
-          supported: false
-          url: http://aspendb.uga.edu:8085/
         APOSTL Galaxy:
           supported: false
           url: http://apostl.moffitt.org/
@@ -6084,12 +5601,6 @@ transcriptomics:
         GVL Melbourne:
           supported: false
           url: http://galaxy-mel.genome.edu.au/galaxy/
-        GVL Queensland:
-          supported: false
-          url: https://galaxy-qld.genome.edu.au/galaxy/
-        GVL-QLD:
-          supported: false
-          url: https://galaxy-qld.genome.edu.au/galaxy
         GVL-Tutorial:
           supported: false
           url: http://galaxy-tut.genome.edu.au/galaxy/
@@ -6120,9 +5631,9 @@ transcriptomics:
         GrAPPA:
           supported: false
           url: https://grappa.eecs.utk.edu/grappa/
-        Halogen Bonding Galaxy:
+        Huttenhower Lab:
           supported: false
-          url: http://134.2.17.68:8081/
+          url: http://huttenhower.sph.harvard.edu/galaxy/
         Koslicki Lab Galaxy:
           supported: false
           url: http://math-galaxy.cgrb.oregonstate.edu:8080/
@@ -6159,9 +5670,6 @@ transcriptomics:
         Pitagora-Galaxy:
           supported: false
           url: http://try.pitagora-galaxy.org/galaxy/
-        RNA-Seq Portal:
-          supported: false
-          url: http://weizhongli-lab.org:8088
         South Green Galaxy:
           supported: false
           url: http://galaxy.southgreen.fr/galaxy/
@@ -6192,9 +5700,6 @@ variant-analysis:
         ABiMS Tools:
           supported: false
           url: http://webtools.sb-roscoff.fr
-        AGEseq Galaxy @ AspenDB:
-          supported: false
-          url: http://aspendb.uga.edu:8085/
         APOSTL Galaxy:
           supported: false
           url: http://apostl.moffitt.org/
@@ -6237,12 +5742,6 @@ variant-analysis:
         GVL Melbourne:
           supported: false
           url: http://galaxy-mel.genome.edu.au/galaxy/
-        GVL Queensland:
-          supported: false
-          url: https://galaxy-qld.genome.edu.au/galaxy/
-        GVL-QLD:
-          supported: false
-          url: https://galaxy-qld.genome.edu.au/galaxy
         GVL-Tutorial:
           supported: false
           url: http://galaxy-tut.genome.edu.au/galaxy/
@@ -6250,7 +5749,7 @@ variant-analysis:
           supported: false
           url: http://use.galaxeast.fr/
         Galaxy Europe:
-          supported: false
+          supported: true
           url: https://usegalaxy.eu
         Galaxy Palfinder:
           supported: false
@@ -6273,9 +5772,9 @@ variant-analysis:
         GrAPPA:
           supported: false
           url: https://grappa.eecs.utk.edu/grappa/
-        Halogen Bonding Galaxy:
+        Huttenhower Lab:
           supported: false
-          url: http://134.2.17.68:8081/
+          url: http://huttenhower.sph.harvard.edu/galaxy/
         Koslicki Lab Galaxy:
           supported: false
           url: http://math-galaxy.cgrb.oregonstate.edu:8080/
@@ -6312,9 +5811,6 @@ variant-analysis:
         Pitagora-Galaxy:
           supported: false
           url: http://try.pitagora-galaxy.org/galaxy/
-        RNA-Seq Portal:
-          supported: false
-          url: http://weizhongli-lab.org:8088
         South Green Galaxy:
           supported: false
           url: http://galaxy.southgreen.fr/galaxy/
@@ -6333,7 +5829,7 @@ variant-analysis:
         workflow4metabolomics:
           supported: false
           url: http://galaxy.workflow4metabolomics.org
-      supported: false
+      supported: true
     exome-seq:
       instances:
         ABiMS:
@@ -6342,9 +5838,6 @@ variant-analysis:
         ABiMS Tools:
           supported: false
           url: http://webtools.sb-roscoff.fr
-        AGEseq Galaxy @ AspenDB:
-          supported: false
-          url: http://aspendb.uga.edu:8085/
         APOSTL Galaxy:
           supported: false
           url: http://apostl.moffitt.org/
@@ -6387,12 +5880,6 @@ variant-analysis:
         GVL Melbourne:
           supported: false
           url: http://galaxy-mel.genome.edu.au/galaxy/
-        GVL Queensland:
-          supported: false
-          url: https://galaxy-qld.genome.edu.au/galaxy/
-        GVL-QLD:
-          supported: false
-          url: https://galaxy-qld.genome.edu.au/galaxy
         GVL-Tutorial:
           supported: false
           url: http://galaxy-tut.genome.edu.au/galaxy/
@@ -6400,7 +5887,7 @@ variant-analysis:
           supported: false
           url: http://use.galaxeast.fr/
         Galaxy Europe:
-          supported: false
+          supported: true
           url: https://usegalaxy.eu
         Galaxy Palfinder:
           supported: false
@@ -6423,9 +5910,9 @@ variant-analysis:
         GrAPPA:
           supported: false
           url: https://grappa.eecs.utk.edu/grappa/
-        Halogen Bonding Galaxy:
+        Huttenhower Lab:
           supported: false
-          url: http://134.2.17.68:8081/
+          url: http://huttenhower.sph.harvard.edu/galaxy/
         Koslicki Lab Galaxy:
           supported: false
           url: http://math-galaxy.cgrb.oregonstate.edu:8080/
@@ -6462,9 +5949,6 @@ variant-analysis:
         Pitagora-Galaxy:
           supported: false
           url: http://try.pitagora-galaxy.org/galaxy/
-        RNA-Seq Portal:
-          supported: false
-          url: http://weizhongli-lab.org:8088
         South Green Galaxy:
           supported: false
           url: http://galaxy.southgreen.fr/galaxy/
@@ -6483,7 +5967,7 @@ variant-analysis:
         workflow4metabolomics:
           supported: false
           url: http://galaxy.workflow4metabolomics.org
-      supported: false
+      supported: true
     mapping-by-sequencing:
       instances:
         ABiMS:
@@ -6492,9 +5976,6 @@ variant-analysis:
         ABiMS Tools:
           supported: false
           url: http://webtools.sb-roscoff.fr
-        AGEseq Galaxy @ AspenDB:
-          supported: false
-          url: http://aspendb.uga.edu:8085/
         APOSTL Galaxy:
           supported: false
           url: http://apostl.moffitt.org/
@@ -6537,12 +6018,6 @@ variant-analysis:
         GVL Melbourne:
           supported: false
           url: http://galaxy-mel.genome.edu.au/galaxy/
-        GVL Queensland:
-          supported: false
-          url: https://galaxy-qld.genome.edu.au/galaxy/
-        GVL-QLD:
-          supported: false
-          url: https://galaxy-qld.genome.edu.au/galaxy
         GVL-Tutorial:
           supported: false
           url: http://galaxy-tut.genome.edu.au/galaxy/
@@ -6573,9 +6048,9 @@ variant-analysis:
         GrAPPA:
           supported: false
           url: https://grappa.eecs.utk.edu/grappa/
-        Halogen Bonding Galaxy:
+        Huttenhower Lab:
           supported: false
-          url: http://134.2.17.68:8081/
+          url: http://huttenhower.sph.harvard.edu/galaxy/
         Koslicki Lab Galaxy:
           supported: false
           url: http://math-galaxy.cgrb.oregonstate.edu:8080/
@@ -6612,9 +6087,6 @@ variant-analysis:
         Pitagora-Galaxy:
           supported: false
           url: http://try.pitagora-galaxy.org/galaxy/
-        RNA-Seq Portal:
-          supported: false
-          url: http://weizhongli-lab.org:8088
         South Green Galaxy:
           supported: false
           url: http://galaxy.southgreen.fr/galaxy/
@@ -6642,9 +6114,6 @@ variant-analysis:
         ABiMS Tools:
           supported: false
           url: http://webtools.sb-roscoff.fr
-        AGEseq Galaxy @ AspenDB:
-          supported: false
-          url: http://aspendb.uga.edu:8085/
         APOSTL Galaxy:
           supported: false
           url: http://apostl.moffitt.org/
@@ -6687,12 +6156,6 @@ variant-analysis:
         GVL Melbourne:
           supported: true
           url: http://galaxy-mel.genome.edu.au/galaxy/
-        GVL Queensland:
-          supported: false
-          url: https://galaxy-qld.genome.edu.au/galaxy/
-        GVL-QLD:
-          supported: false
-          url: https://galaxy-qld.genome.edu.au/galaxy
         GVL-Tutorial:
           supported: false
           url: http://galaxy-tut.genome.edu.au/galaxy/
@@ -6723,9 +6186,9 @@ variant-analysis:
         GrAPPA:
           supported: false
           url: https://grappa.eecs.utk.edu/grappa/
-        Halogen Bonding Galaxy:
+        Huttenhower Lab:
           supported: false
-          url: http://134.2.17.68:8081/
+          url: http://huttenhower.sph.harvard.edu/galaxy/
         Koslicki Lab Galaxy:
           supported: false
           url: http://math-galaxy.cgrb.oregonstate.edu:8080/
@@ -6762,9 +6225,6 @@ variant-analysis:
         Pitagora-Galaxy:
           supported: false
           url: http://try.pitagora-galaxy.org/galaxy/
-        RNA-Seq Portal:
-          supported: false
-          url: http://weizhongli-lab.org:8088
         South Green Galaxy:
           supported: false
           url: http://galaxy.southgreen.fr/galaxy/

--- a/topics/chip-seq/tutorials/tal1-binding-site-identification/tools.yaml
+++ b/topics/chip-seq/tutorials/tal1-binding-site-identification/tools.yaml
@@ -3,15 +3,47 @@ api_key: admin
 galaxy_instance: http://localhost:8080
 
 tools:
-  - name: suite_samtools_1_2
-    owner: devteam
-    tool_panel_section_label: "SAMtools"
-
   - name: macs2
     owner: iuc
     tool_panel_section_label: "Macs2"
 
-  - name: suite_deeptools
+  - name: deeptools_correct_gc_bias
+    owner: bgruening
+    tool_panel_section_label: "deepTools"
+
+  - name: deeptools_multi_bam_summary
+    owner: bgruening
+    tool_panel_section_label: "deepTools"
+
+  - name: deeptools_plot_correlation
+    owner: bgruening
+    tool_panel_section_label: "deepTools"
+
+  - name: deeptools_plot_fingerprint
+    owner: bgruening
+    tool_panel_section_label: "deepTools"
+
+  - name: deeptools_bam_compare
+    owner: bgruening
+    tool_panel_section_label: "deepTools"
+
+  - name: deeptools_plot_profile
+    owner: bgruening
+    tool_panel_section_label: "deepTools"
+
+  - name: deeptools_compute_matrix
+    owner: bgruening
+    tool_panel_section_label: "deepTools"
+
+  - name: deeptools_plot_heatmap
+    owner: bgruening
+    tool_panel_section_label: "deepTools"
+
+  - name: deeptools_compute_gc_bias
+    owner: bgruening
+    tool_panel_section_label: "deepTools"
+
+   - name: deeptools_compute_matrix
     owner: bgruening
     tool_panel_section_label: "deepTools"
 

--- a/topics/chip-seq/tutorials/tal1-binding-site-identification/tools.yaml
+++ b/topics/chip-seq/tutorials/tal1-binding-site-identification/tools.yaml
@@ -43,7 +43,7 @@ tools:
     owner: bgruening
     tool_panel_section_label: "deepTools"
 
-   - name: deeptools_compute_matrix
+  - name: deeptools_compute_matrix
     owner: bgruening
     tool_panel_section_label: "deepTools"
 

--- a/topics/metagenomics/tutorials/general-tutorial/tools.yaml
+++ b/topics/metagenomics/tutorials/general-tutorial/tools.yaml
@@ -3,28 +3,71 @@
 api_key: admin
 galaxy_instance: http://localhost:8080
 tools:
+  - name: taxonomy_krona_chart
+    owner: crs4
+    tool_panel_section_label: Krona
 
-  - name: 'suite_metaphlan2'
-    owner: 'iuc'
-    tool_panel_section_label: 'MetaPhlAn2'
-
-  - name: 'suite_humann2'
-    owner: 'iuc'
-    tool_panel_section_label: 'HUMAnN2'
-
-  - name: 'combine_metaphlan2_humann2'
-    owner: 'bebatut'
-    tool_panel_section_label: 'Combine MetaPhlAn2 and HUMAnN2'
-
-  - name: 'taxonomy_krona_chart'
-    owner: 'crs4'
-    tool_panel_section_label: 'KRONA'
-
-  - name: suite_mothur
+  # WGS workflow
+  - name: metaphlan2
     owner: iuc
-    tool_panel_section_label: "Mothur"
+    tool_panel_section_label: MetaPhlAn2
+  - name: humann2
+    owner: iuc
+    tool_panel_section_label: MetaPhlAn2
+  - name: metaphlan2krona
+    owner: iuc
+    tool_panel_section_label: HUMAnN2
+  - name: humann2_renorm_table
+    owner: iuc
+    tool_panel_section_label: HUMAnN2
+  - name: humann2_regroup_table
+    owner: iuc
+    tool_panel_section_label: HUMAnN2
 
-  # this version of Krona saves some annoying file conversion steps from mothur output files
-  - name: krona_text
-    owner: saskia-hiltemann
-    tool_panel_section_label: "Krona"
+  # Amplicon workflow
+  - name: mothur_make_biom
+    owner: iuc
+    tool_panel_section_label: Mothur
+  - name: mothur_merge_files
+    owner: iuc
+    tool_panel_section_label: Mothur
+  - name: mothur_unique_seqs
+    owner: iuc
+    tool_panel_section_label: Mothur
+  - name: mothur_make_group
+    owner: iuc
+    tool_panel_section_label: Mothur
+  - name: mothur_summary_seqs
+    owner: iuc
+    tool_panel_section_label: Mothur
+  - name: mothur_count_seqs
+    owner: iuc
+    tool_panel_section_label: Mothur
+  - name: mothur_align_seqs
+    owner: iuc
+    tool_panel_section_label: Mothur
+  - name: mothur_screen_seqs
+    owner: iuc
+    tool_panel_section_label: Mothur
+  - name: mothur_pre_cluster
+    owner: iuc
+    tool_panel_section_label: Mothur
+  - name: mothur_filter_seqs
+    owner: iuc
+    tool_panel_section_label: Mothur
+  - name: mothur_cluster_split
+    owner: iuc
+    tool_panel_section_label: Mothur
+  - name: mothur_classify_seqs
+    owner: iuc
+    tool_panel_section_label: Mothur
+  - name: mothur_classify_otu
+    owner: iuc
+    tool_panel_section_label: Mothur
+  - name: mothur_make_shared
+    owner: iuc
+    tool_panel_section_label: Mothur
+  - name: mothur_taxonomy_to_krona
+    owner: iuc
+    tool_panel_section_label: Mothur
+

--- a/topics/metagenomics/tutorials/general-tutorial/tools.yaml
+++ b/topics/metagenomics/tutorials/general-tutorial/tools.yaml
@@ -70,4 +70,3 @@ tools:
   - name: mothur_taxonomy_to_krona
     owner: iuc
     tool_panel_section_label: Mothur
-

--- a/topics/metagenomics/tutorials/mothur-miseq-sop/tools.yaml
+++ b/topics/metagenomics/tutorials/mothur-miseq-sop/tools.yaml
@@ -131,3 +131,6 @@ tools:
   - name: mothur_corr_axes
     owner: iuc
     tool_panel_section_label: "Mothur"
+  - name: mothur_taxonomy_to_krona
+    owner: iuc
+    tool_panel_section_label: "Mothur"

--- a/topics/metagenomics/tutorials/mothur-miseq-sop/tools.yaml
+++ b/topics/metagenomics/tutorials/mothur-miseq-sop/tools.yaml
@@ -1,13 +1,10 @@
 ---
 api_key: admin
 galaxy_instance: http://localhost:8080
-tool_shed_url: https://toolshed.g2.bx.psu.edu/
+
 install_resolver_dependencies: true
 install_tool_dependencies: false
 tools:
-  - name: suite_mothur
-    owner: iuc
-    tool_panel_section_label: "Mothur"
   - name: xy_plot
     owner: devteam
     tool_panel_section_label: "Visualisation"
@@ -20,3 +17,117 @@ tools:
   - name: taxonomy_krona_chart
     owner: crs4
     tool_panel_section_label: "Visualisation"
+  - name: mothur_make_contigs
+    owner: iuc
+    tool_panel_section_label: "Mothur"
+  - name: mothur_summary_seqs
+    owner: iuc
+    tool_panel_section_label: "Mothur"
+  - name: mothur_screen_seqs
+    owner: iuc
+    tool_panel_section_label: "Mothur"
+  - name: mothur_unique_seqs
+    owner: iuc
+    tool_panel_section_label: "Mothur"
+  - name: mothur_count_seqs
+    owner: iuc
+    tool_panel_section_label: "Mothur"
+  - name: mothur_align_seqs
+    owner: iuc
+    tool_panel_section_label: "Mothur"
+  - name: mothur_filter_seqs
+    owner: iuc
+    tool_panel_section_label: "Mothur"
+  - name: mothur_pre_cluster
+    owner: iuc
+    tool_panel_section_label: "Mothur"
+  - name: mothur_chimera_uchime
+    owner: iuc
+    tool_panel_section_label: "Mothur"
+  - name: mothur_remove_seqs
+    owner: iuc
+    tool_panel_section_label: "Mothur"
+  - name: mothur_classify_seqs
+    owner: iuc
+    tool_panel_section_label: "Mothur"
+  - name: mothur_remove_lineage
+    owner: iuc
+    tool_panel_section_label: "Mothur"
+  - name: mothur_get_groups
+    owner: iuc
+    tool_panel_section_label: "Mothur"
+  - name: mothur_remove_groups
+    owner: iuc
+    tool_panel_section_label: "Mothur"
+  - name: mothur_seq_error
+    owner: iuc
+    tool_panel_section_label: "Mothur"
+  - name: mothur_dist_seqs
+    owner: iuc
+    tool_panel_section_label: "Mothur"
+  - name: mothur_cluster_split
+    owner: iuc
+    tool_panel_section_label: "Mothur"
+  - name: mothur_cluster
+    owner: iuc
+    tool_panel_section_label: "Mothur"
+  - name: mothur_make_shared
+    owner: iuc
+    tool_panel_section_label: "Mothur"
+  - name: mothur_classify_otu
+    owner: iuc
+    tool_panel_section_label: "Mothur"
+  - name: mothur_count_groups
+    owner: iuc
+    tool_panel_section_label: "Mothur"
+  - name: mothur_sub_sample
+    owner: iuc
+    tool_panel_section_label: "Mothur"
+  - name: mothur_rarefaction_single
+    owner: iuc
+    tool_panel_section_label: "Mothur"
+  - name: mothur_summary_single
+    owner: iuc
+    tool_panel_section_label: "Mothur"
+  - name: mothur_dist_shared
+    owner: iuc
+    tool_panel_section_label: "Mothur"
+  - name: mothur_heatmap_sim
+    owner: iuc
+    tool_panel_section_label: "Mothur"
+  - name: mothur_tree_shared
+    owner: iuc
+    tool_panel_section_label: "Mothur"
+  - name: mothur_pcoa
+    owner: iuc
+    tool_panel_section_label: "Mothur"
+  - name: mothur_nmds
+    owner: iuc
+    tool_panel_section_label: "Mothur"
+  - name: mothur_amova
+    owner: iuc
+    tool_panel_section_label: "Mothur"
+  - name: mothur_homova
+    owner: iuc
+    tool_panel_section_label: "Mothur"
+  - name: mothur_venn
+    owner: iuc
+    tool_panel_section_label: "Mothur"
+  - name: mothur_get_communitytype
+    owner: iuc
+    tool_panel_section_label: "Mothur"
+  - name: mothur_metastats
+    owner: iuc
+    tool_panel_section_label: "Mothur"
+  - name: mothur_lefse
+    owner: iuc
+    tool_panel_section_label: "Mothur"
+  - name: mothur_classify_rf
+    owner: iuc
+    tool_panel_section_label: "Mothur"
+  - name: mothur_parsimony
+    owner: iuc
+    tool_panel_section_label: "Mothur"
+  - name: mothur_corr_axes
+    owner: iuc
+    tool_panel_section_label: "Mothur"

--- a/topics/proteomics/tutorials/metaproteomics/tools.yaml
+++ b/topics/proteomics/tutorials/metaproteomics/tools.yaml
@@ -4,13 +4,16 @@ galaxy_instance: http://localhost:8080
 tools:
   - name: peptideshaker
     owner: galaxyp
-    tool_panel_section_label: "Proteomics"
+    tool_panel_section_label: Proteomics
   - name: unipept
     owner: galaxyp
-    tool_panel_section_label: "Proteomics"
+    tool_panel_section_label: Proteomics
   - name: searchgui
     owner: galaxyp
     tool_panel_section_label: Proteomics
-  - name: suite_query_tabular
+  - name: sqlite_to_tabular
     owner: iuc
-    tool_panel_section_label: "Text Manipulation"
+    tool_panel_section_label: Text Manipulation
+  - name: query_tabular
+    owner: iuc
+    tool_panel_section_label: Text Manipulation

--- a/topics/sequence-analysis/tutorials/de-novo-rad-seq/tools.yaml
+++ b/topics/sequence-analysis/tutorials/de-novo-rad-seq/tools.yaml
@@ -5,14 +5,21 @@ install_resolver_dependencies: true
 install_tool_dependencies: false
 
 tools:
-  - name: suite_stacks
+  - name: stacks_populations
     owner: iuc
-    tool_panel_section_label: "RAD-Seq"
-
+    tool_panel_section_label: RAD-Seq
+  - name: stacks_denovomap
+    owner: iuc
+    tool_panel_section_label: RAD-Seq
+  - name: stacks_procrad
+    owner: iuc
+    tool_panel_section_label: RAD-Seq
   - name: fastqc
     owner: devteam
-    tool_panel_section_label: "FastQC"
-
+    tool_panel_section_label: RAD-Seq
+  - name: fastqc
+    owner: devteam
+    tool_panel_section_label: Quality Control
   - name: concatenate_multiple_datasets
     owner: mvdbeek
-    tool_panel_section_label: "Concatenate datasets tail-to-head"
+    tool_panel_section_label: Text Manipulation

--- a/topics/sequence-analysis/tutorials/genetic-map-rad-seq/tools.yaml
+++ b/topics/sequence-analysis/tutorials/genetic-map-rad-seq/tools.yaml
@@ -4,6 +4,9 @@ galaxy_instance: http://localhost:8080
 install_resolver_dependencies: true
 install_tool_dependencies: false
 tools:
-  - name: suite_stacks
+  - name: stacks_denovomap
     owner: iuc
-    tool_panel_section_label: "RAD-Seq"
+    tool_panel_section_label: RAD-Seq
+  - name: stacks_genotypes
+    owner: iuc
+    tool_panel_section_label: RAD-Seq

--- a/topics/sequence-analysis/tutorials/ref-based-rad-seq/tools.yaml
+++ b/topics/sequence-analysis/tutorials/ref-based-rad-seq/tools.yaml
@@ -23,4 +23,3 @@ tools:
   - name: concatenate_multiple_datasets
     owner: mvdbeek
     tool_panel_section_label: Text Manipulation
-

--- a/topics/sequence-analysis/tutorials/ref-based-rad-seq/tools.yaml
+++ b/topics/sequence-analysis/tutorials/ref-based-rad-seq/tools.yaml
@@ -5,18 +5,22 @@ install_resolver_dependencies: true
 install_tool_dependencies: false
 
 tools:
-  - name: suite_stacks
+  - name: stacks_populations
     owner: iuc
-    tool_panel_section_label: "RAD-Seq"
-
+    tool_panel_section_label: RAD-Seq
+  - name: stacks_refmap
+    owner: iuc
+    tool_panel_section_label: RAD-Seq
+  - name: stacks_procrad
+    owner: iuc
+    tool_panel_section_label: RAD-Seq
+  - name: bwa_wrappers
+    owner: devteam
+    tool_panel_section_label: Mapping
   - name: fastqc
     owner: devteam
-    tool_panel_section_label: "FastQC"
-
+    tool_panel_section_label: Quality Control
   - name: concatenate_multiple_datasets
     owner: mvdbeek
-    tool_panel_section_label: "Concatenate datasets tail-to-head"
+    tool_panel_section_label: Text Manipulation
 
-  - name: bwa
-    owner: devteam
-    tool_panel_section_label: "BWA"

--- a/topics/variant-analysis/tutorials/diploid-variant-calling/tools.yaml
+++ b/topics/variant-analysis/tutorials/diploid-variant-calling/tools.yaml
@@ -8,9 +8,9 @@ tools:
     owner: iuc
     tool_panel_section_label: "Convert Formats"
 
-  - name: suite_vcflib_14_08
+  - name: vcfallelicprimitives
     owner: devteam
-    tool_panel_section_label: "VCF Tools"
+    tool_panel_section_label: "NGS: VCF Manipulation"
 
   - name: freebayes
     owner: devteam
@@ -24,7 +24,11 @@ tools:
     owner: iuc
     tool_panel_section_label: "Annotation"
 
-  - name: suite_gemini
+  - name: gemini_load
+    owner: iuc
+    tool_panel_section_label: "Gemini"
+
+  - name: gemini_query
     owner: iuc
     tool_panel_section_label: "Gemini"
 

--- a/topics/variant-analysis/tutorials/diploid-variant-calling/tools.yaml
+++ b/topics/variant-analysis/tutorials/diploid-variant-calling/tools.yaml
@@ -31,4 +31,3 @@ tools:
   - name: gemini_query
     owner: iuc
     tool_panel_section_label: "Gemini"
-

--- a/topics/variant-analysis/tutorials/diploid-variant-calling/tools.yaml
+++ b/topics/variant-analysis/tutorials/diploid-variant-calling/tools.yaml
@@ -32,10 +32,6 @@ tools:
     owner: iuc
     tool_panel_section_label: "Gemini"
 
-  - name: suite_samtools_1_2
-    owner: devteam
-    tool_panel_section_label: "SAM Tools"
-
   - name: vt_variant_tools
     owner: iuc
     tool_panel_section_label: "VCF Tools"

--- a/topics/variant-analysis/tutorials/diploid-variant-calling/tools.yaml
+++ b/topics/variant-analysis/tutorials/diploid-variant-calling/tools.yaml
@@ -32,6 +32,3 @@ tools:
     owner: iuc
     tool_panel_section_label: "Gemini"
 
-  - name: vt_variant_tools
-    owner: iuc
-    tool_panel_section_label: "VCF Tools"

--- a/topics/variant-analysis/tutorials/exome-seq/tools.yaml
+++ b/topics/variant-analysis/tutorials/exome-seq/tools.yaml
@@ -8,9 +8,13 @@ tools:
     owner: iuc
     tool_panel_section_label: "Convert Formats"
 
-  - name: suite_vcflib_14_08
+  - name: vcfallelicprimitives
     owner: devteam
-    tool_panel_section_label: "VCF Tools"
+    tool_panel_section_label: "NGS: VCF Manipulation"
+
+  - name: vcfcombine
+    owner: devteam
+    tool_panel_section_label: "NGS: VCF Manipulation"
 
   - name: freebayes
     owner: devteam
@@ -24,13 +28,13 @@ tools:
     owner: iuc
     tool_panel_section_label: "Annotation"
 
-  - name: suite_gemini
+  - name: gemini_load
     owner: iuc
     tool_panel_section_label: "Gemini"
 
-  - name: suite_samtools_1_2
-    owner: devteam
-    tool_panel_section_label: "SAM Tools"
+  - name: gemini_query
+    owner: iuc
+    tool_panel_section_label: "Gemini"
 
   - name: vt_variant_tools
     owner: iuc


### PR DESCRIPTION
The instance annotation cannot detect whether suites are installed, so explicitly list all the tools from the suite that are used in the tutorial in the tool.yaml file

also regenerates the instance annotation and badges