### PR TITLE
Embed a short feedback form at the bottom of the tutorial

### DIFF
--- a/_layouts/tutorial_hands_on.html
+++ b/_layouts/tutorial_hands_on.html
@@ -217,9 +217,9 @@ layout: base
         </blockquote>
         {% endif %}
 
-        <br>
         <h3>{% icon congratulations %} Congratulations on successfully completing this tutorial!</h3>
-
+        <hr>
+        <br>
 
         <iframe class="google-form" src="https://docs.google.com/forms/d/e/1FAIpQLSd4VZptFTQ03kHkMz0JyW9b6_S8geU5KjNE_tLM0dixT3ZQmA/viewform?embedded=true&entry.1235803833={{ page.title }} ({{ topic.title }})">Loading...
         </iframe>

--- a/_layouts/tutorial_hands_on.html
+++ b/_layouts/tutorial_hands_on.html
@@ -221,12 +221,12 @@ layout: base
 
         <hr>
 
+        <iframe class="google-form" src="https://docs.google.com/forms/d/e/1FAIpQLSd4VZptFTQ03kHkMz0JyW9b6_S8geU5KjNE_tLM0dixT3ZQmA/viewform?embedded=true&entry.1235803833={{ page.title }} ({{ topic.title }})">Loading...
+        </iframe>
+
         <blockquote class="feedback">
-            <h3>{% icon feedback %} Help us improve this content!</h3>
-            Please take a moment to fill in the Galaxy Training Network
-            <a href="https://tinyurl.com/GTNfeedback">Feedback Form</a>.
-            Your feedback helps us improve this tutorial and will be considered
-            in future revisions.
+            <h3>{% icon feedback %} To give us even more feedbacks on this content!</h3>
+            <p>You can take a moment to fill in the extended <a href="https://tinyurl.com/GTNfeedback">Feedback Form</a>.</p>
         </blockquote>
     </section>
 </div>

--- a/_layouts/tutorial_hands_on.html
+++ b/_layouts/tutorial_hands_on.html
@@ -226,7 +226,7 @@ layout: base
 
         <blockquote class="feedback">
             <h3>{% icon feedback %} To give us even more feedbacks on this content!</h3>
-            <p>You can take a moment to fill in the extended <a href="https://tinyurl.com/GTNfeedback">Feedback Form</a>.</p>
+            <p>You can take a moment to fill in the extended <a href="https://docs.google.com/forms/d/e/1FAIpQLSc_GLZRpxZGAL9tN6DA1bE6WkNhmQdXT7B16TpOb-X4YwKUsQ/viewform?entry.1548889262={{ page.title }} ({{ topic.title }})">Feedback Form</a>.</p>
         </blockquote>
     </section>
 </div>

--- a/_layouts/tutorial_hands_on.html
+++ b/_layouts/tutorial_hands_on.html
@@ -221,6 +221,10 @@ layout: base
 
         <hr>
 
+        <p>Please let us know what you thought of this tutorial below! This feedback should be about the training materials themselves only. If tools were not working or missing, please contact the administrators of the Galaxy instance you used. </p>
+
+        <p>Please note that your feedback will be anonymous, but <strong>publicly visible</strong> (on this <a href="https://github.com/galaxyproject/training-material/issues/989">GitHub issue</a>).</p>
+
         <iframe class="google-form" src="https://docs.google.com/forms/d/e/1FAIpQLSd4VZptFTQ03kHkMz0JyW9b6_S8geU5KjNE_tLM0dixT3ZQmA/viewform?embedded=true&entry.1235803833={{ page.title }} ({{ topic.title }})">Loading...
         </iframe>
 

--- a/_layouts/tutorial_hands_on.html
+++ b/_layouts/tutorial_hands_on.html
@@ -225,8 +225,8 @@ layout: base
         </iframe>
 
         <blockquote class="feedback">
