### PR TITLE
Added extra schema.org fields for available metadata

### DIFF
--- a/_includes/material.jsonld
+++ b/_includes/material.jsonld
@@ -84,5 +84,8 @@
                 {% endif %}
         {% endif %}
     {% endif %}
-    "learningResourceType": "{{material.type}}"
+    "learningResourceType": "{{material.type}}",
+    "description": "The objectives of this {{material.type}} are: \n- {{material.objectives | join: "\n-" }}",
+    "timeRequired": "{{material.time_estimation}}",
+    "keywords": "{{material.tags | join: ", "}}"
 }


### PR DESCRIPTION
Schema.org-ified some more of the available metadata fields.

I've used a joined list of objectives as the Description field. It's a very important field to have for search engines and TeSS (it's a minimum field in TeSS). We will need to make a decision on whether to use Objectives, Key Points, Questions; or a combination of more than one.