### PR TITLE
Add possibility of shared parts inside tutorials

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -32,7 +32,7 @@ destination: ./_site
 plugins_dir: _plugins
 layouts_dir: _layouts
 data_dir: metadata
-includes_dir: _includes
+includes_dir: .
 
 # Conversion
 markdown: kramdown

--- a/_config.yml
+++ b/_config.yml
@@ -83,7 +83,8 @@ icon-tag:
   galaxy-refresh: fa-refresh
   galaxy-barchart: fa-bar-chart
   galaxy-cross: fa-times
-  galaxy-columns: fa-columns 
+  galaxy-columns: fa-columns
+  galaxy-tags: fa-tags
 
   # menus, links
   zenodo_link: fa-files-o

--- a/_includes/default-header.html
+++ b/_includes/default-header.html
@@ -16,7 +16,7 @@
                             {% icon github %} View on GitHub
                         </a>
                     </li>
-                    {% include help.html %}
+                    {% include _includes/help.html %}
                 </ul>
             </div>
         </div>

--- a/_layouts/badges.html
+++ b/_layouts/badges.html
@@ -2,7 +2,7 @@
 layout: base
 ---
 
-{% include default-header.html %}
+{% include _includes/default-header.html %}
 
 {% assign sorted_topics = "" | split: "," %}
 {% assign sorted_topics_pre = site.data | sort | order: "title" %}
@@ -97,4 +97,4 @@ layout: base
     </section>
 </div>
 
-{% include default-footer.html %}
+{% include _includes/default-footer.html %}

--- a/_layouts/faq.html
+++ b/_layouts/faq.html
@@ -2,7 +2,7 @@
 layout: base
 ---
 
-{% include default-header.html %}
+{% include _includes/default-header.html %}
 
 <div class="container main-content">
     <section>
@@ -13,4 +13,4 @@ layout: base
     </section>
 </div>
 
-{% include default-footer.html %}
+{% include _includes/default-footer.html %}

--- a/_layouts/hall-of-fame.html
+++ b/_layouts/hall-of-fame.html
@@ -5,7 +5,7 @@ layout: base
 {% assign contributors = site.data['contributors'] %}
 
 
-{% include default-header.html %}
+{% include _includes/default-header.html %}
 
 <div class="container main-content">
     <section>
@@ -72,4 +72,4 @@ layout: base
     </section>
 </div>
 
-{% include default-footer.html %}
+{% include _includes/default-footer.html %}

--- a/_layouts/home.html
+++ b/_layouts/home.html
@@ -2,7 +2,7 @@
 layout: base
 ---
 
-{% include default-header.html %}
+{% include _includes/default-header.html %}
 {% assign contributors = site.data['contributors'] %}
 
 {% assign sorted_topics = "" | split: "," %}
@@ -238,4 +238,4 @@ layout: base
     </section>
 </div>
 
-{% include default-footer.html %}
+{% include _includes/default-footer.html %}

--- a/_layouts/topic.html
+++ b/_layouts/topic.html
@@ -2,7 +2,7 @@
 layout: base
 ---
 
-{% include default-header.html %}
+{% include _includes/default-header.html %}
 
 {% assign topic = site.data[page.topic_name] %}
 {% assign contributors = site.data['contributors'] %}
@@ -51,7 +51,7 @@ layout: base
             {% for material in topic.material %}
                 {% if material.enable == nil or material.enable == true %}
                         <script type="application/ld+json">
-                            {% include material.jsonld content=material %}
+                            {% include _includes/material.jsonld content=material %}
                         </script>
                     <tr>
                         <td>
@@ -223,4 +223,4 @@ layout: base
     </section>
 </div>
 
-{% include default-footer.html %}
+{% include _includes/default-footer.html %}

--- a/_layouts/tutorial_hands_on.html
+++ b/_layouts/tutorial_hands_on.html
@@ -116,7 +116,7 @@ layout: base
                     </li>
                     {% endif %}
 
-                    {% include help.html %}
+                    {% include _includes/help.html %}
 
                     <li class="nav-item">
                         <a class="nav-link" href="{{ site.github_repository }}/edit/master/topics/{{ topic.name }}/tutorials/{{ tutorial.name }}/tutorial.md">

