### PR TITLE
Add script to generate data-library.yaml file from Zenodo link

### DIFF
--- a/bin/create-data-libraries.sh
+++ b/bin/create-data-libraries.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+
+for tuto_dir in topics/*/tutorials/*
+do
+    tuto="$(basename $tuto_dir)"
+    topic="$(basename $(dirname $(dirname $tuto_dir)))"
+    echo "$topic / $tuto"
+    python bin/create-data-library.py --tutorial $tuto --topic $topic
+    echo ""
+done

--- a/bin/create-data-library.py
+++ b/bin/create-data-library.py
@@ -6,6 +6,12 @@ import yaml
 from pathlib import Path
 
 
+class MyDumper(yaml.Dumper):
+
+    def increase_indent(self, flow=False, indentless=False):
+        return super(MyDumper, self).increase_indent(flow, False)
+
+
 def get_metadata_info(tuto, metadata_filepath):
     '''
     Extract the Zenodo DOI of the tutorial from the metadata.yaml file and also 
@@ -88,7 +94,13 @@ def create_data_library(meta_info, tuto_dir, overwrite = False):
         print("The data library file already exist and will be overwrite")
 
     with open(data_lib_filepath, 'w') as stream:
-        yaml.dump(data_lib, stream, default_flow_style=False, default_style='' )
+        yaml.dump(data_lib,
+                  stream,
+                  Dumper=MyDumper,
+                  indent=2,
+                  default_flow_style=False,
+                  default_style='',
+                  explicit_start=True)
 
 
 if __name__ == '__main__':

--- a/bin/create-data-library.py
+++ b/bin/create-data-library.py
@@ -38,7 +38,11 @@ def get_metadata_info(tuto, metadata_filepath):
                 raise ValueError("Empty Zenodo record found for the tutorial")
 
             meta_info['z_link'] = mat['zenodo_link']
-            meta_info['z_record'] = meta_info['z_link'].split('.')[-1]
+
+            if 'doi' in meta_info['z_link']:
+                meta_info['z_record'] = meta_info['z_link'].split('.')[-1]
+            else:
+                meta_info['z_record'] = meta_info['z_link'].split('/')[-1]
 
     if meta_info['z_record'] is None:
         raise ValueError("No information about the tutorial in the metadata file")
@@ -77,8 +81,6 @@ def create_data_library(meta_info, tuto_dir, overwrite = False):
         if 'links' not in file and 'self' not in file['links']:
             raise ValueError("No link for file %s" % file)
         file_dict['url'] = file['links']['self']
-        print(file_dict)
-        print(file)
         data_lib['items'][0]['items'].append(file_dict)
 
     data_lib_filepath = tuto_dir / Path("data-library.yaml")

--- a/bin/create-data-library.py
+++ b/bin/create-data-library.py
@@ -1,0 +1,110 @@
+#!/usr/bin/env python
+import argparse
+import requests
+import yaml
+
+from pathlib import Path
+
+
+def get_metadata_info(tuto, metadata_filepath):
+    '''
+    Extract the Zenodo DOI of the tutorial from the metadata.yaml file and also 
+    the topic title and description
+
+    :param tuto: tutorial name
+    :param metadata_filepath: path to the topic metadata.yaml file
+
+    :return: a dictionary with Zenodo record id and DOI, topic title and description
+    '''
+    meta_info = {'z_record': None, 'z_link': None, 'topic_title': None, 'topic_desc': None}
+    with open(metadata_filepath, "r") as m_file:
+        metadata = yaml.load(m_file)
+
+        if 'title' not in metadata:
+            raise ValueError("No title for the topic in the metadata file")
+        meta_info['topic_title'] = metadata['title']
+
+        if 'summary' not in metadata:
+            raise ValueError("No summary for the topic in the metadata file")
+        meta_info['topic_desc'] = metadata['summary']
+
+        if 'material' not in metadata:
+            raise ValueError("No material found in the metadata file")
+
+        for mat in metadata['material']:
+            if mat['name'] != tuto:
+                continue
+            if 'zenodo_link' not in mat or mat['zenodo_link'] == '':
+                raise ValueError("Empty Zenodo record found for the tutorial")
+
+            meta_info['z_link'] = mat['zenodo_link']
+            meta_info['z_record'] = meta_info['z_link'].split('.')[-1]
+
+    if meta_info['z_record'] is None:
+        raise ValueError("No information about the tutorial in the metadata file")
+
+    return meta_info
+
+
+def create_data_library(meta_info, tuto_dir, overwrite = False):
+    '''
+    Create the data-library file in the tutorial folder using the information
+    on Zenodo (queried though Zenodo API)
+
+    :param meta_info:  a dictionary with Zenodo record id and DOI, topic title and description
+    :param tuto_dir: Folder in which the data-library file should be created
+    '''
+    req = "https://zenodo.org/api/records/%s" % (meta_info['z_record'])
+    r = requests.get(req)
+    r.raise_for_status()
+    req_res = r.json()
+
+    if 'files' not in req_res:
+        raise ValueError("No files in the Zenodo record")
+
+    data_lib = {'destination': {'type': 'library',
+                                'name': 'GTN - Material',
+                                'description': 'Galaxy Training Network Material',
+                                'synopsis': 'Galaxy Training Network Material. See https://training.galaxyproject.org'},
+                'items': [{'name': '%s' % meta_info['topic_title'],
+                          'description': '%s' % meta_info['topic_desc'],
+                          'items': []}]}
+
+    for file in req_res['files']:
+        file_dict = {'url':'', 'src': 'url', 'ext': '', 'info': meta_info['z_link']}
+        if 'type' in file:
+            file_dict['ext'] = file['type']
+        if 'links' not in file and 'self' not in file['links']:
+            raise ValueError("No link for file %s" % file)
+        file_dict['url'] = file['links']['self']
+        print(file_dict)
+        print(file)
+        data_lib['items'][0]['items'].append(file_dict)
+
+    data_lib_filepath = tuto_dir / Path("data-library.yaml")
+    if data_lib_filepath.is_file():
+        print("The data library file already exist and will be overwrite")
+
+    with open(data_lib_filepath, 'w') as stream:
+        yaml.dump(data_lib, stream, default_flow_style=False, default_style='' )
+
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser(description='Create the skeleton of the data-library file for a tutorial with a Zenodo link')
+    parser.add_argument('--tutorial', help='Tutorial')
+    parser.add_argument('--topic', help='Topic in which the tutorial is')
+    #parser.add_argument('--overwrite', help='Topic in which the tutorial is')
+    args = parser.parse_args()
+
+    topic_dir = Path("topics") / Path(args.topic)
+    if not topic_dir.is_dir():
+        raise ValueError("%s is not a topic" % args.topic)
+    metadata_filepath = topic_dir / Path("metadata.yaml")
+    if not metadata_filepath.is_file():
+        raise ValueError("No metadata.yaml file for %s" % args.topic)
+    tuto_dir = topic_dir / Path("tutorials") / Path(args.tutorial)
+    if not tuto_dir.is_dir():
+        raise ValueError("%s is not a tutorial of %s" %(args.tutorial, args.topic))
+
+    meta_info = get_metadata_info(args.tutorial, metadata_filepath)    
+    create_data_library(meta_info, tuto_dir)

--- a/topics/assembly/tutorials/debruijn-graph-assembly/data-library.yaml
+++ b/topics/assembly/tutorials/debruijn-graph-assembly/data-library.yaml
@@ -1,8 +1,35 @@
 ---
-libraries:
-  - name: assembly_data
-    files:
-      - url: https://zenodo.org/record/582600/files/mutant_R1.fastq
-        file_type: "fastqsanger"
-      - url: https://zenodo.org/record/582600/files/mutant_R2.fastq
-        file_type: "fastqsanger"
+destination:
+  description: Galaxy Training Network Material
+  name: GTN - Material
+  synopsis: Galaxy Training Network Material. See https://training.galaxyproject.org
+  type: library
+items:
+  - description: DNA sequence data has become an indispensable tool for Molecular
+      Biology & Evolutionary Biology. Study in these fields now require a genome sequence
+      to work from. We call this a 'Reference Sequence.' We need to build a reference
+      for each species. We do this by Genome Assembly. De novo Genome Assembly is
+      the process of reconstructing the original DNA sequence from the fragment reads
+      alone.
+    items:
+      - ext: fastq
+        info: https://doi.org/10.5281/zenodo.582600
+        src: url
+        url: https://zenodo.org/api/files/287966da-5411-4f79-8cfb-0ffa84d0d6cc/mutant_R1.fastq
+      - ext: fastq
+        info: https://doi.org/10.5281/zenodo.582600
+        src: url
+        url: https://zenodo.org/api/files/287966da-5411-4f79-8cfb-0ffa84d0d6cc/mutant_R2.fastq
+      - ext: fna
+        info: https://doi.org/10.5281/zenodo.582600
+        src: url
+        url: https://zenodo.org/api/files/287966da-5411-4f79-8cfb-0ffa84d0d6cc/wildtype.fna
+      - ext: gbk
+        info: https://doi.org/10.5281/zenodo.582600
+        src: url
+        url: https://zenodo.org/api/files/287966da-5411-4f79-8cfb-0ffa84d0d6cc/wildtype.gbk
+      - ext: gff
+        info: https://doi.org/10.5281/zenodo.582600
+        src: url
+        url: https://zenodo.org/api/files/287966da-5411-4f79-8cfb-0ffa84d0d6cc/wildtype.gff
+    name: Assembly

--- a/topics/assembly/tutorials/ecoli_comparison/data-library.yaml
+++ b/topics/assembly/tutorials/ecoli_comparison/data-library.yaml
@@ -1,30 +1,35 @@
 ---
 destination:
+  description: Galaxy Training Network Material
+  name: GTN - Material
+  synopsis: Galaxy Training Network Material. See https://training.galaxyproject.org
   type: library
-  name: "GTN - Material"
-  description: "Galaxy Training Network Material"
-  synopsis: "Galaxy Training Network Material. See https://training.galaxyproject.org"
 items:
-  - name: "Raw reads and assembly"
-    description: "Training material for analysis of new assemblies"
+  - description: DNA sequence data has become an indispensable tool for Molecular
+      Biology & Evolutionary Biology. Study in these fields now require a genome sequence
+      to work from. We call this a 'Reference Sequence.' We need to build a reference
+      for each species. We do this by Genome Assembly. De novo Genome Assembly is
+      the process of reconstructing the original DNA sequence from the fragment reads
+      alone.
     items:
-      - url: https://zenodo.org/record/1257429/files/Ecoli_C_ONT.pass.fast5.tar.gz
+      - ext: fna
+        info: https://doi.org/10.5281/zenodo.1257429
         src: url
-        ext: fast5.tar.gz
-        info: https://zenodo.org/record/1257429
-      - url: https://zenodo.org/record/1257429/files/ont.fastqsanger.gz
+        url: https://zenodo.org/api/files/557ed5b5-541d-4109-a23e-354a214c9309/Ecoli_C_assembly.fna
+      - ext: gz
+        info: https://doi.org/10.5281/zenodo.1257429
         src: url
-        ext: fastqsanger.gz
-        info: https://zenodo.org/record/1257429
-      - url: https://zenodo.org/record/1257429/files/forward.fastqsanger.gz
+        url: https://zenodo.org/api/files/557ed5b5-541d-4109-a23e-354a214c9309/Ecoli_C_ONT.pass.fast5.tar.gz
+      - ext: gz
+        info: https://doi.org/10.5281/zenodo.1257429
         src: url
-        ext: fastqsanger.gz
-        info: https://zenodo.org/record/1257429
-      - url: https://zenodo.org/record/1257429/files/forward.fastqsanger.gz
+        url: https://zenodo.org/api/files/557ed5b5-541d-4109-a23e-354a214c9309/forward.fastqsanger.gz
+      - ext: gz
+        info: https://doi.org/10.5281/zenodo.1257429
         src: url
-        ext: fastqsanger.gz
-        info: https://zenodo.org/record/1257429
-      - url: https://zenodo.org/record/1257429/files/Ecoli_C_assembly.fna
+        url: https://zenodo.org/api/files/557ed5b5-541d-4109-a23e-354a214c9309/ont.fastqsanger.gz
+      - ext: gz
+        info: https://doi.org/10.5281/zenodo.1257429
         src: url
-        ext: fasta
-        info: https://zenodo.org/record/1257429
+        url: https://zenodo.org/api/files/557ed5b5-541d-4109-a23e-354a214c9309/reverse.fastqsanger.gz
+    name: Assembly

--- a/topics/assembly/tutorials/general-introduction/data-library.yaml
+++ b/topics/assembly/tutorials/general-introduction/data-library.yaml
@@ -1,8 +1,35 @@
 ---
-libraries:
-  - name: assembly_data
-    files:
-      - url: https://zenodo.org/record/582600/files/mutant_R1.fastq
-        file_type: "fastqsanger"
-      - url: https://zenodo.org/record/582600/files/mutant_R2.fastq
-        file_type: "fastqsanger"
+destination:
+  description: Galaxy Training Network Material
+  name: GTN - Material
+  synopsis: Galaxy Training Network Material. See https://training.galaxyproject.org
+  type: library
+items:
+  - description: DNA sequence data has become an indispensable tool for Molecular
+      Biology & Evolutionary Biology. Study in these fields now require a genome sequence
+      to work from. We call this a 'Reference Sequence.' We need to build a reference
+      for each species. We do this by Genome Assembly. De novo Genome Assembly is
+      the process of reconstructing the original DNA sequence from the fragment reads
+      alone.
+    items:
+      - ext: fastq
+        info: https://doi.org/10.5281/zenodo.582600
+        src: url
+        url: https://zenodo.org/api/files/287966da-5411-4f79-8cfb-0ffa84d0d6cc/mutant_R1.fastq
+      - ext: fastq
+        info: https://doi.org/10.5281/zenodo.582600
+        src: url
+        url: https://zenodo.org/api/files/287966da-5411-4f79-8cfb-0ffa84d0d6cc/mutant_R2.fastq
+      - ext: fna
+        info: https://doi.org/10.5281/zenodo.582600
+        src: url
+        url: https://zenodo.org/api/files/287966da-5411-4f79-8cfb-0ffa84d0d6cc/wildtype.fna
+      - ext: gbk
+        info: https://doi.org/10.5281/zenodo.582600
+        src: url
+        url: https://zenodo.org/api/files/287966da-5411-4f79-8cfb-0ffa84d0d6cc/wildtype.gbk
+      - ext: gff
+        info: https://doi.org/10.5281/zenodo.582600
+        src: url
+        url: https://zenodo.org/api/files/287966da-5411-4f79-8cfb-0ffa84d0d6cc/wildtype.gff
+    name: Assembly

--- a/topics/assembly/tutorials/unicycler-assembly/data-library.yaml
+++ b/topics/assembly/tutorials/unicycler-assembly/data-library.yaml
@@ -1,25 +1,27 @@
+---
 destination:
   description: Galaxy Training Network Material
   name: GTN - Material
   synopsis: Galaxy Training Network Material. See https://training.galaxyproject.org
   type: library
 items:
-- description: DNA sequence data has become an indispensable tool for Molecular Biology
-    & Evolutionary Biology. Study in these fields now require a genome sequence to
-    work from. We call this a 'Reference Sequence.' We need to build a reference for
-    each species. We do this by Genome Assembly. De novo Genome Assembly is the process
-    of reconstructing the original DNA sequence from the fragment reads alone.
-  items:
-  - ext: fq
-    info: https://doi.org/10.5281/zenodo.940733
-    src: url
-    url: https://zenodo.org/api/files/0b6b7422-42dc-489e-9567-a9de12c6972e/illumina_f.fq
-  - ext: fq
-    info: https://doi.org/10.5281/zenodo.940733
-    src: url
-    url: https://zenodo.org/api/files/0b6b7422-42dc-489e-9567-a9de12c6972e/illumina_r.fq
-  - ext: fq
-    info: https://doi.org/10.5281/zenodo.940733
-    src: url
-    url: https://zenodo.org/api/files/0b6b7422-42dc-489e-9567-a9de12c6972e/minion_2d.fq
-  name: Assembly
+  - description: DNA sequence data has become an indispensable tool for Molecular
+      Biology & Evolutionary Biology. Study in these fields now require a genome sequence
+      to work from. We call this a 'Reference Sequence.' We need to build a reference
+      for each species. We do this by Genome Assembly. De novo Genome Assembly is
+      the process of reconstructing the original DNA sequence from the fragment reads
+      alone.
+    items:
+      - ext: fq
+        info: https://doi.org/10.5281/zenodo.940733
+        src: url
+        url: https://zenodo.org/api/files/0b6b7422-42dc-489e-9567-a9de12c6972e/illumina_f.fq
+      - ext: fq
+        info: https://doi.org/10.5281/zenodo.940733
+        src: url
+        url: https://zenodo.org/api/files/0b6b7422-42dc-489e-9567-a9de12c6972e/illumina_r.fq
+      - ext: fq
+        info: https://doi.org/10.5281/zenodo.940733
+        src: url
+        url: https://zenodo.org/api/files/0b6b7422-42dc-489e-9567-a9de12c6972e/minion_2d.fq
+    name: Assembly

--- a/topics/assembly/tutorials/unicycler-assembly/data-library.yaml
+++ b/topics/assembly/tutorials/unicycler-assembly/data-library.yaml
@@ -1,0 +1,25 @@
+destination:
+  description: Galaxy Training Network Material
+  name: GTN - Material
+  synopsis: Galaxy Training Network Material. See https://training.galaxyproject.org
+  type: library
+items:
+- description: DNA sequence data has become an indispensable tool for Molecular Biology
+    & Evolutionary Biology. Study in these fields now require a genome sequence to
+    work from. We call this a 'Reference Sequence.' We need to build a reference for
+    each species. We do this by Genome Assembly. De novo Genome Assembly is the process
+    of reconstructing the original DNA sequence from the fragment reads alone.
+  items:
+  - ext: fq
+    info: https://doi.org/10.5281/zenodo.940733
+    src: url
+    url: https://zenodo.org/api/files/0b6b7422-42dc-489e-9567-a9de12c6972e/illumina_f.fq
+  - ext: fq
+    info: https://doi.org/10.5281/zenodo.940733
+    src: url
+    url: https://zenodo.org/api/files/0b6b7422-42dc-489e-9567-a9de12c6972e/illumina_r.fq
+  - ext: fq
+    info: https://doi.org/10.5281/zenodo.940733
+    src: url
+    url: https://zenodo.org/api/files/0b6b7422-42dc-489e-9567-a9de12c6972e/minion_2d.fq
+  name: Assembly

--- a/topics/chip-seq/tutorials/estrogen-receptor-binding-site-identification/data-library.yaml
+++ b/topics/chip-seq/tutorials/estrogen-receptor-binding-site-identification/data-library.yaml
@@ -1,22 +1,47 @@
 ---
-libraries:
-    - name: estrogen-receptor-binding-site-identification
-      files:
-          - url: https://zenodo.org/record/892432/files/patient1_ChIP_ER_good_outcome.bam
-            file_type: "bam"
-          - url: https://zenodo.org/record/892432/files/patient1_input_good_outcome.bam
-            file_type: "bam"
-          - url: https://zenodo.org/record/892432/files/patient1_input_good_outcome.fastq
-            file_type: "fastqsanger"
-          - url: https://zenodo.org/record/892432/files/patient2_ChIP_ER_good_outcome.bam
-            file_type: "bam"
-          - url: https://zenodo.org/record/892432/files/patient2_input_good_outcome.bam
-            file_type: "bam"
-          - url: https://zenodo.org/record/892432/files/patient3_ChIP_ER_poor_outcome.bam
-            file_type: "bam"
-          - url: https://zenodo.org/record/892432/files/patient3_input_poor_outcome.bam
-            file_type: "bam"
-          - url: https://zenodo.org/record/892432/files/patient4_ChIP_ER_poor_outcome.bam
-            file_type: "bam"
-          - url: https://zenodo.org/record/892432/files/patient4_input_poor_outcome.bam
-            file_type: "bam"
+destination:
+  description: Galaxy Training Network Material
+  name: GTN - Material
+  synopsis: Galaxy Training Network Material. See https://training.galaxyproject.org
+  type: library
+items:
+  - description: ChIP-sequencing is a method used to analyze protein interactions
+      with DNA.
+    items:
+      - ext: bam
+        info: https://doi.org/10.5281/zenodo.892432
+        src: url
+        url: https://zenodo.org/api/files/520e6670-58f7-4cff-ac59-8d11ae361a78/patient1_ChIP_ER_good_outcome.bam
+      - ext: bam
+        info: https://doi.org/10.5281/zenodo.892432
+        src: url
+        url: https://zenodo.org/api/files/520e6670-58f7-4cff-ac59-8d11ae361a78/patient1_input_good_outcome.bam
+      - ext: fastq
+        info: https://doi.org/10.5281/zenodo.892432
+        src: url
+        url: https://zenodo.org/api/files/520e6670-58f7-4cff-ac59-8d11ae361a78/patient1_input_good_outcome.fastq
+      - ext: bam
+        info: https://doi.org/10.5281/zenodo.892432
+        src: url
+        url: https://zenodo.org/api/files/520e6670-58f7-4cff-ac59-8d11ae361a78/patient2_ChIP_ER_good_outcome.bam
+      - ext: bam
+        info: https://doi.org/10.5281/zenodo.892432
+        src: url
+        url: https://zenodo.org/api/files/520e6670-58f7-4cff-ac59-8d11ae361a78/patient2_input_good_outcome.bam
+      - ext: bam
+        info: https://doi.org/10.5281/zenodo.892432
+        src: url
+        url: https://zenodo.org/api/files/520e6670-58f7-4cff-ac59-8d11ae361a78/patient3_ChIP_ER_poor_outcome.bam
+      - ext: bam
+        info: https://doi.org/10.5281/zenodo.892432
+        src: url
+        url: https://zenodo.org/api/files/520e6670-58f7-4cff-ac59-8d11ae361a78/patient3_input_poor_outcome.bam
+      - ext: bam
+        info: https://doi.org/10.5281/zenodo.892432
+        src: url
+        url: https://zenodo.org/api/files/520e6670-58f7-4cff-ac59-8d11ae361a78/patient4_ChIP_ER_poor_outcome.bam
+      - ext: bam
+        info: https://doi.org/10.5281/zenodo.892432
+        src: url
+        url: https://zenodo.org/api/files/520e6670-58f7-4cff-ac59-8d11ae361a78/patient4_input_poor_outcome.bam
+    name: ChIP-Seq data analysis

--- a/topics/chip-seq/tutorials/tal1-binding-site-identification/data-library.yaml
+++ b/topics/chip-seq/tutorials/tal1-binding-site-identification/data-library.yaml
@@ -1,24 +1,51 @@
 ---
-libraries:
-    - name: tal1-binding-site-identification
-      files:
-          - url: https://zenodo.org/record/197100/files/ChIPseq_regions_of_interest_v4.bed
-            file_type: "bed"
-          - url: https://zenodo.org/record/197100/files/G1E_input_R1_downsampled_SRR507859.fastqsanger
-            file_type: "fastqsanger"
-          - url: https://zenodo.org/record/197100/files/G1E_input_R2_downsampled_SRR507860.fastqsanger
-            file_type: "fastqsanger"
-          - url: https://zenodo.org/record/197100/files/G1E_Tal1_R1_downsampled_SRR492444.fastqsanger
-            file_type: "fastqsanger"
-          - url: https://zenodo.org/record/197100/files/G1E_Tal1_R2_downsampled_SRR492445.fastqsanger
-            file_type: "fastqsanger"
-          - url: https://zenodo.org/record/197100/files/Megakaryocyte_input_R1_downsampled_SRR492453.fastqsanger
-            file_type: "fastqsanger"
-          - url: https://zenodo.org/record/197100/files/Megakaryocyte_input_R2_downsampled_SRR492454.fastqsanger
-            file_type: "fastqsanger"
-          - url: https://zenodo.org/record/197100/files/Megakaryocyte_Tal1_R1_downsampled_SRR549006.fastqsanger
-            file_type: "fastqsanger"
-          - url: https://zenodo.org/record/197100/files/Megakaryocytes_Tal1_R2_downsampled_SRR549007.fastqsanger
-            file_type: "fastqsanger"
-          - url: https://zenodo.org/record/197100/files/RefSeq_gene_annotations_mm10.bed
-            file_type: "bed"
+destination:
+  description: Galaxy Training Network Material
+  name: GTN - Material
+  synopsis: Galaxy Training Network Material. See https://training.galaxyproject.org
+  type: library
+items:
+  - description: ChIP-sequencing is a method used to analyze protein interactions
+      with DNA.
+    items:
+      - ext: bed
+        info: https://doi.org/10.5281/zenodo.197100
+        src: url
+        url: https://zenodo.org/api/files/20ff737e-c485-45e9-99dc-8bfb6a776478/ChIPseq_regions_of_interest_v4.bed
+      - ext: fastqsanger
+        info: https://doi.org/10.5281/zenodo.197100
+        src: url
+        url: https://zenodo.org/api/files/20ff737e-c485-45e9-99dc-8bfb6a776478/G1E_input_R1_downsampled_SRR507859.fastqsanger
+      - ext: fastqsanger
+        info: https://doi.org/10.5281/zenodo.197100
+        src: url
+        url: https://zenodo.org/api/files/20ff737e-c485-45e9-99dc-8bfb6a776478/G1E_input_R2_downsampled_SRR507860.fastqsanger
+      - ext: fastqsanger
+        info: https://doi.org/10.5281/zenodo.197100
+        src: url
+        url: https://zenodo.org/api/files/20ff737e-c485-45e9-99dc-8bfb6a776478/G1E_Tal1_R1_downsampled_SRR492444.fastqsanger
+      - ext: fastqsanger
+        info: https://doi.org/10.5281/zenodo.197100
+        src: url
+        url: https://zenodo.org/api/files/20ff737e-c485-45e9-99dc-8bfb6a776478/G1E_Tal1_R2_downsampled_SRR492445.fastqsanger
+      - ext: fastqsanger
+        info: https://doi.org/10.5281/zenodo.197100
+        src: url
+        url: https://zenodo.org/api/files/20ff737e-c485-45e9-99dc-8bfb6a776478/Megakaryocyte_input_R1_downsampled_SRR492453.fastqsanger
+      - ext: fastqsanger
+        info: https://doi.org/10.5281/zenodo.197100
+        src: url
+        url: https://zenodo.org/api/files/20ff737e-c485-45e9-99dc-8bfb6a776478/Megakaryocyte_input_R2_downsampled_SRR492454.fastqsanger
+      - ext: fastqsanger
+        info: https://doi.org/10.5281/zenodo.197100
+        src: url
+        url: https://zenodo.org/api/files/20ff737e-c485-45e9-99dc-8bfb6a776478/Megakaryocytes_Tal1_R2_downsampled_SRR549007.fastqsanger
+      - ext: fastqsanger
+        info: https://doi.org/10.5281/zenodo.197100
+        src: url
+        url: https://zenodo.org/api/files/20ff737e-c485-45e9-99dc-8bfb6a776478/Megakaryocyte_Tal1_R1_downsampled_SRR549006.fastqsanger
+      - ext: bed
+        info: https://doi.org/10.5281/zenodo.197100
+        src: url
+        url: https://zenodo.org/api/files/20ff737e-c485-45e9-99dc-8bfb6a776478/RefSeq_gene_annotations_mm10.bed
+    name: ChIP-Seq data analysis

--- a/topics/contributing/tutorials/create-new-tutorial-technical/tutorial.md
+++ b/topics/contributing/tutorials/create-new-tutorial-technical/tutorial.md
@@ -87,28 +87,39 @@ The data can also be integrated in the Galaxy instance inside a data libraries a
 Such data are described in the `data-library.yaml`:
 
 ```
-libraries:
-    - name: Name of the tutorial
-      files:
-        - url: "https://raw.githubusercontent.com/bgruening/galaxytools/master/tools/rna_tools/sortmerna/test-data/read_small.fasta"
-          file_type: fasta
-        - url: ""
-          file_type: ""
+destination:
+  description: Galaxy Training Network Material
+  name: GTN - Material
+  synopsis: Galaxy Training Network Material. See https://training.galaxyproject.org
+  type: library
+items:
+- name: <Topic title>
+  description: <Topic summary>
+  items:
+  - url: <URL to one of the file on Zenodo>
+    ext: <Format of the file>
+    info: <DOI on Zenodo>
+    src: url
+    
 ```
 
 with:
 
-- `name`: name of the tutorial, where to put the data in the data libraries
-- `files`: list of the files to download
-    - `url`: URL to the input file
-    - `file-type`: type of the input file
+- `name`: name of the topic
+- `items`: list of the input files to download and put on the data library
+    - `url`: URL to the input file on [Zenodo](https://zenodo.org)
+    - `ext`: format of the input file
+    - `info`: URL to the DOI on Zendo
 
-The URL must refer to the URL of the files in [Zenodo](https://zenodo.org).
+This file can be automatically generated from the metadata information:
+
+```
+$ python bin/create-data-library.py --tutorial <tutorial-name> --topic <topic-name>
+```
 
 > ### {% icon hands_on %} Hands-on: Fill the `data-library.yaml`
 >
 > 1. Add the input files into the `data-library.yaml` file
-> 2. Add the link to Zenodo in the `metadata.yaml` file
 {: .hands_on}
 
 ## Filling the `data-manager.yaml`

--- a/topics/epigenetics/tutorials/hicexplorer/data-library.yaml
+++ b/topics/epigenetics/tutorials/hicexplorer/data-library.yaml
@@ -1,10 +1,40 @@
 ---
-libraries:
-    - name: Galaxy Hi-C Training material dm6
-      files:
-          - url: https://zenodo.org/record/1176070/files/dm6_genes.bed
-            file_type: "bed"
-          - url: https://zenodo.org/record/1176070/files/HiC_S2_1p_10min_lowU_R1.fastq.gz
-            file_type: "fastqsanger"
-          - url: https://zenodo.org/record/1176070/files/HiC_S2_1p_10min_lowU_R2.fastq.gz
-            file_type: "fastqsanger"
+destination:
+  description: Galaxy Training Network Material
+  name: GTN - Material
+  synopsis: Galaxy Training Network Material. See https://training.galaxyproject.org
+  type: library
+items:
+  - description: DNA methylation is an epigenetic mechanism used by higher eukaryotes
+      and involved in e.g. gene expression, X-Chromosome inactivating, imprinting,
+      and gene silencing of germline specific gene and repetitive elements.
+    items:
+      - ext: h5
+        info: https://doi.org/10.5281/zenodo.1183661
+        src: url
+        url: https://zenodo.org/api/files/a77fcd26-9185-4947-9fed-54d2851c5eed/corrected%20contact%20matrix%20dm3%20large.h5
+      - ext: bed
+        info: https://doi.org/10.5281/zenodo.1183661
+        src: url
+        url: https://zenodo.org/api/files/a77fcd26-9185-4947-9fed-54d2851c5eed/dm3_genes.bed
+      - ext: bw
+        info: https://doi.org/10.5281/zenodo.1183661
+        src: url
+        url: https://zenodo.org/api/files/a77fcd26-9185-4947-9fed-54d2851c5eed/H3K27me3.bw
+      - ext: bw
+        info: https://doi.org/10.5281/zenodo.1183661
+        src: url
+        url: https://zenodo.org/api/files/a77fcd26-9185-4947-9fed-54d2851c5eed/H3K36me3.bw
+      - ext: bw
+        info: https://doi.org/10.5281/zenodo.1183661
+        src: url
+        url: https://zenodo.org/api/files/a77fcd26-9185-4947-9fed-54d2851c5eed/H4K16ac.bw
+      - ext: gz
+        info: https://doi.org/10.5281/zenodo.1183661
+        src: url
+        url: https://zenodo.org/api/files/a77fcd26-9185-4947-9fed-54d2851c5eed/HiC_S2_1p_10min_lowU_R1.fastq.gz
+      - ext: gz
+        info: https://doi.org/10.5281/zenodo.1183661
+        src: url
+        url: https://zenodo.org/api/files/a77fcd26-9185-4947-9fed-54d2851c5eed/HiC_S2_1p_10min_lowU_R2.fastq.gz
+    name: Epigenetics

--- a/topics/epigenetics/tutorials/methylation-seq/data-library.yaml
+++ b/topics/epigenetics/tutorials/methylation-seq/data-library.yaml
@@ -1,0 +1,76 @@
+---
+destination:
+  description: Galaxy Training Network Material
+  name: GTN - Material
+  synopsis: Galaxy Training Network Material. See https://training.galaxyproject.org
+  type: library
+items:
+  - description: DNA methylation is an epigenetic mechanism used by higher eukaryotes
+      and involved in e.g. gene expression, X-Chromosome inactivating, imprinting,
+      and gene silencing of germline specific gene and repetitive elements.
+    items:
+      - ext: bedgraph
+        info: https://zenodo.org/record/557099
+        src: url
+        url: https://zenodo.org/api/files/ab7dc7ee-d1dd-48fe-bfc4-ca67f4683c72/BT089_CpG.meth.bedGraph
+      - ext: bedgraph
+        info: https://zenodo.org/record/557099
+        src: url
+        url: https://zenodo.org/api/files/ab7dc7ee-d1dd-48fe-bfc4-ca67f4683c72/BT089_CpG.meth_ucsc.bedGraph
+      - ext: bedgraph
+        info: https://zenodo.org/record/557099
+        src: url
+        url: https://zenodo.org/api/files/ab7dc7ee-d1dd-48fe-bfc4-ca67f4683c72/BT126_CpG.meth.bedGraph
+      - ext: bedgraph
+        info: https://zenodo.org/record/557099
+        src: url
+        url: https://zenodo.org/api/files/ab7dc7ee-d1dd-48fe-bfc4-ca67f4683c72/BT126_CpG.meth_ucsc.bedGraph
+      - ext: bedgraph
+        info: https://zenodo.org/record/557099
+        src: url
+        url: https://zenodo.org/api/files/ab7dc7ee-d1dd-48fe-bfc4-ca67f4683c72/BT198_CpG.meth.bedGraph
+      - ext: bedgraph
+        info: https://zenodo.org/record/557099
+        src: url
+        url: https://zenodo.org/api/files/ab7dc7ee-d1dd-48fe-bfc4-ca67f4683c72/BT198_CpG.meth_ucsc.bedGraph
+      - ext: bed
+        info: https://zenodo.org/record/557099
+        src: url
+        url: https://zenodo.org/api/files/ab7dc7ee-d1dd-48fe-bfc4-ca67f4683c72/CpGIslands.bed
+      - ext: bedgraph
+        info: https://zenodo.org/record/557099
+        src: url
+        url: https://zenodo.org/api/files/ab7dc7ee-d1dd-48fe-bfc4-ca67f4683c72/MCF7_CpG.meth.bedGraph
+      - ext: bedgraph
+        info: https://zenodo.org/record/557099
+        src: url
+        url: https://zenodo.org/api/files/ab7dc7ee-d1dd-48fe-bfc4-ca67f4683c72/MCF7_CpG.meth_ucsc.bedGraph
+      - ext: bedgraph
+        info: https://zenodo.org/record/557099
+        src: url
+        url: https://zenodo.org/api/files/ab7dc7ee-d1dd-48fe-bfc4-ca67f4683c72/NB1_CpG.meth.bedGraph
+      - ext: bedgraph
+        info: https://zenodo.org/record/557099
+        src: url
+        url: https://zenodo.org/api/files/ab7dc7ee-d1dd-48fe-bfc4-ca67f4683c72/NB1_CpG.meth_ucsc.bedGraph
+      - ext: bedgraph
+        info: https://zenodo.org/record/557099
+        src: url
+        url: https://zenodo.org/api/files/ab7dc7ee-d1dd-48fe-bfc4-ca67f4683c72/NB2_CpG.meth.bedGraph
+      - ext: bedgraph
+        info: https://zenodo.org/record/557099
+        src: url
+        url: https://zenodo.org/api/files/ab7dc7ee-d1dd-48fe-bfc4-ca67f4683c72/NB2_CpG.meth_ucsc.bedGraph
+      - ext: fastq
+        info: https://zenodo.org/record/557099
+        src: url
+        url: https://zenodo.org/api/files/ab7dc7ee-d1dd-48fe-bfc4-ca67f4683c72/subset_1.fastq
+      - ext: fastq
+        info: https://zenodo.org/record/557099
+        src: url
+        url: https://zenodo.org/api/files/ab7dc7ee-d1dd-48fe-bfc4-ca67f4683c72/subset_2.fastq
+      - ext: bam
+        info: https://zenodo.org/record/557099
+        src: url
+        url: https://zenodo.org/api/files/ab7dc7ee-d1dd-48fe-bfc4-ca67f4683c72/aligned_subset.bam
+    name: Epigenetics

--- a/topics/genome-annotation/tutorials/annotation-with-prokka/data-library.yaml
+++ b/topics/genome-annotation/tutorials/annotation-with-prokka/data-library.yaml
@@ -1,7 +1,17 @@
 ---
-libraries:
-    # This needs to be changed to reference your Zenodo data
-    - name: "Assembled contigs for annotation"
-      files:
-          - url: "https://doi.org/10.5281/zenodo.1156405"
-            file_type: "fasta"
+destination:
+  description: Galaxy Training Network Material
+  name: GTN - Material
+  synopsis: Galaxy Training Network Material. See https://training.galaxyproject.org
+  type: library
+items:
+  - description: Genome annotation is a multi-level process that includes prediction
+      of protein-coding genes, as well as other functional genome units such as structural
+      RNAs, tRNAs, small RNAs, pseudogenes, control regions, direct and inverted repeats,
+      insertion sequences, transposons and other mobile elements.
+    items:
+      - ext: fasta
+        info: https://doi.org/10.5281/zenodo.1156405
+        src: url
+        url: https://zenodo.org/api/files/88c62429-b2b4-49c6-a2f7-89d471715e39/contigs.fasta
+    name: Genome Annotation

--- a/topics/genome-annotation/tutorials/genome-annotation/data-library.yaml
+++ b/topics/genome-annotation/tutorials/genome-annotation/data-library.yaml
@@ -1,6 +1,17 @@
 ---
-libraries:
-    - name: "Small file (to change)"
-      files:
-          - url: "http://raw.githubusercontent.com/bgruening/galaxytools/master/tools/rna_tools/sortmerna/test-data/read_small.fasta"
-            file_type: "fasta"
+destination:
+  description: Galaxy Training Network Material
+  name: GTN - Material
+  synopsis: Galaxy Training Network Material. See https://training.galaxyproject.org
+  type: library
+items:
+  - description: Genome annotation is a multi-level process that includes prediction
+      of protein-coding genes, as well as other functional genome units such as structural
+      RNAs, tRNAs, small RNAs, pseudogenes, control regions, direct and inverted repeats,
+      insertion sequences, transposons and other mobile elements.
+    items:
+      - ext: fasta
+        info: https://doi.org/10.5281/zenodo.1250793
+        src: url
+        url: https://zenodo.org/api/files/b8d6d4f1-bf7b-4bcd-a6f1-a84ac80ff337/Aspergillus_sequence.fasta
+    name: Genome Annotation

--- a/topics/introduction/tutorials/galaxy-intro-peaks2genes/data-library.yaml
+++ b/topics/introduction/tutorials/galaxy-intro-peaks2genes/data-library.yaml
@@ -1,8 +1,21 @@
 ---
-libraries:
-    - name: "Introduction - From peaks to genes"
-      files:
-          - url: https://zenodo.org/record/1025586/files/GSE37268_mof3.out.hpeak.txt
-            file_type: tsv
-          - url: https://zenodo.org/record/1025586/files/mm9.RefSeq_genes_from_UCSC.bed
-            file_type: bed
+destination:
+  description: Galaxy Training Network Material
+  name: GTN - Material
+  synopsis: Galaxy Training Network Material. See https://training.galaxyproject.org
+  type: library
+items:
+  - description: 'Galaxy is a scientific workflow, data integration, and data and
+      analysis persistence and publishing platform that aims to make computational
+      biology accessible to research scientists that do not have computer programming
+      experience. '
+    items:
+      - ext: txt
+        info: https://doi.org/10.5281/zenodo.1025585
+        src: url
+        url: https://zenodo.org/api/files/5770c688-ac75-4c16-b371-107bcdb68ff2/GSE37268_mof3.out.hpeak.txt
+      - ext: bed
+        info: https://doi.org/10.5281/zenodo.1025585
+        src: url
+        url: https://zenodo.org/api/files/5770c688-ac75-4c16-b371-107bcdb68ff2/mm9.RefSeq_genes_from_UCSC.bed
+    name: Introduction to Galaxy

--- a/topics/metagenomics/tutorials/general-tutorial/data-library.yaml
+++ b/topics/metagenomics/tutorials/general-tutorial/data-library.yaml
@@ -1,22 +1,47 @@
 ---
-libraries:
-    - name: "Analyses of metagenomics data - The global picture"
-      files:
-          - url: https://zenodo.org/record/815875/files/SRR606451_pampa.fasta
-            file_type: fasta
-          - url: https://zenodo.org/record/815875/files/SRR531818_pampa.fasta
-            file_type: fasta
-          - url: https://zenodo.org/record/815875/files/SRR651839_anguil.fasta
-            file_type: fasta
-          - url: https://zenodo.org/record/800651/files/silva.v4.fasta
-            file_type: fasta
-          - url: https://zenodo.org/record/815875/files/trainset16_022016.pds.fasta
-            file_type: fasta
-          - url: https://zenodo.org/record/815875/files/trainset16_022016.pds.tax
-            file_type: mothur.ref.taxonomy
-          - url: https://zenodo.org/record/815875/files/humann2_gene_families_abundance.tsv
-            file_type: tsv
-          - url: https://zenodo.org/record/815875/files/humann2_pathways_abundance.tsv
-            file_type: tsv
-          - url: https://zenodo.org/record/815875/files/humann2_pathways_coverage.tsv
-            file_type: tsv
+destination:
+  description: Galaxy Training Network Material
+  name: GTN - Material
+  synopsis: Galaxy Training Network Material. See https://training.galaxyproject.org
+  type: library
+items:
+  - description: Metagenomics is a discipline that enables the genomic study of uncultured
+      microorganisms
+    items:
+      - ext: tsv
+        info: https://doi.org/10.5281/zenodo.815875
+        src: url
+        url: https://zenodo.org/api/files/0e062e89-e6ce-463b-a8cb-0151e5aabc69/humann2_gene_families_abundance.tsv
+      - ext: tsv
+        info: https://doi.org/10.5281/zenodo.815875
+        src: url
+        url: https://zenodo.org/api/files/0e062e89-e6ce-463b-a8cb-0151e5aabc69/humann2_pathways_abundance.tsv
+      - ext: tsv
+        info: https://doi.org/10.5281/zenodo.815875
+        src: url
+        url: https://zenodo.org/api/files/0e062e89-e6ce-463b-a8cb-0151e5aabc69/humann2_pathways_coverage.tsv
+      - ext: fasta
+        info: https://doi.org/10.5281/zenodo.815875
+        src: url
+        url: https://zenodo.org/api/files/0e062e89-e6ce-463b-a8cb-0151e5aabc69/silva.v4.fasta
+      - ext: fasta
+        info: https://doi.org/10.5281/zenodo.815875
+        src: url
+        url: https://zenodo.org/api/files/0e062e89-e6ce-463b-a8cb-0151e5aabc69/SRR531818_pampa.fasta
+      - ext: fasta
+        info: https://doi.org/10.5281/zenodo.815875
+        src: url
+        url: https://zenodo.org/api/files/0e062e89-e6ce-463b-a8cb-0151e5aabc69/SRR606451_pampa.fasta
+      - ext: fasta
+        info: https://doi.org/10.5281/zenodo.815875
+        src: url
+        url: https://zenodo.org/api/files/0e062e89-e6ce-463b-a8cb-0151e5aabc69/SRR651839_anguil.fasta
+      - ext: fasta
+        info: https://doi.org/10.5281/zenodo.815875
+        src: url
+        url: https://zenodo.org/api/files/0e062e89-e6ce-463b-a8cb-0151e5aabc69/trainset16_022016.pds.fasta
+      - ext: tax
+        info: https://doi.org/10.5281/zenodo.815875
+        src: url
+        url: https://zenodo.org/api/files/0e062e89-e6ce-463b-a8cb-0151e5aabc69/trainset16_022016.pds.tax
+    name: Metagenomics

--- a/topics/metagenomics/tutorials/mothur-miseq-sop/data-library.yaml
+++ b/topics/metagenomics/tutorials/mothur-miseq-sop/data-library.yaml
@@ -1,99 +1,19 @@
 ---
-libraries:
-    - name: Mothur MiSeq SOP sample data
-      files:
-          - url: https://zenodo.org/record/800651/files/F3D0_R1.fastq
-            file_type: "fastq"
-          - url: https://zenodo.org/record/800651/files/F3D0_R2.fastq
-            file_type: "fastq"
-          - url: https://zenodo.org/record/800651/files/F3D141_R1.fastq
-            file_type: "fastq"
-          - url: https://zenodo.org/record/800651/files/F3D141_R2.fastq
-            file_type: "fastq"
-          - url: https://zenodo.org/record/800651/files/F3D142_R1.fastq
-            file_type: "fastq"
-          - url: https://zenodo.org/record/800651/files/F3D142_R2.fastq
-            file_type: "fastq"
-          - url: https://zenodo.org/record/800651/files/F3D143_R1.fastq
-            file_type: "fastq"
-          - url: https://zenodo.org/record/800651/files/F3D143_R2.fastq
-            file_type: "fastq"
-          - url: https://zenodo.org/record/800651/files/F3D144_R1.fastq
-            file_type: "fastq"
-          - url: https://zenodo.org/record/800651/files/F3D144_R2.fastq
-            file_type: "fastq"
-          - url: https://zenodo.org/record/800651/files/F3D145_R1.fastq
-            file_type: "fastq"
-          - url: https://zenodo.org/record/800651/files/F3D145_R2.fastq
-            file_type: "fastq"
-          - url: https://zenodo.org/record/800651/files/F3D146_R1.fastq
-            file_type: "fastq"
-          - url: https://zenodo.org/record/800651/files/F3D146_R2.fastq
-            file_type: "fastq"
-          - url: https://zenodo.org/record/800651/files/F3D147_R1.fastq
-            file_type: "fastq"
-          - url: https://zenodo.org/record/800651/files/F3D147_R2.fastq
-            file_type: "fastq"
-          - url: https://zenodo.org/record/800651/files/F3D148_R1.fastq
-            file_type: "fastq"
-          - url: https://zenodo.org/record/800651/files/F3D148_R2.fastq
-            file_type: "fastq"
-          - url: https://zenodo.org/record/800651/files/F3D149_R1.fastq
-            file_type: "fastq"
-          - url: https://zenodo.org/record/800651/files/F3D149_R2.fastq
-            file_type: "fastq"
-          - url: https://zenodo.org/record/800651/files/F3D150_R1.fastq
-            file_type: "fastq"
-          - url: https://zenodo.org/record/800651/files/F3D150_R2.fastq
-            file_type: "fastq"
-          - url: https://zenodo.org/record/800651/files/F3D1_R1.fastq
-            file_type: "fastq"
-          - url: https://zenodo.org/record/800651/files/F3D1_R2.fastq
-            file_type: "fastq"
-          - url: https://zenodo.org/record/800651/files/F3D2_R1.fastq
-            file_type: "fastq"
-          - url: https://zenodo.org/record/800651/files/F3D2_R2.fastq
-            file_type: "fastq"
-          - url: https://zenodo.org/record/800651/files/F3D3_R1.fastq
-            file_type: "fastq"
-          - url: https://zenodo.org/record/800651/files/F3D3_R2.fastq
-            file_type: "fastq"
-          - url: https://zenodo.org/record/800651/files/F3D5_R1.fastq
-            file_type: "fastq"
-          - url: https://zenodo.org/record/800651/files/F3D5_R2.fastq
-            file_type: "fastq"
-          - url: https://zenodo.org/record/800651/files/F3D6_R1.fastq
-            file_type: "fastq"
-          - url: https://zenodo.org/record/800651/files/F3D6_R2.fastq
-            file_type: "fastq"
-          - url: https://zenodo.org/record/800651/files/F3D7_R1.fastq
-            file_type: "fastq"
-          - url: https://zenodo.org/record/800651/files/F3D7_R2.fastq
-            file_type: "fastq"
-          - url: https://zenodo.org/record/800651/files/F3D8_R1.fastq
-            file_type: "fastq"
-          - url: https://zenodo.org/record/800651/files/F3D8_R2.fastq
-            file_type: "fastq"
-          - url: https://zenodo.org/record/800651/files/F3D9_R1.fastq
-            file_type: "fastq"
-          - url: https://zenodo.org/record/800651/files/F3D9_R2.fastq
-            file_type: "fastq"
-          - url: https://zenodo.org/record/800651/files/Mock_R1.fastq
-            file_type: "fastq"
-          - url: https://zenodo.org/record/800651/files/Mock_R2.fastq
-            file_type: "fastq"
-          - url: https://zenodo.org/record/800651/files/mouse.dpw.metadata
-            file_type: "tabular"
-          - url: https://zenodo.org/record/800651/files/mouse.time.design
-            file_type: "mothur.design"
-
-    - name: Mothur MiSeq SOP reference data
-      files:
-          - url: https://zenodo.org/record/800651/files/HMP_MOCK.v35.fasta
-            file_type: "fasta"
-          - url: https://zenodo.org/record/800651/files/silva.v4.fasta
-            file_type: "fasta"
-          - url: https://zenodo.org/record/800651/files/trainset9_032012.pds.fasta
-            file_type: "fasta"
-          - url: https://zenodo.org/record/800651/files/trainset9_032012.pds.tax
-            file_type: "mothur.seq.taxonomy"
+destination:
+  description: Galaxy Training Network Material
+  name: GTN - Material
+  synopsis: Galaxy Training Network Material. See https://training.galaxyproject.org
+  type: library
+items:
+  - description: Metagenomics is a discipline that enables the genomic study of uncultured
+      microorganisms
+    items:
+      - ext: zip
+        info: https://doi.org/10.5281/zenodo.165147
+        src: url
+        url: https://zenodo.org/api/files/83683845-ba4a-4b0f-bd44-39cd749b604f/input_data.zip
+      - ext: zip
+        info: https://doi.org/10.5281/zenodo.165147
+        src: url
+        url: https://zenodo.org/api/files/83683845-ba4a-4b0f-bd44-39cd749b604f/reference_data.zip
+    name: Metagenomics

--- a/topics/proteomics/tutorials/metaproteomics/data-library.yaml
+++ b/topics/proteomics/tutorials/metaproteomics/data-library.yaml
@@ -1,0 +1,34 @@
+---
+destination:
+  description: Galaxy Training Network Material
+  name: GTN - Material
+  synopsis: Galaxy Training Network Material. See https://training.galaxyproject.org
+  type: library
+items:
+  - description: Training material for proteomics workflows in Galaxy
+    items:
+      - ext: mgf
+        info: https://doi.org/10.5281/zenodo.839701
+        src: url
+        url: https://zenodo.org/api/files/ce8c2daa-fbf6-485f-beea-5b53ce1019b1/2016_Jan_12_QE2_45.mgf
+      - ext: mgf
+        info: https://doi.org/10.5281/zenodo.839701
+        src: url
+        url: https://zenodo.org/api/files/ce8c2daa-fbf6-485f-beea-5b53ce1019b1/2016_Jan_12_QE2_46.mgf
+      - ext: mgf
+        info: https://doi.org/10.5281/zenodo.839701
+        src: url
+        url: https://zenodo.org/api/files/ce8c2daa-fbf6-485f-beea-5b53ce1019b1/2016_Jan_12_QE2_47.mgf
+      - ext: fasta
+        info: https://doi.org/10.5281/zenodo.839701
+        src: url
+        url: https://zenodo.org/api/files/ce8c2daa-fbf6-485f-beea-5b53ce1019b1/FASTA_Bering_Strait_Trimmed_metapeptides_cRAP.fasta
+      - ext: tabular
+        info: https://doi.org/10.5281/zenodo.839701
+        src: url
+        url: https://zenodo.org/api/files/ce8c2daa-fbf6-485f-beea-5b53ce1019b1/Gene_Ontology_Terms_full_07.08.2017.tabular
+      - ext: tabular
+        info: https://doi.org/10.5281/zenodo.839701
+        src: url
+        url: https://zenodo.org/api/files/ce8c2daa-fbf6-485f-beea-5b53ce1019b1/Gene_Ontology_Terms.tabular
+    name: Proteomics

--- a/topics/proteomics/tutorials/protein-id-oms/data-library.yaml
+++ b/topics/proteomics/tutorials/protein-id-oms/data-library.yaml
@@ -1,0 +1,34 @@
+---
+destination:
+  description: Galaxy Training Network Material
+  name: GTN - Material
+  synopsis: Galaxy Training Network Material. See https://training.galaxyproject.org
+  type: library
+items:
+  - description: Training material for proteomics workflows in Galaxy
+    items:
+      - ext: fasta
+        info: https://zenodo.org/record/546301
+        src: url
+        url: https://zenodo.org/api/files/bbfa3626-aa14-479b-bd62-234cc63520f3/Human_database_%28cRAP_added%29.fasta
+      - ext: fasta
+        info: https://zenodo.org/record/546301
+        src: url
+        url: https://zenodo.org/api/files/bbfa3626-aa14-479b-bd62-234cc63520f3/Human_database_%28cRAP_and_Mycoplasma_added%29.fasta
+      - ext: mgf
+        info: https://zenodo.org/record/546301
+        src: url
+        url: https://zenodo.org/api/files/bbfa3626-aa14-479b-bd62-234cc63520f3/qExactive01819.mgf
+      - ext: mzml
+        info: https://zenodo.org/record/546301
+        src: url
+        url: https://zenodo.org/api/files/bbfa3626-aa14-479b-bd62-234cc63520f3/qExactive01819_profile.mzml
+      - ext: raw
+        info: https://zenodo.org/record/546301
+        src: url
+        url: https://zenodo.org/api/files/bbfa3626-aa14-479b-bd62-234cc63520f3/qExactive01819.raw
+      - ext: mzml
+        info: https://zenodo.org/record/546301
+        src: url
+        url: https://zenodo.org/api/files/bbfa3626-aa14-479b-bd62-234cc63520f3/qExactive01819_vendor-peakPicking.mzml
+    name: Proteomics

--- a/topics/proteomics/tutorials/protein-id-sg-ps/data-library.yaml
+++ b/topics/proteomics/tutorials/protein-id-sg-ps/data-library.yaml
@@ -1,6 +1,34 @@
 ---
-libraries:
-    - name: "Small file (to change)"
-      files:
-          - url: "http://raw.githubusercontent.com/bgruening/galaxytools/master/tools/rna_tools/sortmerna/test-data/read_small.fasta"
-            file_type: "fasta"
+destination:
+  description: Galaxy Training Network Material
+  name: GTN - Material
+  synopsis: Galaxy Training Network Material. See https://training.galaxyproject.org
+  type: library
+items:
+  - description: Training material for proteomics workflows in Galaxy
+    items:
+      - ext: fasta
+        info: https://zenodo.org/record/546301
+        src: url
+        url: https://zenodo.org/api/files/bbfa3626-aa14-479b-bd62-234cc63520f3/Human_database_%28cRAP_added%29.fasta
+      - ext: fasta
+        info: https://zenodo.org/record/546301
+        src: url
+        url: https://zenodo.org/api/files/bbfa3626-aa14-479b-bd62-234cc63520f3/Human_database_%28cRAP_and_Mycoplasma_added%29.fasta
+      - ext: mgf
+        info: https://zenodo.org/record/546301
+        src: url
+        url: https://zenodo.org/api/files/bbfa3626-aa14-479b-bd62-234cc63520f3/qExactive01819.mgf
+      - ext: mzml
+        info: https://zenodo.org/record/546301
+        src: url
+        url: https://zenodo.org/api/files/bbfa3626-aa14-479b-bd62-234cc63520f3/qExactive01819_profile.mzml
+      - ext: raw
+        info: https://zenodo.org/record/546301
+        src: url
+        url: https://zenodo.org/api/files/bbfa3626-aa14-479b-bd62-234cc63520f3/qExactive01819.raw
+      - ext: mzml
+        info: https://zenodo.org/record/546301
+        src: url
+        url: https://zenodo.org/api/files/bbfa3626-aa14-479b-bd62-234cc63520f3/qExactive01819_vendor-peakPicking.mzml
+    name: Proteomics

--- a/topics/proteomics/tutorials/protein-quant-sil/data-library.yaml
+++ b/topics/proteomics/tutorials/protein-quant-sil/data-library.yaml
@@ -1,6 +1,14 @@
 ---
-libraries:
-    - name: "Small file (to change)"
-      files:
-          - url: "http://raw.githubusercontent.com/bgruening/galaxytools/master/tools/rna_tools/sortmerna/test-data/read_small.fasta"
-            file_type: "fasta"
+destination:
+  description: Galaxy Training Network Material
+  name: GTN - Material
+  synopsis: Galaxy Training Network Material. See https://training.galaxyproject.org
+  type: library
+items:
+  - description: Training material for proteomics workflows in Galaxy
+    items:
+      - ext: mzml
+        info: https://zenodo.org/record/1051552
+        src: url
+        url: https://zenodo.org/api/files/3951bef4-9bb9-4828-9c7f-36d7b74ec349/HEK_SILAC-K6R6_ST905_part.mzml
+    name: Proteomics

--- a/topics/proteomics/tutorials/secretome-prediction/data-library.yaml
+++ b/topics/proteomics/tutorials/secretome-prediction/data-library.yaml
@@ -1,6 +1,14 @@
 ---
-libraries:
-    - name: "Small file (to change)"
-      files:
-          - url: "http://raw.githubusercontent.com/bgruening/galaxytools/master/tools/rna_tools/sortmerna/test-data/read_small.fasta"
-            file_type: "fasta"
+destination:
+  description: Galaxy Training Network Material
+  name: GTN - Material
+  synopsis: Galaxy Training Network Material. See https://training.galaxyproject.org
+  type: library
+items:
+  - description: Training material for proteomics workflows in Galaxy
+    items:
+      - ext: tabular
+        info: https://zenodo.org/record/519260
+        src: url
+        url: https://zenodo.org/api/files/381dd5e0-1b6c-4206-aea2-081dcc6e6225/test_data.tabular
+    name: Proteomics

--- a/topics/sequence-analysis/tutorials/de-novo-rad-seq/data-library.yaml
+++ b/topics/sequence-analysis/tutorials/de-novo-rad-seq/data-library.yaml
@@ -1,7 +1,22 @@
 ---
-libraries:
-    # This needs to be changed to reference your Zenodo data
-    - name: "Small test files"
-      files:
-          - url: "http://raw.githubusercontent.com/bgruening/galaxytools/master/tools/rna_tools/sortmerna/test-data/read_small.fasta"
-            file_type: "fasta"
+destination:
+  description: Galaxy Training Network Material
+  name: GTN - Material
+  synopsis: Galaxy Training Network Material. See https://training.galaxyproject.org
+  type: library
+items:
+  - description: Analyses of sequences
+    items:
+      - ext: txt
+        info: https://doi.org/10.5281/zenodo.1134547
+        src: url
+        url: https://zenodo.org/api/files/dc22cf60-8ec9-4d2f-83e3-16e1922aa079/Barcode_SRR034310.txt
+      - ext: txt
+        info: https://doi.org/10.5281/zenodo.1134547
+        src: url
+        url: https://zenodo.org/api/files/dc22cf60-8ec9-4d2f-83e3-16e1922aa079/Details_Barcode_Population_SRR034310.txt
+      - ext: fasta
+        info: https://doi.org/10.5281/zenodo.1134547
+        src: url
+        url: https://zenodo.org/api/files/dc22cf60-8ec9-4d2f-83e3-16e1922aa079/Reference_genome_11_chromosomes.fasta
+    name: Sequence analysis

--- a/topics/sequence-analysis/tutorials/genetic-map-rad-seq/data-library.yaml
+++ b/topics/sequence-analysis/tutorials/genetic-map-rad-seq/data-library.yaml
@@ -1,6 +1,98 @@
 ---
-libraries:
-    - name: "Small file (to change)"
-      files:
-          - url: "http://raw.githubusercontent.com/bgruening/galaxytools/master/tools/rna_tools/sortmerna/test-data/read_small.fasta"
-            file_type: "fasta"
+destination:
+  description: Galaxy Training Network Material
+  name: GTN - Material
+  synopsis: Galaxy Training Network Material. See https://training.galaxyproject.org
+  type: library
+items:
+  - description: Analyses of sequences
+    items:
+      - ext: ''
+        info: https://doi.org/10.5281/zenodo.1219888
+        src: url
+        url: https://zenodo.org/api/files/af88bbbe-43a7-4c6b-8e12-3477cd3106ad/female
+      - ext: ''
+        info: https://doi.org/10.5281/zenodo.1219888
+        src: url
+        url: https://zenodo.org/api/files/af88bbbe-43a7-4c6b-8e12-3477cd3106ad/male
+      - ext: ''
+        info: https://doi.org/10.5281/zenodo.1219888
+        src: url
+        url: https://zenodo.org/api/files/af88bbbe-43a7-4c6b-8e12-3477cd3106ad/progeny_1
+      - ext: ''
+        info: https://doi.org/10.5281/zenodo.1219888
+        src: url
+        url: https://zenodo.org/api/files/af88bbbe-43a7-4c6b-8e12-3477cd3106ad/progeny_10
+      - ext: ''
+        info: https://doi.org/10.5281/zenodo.1219888
+        src: url
+        url: https://zenodo.org/api/files/af88bbbe-43a7-4c6b-8e12-3477cd3106ad/progeny_11
+      - ext: ''
+        info: https://doi.org/10.5281/zenodo.1219888
+        src: url
+        url: https://zenodo.org/api/files/af88bbbe-43a7-4c6b-8e12-3477cd3106ad/progeny_12
+      - ext: ''
+        info: https://doi.org/10.5281/zenodo.1219888
+        src: url
+        url: https://zenodo.org/api/files/af88bbbe-43a7-4c6b-8e12-3477cd3106ad/progeny_13
+      - ext: ''
+        info: https://doi.org/10.5281/zenodo.1219888
+        src: url
+        url: https://zenodo.org/api/files/af88bbbe-43a7-4c6b-8e12-3477cd3106ad/progeny_14
+      - ext: ''
+        info: https://doi.org/10.5281/zenodo.1219888
+        src: url
+        url: https://zenodo.org/api/files/af88bbbe-43a7-4c6b-8e12-3477cd3106ad/progeny_15
+      - ext: ''
+        info: https://doi.org/10.5281/zenodo.1219888
+        src: url
+        url: https://zenodo.org/api/files/af88bbbe-43a7-4c6b-8e12-3477cd3106ad/progeny_16
+      - ext: ''
+        info: https://doi.org/10.5281/zenodo.1219888
+        src: url
+        url: https://zenodo.org/api/files/af88bbbe-43a7-4c6b-8e12-3477cd3106ad/progeny_17
+      - ext: ''
+        info: https://doi.org/10.5281/zenodo.1219888
+        src: url
+        url: https://zenodo.org/api/files/af88bbbe-43a7-4c6b-8e12-3477cd3106ad/progeny_18
+      - ext: ''
+        info: https://doi.org/10.5281/zenodo.1219888
+        src: url
+        url: https://zenodo.org/api/files/af88bbbe-43a7-4c6b-8e12-3477cd3106ad/progeny_19
+      - ext: ''
+        info: https://doi.org/10.5281/zenodo.1219888
+        src: url
+        url: https://zenodo.org/api/files/af88bbbe-43a7-4c6b-8e12-3477cd3106ad/progeny_2
+      - ext: ''
+        info: https://doi.org/10.5281/zenodo.1219888
+        src: url
+        url: https://zenodo.org/api/files/af88bbbe-43a7-4c6b-8e12-3477cd3106ad/progeny_20
+      - ext: ''
+        info: https://doi.org/10.5281/zenodo.1219888
+        src: url
+        url: https://zenodo.org/api/files/af88bbbe-43a7-4c6b-8e12-3477cd3106ad/progeny_3
+      - ext: ''
+        info: https://doi.org/10.5281/zenodo.1219888
+        src: url
+        url: https://zenodo.org/api/files/af88bbbe-43a7-4c6b-8e12-3477cd3106ad/progeny_4
+      - ext: ''
+        info: https://doi.org/10.5281/zenodo.1219888
+        src: url
+        url: https://zenodo.org/api/files/af88bbbe-43a7-4c6b-8e12-3477cd3106ad/progeny_5
+      - ext: ''
+        info: https://doi.org/10.5281/zenodo.1219888
+        src: url
+        url: https://zenodo.org/api/files/af88bbbe-43a7-4c6b-8e12-3477cd3106ad/progeny_6
+      - ext: ''
+        info: https://doi.org/10.5281/zenodo.1219888
+        src: url
+        url: https://zenodo.org/api/files/af88bbbe-43a7-4c6b-8e12-3477cd3106ad/progeny_7
+      - ext: ''
+        info: https://doi.org/10.5281/zenodo.1219888
+        src: url
+        url: https://zenodo.org/api/files/af88bbbe-43a7-4c6b-8e12-3477cd3106ad/progeny_8
+      - ext: ''
+        info: https://doi.org/10.5281/zenodo.1219888
+        src: url
+        url: https://zenodo.org/api/files/af88bbbe-43a7-4c6b-8e12-3477cd3106ad/progeny_9
+    name: Sequence analysis

--- a/topics/sequence-analysis/tutorials/mapping/data-library.yaml
+++ b/topics/sequence-analysis/tutorials/mapping/data-library.yaml
@@ -1,7 +1,138 @@
 ---
-libraries:
-    # This needs to be changed to reference your Zenodo data
-    - name: "Small test files"
-      files:
-          - url: "http://raw.githubusercontent.com/bgruening/galaxytools/master/tools/rna_tools/sortmerna/test-data/read_small.fasta"
-            file_type: "fasta"
+destination:
+  description: Galaxy Training Network Material
+  name: GTN - Material
+  synopsis: Galaxy Training Network Material. See https://training.galaxyproject.org
+  type: library
+items:
+  - description: Analyses of sequences
+    items:
+      - ext: counts
+        info: https://doi.org/10.5281/zenodo.61771
+        src: url
+        url: https://zenodo.org/api/files/8277b9f8-3c39-412a-8a1f-76bc810630e3/GSM461180_treat_paired.counts
+      - ext: bed
+        info: https://doi.org/10.5281/zenodo.61771
+        src: url
+        url: https://zenodo.org/api/files/8277b9f8-3c39-412a-8a1f-76bc810630e3/GSM461177_untreat_paired_junctions_chr4.bed
+      - ext: gtf
+        info: https://doi.org/10.5281/zenodo.61771
+        src: url
+        url: https://zenodo.org/api/files/8277b9f8-3c39-412a-8a1f-76bc810630e3/Drosophila_melanogaster.BDGP5.78.gtf
+      - ext: fastq
+        info: https://doi.org/10.5281/zenodo.61771
+        src: url
+        url: https://zenodo.org/api/files/8277b9f8-3c39-412a-8a1f-76bc810630e3/GSM461176_untreat_single_subset.fastq
+      - ext: counts
+        info: https://doi.org/10.5281/zenodo.61771
+        src: url
+        url: https://zenodo.org/api/files/8277b9f8-3c39-412a-8a1f-76bc810630e3/GSM461181_treat_paired.counts
+      - ext: bed
+        info: https://doi.org/10.5281/zenodo.61771
+        src: url
+        url: https://zenodo.org/api/files/8277b9f8-3c39-412a-8a1f-76bc810630e3/GSM461177_untreat_paired_insertions_chr4.bed
+      - ext: txt
+        info: https://doi.org/10.5281/zenodo.61771
+        src: url
+        url: https://zenodo.org/api/files/8277b9f8-3c39-412a-8a1f-76bc810630e3/treated3_paired.txt
+      - ext: fastq
+        info: https://doi.org/10.5281/zenodo.61771
+        src: url
+        url: https://zenodo.org/api/files/8277b9f8-3c39-412a-8a1f-76bc810630e3/GSM461180_treat_paired_subset_2.fastq
+      - ext: fastq
+        info: https://doi.org/10.5281/zenodo.61771
+        src: url
+        url: https://zenodo.org/api/files/8277b9f8-3c39-412a-8a1f-76bc810630e3/GSM461177_untreat_paired_subset_1.fastq
+      - ext: txt
+        info: https://doi.org/10.5281/zenodo.61771
+        src: url
+        url: https://zenodo.org/api/files/8277b9f8-3c39-412a-8a1f-76bc810630e3/untreated1_single.txt
+      - ext: bed
+        info: https://doi.org/10.5281/zenodo.61771
+        src: url
+        url: https://zenodo.org/api/files/8277b9f8-3c39-412a-8a1f-76bc810630e3/GSM461177_untreat_paired_deletions_chr4.bed
+      - ext: counts
+        info: https://doi.org/10.5281/zenodo.61771
+        src: url
+        url: https://zenodo.org/api/files/8277b9f8-3c39-412a-8a1f-76bc810630e3/GSM461176_untreat_single.counts
+      - ext: bam
+        info: https://doi.org/10.5281/zenodo.61771
+        src: url
+        url: https://zenodo.org/api/files/8277b9f8-3c39-412a-8a1f-76bc810630e3/GSM461177_untreat_paired_chr4.bam
+      - ext: fastq
+        info: https://doi.org/10.5281/zenodo.61771
+        src: url
+        url: https://zenodo.org/api/files/8277b9f8-3c39-412a-8a1f-76bc810630e3/GSM461180_treat_paired_subset_1.fastq
+      - ext: fastq
+        info: https://doi.org/10.5281/zenodo.61771
+        src: url
+        url: https://zenodo.org/api/files/8277b9f8-3c39-412a-8a1f-76bc810630e3/GSM461181_treat_paired_subset_2.fastq
+      - ext: counts
+        info: https://doi.org/10.5281/zenodo.61771
+        src: url
+        url: https://zenodo.org/api/files/8277b9f8-3c39-412a-8a1f-76bc810630e3/GSM461178_untreat_paired.counts
+      - ext: txt
+        info: https://doi.org/10.5281/zenodo.61771
+        src: url
+        url: https://zenodo.org/api/files/8277b9f8-3c39-412a-8a1f-76bc810630e3/untreated2_single.txt
+      - ext: txt
+        info: https://doi.org/10.5281/zenodo.61771
+        src: url
+        url: https://zenodo.org/api/files/8277b9f8-3c39-412a-8a1f-76bc810630e3/untreated3_paired.txt
+      - ext: counts
+        info: https://doi.org/10.5281/zenodo.61771
+        src: url
+        url: https://zenodo.org/api/files/8277b9f8-3c39-412a-8a1f-76bc810630e3/GSM461182_untreat_single.counts
+      - ext: counts
+        info: https://doi.org/10.5281/zenodo.61771
+        src: url
+        url: https://zenodo.org/api/files/8277b9f8-3c39-412a-8a1f-76bc810630e3/GSM461179_treat_single.counts
+      - ext: gtf
+        info: https://doi.org/10.5281/zenodo.61771
+        src: url
+        url: https://zenodo.org/api/files/8277b9f8-3c39-412a-8a1f-76bc810630e3/dexseq.gtf
+      - ext: fastq
+        info: https://doi.org/10.5281/zenodo.61771
+        src: url
+        url: https://zenodo.org/api/files/8277b9f8-3c39-412a-8a1f-76bc810630e3/GSM461179_treat_single_subset.fastq
+      - ext: fastq
+        info: https://doi.org/10.5281/zenodo.61771
+        src: url
+        url: https://zenodo.org/api/files/8277b9f8-3c39-412a-8a1f-76bc810630e3/GSM461178_untreat_paired_subset_2.fastq
+      - ext: fastq
+        info: https://doi.org/10.5281/zenodo.61771
+        src: url
+        url: https://zenodo.org/api/files/8277b9f8-3c39-412a-8a1f-76bc810630e3/GSM461177_untreat_paired_subset_2.fastq
+      - ext: txt
+        info: https://doi.org/10.5281/zenodo.61771
+        src: url
+        url: https://zenodo.org/api/files/8277b9f8-3c39-412a-8a1f-76bc810630e3/untreated4_paired.txt
+      - ext: fastq
+        info: https://doi.org/10.5281/zenodo.61771
+        src: url
+        url: https://zenodo.org/api/files/8277b9f8-3c39-412a-8a1f-76bc810630e3/GSM461182_untreat_single_subset.fastq
+      - ext: fastq
+        info: https://doi.org/10.5281/zenodo.61771
+        src: url
+        url: https://zenodo.org/api/files/8277b9f8-3c39-412a-8a1f-76bc810630e3/GSM461178_untreat_paired_subset_1.fastq
+      - ext: txt
+        info: https://doi.org/10.5281/zenodo.61771
+        src: url
+        url: https://zenodo.org/api/files/8277b9f8-3c39-412a-8a1f-76bc810630e3/treated1_single.txt
+      - ext: counts
+        info: https://doi.org/10.5281/zenodo.61771
+        src: url
+        url: https://zenodo.org/api/files/8277b9f8-3c39-412a-8a1f-76bc810630e3/GSM461177_untreat_paired.counts
+      - ext: txt
+        info: https://doi.org/10.5281/zenodo.61771
+        src: url
+        url: https://zenodo.org/api/files/8277b9f8-3c39-412a-8a1f-76bc810630e3/treated2_paired.txt
+      - ext: bam
+        info: https://doi.org/10.5281/zenodo.61771
+        src: url
+        url: https://zenodo.org/api/files/8277b9f8-3c39-412a-8a1f-76bc810630e3/GSM461178_untreat_paired_chr4.bam
+      - ext: fastq
+        info: https://doi.org/10.5281/zenodo.61771
+        src: url
+        url: https://zenodo.org/api/files/8277b9f8-3c39-412a-8a1f-76bc810630e3/GSM461181_treat_paired_subset_1.fastq
+    name: Sequence analysis

--- a/topics/sequence-analysis/tutorials/quality-control/data-library.yaml
+++ b/topics/sequence-analysis/tutorials/quality-control/data-library.yaml
@@ -1,6 +1,138 @@
 ---
-libraries:
-    - name: "Small file (to change)"
-      files:
-          - url: "http://raw.githubusercontent.com/bgruening/galaxytools/master/tools/rna_tools/sortmerna/test-data/read_small.fasta"
-            file_type: "fasta"
+destination:
+  description: Galaxy Training Network Material
+  name: GTN - Material
+  synopsis: Galaxy Training Network Material. See https://training.galaxyproject.org
+  type: library
+items:
+  - description: Analyses of sequences
+    items:
+      - ext: counts
+        info: https://doi.org/10.5281/zenodo.61771
+        src: url
+        url: https://zenodo.org/api/files/8277b9f8-3c39-412a-8a1f-76bc810630e3/GSM461180_treat_paired.counts
+      - ext: bed
+        info: https://doi.org/10.5281/zenodo.61771
+        src: url
+        url: https://zenodo.org/api/files/8277b9f8-3c39-412a-8a1f-76bc810630e3/GSM461177_untreat_paired_junctions_chr4.bed
+      - ext: gtf
+        info: https://doi.org/10.5281/zenodo.61771
+        src: url
+        url: https://zenodo.org/api/files/8277b9f8-3c39-412a-8a1f-76bc810630e3/Drosophila_melanogaster.BDGP5.78.gtf
+      - ext: fastq
+        info: https://doi.org/10.5281/zenodo.61771
+        src: url
+        url: https://zenodo.org/api/files/8277b9f8-3c39-412a-8a1f-76bc810630e3/GSM461176_untreat_single_subset.fastq
+      - ext: counts
+        info: https://doi.org/10.5281/zenodo.61771
+        src: url
+        url: https://zenodo.org/api/files/8277b9f8-3c39-412a-8a1f-76bc810630e3/GSM461181_treat_paired.counts
+      - ext: bed
+        info: https://doi.org/10.5281/zenodo.61771
+        src: url
+        url: https://zenodo.org/api/files/8277b9f8-3c39-412a-8a1f-76bc810630e3/GSM461177_untreat_paired_insertions_chr4.bed
+      - ext: txt
+        info: https://doi.org/10.5281/zenodo.61771
+        src: url
+        url: https://zenodo.org/api/files/8277b9f8-3c39-412a-8a1f-76bc810630e3/treated3_paired.txt
+      - ext: fastq
+        info: https://doi.org/10.5281/zenodo.61771
+        src: url
+        url: https://zenodo.org/api/files/8277b9f8-3c39-412a-8a1f-76bc810630e3/GSM461180_treat_paired_subset_2.fastq
+      - ext: fastq
+        info: https://doi.org/10.5281/zenodo.61771
+        src: url
+        url: https://zenodo.org/api/files/8277b9f8-3c39-412a-8a1f-76bc810630e3/GSM461177_untreat_paired_subset_1.fastq
+      - ext: txt
+        info: https://doi.org/10.5281/zenodo.61771
+        src: url
+        url: https://zenodo.org/api/files/8277b9f8-3c39-412a-8a1f-76bc810630e3/untreated1_single.txt
+      - ext: bed
+        info: https://doi.org/10.5281/zenodo.61771
+        src: url
+        url: https://zenodo.org/api/files/8277b9f8-3c39-412a-8a1f-76bc810630e3/GSM461177_untreat_paired_deletions_chr4.bed
+      - ext: counts
+        info: https://doi.org/10.5281/zenodo.61771
+        src: url
+        url: https://zenodo.org/api/files/8277b9f8-3c39-412a-8a1f-76bc810630e3/GSM461176_untreat_single.counts
+      - ext: bam
+        info: https://doi.org/10.5281/zenodo.61771
+        src: url
+        url: https://zenodo.org/api/files/8277b9f8-3c39-412a-8a1f-76bc810630e3/GSM461177_untreat_paired_chr4.bam
+      - ext: fastq
+        info: https://doi.org/10.5281/zenodo.61771
+        src: url
+        url: https://zenodo.org/api/files/8277b9f8-3c39-412a-8a1f-76bc810630e3/GSM461180_treat_paired_subset_1.fastq
+      - ext: fastq
+        info: https://doi.org/10.5281/zenodo.61771
+        src: url
+        url: https://zenodo.org/api/files/8277b9f8-3c39-412a-8a1f-76bc810630e3/GSM461181_treat_paired_subset_2.fastq
+      - ext: counts
+        info: https://doi.org/10.5281/zenodo.61771
+        src: url
+        url: https://zenodo.org/api/files/8277b9f8-3c39-412a-8a1f-76bc810630e3/GSM461178_untreat_paired.counts
+      - ext: txt
+        info: https://doi.org/10.5281/zenodo.61771
+        src: url
+        url: https://zenodo.org/api/files/8277b9f8-3c39-412a-8a1f-76bc810630e3/untreated2_single.txt
+      - ext: txt
+        info: https://doi.org/10.5281/zenodo.61771
+        src: url
+        url: https://zenodo.org/api/files/8277b9f8-3c39-412a-8a1f-76bc810630e3/untreated3_paired.txt
+      - ext: counts
+        info: https://doi.org/10.5281/zenodo.61771
+        src: url
+        url: https://zenodo.org/api/files/8277b9f8-3c39-412a-8a1f-76bc810630e3/GSM461182_untreat_single.counts
+      - ext: counts
+        info: https://doi.org/10.5281/zenodo.61771
+        src: url
+        url: https://zenodo.org/api/files/8277b9f8-3c39-412a-8a1f-76bc810630e3/GSM461179_treat_single.counts
+      - ext: gtf
+        info: https://doi.org/10.5281/zenodo.61771
+        src: url
+        url: https://zenodo.org/api/files/8277b9f8-3c39-412a-8a1f-76bc810630e3/dexseq.gtf
+      - ext: fastq
+        info: https://doi.org/10.5281/zenodo.61771
+        src: url
+        url: https://zenodo.org/api/files/8277b9f8-3c39-412a-8a1f-76bc810630e3/GSM461179_treat_single_subset.fastq
+      - ext: fastq
+        info: https://doi.org/10.5281/zenodo.61771
+        src: url
+        url: https://zenodo.org/api/files/8277b9f8-3c39-412a-8a1f-76bc810630e3/GSM461178_untreat_paired_subset_2.fastq
+      - ext: fastq
+        info: https://doi.org/10.5281/zenodo.61771
+        src: url
+        url: https://zenodo.org/api/files/8277b9f8-3c39-412a-8a1f-76bc810630e3/GSM461177_untreat_paired_subset_2.fastq
+      - ext: txt
+        info: https://doi.org/10.5281/zenodo.61771
+        src: url
+        url: https://zenodo.org/api/files/8277b9f8-3c39-412a-8a1f-76bc810630e3/untreated4_paired.txt
+      - ext: fastq
+        info: https://doi.org/10.5281/zenodo.61771
+        src: url
+        url: https://zenodo.org/api/files/8277b9f8-3c39-412a-8a1f-76bc810630e3/GSM461182_untreat_single_subset.fastq
+      - ext: fastq
+        info: https://doi.org/10.5281/zenodo.61771
+        src: url
+        url: https://zenodo.org/api/files/8277b9f8-3c39-412a-8a1f-76bc810630e3/GSM461178_untreat_paired_subset_1.fastq
+      - ext: txt
+        info: https://doi.org/10.5281/zenodo.61771
+        src: url
+        url: https://zenodo.org/api/files/8277b9f8-3c39-412a-8a1f-76bc810630e3/treated1_single.txt
+      - ext: counts
+        info: https://doi.org/10.5281/zenodo.61771
+        src: url
+        url: https://zenodo.org/api/files/8277b9f8-3c39-412a-8a1f-76bc810630e3/GSM461177_untreat_paired.counts
+      - ext: txt
+        info: https://doi.org/10.5281/zenodo.61771
+        src: url
+        url: https://zenodo.org/api/files/8277b9f8-3c39-412a-8a1f-76bc810630e3/treated2_paired.txt
+      - ext: bam
+        info: https://doi.org/10.5281/zenodo.61771
+        src: url
+        url: https://zenodo.org/api/files/8277b9f8-3c39-412a-8a1f-76bc810630e3/GSM461178_untreat_paired_chr4.bam
+      - ext: fastq
+        info: https://doi.org/10.5281/zenodo.61771
+        src: url
+        url: https://zenodo.org/api/files/8277b9f8-3c39-412a-8a1f-76bc810630e3/GSM461181_treat_paired_subset_1.fastq
+    name: Sequence analysis

--- a/topics/sequence-analysis/tutorials/ref-based-rad-seq/data-library.yaml
+++ b/topics/sequence-analysis/tutorials/ref-based-rad-seq/data-library.yaml
@@ -1,7 +1,22 @@
 ---
-libraries:
-    # This needs to be changed to reference your Zenodo data
-    - name: "Small test files"
-      files:
-          - url: "http://raw.githubusercontent.com/bgruening/galaxytools/master/tools/rna_tools/sortmerna/test-data/read_small.fasta"
-            file_type: "fasta"
+destination:
+  description: Galaxy Training Network Material
+  name: GTN - Material
+  synopsis: Galaxy Training Network Material. See https://training.galaxyproject.org
+  type: library
+items:
+  - description: Analyses of sequences
+    items:
+      - ext: txt
+        info: https://doi.org/10.5281/zenodo.1134547
+        src: url
+        url: https://zenodo.org/api/files/dc22cf60-8ec9-4d2f-83e3-16e1922aa079/Barcode_SRR034310.txt
+      - ext: txt
+        info: https://doi.org/10.5281/zenodo.1134547
+        src: url
+        url: https://zenodo.org/api/files/dc22cf60-8ec9-4d2f-83e3-16e1922aa079/Details_Barcode_Population_SRR034310.txt
+      - ext: fasta
+        info: https://doi.org/10.5281/zenodo.1134547
+        src: url
+        url: https://zenodo.org/api/files/dc22cf60-8ec9-4d2f-83e3-16e1922aa079/Reference_genome_11_chromosomes.fasta
+    name: Sequence analysis

--- a/topics/statistics/tutorials/iwtomics/data-library.yaml
+++ b/topics/statistics/tutorials/iwtomics/data-library.yaml
@@ -1,6 +1,14 @@
 ---
-libraries:
-  - name: ETn_example
-    files:
-      - url: https://doi.org/10.5281/zenodo.1184682
-        file_type: "zip"
+destination:
+  description: Galaxy Training Network Material
+  name: GTN - Material
+  synopsis: Galaxy Training Network Material. See https://training.galaxyproject.org
+  type: library
+items:
+  - description: Statistical Analyses for omics data
+    items:
+      - ext: zip
+        info: https://doi.org/10.5281/zenodo.1184682
+        src: url
+        url: https://zenodo.org/api/files/d43d8e47-11fc-42de-a10f-461103f4be05/IWTomics_ETn_dataset_example.zip
+    name: Statistics

--- a/topics/transcriptomics/tutorials/de-novo/data-library.yaml
+++ b/topics/transcriptomics/tutorials/de-novo/data-library.yaml
@@ -1,24 +1,50 @@
 ---
-libraries:
-    - name: de-novo
-      files:
-          - url: https://zenodo.org/record/254485/files/G1E_R1_forward_downsampled_SRR549355.fastqsanger.gz
-            file_type: "fastqsanger"
-          - url: https://zenodo.org/record/254485/files/G1E_R1_reverse_downsampled_SRR549355.fastqsanger.gz
-            file_type: "fastqsanger"
-          - url: https://zenodo.org/record/254485/files/G1E_R2_forward_downsampled_SRR549356.fastqsanger.gz
-            file_type: "fastqsanger"
-          - url: https://zenodo.org/record/254485/files/G1E_R2_reverse_downsampled_SRR549356.fastqsanger.gz
-            file_type: "fastqsanger"
-          - url: https://zenodo.org/record/254485/files/Megakaryocyte_R1_forward_downsampled_SRR549357.fastqsanger.gz
-            file_type: "fastqsanger"
-          - url: https://zenodo.org/record/254485/files/Megakaryocyte_R1_reverse_downsampled_SRR549357.fastqsanger.gz
-            file_type: "fastqsanger"
-          - url: https://zenodo.org/record/254485/files/Megakaryocyte_R2_forward_downsampled_SRR549358.fastqsanger.gz
-            file_type: "fastqsanger"
-          - url: https://zenodo.org/record/254485/files/Megakaryocyte_R2_reverse_downsampled_SRR549358.fastqsanger.gz
-            file_type: "fastqsanger"
-          - url: https://zenodo.org/record/254485/files/RefSeq_gene_annotations_mm10.bed.gtf.gz
-            file_type: "gtf"
-          - url: https://zenodo.org/record/254485/files/RNAseq_regions_of_interest.bed.gz
-            file_type: "bed"
+destination:
+  description: Galaxy Training Network Material
+  name: GTN - Material
+  synopsis: Galaxy Training Network Material. See https://training.galaxyproject.org
+  type: library
+items:
+  - description: Training material for all kinds of transcriptomics analysis.
+    items:
+      - ext: gz
+        info: https://zenodo.org/record/254485#.WKODmRIrKRu
+        src: url
+        url: https://zenodo.org/api/files/47580600-dce0-44cf-b4d9-62713ab9fa63/G1E_R1_forward_downsampled_SRR549355.fastqsanger.gz
+      - ext: gz
+        info: https://zenodo.org/record/254485#.WKODmRIrKRu
+        src: url
+        url: https://zenodo.org/api/files/47580600-dce0-44cf-b4d9-62713ab9fa63/G1E_R1_reverse_downsampled_SRR549355.fastqsanger.gz
+      - ext: gz
+        info: https://zenodo.org/record/254485#.WKODmRIrKRu
+        src: url
+        url: https://zenodo.org/api/files/47580600-dce0-44cf-b4d9-62713ab9fa63/G1E_R2_forward_downsampled_SRR549356.fastqsanger.gz
+      - ext: gz
+        info: https://zenodo.org/record/254485#.WKODmRIrKRu
+        src: url
+        url: https://zenodo.org/api/files/47580600-dce0-44cf-b4d9-62713ab9fa63/G1E_R2_reverse_downsampled_SRR549356.fastqsanger.gz
+      - ext: gz
+        info: https://zenodo.org/record/254485#.WKODmRIrKRu
+        src: url
+        url: https://zenodo.org/api/files/47580600-dce0-44cf-b4d9-62713ab9fa63/Megakaryocyte_R1_forward_downsampled_SRR549357.fastqsanger.gz
+      - ext: gz
+        info: https://zenodo.org/record/254485#.WKODmRIrKRu
+        src: url
+        url: https://zenodo.org/api/files/47580600-dce0-44cf-b4d9-62713ab9fa63/Megakaryocyte_R1_reverse_downsampled_SRR549357.fastqsanger.gz
+      - ext: gz
+        info: https://zenodo.org/record/254485#.WKODmRIrKRu
+        src: url
+        url: https://zenodo.org/api/files/47580600-dce0-44cf-b4d9-62713ab9fa63/Megakaryocyte_R2_forward_downsampled_SRR549358.fastqsanger.gz
+      - ext: gz
+        info: https://zenodo.org/record/254485#.WKODmRIrKRu
+        src: url
+        url: https://zenodo.org/api/files/47580600-dce0-44cf-b4d9-62713ab9fa63/Megakaryocyte_R2_reverse_downsampled_SRR549358.fastqsanger.gz
+      - ext: gz
+        info: https://zenodo.org/record/254485#.WKODmRIrKRu
+        src: url
+        url: https://zenodo.org/api/files/47580600-dce0-44cf-b4d9-62713ab9fa63/RefSeq_gene_annotations_mm10.bed.gtf.gz
+      - ext: gz
+        info: https://zenodo.org/record/254485#.WKODmRIrKRu
+        src: url
+        url: https://zenodo.org/api/files/47580600-dce0-44cf-b4d9-62713ab9fa63/RNAseq_regions_of_interest.bed.gz
+    name: Transcriptomics

--- a/topics/transcriptomics/tutorials/ref-based/data-library.yaml
+++ b/topics/transcriptomics/tutorials/ref-based/data-library.yaml
@@ -1,60 +1,122 @@
 ---
-libraries:
-  - name: ref-based
-    files:
-      - url: https://zenodo.org/record/1185122/files/Drosophila_melanogaster.BDGP6.87.dexseq.gtf
-        file_type: "gtf"
-      - url: https://zenodo.org/record/1185122/files/Drosophila_melanogaster.BDGP6.87.gene_lengths
-        file_type: "tabular"
-      - url: https://zenodo.org/record/1185122/files/Drosophila_melanogaster.BDGP6.87.gtf
-        file_type: "gtf"
-      - url: https://zenodo.org/record/1185122/files/GSM461176.fastqsanger
-        file_type: "fastqsanger"
-      - url: https://zenodo.org/record/1185122/files/GSM461176_untreat_single.counts
-        file_type: "tabular"
-      - url: https://zenodo.org/record/1185122/files/GSM461176_untreat_single.exon.counts
-        file_type: "tabular"
-      - url: https://zenodo.org/record/1185122/files/GSM461177_1.fastqsanger
-        file_type: "fastqsanger"
-      - url: https://zenodo.org/record/1185122/files/GSM461177_2.fastqsanger
-        file_type: "fastqsanger"
-      - url: https://zenodo.org/record/1185122/files/GSM461177_untreat_paired.counts
-        file_type: "tabular"
-      - url: https://zenodo.org/record/1185122/files/GSM461177_untreat_paired.exon.counts
-        file_type: "tabular"
-      - url: https://zenodo.org/record/1185122/files/GSM461178_1.fastqsanger
-        file_type: "fastqsanger"
-      - url: https://zenodo.org/record/1185122/files/GSM461178_2.fastqsanger
-        file_type: "fastqsanger"
-      - url: https://zenodo.org/record/1185122/files/GSM461178_untreat_paired.counts
-        file_type: "tabular"
-      - url: https://zenodo.org/record/1185122/files/GSM461178_untreat_paired.exon.counts
-        file_type: "tabular"
-      - url: https://zenodo.org/record/1185122/files/GSM461179.fastqsanger
-        file_type: "fastqsanger"
-      - url: https://zenodo.org/record/1185122/files/GSM461179_treat_single.counts
-        file_type: "tabular"
-      - url: https://zenodo.org/record/1185122/files/GSM461179_treat_single.exon.counts
-        file_type: "tabular"
-      - url: https://zenodo.org/record/1185122/files/GSM461180_1.fastqsanger
-        file_type: "fastqsanger"
-      - url: https://zenodo.org/record/1185122/files/GSM461180_2.fastqsanger
-        file_type: "fastqsanger"
-      - url: https://zenodo.org/record/1185122/files/GSM461180_treat_paired.counts
-        file_type: "tabular"
-      - url: https://zenodo.org/record/1185122/files/GSM461180_treat_paired.exon.counts
-        file_type: "tabular"
-      - url: https://zenodo.org/record/1185122/files/GSM461181_1.fastqsanger
-        file_type: "fastqsanger"
-      - url: https://zenodo.org/record/1185122/files/GSM461181_2.fastqsanger
-        file_type: "fastqsanger"
-      - url: https://zenodo.org/record/1185122/files/GSM461181_treat_paired.counts
-        file_type: "tabular"
-      - url: https://zenodo.org/record/1185122/files/GSM461181_treat_paired.exon.counts
-        file_type: "tabular"
-      - url: https://zenodo.org/record/1185122/files/GSM461182.fastqsanger
-        file_type: "fastqsanger"
-      - url: https://zenodo.org/record/1185122/files/GSM461182_untreat_single.counts
-        file_type: "tabular"
-      - url: https://zenodo.org/record/1185122/files/GSM461182_untreat_single.exon.counts
-        file_type: "tabular"
+destination:
+  description: Galaxy Training Network Material
+  name: GTN - Material
+  synopsis: Galaxy Training Network Material. See https://training.galaxyproject.org
+  type: library
+items:
+  - description: Training material for all kinds of transcriptomics analysis.
+    items:
+      - ext: gtf
+        info: https://zenodo.org/record/1185122
+        src: url
+        url: https://zenodo.org/api/files/1d804082-4153-47f1-a320-4ac261ce091d/Drosophila_melanogaster.BDGP6.87.dexseq.gtf
+      - ext: gene_lengths
+        info: https://zenodo.org/record/1185122
+        src: url
+        url: https://zenodo.org/api/files/1d804082-4153-47f1-a320-4ac261ce091d/Drosophila_melanogaster.BDGP6.87.gene_lengths
+      - ext: gtf
+        info: https://zenodo.org/record/1185122
+        src: url
+        url: https://zenodo.org/api/files/1d804082-4153-47f1-a320-4ac261ce091d/Drosophila_melanogaster.BDGP6.87.gtf
+      - ext: fastqsanger
+        info: https://zenodo.org/record/1185122
+        src: url
+        url: https://zenodo.org/api/files/1d804082-4153-47f1-a320-4ac261ce091d/GSM461176.fastqsanger
+      - ext: counts
+        info: https://zenodo.org/record/1185122
+        src: url
+        url: https://zenodo.org/api/files/1d804082-4153-47f1-a320-4ac261ce091d/GSM461176_untreat_single.counts
+      - ext: counts
+        info: https://zenodo.org/record/1185122
+        src: url
+        url: https://zenodo.org/api/files/1d804082-4153-47f1-a320-4ac261ce091d/GSM461176_untreat_single.exon.counts
+      - ext: fastqsanger
+        info: https://zenodo.org/record/1185122
+        src: url
+        url: https://zenodo.org/api/files/1d804082-4153-47f1-a320-4ac261ce091d/GSM461177_1.fastqsanger
+      - ext: fastqsanger
+        info: https://zenodo.org/record/1185122
+        src: url
+        url: https://zenodo.org/api/files/1d804082-4153-47f1-a320-4ac261ce091d/GSM461177_2.fastqsanger
+      - ext: counts
+        info: https://zenodo.org/record/1185122
+        src: url
+        url: https://zenodo.org/api/files/1d804082-4153-47f1-a320-4ac261ce091d/GSM461177_untreat_paired.counts
+      - ext: counts
+        info: https://zenodo.org/record/1185122
+        src: url
+        url: https://zenodo.org/api/files/1d804082-4153-47f1-a320-4ac261ce091d/GSM461177_untreat_paired.exon.counts
+      - ext: fastqsanger
+        info: https://zenodo.org/record/1185122
+        src: url
+        url: https://zenodo.org/api/files/1d804082-4153-47f1-a320-4ac261ce091d/GSM461178_1.fastqsanger
+      - ext: fastqsanger
+        info: https://zenodo.org/record/1185122
+        src: url
+        url: https://zenodo.org/api/files/1d804082-4153-47f1-a320-4ac261ce091d/GSM461178_2.fastqsanger
+      - ext: counts
+        info: https://zenodo.org/record/1185122
+        src: url
+        url: https://zenodo.org/api/files/1d804082-4153-47f1-a320-4ac261ce091d/GSM461178_untreat_paired.counts
+      - ext: counts
+        info: https://zenodo.org/record/1185122
+        src: url
+        url: https://zenodo.org/api/files/1d804082-4153-47f1-a320-4ac261ce091d/GSM461178_untreat_paired.exon.counts
+      - ext: fastqsanger
+        info: https://zenodo.org/record/1185122
+        src: url
+        url: https://zenodo.org/api/files/1d804082-4153-47f1-a320-4ac261ce091d/GSM461179.fastqsanger
+      - ext: counts
+        info: https://zenodo.org/record/1185122
+        src: url
+        url: https://zenodo.org/api/files/1d804082-4153-47f1-a320-4ac261ce091d/GSM461179_treat_single.counts
+      - ext: counts
+        info: https://zenodo.org/record/1185122
+        src: url
+        url: https://zenodo.org/api/files/1d804082-4153-47f1-a320-4ac261ce091d/GSM461179_treat_single.exon.counts
+      - ext: fastqsanger
+        info: https://zenodo.org/record/1185122
+        src: url
+        url: https://zenodo.org/api/files/1d804082-4153-47f1-a320-4ac261ce091d/GSM461180_1.fastqsanger
+      - ext: fastqsanger
+        info: https://zenodo.org/record/1185122
+        src: url
+        url: https://zenodo.org/api/files/1d804082-4153-47f1-a320-4ac261ce091d/GSM461180_2.fastqsanger
+      - ext: counts
+        info: https://zenodo.org/record/1185122
+        src: url
+        url: https://zenodo.org/api/files/1d804082-4153-47f1-a320-4ac261ce091d/GSM461180_treat_paired.counts
+      - ext: counts
+        info: https://zenodo.org/record/1185122
+        src: url
+        url: https://zenodo.org/api/files/1d804082-4153-47f1-a320-4ac261ce091d/GSM461180_treat_paired.exon.counts
+      - ext: fastqsanger
+        info: https://zenodo.org/record/1185122
+        src: url
+        url: https://zenodo.org/api/files/1d804082-4153-47f1-a320-4ac261ce091d/GSM461181_1.fastqsanger
+      - ext: fastqsanger
+        info: https://zenodo.org/record/1185122
+        src: url
+        url: https://zenodo.org/api/files/1d804082-4153-47f1-a320-4ac261ce091d/GSM461181_2.fastqsanger
+      - ext: counts
+        info: https://zenodo.org/record/1185122
+        src: url
+        url: https://zenodo.org/api/files/1d804082-4153-47f1-a320-4ac261ce091d/GSM461181_treat_paired.counts
+      - ext: counts
+        info: https://zenodo.org/record/1185122
+        src: url
+        url: https://zenodo.org/api/files/1d804082-4153-47f1-a320-4ac261ce091d/GSM461181_treat_paired.exon.counts
+      - ext: fastqsanger
+        info: https://zenodo.org/record/1185122
+        src: url
+        url: https://zenodo.org/api/files/1d804082-4153-47f1-a320-4ac261ce091d/GSM461182.fastqsanger
+      - ext: counts
+        info: https://zenodo.org/record/1185122
+        src: url
+        url: https://zenodo.org/api/files/1d804082-4153-47f1-a320-4ac261ce091d/GSM461182_untreat_single.counts
+      - ext: counts
+        info: https://zenodo.org/record/1185122
+        src: url
+        url: https://zenodo.org/api/files/1d804082-4153-47f1-a320-4ac261ce091d/GSM461182_untreat_single.exon.counts
+    name: Transcriptomics

--- a/topics/transcriptomics/tutorials/rna-seq-viz-with-cummerbund/data-library.yaml
+++ b/topics/transcriptomics/tutorials/rna-seq-viz-with-cummerbund/data-library.yaml
@@ -1,6 +1,14 @@
 ---
-libraries:
-    - name: "Small file (to change)"
-      files:
-          - url: "http://raw.githubusercontent.com/bgruening/galaxytools/master/tools/rna_tools/sortmerna/test-data/read_small.fasta"
-            file_type: "fasta"
+destination:
+  description: Galaxy Training Network Material
+  name: GTN - Material
+  synopsis: Galaxy Training Network Material. See https://training.galaxyproject.org
+  type: library
+items:
+  - description: Training material for all kinds of transcriptomics analysis.
+    items:
+      - ext: sqlite
+        info: https://zenodo.org/record/1001880
+        src: url
+        url: https://zenodo.org/api/files/f2dd5d28-4948-47f9-87c0-9075e256606d/CuffDiff_SQLite_database.sqlite
+    name: Transcriptomics

--- a/topics/transcriptomics/tutorials/srna/data-library.yaml
+++ b/topics/transcriptomics/tutorials/srna/data-library.yaml
@@ -1,6 +1,50 @@
 ---
-libraries:
-    - name: "Small file (to change)"
-      files:
-          - url: "http://raw.githubusercontent.com/bgruening/galaxytools/master/tools/rna_tools/sortmerna/test-data/read_small.fasta"
-            file_type: "fasta"
+destination:
+  description: Galaxy Training Network Material
+  name: GTN - Material
+  synopsis: Galaxy Training Network Material. See https://training.galaxyproject.org
+  type: library
+items:
+  - description: Training material for all kinds of transcriptomics analysis.
+    items:
+      - ext: gz
+        info: https://zenodo.org/record/826906
+        src: url
+        url: https://zenodo.org/api/files/91891445-b940-4880-a087-751075b0f8f9/Blank_RNAi_sRNA-seq_rep1_downsampled.fastqsanger.gz
+      - ext: gz
+        info: https://zenodo.org/record/826906
+        src: url
+        url: https://zenodo.org/api/files/91891445-b940-4880-a087-751075b0f8f9/Blank_RNAi_sRNA-seq_rep2_downsampled.fastqsanger.gz
+      - ext: gz
+        info: https://zenodo.org/record/826906
+        src: url
+        url: https://zenodo.org/api/files/91891445-b940-4880-a087-751075b0f8f9/Blank_RNAi_sRNA-seq_rep3_downsampled.fastqsanger.gz
+      - ext: gz
+        info: https://zenodo.org/record/826906
+        src: url
+        url: https://zenodo.org/api/files/91891445-b940-4880-a087-751075b0f8f9/dm3_miRNA_hairpin_sequences.fa.gz
+      - ext: gz
+        info: https://zenodo.org/record/826906
+        src: url
+        url: https://zenodo.org/api/files/91891445-b940-4880-a087-751075b0f8f9/dm3_rRNA_sequences.fa.gz
+      - ext: gz
+        info: https://zenodo.org/record/826906
+        src: url
+        url: https://zenodo.org/api/files/91891445-b940-4880-a087-751075b0f8f9/dm3_transcriptome_sequences_downsampled.fa.gz
+      - ext: gz
+        info: https://zenodo.org/record/826906
+        src: url
+        url: https://zenodo.org/api/files/91891445-b940-4880-a087-751075b0f8f9/dm3_transcriptome_Tx2Gene_downsampled.tab.gz
+      - ext: gz
+        info: https://zenodo.org/record/826906
+        src: url
+        url: https://zenodo.org/api/files/91891445-b940-4880-a087-751075b0f8f9/Symp_RNAi_sRNA-seq_rep1_downsampled.fastqsanger.gz
+      - ext: gz
+        info: https://zenodo.org/record/826906
+        src: url
+        url: https://zenodo.org/api/files/91891445-b940-4880-a087-751075b0f8f9/Symp_RNAi_sRNA-seq_rep2_downsampled.fastqsanger.gz
+      - ext: gz
+        info: https://zenodo.org/record/826906
+        src: url
+        url: https://zenodo.org/api/files/91891445-b940-4880-a087-751075b0f8f9/Symp_RNAi_sRNA-seq_rep3_downsampled.fastqsanger.gz
+    name: Transcriptomics

--- a/topics/variant-analysis/tutorials/exome-seq/data-library.yaml
+++ b/topics/variant-analysis/tutorials/exome-seq/data-library.yaml
@@ -1,21 +1,35 @@
 ---
-libraries:
-    - name: exome-seq
-      files:
-          - url: https://zenodo.org/record/60520/files/dbSNP_138.hg19.vcf
-            file_type: vcf
-          - url: https://zenodo.org/record/60520/files/father.bam
-            file_type: bam
-          - url: https://zenodo.org/record/60520/files/GIAB-Ashkenazim-Trio-hg19.gz
-            file_type: fasta
-          - url: https://zenodo.org/record/60520/files/GIAB-Ashkenazim-Trio.txt
-            file_type: txt
-          - url: https://zenodo.org/record/60520/files/mother.bam
-            file_type: bam
-          - url: https://zenodo.org/record/60520/files/patient.bam
-            file_type: bam
-
-# - name: hg19
-#   files:
-#       - url: http://hgdownload.soe.ucsc.edu/goldenPath/hg19/bigZips/hg19.2bit
-#         file_type: twobit
+destination:
+  description: Galaxy Training Network Material
+  name: GTN - Material
+  synopsis: Galaxy Training Network Material. See https://training.galaxyproject.org
+  type: library
+items:
+  - description: Exome sequencing means that all protein-coding genes in a genome
+      are sequenced
+    items:
+      - ext: bam
+        info: https://doi.org/10.5281/zenodo.60520
+        src: url
+        url: https://zenodo.org/api/files/fc05c2ad-eff6-430c-8138-3b6f5934f87c/father.bam
+      - ext: vcf
+        info: https://doi.org/10.5281/zenodo.60520
+        src: url
+        url: https://zenodo.org/api/files/fc05c2ad-eff6-430c-8138-3b6f5934f87c/dbSNP_138.hg19.vcf
+      - ext: bam
+        info: https://doi.org/10.5281/zenodo.60520
+        src: url
+        url: https://zenodo.org/api/files/fc05c2ad-eff6-430c-8138-3b6f5934f87c/patient.bam
+      - ext: txt
+        info: https://doi.org/10.5281/zenodo.60520
+        src: url
+        url: https://zenodo.org/api/files/fc05c2ad-eff6-430c-8138-3b6f5934f87c/GIAB-Ashkenazim-Trio.txt
+      - ext: gz
+        info: https://doi.org/10.5281/zenodo.60520
+        src: url
+        url: https://zenodo.org/api/files/fc05c2ad-eff6-430c-8138-3b6f5934f87c/GIAB-Ashkenazim-Trio-hg19.gz
+      - ext: bam
+        info: https://doi.org/10.5281/zenodo.60520
+        src: url
+        url: https://zenodo.org/api/files/fc05c2ad-eff6-430c-8138-3b6f5934f87c/mother.bam
+    name: Variant Analysis

--- a/topics/variant-analysis/tutorials/mapping-by-sequencing/data-library.yaml
+++ b/topics/variant-analysis/tutorials/mapping-by-sequencing/data-library.yaml
@@ -1,10 +1,19 @@
 ---
-libraries:
-    - name: mapping-by-sequencing
-      files:
-          - url: https://zenodo.org/record/1098034/files/Ler_mapping_strain.bam
-            file_type: "bam"
-          - url: https://zenodo.org/record/1098034/files/outcrossed_F2.bam
-            file_type: "bam"
-          - url: https://www.arabidopsis.org/download_files/Genes/TAIR10_genome_release/TAIR10_chromosome_files/TAIR10_chr_all.fas
-            file_type: "fasta"
+destination:
+  description: Galaxy Training Network Material
+  name: GTN - Material
+  synopsis: Galaxy Training Network Material. See https://training.galaxyproject.org
+  type: library
+items:
+  - description: Exome sequencing means that all protein-coding genes in a genome
+      are sequenced
+    items:
+      - ext: bam
+        info: https://doi.org/10.5281/zenodo.1098033
+        src: url
+        url: https://zenodo.org/api/files/46fdf82f-b16a-4c96-801f-02a105c2b0e8/Ler_mapping_strain.bam
+      - ext: bam
+        info: https://doi.org/10.5281/zenodo.1098033
+        src: url
+        url: https://zenodo.org/api/files/46fdf82f-b16a-4c96-801f-02a105c2b0e8/outcrossed_F2.bam
+    name: Variant Analysis

--- a/topics/variant-analysis/tutorials/microbial-variants/data-library.yaml
+++ b/topics/variant-analysis/tutorials/microbial-variants/data-library.yaml
@@ -1,14 +1,31 @@
 ---
-libraries:
-  - name: assembly_data
-    files:
-      - url: https://zenodo.org/record/582600/files/mutant_R1.fastq
-        file_type: "fastqsanger"
-      - url: https://zenodo.org/record/582600/files/mutant_R2.fastq
-        file_type: "fastqsanger"
-      - url: https://zenodo.org/record/582600/files/wildtype.gbk
-        file_type: "genbank"
-      - url: https://zenodo.org/record/582600/files/wildtype.gff
-        file_type: "gff3"
-      - url: https://zenodo.org/record/582600/files/wildtype.fna
-        file_type: "fasta"
+destination:
+  description: Galaxy Training Network Material
+  name: GTN - Material
+  synopsis: Galaxy Training Network Material. See https://training.galaxyproject.org
+  type: library
+items:
+  - description: Exome sequencing means that all protein-coding genes in a genome
+      are sequenced
+    items:
+      - ext: fastq
+        info: https://doi.org/10.5281/zenodo.582600
+        src: url
+        url: https://zenodo.org/api/files/287966da-5411-4f79-8cfb-0ffa84d0d6cc/mutant_R1.fastq
+      - ext: fastq
+        info: https://doi.org/10.5281/zenodo.582600
+        src: url
+        url: https://zenodo.org/api/files/287966da-5411-4f79-8cfb-0ffa84d0d6cc/mutant_R2.fastq
+      - ext: fna
+        info: https://doi.org/10.5281/zenodo.582600
+        src: url
+        url: https://zenodo.org/api/files/287966da-5411-4f79-8cfb-0ffa84d0d6cc/wildtype.fna
+      - ext: gbk
+        info: https://doi.org/10.5281/zenodo.582600
+        src: url
+        url: https://zenodo.org/api/files/287966da-5411-4f79-8cfb-0ffa84d0d6cc/wildtype.gbk
+      - ext: gff
+        info: https://doi.org/10.5281/zenodo.582600
+        src: url
+        url: https://zenodo.org/api/files/287966da-5411-4f79-8cfb-0ffa84d0d6cc/wildtype.gff
+    name: Variant Analysis

--- a/topics/variant-analysis/tutorials/non-dip/data-library.yaml
+++ b/topics/variant-analysis/tutorials/non-dip/data-library.yaml
@@ -1,0 +1,27 @@
+---
+destination:
+  description: Galaxy Training Network Material
+  name: GTN - Material
+  synopsis: Galaxy Training Network Material. See https://training.galaxyproject.org
+  type: library
+items:
+  - description: Exome sequencing means that all protein-coding genes in a genome
+      are sequenced
+    items:
+      - ext: fq
+        info: https://doi.org/10.5281/zenodo.1251112
+        src: url
+        url: https://zenodo.org/api/files/c7f28da4-3925-41c6-8bd1-81d6e6441dc2/raw_child-ds-1.fq
+      - ext: fq
+        info: https://doi.org/10.5281/zenodo.1251112
+        src: url
+        url: https://zenodo.org/api/files/c7f28da4-3925-41c6-8bd1-81d6e6441dc2/raw_child-ds-2.fq
+      - ext: fq
+        info: https://doi.org/10.5281/zenodo.1251112
+        src: url
+        url: https://zenodo.org/api/files/c7f28da4-3925-41c6-8bd1-81d6e6441dc2/raw_mother-ds-1.fq
+      - ext: fq
+        info: https://doi.org/10.5281/zenodo.1251112
+        src: url
+        url: https://zenodo.org/api/files/c7f28da4-3925-41c6-8bd1-81d6e6441dc2/raw_mother-ds-2.fq
+    name: Variant Analysis


### PR DESCRIPTION
This PR:
- Add a Python script to generate `data-library.yaml` file from Zenodo link
   It retrieves the Zenodo record from the `metadata.yaml` file, queries the Zenodo API to get the files in the Zenodo and then create the `data-library.yaml` file following the structure in #759
   
- Add a BASH script to run the Python script on all tutorial
- Add missing data library files
- Update the tutorial explaining the `data-library.yaml` file