### PR TITLE
added QCFAIL blog link

### DIFF
--- a/topics/sequence-analysis/metadata.yaml
+++ b/topics/sequence-analysis/metadata.yaml
@@ -149,6 +149,11 @@ maintainers:
 
 references:
   -
+    authors: "SciLifeLab"
+    title: "QCFAIL"
+    link: "https://sequencing.qcfail.com/"
+    summary: "Articles about common next-generation sequencing problems"
+  -
     authors: "Marco-Antonio Mendoza-Parra et al"
     title: "A quality control system for profiles obtained by ChIP sequencing"
     link: "http://nar.oxfordjournals.org/content/41/21/e196.short"


### PR DESCRIPTION
Added the QCFAIL blog entry in the References. This would be the result:

![generated-html](https://user-images.githubusercontent.com/9406259/42236206-855ff5f8-7efa-11e8-9088-ad516e290b81.png)
