### PR TITLE
Make yamllint less strict for indentation

### DIFF
--- a/.yamllint
+++ b/.yamllint
@@ -5,3 +5,5 @@ extends: default
 rules:
   line-length: disable
   truthy: disable
+  indentation:
+    indent-sequences: consistent


### PR DESCRIPTION
To avoid error with automatically generated content