### PR TITLE
yamllint: don't fail on trailling whitespace

### DIFF
--- a/.yamllint
+++ b/.yamllint
@@ -5,5 +5,6 @@ extends: default
 rules:
   line-length: disable
   truthy: disable
+  trailing-spaces: disable
   indentation:
     indent-sequences: consistent


### PR DESCRIPTION
no longer fail the travis test due to trailing spaces in yaml files