### PR TITLE
2 small updates for proteomics SIL tutorial

### DIFF
--- a/topics/proteomics/tutorials/protein-quant-sil/tutorial.md
+++ b/topics/proteomics/tutorials/protein-quant-sil/tutorial.md
@@ -136,15 +136,13 @@ Finally, we will combine the peptide quantifications to protein quantifications.
 >   - **RT tolerance (in seconds) for the matching of peptide identifications and (consensus) features** set to `20`,
 >   - **m/z tolerance (in ppm or Da) for matching of peptide identifications and (consensus) features** set to `10`, and
 >   - **Match using RT and m/z of sub-features instead of consensus RT and m/z** set to `Yes`.
-> 2. Change the filetype of the ***IDMapper*** output to `consensusXML`.
-> 3. Run ***FileFilter*** {% icon tool %} with
+> 2. Run ***FileFilter*** {% icon tool %} with
 >   - **Remove unassigned peptide identifications** set to `Yes`.
-> 4. Run ***IDConflictResolver*** {% icon tool %}.
-> 5. Run ***ProteinQuantifier*** {% icon tool %} with
+> 3. Run ***IDConflictResolver*** {% icon tool %}.
+> 4. Run ***ProteinQuantifier*** {% icon tool %} with
 >   - the output of ***IDConflictResolver*** as **Input file**,
 >   - the output of ***IDFilter*** as **Protein inference results [...]**,
 >   - **Calculate protein abundance from this number of proteotypic peptides (most abundant first; '0' for all)** set to `0`, 
->   - **Include results for proteins with fewer proteotypic peptides than indicated by 'top'** set to `Yes`,
 >   - **Averaging method used to compute protein abundances from peptide abundances** set to `sum`, and
 >   - **Add the log2 ratios of the abundance values to the output** set to `Yes`.
 >


### PR DESCRIPTION
IDmapper: output is now automatically consensusXML, does not need manual change anymore. 
Proteinquantifier: When number of proteotypic peptides is '0', the 'include results for proteins with fewer proteotypic peptides' option does not change anything and can stay default 'No'.