### PR TITLE
Preferred contact

### DIFF
--- a/CONTRIBUTORS.yaml
+++ b/CONTRIBUTORS.yaml
@@ -131,6 +131,7 @@ hrhotz:
 
 jennaj:
     name: Jennifer Hillman-Jackson
+    maintainer_contact: https://biostar.usegalaxy.org
     email: jen@galaxyproject.org
     gitter: jennaj
     twitter: jenhjackson
@@ -230,6 +231,7 @@ reginaesinamabotsi:
 
 shiltemann:
     name: Saskia Hiltemann
+    maintainer_contact: gitter
     email: zazkia@gmail.com
     twitter: shiltemann
     linkedin: shiltemann

--- a/_layouts/topic.html
+++ b/_layouts/topic.html
@@ -168,9 +168,9 @@ layout: base
                 <a href="{{ site.baseurl }}/hall-of-fame#{{ maintainer }}">{{ contributors[maintainer].name }}</a>
                 {% if contributors[maintainer].maintainer_contact %}
                     {% if contributors[maintainer].maintainer_contact == 'email' %}
-                    (<a href="mailto:{{ contributors[maintainer].email }}">Contact {% icon email %}</a>)
+                    (<a href="mailto:{{ contributors[maintainer].email }}">Contact {% icon email %}</a> )
                     {% elsif contributors[maintainer].maintainer_contact == 'gitter' %}
-                    (<a href="https://gitter.im/{{ contributors[maintainer].gitter }}">Contact {% icon gitter %}</a>)
+                    (<a href="https://gitter.im/{{ contributors[maintainer].gitter }}">Contact {% icon gitter %}</a> )
                     {% else %}
                     (<a href="{{ contributors[maintainer].maintainer_contact }}">Contact</a>)
                     {% endif %}

--- a/_layouts/topic.html
+++ b/_layouts/topic.html
@@ -52,7 +52,7 @@ layout: base
                 {% if material.enable != "false" %}
                         <script type="application/ld+json">
                             {% include material.jsonld content=material %}
-                        </script>  
+                        </script>
                     <tr>
                         <td>
                             {{ material.title }}
@@ -166,15 +166,22 @@ layout: base
         {% for maintainer in topic.maintainers %}
             <li>
                 <a href="{{ site.baseurl }}/hall-of-fame#{{ maintainer }}">{{ contributors[maintainer].name }}</a>
-                {% if contributors[maintainer].email and contributors[maintainer].email != "" %}
-                    (<a href="mailto:{{ contributors[maintainer].email }}">{{ contributors[maintainer].email }}</a>)
+                {% if contributors[maintainer].maintainer_contact %}
+                    {% if contributors[maintainer].maintainer_contact == 'email' %}
+                    (<a href="mailto:{{ contributors[maintainer].email }}">Contact {% icon email %}</a>)
+                    {% elsif contributors[maintainer].maintainer_contact == 'gitter' %}
+                    (<a href="https://gitter.im/{{ contributors[maintainer].gitter }}">Contact {% icon gitter %}</a>)
+                    {% else %}
+                    (<a href="{{ contributors[maintainer].maintainer_contact }}">Contact</a>)
+                    {% endif %}
+
                 {% endif %}
             </li>
         {% endfor %}
         </ul>
 
         <p>
-            <em>For any question related to this topic and the content, you can contact them.</em>
+            <em>For any question related to this topic and the content, you can contact them or visit our <a href="https://gitter.im/Galaxy-Training-Network/Lobby">Gitter channel</a>.</em>
         </p>
 
         <h2 id="contributors">Contributors</h2>


### PR DESCRIPTION
fixes #791 

if `maintainer_contact` is set in CONTRIBUTORS.yaml, display that after maintainer name. currently supports values `email`, `gitter` or a custom url. If nothing specified, the maintainer's name just links to their hall of fame entry.