### PR TITLE
test fixing a couple urls

### DIFF
--- a/topics/dev/tutorials/toolshed/slides.html
+++ b/topics/dev/tutorials/toolshed/slides.html
@@ -82,12 +82,7 @@ contributors:
 ### Connect your Galaxy to a Tool Shed
 
 - Only for third party toolsheds (Main and Test by default)
-- In `config/tool_sheds_conf.xml`:
-```xml
-  <tool_sheds>
-    <tool_shed name="Galaxy main tool shed" url="https://toolshed.g2.bx.psu.edu/#" />
-  </tool_sheds>
-```
+- Add `<tool_shed />` block in `config/tool_sheds_conf.xml`
 - Restart Galaxy
 
 ---

--- a/topics/dev/tutorials/toolshed/slides.html
+++ b/topics/dev/tutorials/toolshed/slides.html
@@ -59,7 +59,7 @@ contributors:
 
 - [Galaxy community Tool Shed](https://toolshed.g2.bx.psu.edu/) -> Main Tool Shed
 - [Galaxy community test Tool Shed](https://testtoolshed.g2.bx.psu.edu/) -> Sandbox for testing
-- [List of public Tool Sheds](https://wiki.galaxyproject.org/PublicGalaxyServers#Public_ToolSheds)
+- [List of public Tool Sheds](https://galaxyproject.org/toolshed/public-toolsheds/)
 
 ---
 
@@ -83,9 +83,9 @@ contributors:
 
 - Only for third party toolsheds (Main and Test by default)
 - In `config/tool_sheds_conf.xml`:
-```bash
+```xml
   <tool_sheds>
-    <tool_shed name="Galaxy main tool shed" url="https://toolshed.g2.bx.psu.edu/" />
+    <tool_shed name="Galaxy main tool shed" url="https://toolshed.g2.bx.psu.edu/#" />
   </tool_sheds>
 ```
 - Restart Galaxy


### PR DESCRIPTION
Noticed that slides were failing due to `toolshed.g2.bx.psu.edu/&quot;`, trying with a `#` after it to see if I can get the slides checker to pass

Please do not merge until after slide check has run.