### PR TITLE
Attempt to fix slide render problem with Tool Deps and Conda slides

### DIFF
--- a/topics/dev/tutorials/conda/slides.html
+++ b/topics/dev/tutorials/conda/slides.html
@@ -382,7 +382,7 @@ $ cd seqtk_example
 $ planemo conda_install seqtk_seq.xml
 ```
 ```bash
-$ . <(planemo conda_env seqtk_seq.xml)
+$ . &lt;(planemo conda_env seqtk_seq.xml)
 ```
 ```bash
 $ planemo test seqtk_seq.xml


### PR DESCRIPTION
Right now it looks like this: 

![slide](https://user-images.githubusercontent.com/286969/41928239-607a6dc6-7929-11e8-9b59-3d84fe965e5e.png)

And a bunch of the following slides are unviewable. But this fix is just a guess as to what's wrong (I'm using the PR to build the slides to test).