--- a/snippets/add_tag.md
+++ b/snippets/add_tag.md
@@ -1,0 +1,12 @@
+>
+>    > ### {% icon tip %} Tip: Adding a tag
+>    > * Click on the dataset
+>    > * Click on {% icon galaxy-tags %} **Edit dataset tags**
+>    > * Add the tag starting with `#`
+>    >
+>    >     The tags starting with `#` will be automatically propagated to the outputs of tools using this dataset.
+>    >
+>    > * Check that the tag is apparing below the dataset name
+>    >
+>    {: .tip}
+>

--- a/snippets/change_datatype.md
+++ b/snippets/change_datatype.md
@@ -1,0 +1,8 @@
+>
+>    > ### {% icon tip %} Tip: Changing the datatype
+>    > * Click on the pencil button displayed in your dataset in the history
+>    > * Choose **Datatype** on the top
+>    > * Select `{{ include.datatype }}`
+>    > * Press **Save**
+>    {: .tip}
+>

--- a/snippets/import_from_data_library.md
+++ b/snippets/import_from_data_library.md
@@ -1,0 +1,10 @@
+>
+>    > ### {% icon tip %} Tip: Importing data from a data library
+>    >
+>    > * Go into "Shared data" (top panel) then "Data libraries"
+>    > * Find the correct folder (ask your instructor)
+>    > * Select interesting files
+>    > * Click on "Import selected datasets into history"
+>    > * Import in the history
+>    {: .tip}
+>

--- a/snippets/import_via_link.md
+++ b/snippets/import_via_link.md
@@ -1,0 +1,10 @@
+>
+>    > ### {% icon tip %} Tip: Importing data via links
+>    >
+>    > * Copy the link location
+>    > * Open the Galaxy Upload Manager
+>    > * Select **Paste/Fetch Data**
+>    > * Paste the link into the text field
+>    > * Press **Start** and **Close** the window
+>    {: .tip}
+>

--- a/topics/transcriptomics/tutorials/ref-based/tutorial.md
+++ b/topics/transcriptomics/tutorials/ref-based/tutorial.md
@@ -40,55 +40,30 @@ We have extracted sequences from the Sequence Read Archive (SRA) files to build 
 > ### {% icon hands_on %} Hands-on: Data upload
 >
 > 1. Create a new history for this RNA-seq exercise
