### PR TITLE
fixed links to section requirements within all slides

### DIFF
--- a/_layouts/base_slides.html
+++ b/_layouts/base_slides.html
@@ -22,12 +22,12 @@ layout: true
 class: center, middle, inverse
 
 <div class="my-header"><span>
-<a href="{{ site.baseurl }}/topics/{{ topic.name }}" title="Return to topic page" ><i class="fa fa-level-up" aria-hidden="true"></i></a>
+<a href="{{ site.baseurl }}/topics{{ topic.name }}" title="Return to topic page" ><i class="fa fa-level-up" aria-hidden="true"></i></a>
 </span></div>
 
 <div class="my-footer"><span>
 {% if page.logo == "GTN" %}
-<img src="{{ site.baseurl }}/{{ site.small_logo }}" alt="Galaxy Training Network" style="height: 40px;"/>
+<img src="{{ site.baseurl }}/topics{{ site.small_logo }}" alt="Galaxy Training Network" style="height: 40px;"/>
 {% else %}
 <img src="{{ page.logo }}" alt="page logo" style="height: 40px;"/>
 {% endif %}
@@ -46,7 +46,7 @@ class: center, middle, inverse
 
   {% for requirement in topic.requirements %}
     {% if requirement.type == "internal" %}
-  - [{{ requirement.title }}]({{ site.baseurl }}{{ requirement.link }})
+  - [{{ requirement.title }}]({{ site.baseurl }}/topics{{ requirement.link }})
     {% elsif requirement.type == "external" %}
   - [{{ requirement.title }}]({{ requirement.link }})
     {% endif %}

--- a/_layouts/topic.html
+++ b/_layouts/topic.html
@@ -22,7 +22,7 @@ layout: base
             {% for requirement in topic.requirements %}
                 <li>
                     {% if requirement.type == "internal" %}
-                    <a href="{{ site.baseurl }}/topics/{{ requirement.link }}">{{ requirement.title }}</a>
+                    <a href="{{ site.baseurl }}/topics{{ requirement.link }}">{{ requirement.title }}</a>
                     {% elsif material.type == "external" %}
                     <a href="{{ requirement.link }}">{{ requirement.title }}</a>
                     {% endif %}


### PR DESCRIPTION
Links to internal training material, pointed to by entries in the "Requirements" section of many training's slides, were broken. This fixes the issue.

Example:
In the Quality control slides, [page #2](https://galaxyproject.github.io/training-material/topics/sequence-analysis/tutorials/quality-control/slides.html#2) links to the required introductory material using the following link
`https://galaxyproject.github.io/training-material/introduction/`
instead of
`https://galaxyproject.github.io/training-material/topics/introduction/`