### PR TITLE
Update tutorial to include changing index.md

### DIFF
--- a/topics/contributing/tutorials/create-new-topic/tutorial.md
+++ b/topics/contributing/tutorials/create-new-topic/tutorial.md
@@ -111,6 +111,7 @@ Once the topic name has been chosen, we can create it.
 >
 > 1. Copy the `templates` directory in `topics`
 > 2. Rename the copied directory to `my-favorite-topic`
+> 3. Update the index.md file in the new directory to match your topic's name.
 {: .hands_on}
 
 # Make the templating system aware about the topic


### PR DESCRIPTION
New topics also need the default index.md file to have the new topic's name. (Issue faced in the GCCBOSC2018 workshop)