-> 2. Import the FASTQ file pairs for
+> 2. Import the FASTQ file pairs from [Zenodo](https://doi.org/10.5281/zenodo.1185122) or a data library:
 >       - `GSM461177` (untreated): `GSM461177_1` and `GSM461177_2`
 >       - `GSM461180` (treated): `GSM461180_1` and `GSM461180_2`
 >
->       To import the files, there are two options:
->       - Option 1: From a shared data library if available (ask your instructor)
->       - Option 2: From [Zenodo](https://doi.org/10.5281/zenodo.1185122)
+>       ```
+>       https://zenodo.org/record/1185122/files/GSM461177_1.fastqsanger
+>       https://zenodo.org/record/1185122/files/GSM461177_2.fastqsanger
+>       https://zenodo.org/record/1185122/files/GSM461180_1.fastqsanger
+>       https://zenodo.org/record/1185122/files/GSM461180_2.fastqsanger
+>       ```
 >
->           > ### {% icon tip %} Tip: Importing data via links
->           >
->           > * Copy the link location
->           > * Open the Galaxy Upload Manager
->           > * Select **Paste/Fetch Data**
->           > * Paste the link into the text field
->           > * Press **Start**
->           {: .tip}
->
->           You can directly paste:
->
->           ```
->           https://zenodo.org/record/1185122/files/GSM461177_1.fastqsanger
->           https://zenodo.org/record/1185122/files/GSM461177_2.fastqsanger
->           https://zenodo.org/record/1185122/files/GSM461180_1.fastqsanger
->           https://zenodo.org/record/1185122/files/GSM461180_2.fastqsanger
->           ```
+>       {% include snippets/import_via_link.md %}
+>       {% include snippets/import_from_data_library.md %}
 >
 > 3. Rename the datasets according to the samples
 > 4. Check that the datatype is `fastqsanger` (**not** `fastq`).
 >    If the datatype is `fastq`, please change the file type to `fastqsanger`
 >
->    > ### {% icon tip %} Tip: Changing the datatype
->    > * Click on the pencil button displayed in your dataset in the history
->    > * Choose **Datatype** on the top
->    > * Select `fastqsanger`
->    > * Press **Save**
->    {: .tip}
+>    {% include snippets/change_datatype.md datatype="fastqsanger" %}
 >
 > 5. Add to each database a tag corresponding to the name of the sample (`#GSM461177` or `#GSM461180`)
 >
->    > ### {% icon tip %} Tip: Adding a tag
->    > * Click on the dataset
->    > * Click on <i class="fa fa-tags"></i> **Edit dataset tags**
->    > * Add the tag starting with `#`
->    >
->    >     The tags starting with `#` will be automatically propagated to the outputs of tools using this dataset.
->    >
->    > * Check that the tag is apparing below the dataset name
->    >
->    {: .tip}
+>    {% include snippets/add_tag.md %}
+>
 {: .hands_on}
 
 The sequences are raw data from the sequencing machine, without any pretreatments. They need to be assessed for their quality.


### PR DESCRIPTION
With this PR, it is possible to share some parts between different tutorials.

For example here in the ref-based tutorial, the boxes to explain how to import from link, from data library or how to add tags are now in a file in the `_includes` folder. We can then add the same box (without duplicating the text) in other tutorial.

We can even have variables, like `datatype` in the example (`{% include _includes/change_datatype.md datatype="fastqsanger" %}`)

We can even go further. I started for the ChIP-seq tutorial to add some sections that could be in `topics/sequence-analysis/tutorials/mapping`, e.g: 

```
{% include topics/sequence-analysis/tutorials/mapping/mapping_explanation.md
    to_identify="binding sites"
    mapper="Bowtie2"
    mapper_link="http://bowtie-bio.sourceforge.net/bowtie2/index.shtml"
    answer_3="Wang et al. (2018) did ChIP-seq on mouse. So we should use the mouse reference genome. We will use mm10 (the latest build)"
%}
```

with `mapping_explanation.md` being:

```
We first need to figure out where the sequenced DNA fragments originated from in the genome. The reads must be aligned to a reference genome to identify the {{ include.to_identify }}.

This is equivalent to solving a jigsaw puzzles, but unfortunately, not all pieces are unique.

In principle, we could do a BLAST analysis to figure out where the sequenced pieces fit best in the known genome. Aligning millions of short sequences this way may, however, take a couple of weeks. And we do not really care about exact base to base correspondence (**alignment**). We are more interesting on "where did my reads come from?", an approach called **mapping**.

Nowadays, there are many read alignment programs for shotgun sequenced DNA. We will use [{{ include.mapper }}]({{ include.mapper_link }}).

We need a reference genome on which we map the reads.

> ### {% icon question %} Questions
>
> 1. What is a reference genome?
> 2. For human, several possible reference genomes are available: hg18, hg19, hg38, etc. What do they correspond to?
> 2. Which reference genome should we use?
>
> > ### {% icon solution %} Solution
> > 1. A reference genome (or reference assembly) is a DNA sequence assembled as a representative example of a species' DNA sequence. As they are often assembled from the sequencing of the DNA from different donors, they do not accurately represent the set of genes of any single person but a mosaic of different DNA sequences from each donor.
> > 2. As the cost of DNA sequencing falls, and new full genome sequencing technologies emerge, more genome sequences continue to be generated. Using these new sequences, new alignments are builts and the reference genomes improved (fewer gaps, fixed misrepresentations in the sequence, etc). The different reference genomes correspond to the different versions released (named build)
> > 3. {{ include.answer_3}}
> {: .solution }
{: .question}
```

Then, we can add these sections in different tutorials and still have a main tutorial on the subject (here mapping)