### PR TITLE
Add nojekyll file to avoid GitHub page to try to build

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -127,6 +127,8 @@ exclude:
   - templates/
   - vendor/
   - node_modules/
+include:
+  - .nojekyll
 
 # Plugins
 plugins:


### PR DESCRIPTION
To avoid emails from GitHub like:

```
The page build failed for the `gh-pages` branch with the following error:

The tag `icon` on line 2 in `snippets/add_tag.md` is not a recognized Liquid tag. For more information, see https://help.github.com/articles/page-build-failed-unknown-tag-error/.

For information on troubleshooting Jekyll see:

 https://help.github.com/articles/troubleshooting-jekyll-builds

If you have any questions you can contact us by replying to this email.
```
