### PR TITLE
Allow usernames without names

### DIFF
--- a/_layouts/topic.html
+++ b/_layouts/topic.html
@@ -202,7 +202,7 @@ layout: base
         {% for username in contributors_list %}
             {% assign contributor = contributors[username] %}
             <li>
-                <a href="{{ site.baseurl }}/hall-of-fame#{{ username }}"> {{ contributor.name }}</a>
+                <a href="{{ site.baseurl }}/hall-of-fame#{{ username }}">{% if contributor.name %}{{ contributor.name }}{% else %}{{ username }}{% endif %}</a>
             </li>
         {% endfor %}
         </ul>

--- a/topics/dev/metadata.yaml
+++ b/topics/dev/metadata.yaml
@@ -324,7 +324,7 @@ material:
       - "Learn more about different Galaxy aspects in our [development section](/topics/dev/)."
     contributors:
       - jmchilton
-      - bgruening"
+      - bgruening
   -
     title: "Data source integration"
     type: "tutorial"


### PR DESCRIPTION
I noticed that this page https://galaxyproject.github.io/training-material/topics/dev/ had an empty item at the bottom so added support for usernames without a `name` field attached to it. Probably not necessary to do that since everyone has a `name:` but it made tracking down the underlying metadata issue a bit easier.