### PR TITLE
fix links in admin intro slides

### DIFF
--- a/topics/admin/slides/introduction.html
+++ b/topics/admin/slides/introduction.html
@@ -88,6 +88,6 @@ logo: "GTN"
 
 ### Tutorials
 
-- [Deployment and Platform options](http://galaxyproject.github.io/training-material/topics/admin/tutorials/deployment-platforms-options/slides.html#1)
-- [Docker and Galaxy](http://galaxyproject.github.io/training-material/topics/admin/tutorials/galaxy-docker/slides.html#1)
-- [Galaxy Database schema](http://galaxyproject.github.io/training-material/topics/admin/tutorials/database-schema/tutorial.html)
+- [Deployment and Platform options]({{ site.baseurl }}/topics/admin/tutorials/deployment-platforms-options/slides.html#1)
+- [Docker and Galaxy]({{ site.baseurl }}/topics/admin/tutorials/galaxy-docker/slides.html#1)
+- [Galaxy Database schema]({{ site.baseurl }}/topics/admin/tutorials/database-schema/tutorial.html)

--- a/topics/admin/slides/introduction.html
+++ b/topics/admin/slides/introduction.html
@@ -88,7 +88,6 @@ logo: "GTN"
 
 ### Tutorials
 
-- [Move from dev instance to production instance](dev_to_production.html)
-- ['10 rules' for Setting up a Galaxy Instance as a Service](10rules_for_GaaS.html)
-- [Galaxy and Docker](galaxy_docker.html)
-- [Galaxy Database schema](database_schema.html)
+- [Deployment and Platform options](http://galaxyproject.github.io/training-material/topics/admin/tutorials/deployment-platforms-options/slides.html#1)
+- [Docker and Galaxy](http://galaxyproject.github.io/training-material/topics/admin/tutorials/galaxy-docker/slides.html#1)
+- [Galaxy Database schema](http://galaxyproject.github.io/training-material/topics/admin/tutorials/database-schema/tutorial.html)


### PR DESCRIPTION
I do not know how to link relatively here.

Also a slide is inserted with a link to 'Related tutorials' (https://github.com/galaxyproject/training-material/blob/master/topics/admin/tutorials/dev-to-production/tutorial.md) that is incomplete and shouldn't be linked I think