### PR TITLE
Fixes #1086

### DIFF
--- a/_layouts/home.html
+++ b/_layouts/home.html
@@ -38,7 +38,7 @@ layout: base
                         {% if topic[1].type == "use" %}
                         <tr>
                             {% assign tutorial_number = site.pages | topic_filter:topic[1].name | topic_count %}
-                            <td><a href="{{ site.baseurl }}/topics/{{ topic[1].name }}">{{ topic[1].title }}</a></td>
+                            <td><a href="{{ site.baseurl }}/topics/{{ topic[1].name }}/">{{ topic[1].title }}</a></td>
                             <td>{{ tutorial_number }}</td>
                         </tr>
                         {% endif %}
@@ -60,7 +60,7 @@ layout: base
                         {% if topic[1].type == "basics" %}
                         <tr>
                             {% assign tutorial_number = site.pages | topic_filter:topic[1].name | topic_count %}
-                            <td><a href="{{ site.baseurl }}/topics/{{ topic[1].name }}">{{ topic[1].title }}</a></td>
+                            <td><a href="{{ site.baseurl }}/topics/{{ topic[1].name }}/">{{ topic[1].title }}</a></td>
                             <td>{{ tutorial_number }}</td>
                         </tr>
                         {% endif %}
@@ -81,7 +81,7 @@ layout: base
                         {% if topic[1].type == "admin-dev" %}
                         <tr>
                             {% assign tutorial_number = site.pages | topic_filter:topic[1].name | topic_count %}
-                            <td><a href="{{ site.baseurl }}/topics/{{ topic[1].name }}">{{ topic[1].title }}</a></td>
+                            <td><a href="{{ site.baseurl }}/topics/{{ topic[1].name }}/">{{ topic[1].title }}</a></td>
                             <td>{{ tutorial_number }}</td>
                         </tr>
                         {% endif %}
@@ -95,7 +95,7 @@ layout: base
 
                 <p>You can report mistakes or errors, create more contents, etc. Whatever is your background, there is probably a way to do it: via the GitHub website, via command-line. If you feel it is too much, you can even write it with any text editor and contact us: we will work together to integrate it.</p>
 
-                <p>To get you started, check our <a href="{{ site.baseurl }}/topics/contributing">dedicated tutorials</a> or our <a href="{{ site.baseurl }}/faq">Frequently Asked Questions</a></p>
+                <p>To get you started, check our <a href="{{ site.baseurl }}/topics/contributing/">dedicated tutorials</a> or our <a href="{{ site.baseurl }}/faq">Frequently Asked Questions</a></p>
 
                 <h3>Galaxy for Contributors and Instructors</h3>
                 <table class="table table-striped">
@@ -110,7 +110,7 @@ layout: base
                         {% if topic[1].type == "instructors" %}
                         <tr>
                             {% assign tutorial_number = site.pages | topic_filter:topic[1].name | topic_count %}
-                            <td><a href="{{ site.baseurl }}/topics/{{ topic[1].name }}">{{ topic[1].title }}</a></td>
+                            <td><a href="{{ site.baseurl }}/topics/{{ topic[1].name }}/">{{ topic[1].title }}</a></td>
                             <td>{{ tutorial_number }}</td>
                         </tr>
                         {% endif %}
@@ -182,7 +182,7 @@ layout: base
                     Check out the full <a href="{{ site.baseurl }}/hall-of-fame">Hall of Fame</a>.
                 </p>
 
-                <p>Do you want to help with this project and join our Hall of Fame? Please see our <a href="{{ site.baseurl }}/topics/contributing">dedicated tutorials</a> or our <a href="{{ site.baseurl }}/faq">Frequently Asked Questions</a> to get you started.</p>
+                <p>Do you want to help with this project and join our Hall of Fame? Please see our <a href="{{ site.baseurl }}/topics/contributing/">dedicated tutorials</a> or our <a href="{{ site.baseurl }}/faq">Frequently Asked Questions</a> to get you started.</p>
 
                 <h2>License</h2>
                 <p>This work is licensed under the <a rel="license" href="https://creativecommons.org/licenses/by/4.0/">Creative Commons Attribution 4.0 International License</a>.</p>


### PR DESCRIPTION
It looks like #1086 was because of the lack of a trailing slash. I'm not sure why that caused the insecure redirect, but it's an easy fix.

First few requests are normal, last request is after going back to index and manually editing link.

![grafik](https://user-images.githubusercontent.com/458683/47422666-b18f4400-d772-11e8-90c7-2eba8ed9b1f3.png)
