### PR TITLE
Replacement of zenodo link 

### DIFF
--- a/topics/assembly/metadata.yaml
+++ b/topics/assembly/metadata.yaml
@@ -98,7 +98,7 @@ material:
     title: "Making sense of a newly assembled genome"
     type: "tutorial"
     name: "ecoli_comparison"
-    zenodo_link: "https://doi.org/10.5281/zenodo.1257429"
+    zenodo_link: "https://doi.org/10.5281/zenodo.1306128"
     galaxy_tour: no
     hands_on: yes
     slides: no

--- a/topics/assembly/tutorials/ecoli_comparison/data-library.yaml
+++ b/topics/assembly/tutorials/ecoli_comparison/data-library.yaml
@@ -5,26 +5,10 @@ destination:
   description: "Galaxy Training Network Material"
   synopsis: "Galaxy Training Network Material. See https://training.galaxyproject.org"
 items:
-  - name: "Raw reads and assembly"
+  - name: "E. coli C assembly"
     description: "Training material for analysis of new assemblies"
     items:
-      - url: https://zenodo.org/record/1257429/files/Ecoli_C_ONT.pass.fast5.tar.gz
-        src: url
-        ext: fast5.tar.gz
-        info: https://zenodo.org/record/1257429
-      - url: https://zenodo.org/record/1257429/files/ont.fastqsanger.gz
-        src: url
-        ext: fastqsanger.gz
-        info: https://zenodo.org/record/1257429
-      - url: https://zenodo.org/record/1257429/files/forward.fastqsanger.gz
-        src: url
-        ext: fastqsanger.gz
-        info: https://zenodo.org/record/1257429
-      - url: https://zenodo.org/record/1257429/files/forward.fastqsanger.gz
-        src: url
-        ext: fastqsanger.gz
-        info: https://zenodo.org/record/1257429
-      - url: https://zenodo.org/record/1257429/files/Ecoli_C_assembly.fna
+      - url: https://zenodo.org/record/1306128/files/Ecoli_C_assembly.fna
         src: url
         ext: fasta
         info: https://zenodo.org/record/1257429

--- a/topics/assembly/tutorials/ecoli_comparison/tutorial.md
+++ b/topics/assembly/tutorials/ecoli_comparison/tutorial.md
@@ -70,7 +70,7 @@ Before starting any analyses we need to upload the assembly produced in [Unicycl
  >
  > 1. Upload tool {% icon tool %} (Upload icon on the top of the left pane)
  >   - Click **Paste/Fetch data** button (Bottom of the interface box)
- >   - Paste `https://zenodo.org/record/1251125/files/Ecoli_C_assembly.fna` into the box.
+ >   - Paste `https://zenodo.org/record/1306128/files/Ecoli_C_assembly.fna` into the box.
  >   - *"Type"*: `fasta`
  >   - Click **Start**
 {: .hands_on}
@@ -92,7 +92,7 @@ Because phiX173 is around 5,000bp, we can remove those sequences by setting a mi
 > ### {% icon hands_on %} Hands-on: Fixing assembly
 >
 > 1. **Filter sequences by length** {% icon tool %} with the following parameters:
->   - *"Fasta file"*: the dataset you've just uploaded. (`https://zenodo.org/record/1251125/files/Ecoli_C_assembly.fna`).
+>   - *"Fasta file"*: the dataset you've just uploaded. (`https://zenodo.org/record/1306128/files/Ecoli_C_assembly.fna`).
 >   - *"Minimal length"*: `10000`
 >
 >


### PR DESCRIPTION
Replacement of zenodo link by a zenodo repo that contains only the dataset necessary for the training. The previous Zenodo repo contains also the raw data, too big for the import.