### PR TITLE
Implement text fallback for icons

### DIFF
--- a/_plugins/jekyll-icon-tag.rb
+++ b/_plugins/jekyll-icon-tag.rb
@@ -18,9 +18,9 @@ module Jekyll
       end
 
       if icon.start_with?("fa")
-          %Q(<i class="fa #{icon}" aria-hidden="true"></i>)
+          %Q(<i class="fa #{icon}" aria-hidden="true"></i><span class="visually-hidden">#{@text}</span>)
       elsif icon.start_with?("ai")
-          %Q(<i class="ai #{icon}" aria-hidden="true"></i>)
+          %Q(<i class="ai #{icon}" aria-hidden="true"></i><span class="visually-hidden">#{@text}</span>)
       end
     end
 

--- a/assets/css/main.scss
+++ b/assets/css/main.scss
@@ -330,3 +330,14 @@ footer {
 .label-default {
     background-color: #999999;
 }
+
+.visually-hidden {
+    border: 0;
+    clip: rect(0 0 0 0);
+    height: 1px;
+    margin: -1px;
+    overflow: hidden;
+    padding: 0;
+    position: absolute;
+    width: 1px;
+}


### PR DESCRIPTION
Thanks @willdurand  fixes https://github.com/galaxyproject/training-material/issues/933

Only downside is there is sometimes duplicated text (e.g. the github) which may be annoying to people who are using screen readers, but having an accessible fallback for them is probably a big improvement relative to the mild annoyance of duplicated text.

![auswahl_135](https://user-images.githubusercontent.com/458683/42686452-3f8a8fc2-8696-11e8-9011-3362ed131315.png)