-            <h3>{% icon feedback %} To give us even more feedbacks on this content!</h3>
-            <p>You can take a moment to fill in the extended <a href="https://docs.google.com/forms/d/e/1FAIpQLSc_GLZRpxZGAL9tN6DA1bE6WkNhmQdXT7B16TpOb-X4YwKUsQ/viewform?entry.1548889262={{ page.title }} ({{ topic.title }})">Feedback Form</a>.</p>
+            <h3>{% icon feedback %} Give us even more feedback on this content!</h3>
+            <p>To give us more detailed feedback about these materials, please take a moment to fill in the extended <a href="https://docs.google.com/forms/d/e/1FAIpQLSc_GLZRpxZGAL9tN6DA1bE6WkNhmQdXT7B16TpOb-X4YwKUsQ/viewform?entry.1548889262={{ page.title }} ({{ topic.title }})">Feedback Form</a>.</p>
         </blockquote>
     </section>
 </div>

--- a/_layouts/tutorial_hands_on.html
+++ b/_layouts/tutorial_hands_on.html
@@ -221,10 +221,6 @@ layout: base
 
         <hr>
 
-        <p>Please let us know what you thought of this tutorial below! This feedback should be about the training materials themselves only. If tools were not working or missing, please contact the administrators of the Galaxy instance you used. </p>
-
-        <p>Please note that your feedback will be anonymous, but <strong>publicly visible</strong> (on this <a href="https://github.com/galaxyproject/training-material/issues/989">GitHub issue</a>).</p>
-
         <iframe class="google-form" src="https://docs.google.com/forms/d/e/1FAIpQLSd4VZptFTQ03kHkMz0JyW9b6_S8geU5KjNE_tLM0dixT3ZQmA/viewform?embedded=true&entry.1235803833={{ page.title }} ({{ topic.title }})">Loading...
         </iframe>
 

--- a/_layouts/tutorial_hands_on.html
+++ b/_layouts/tutorial_hands_on.html
@@ -217,9 +217,9 @@ layout: base
         </blockquote>
         {% endif %}
 
+        <br>
         <h3>{% icon congratulations %} Congratulations on successfully completing this tutorial!</h3>
 
-        <hr>
 
         <iframe class="google-form" src="https://docs.google.com/forms/d/e/1FAIpQLSd4VZptFTQ03kHkMz0JyW9b6_S8geU5KjNE_tLM0dixT3ZQmA/viewform?embedded=true&entry.1235803833={{ page.title }} ({{ topic.title }})">Loading...
         </iframe>

--- a/assets/css/main.scss
+++ b/assets/css/main.scss
@@ -222,7 +222,7 @@ footer {
 
     .google-form {
         width: 100%;
-        height: 1000px;
+        height: 1200px;
         border: 0;
     }
 }

--- a/assets/css/main.scss
+++ b/assets/css/main.scss
@@ -222,7 +222,7 @@ footer {
 
     .google-form {
         width: 100%;
-        height: 1400px;
+        height: 1100px;
         border: 0;
     }
 }

--- a/assets/css/main.scss
+++ b/assets/css/main.scss
@@ -222,7 +222,7 @@ footer {
 
     .google-form {
         width: 100%;
-        height: 1200px;
+        height: 1400px;
         border: 0;
     }
 }

--- a/assets/css/main.scss
+++ b/assets/css/main.scss
@@ -219,6 +219,12 @@ footer {
     .fold-unfold {
         margin-left: $tutorial-box-spacing;
     }
+
+    .google-form {
+        width: 100%;
+        height: 1000px;
+        border: 0;
+    }
 }
 
 .contributors {


### PR DESCRIPTION
To solve #981, a feedback form can be embedded at the bottom of the tutorial (with the tutorial name already filled):

![screen shot 2018-08-28 at 14 00 13](https://user-images.githubusercontent.com/1842467/44721936-c087ac00-aacb-11e8-8d28-d75c55041fa6.png)

There is 2 issues with the current implementation:

- I can not get rid of the header of the form (previous screenshot)

   I tried to play with it both on Google form side and CSS. But no way to get rid of it. I think we will keep it this way

- When leaving the page, a pop up box open with "This page is asking you to confirm that you want to leave - data you have entered may not be saved" (on Firefox)

@willdurand any idea?
