### PR TITLE
[WIP] Support second cloud for terraform tutorial + in-tutorial templating

### DIFF
--- a/topics/admin/tutorials/terraform/tutorial.md
+++ b/topics/admin/tutorials/terraform/tutorial.md
@@ -138,7 +138,7 @@ Terraform reads all files with the extension `.tf` in your current directory. Re
 >    ```
 >    {: .digitalocean}
 >
->    This specifies the configuration for the OpenStack plugin. You can either specify the configuration in the plugin, or it will automatically load the values from the normal OpenStack environment variable names.
+>    This specifies the configuration for the plugin. You can either specify the configuration in the plugin, or it will automatically load the values from the normal environment variable names.
 >
 > 4. Run `terraform init`
 >


### PR DESCRIPTION
This is a halfway finished PR (waiting on DO image upload to finish, ever.)

But figured I'd push now and see if anyone has feedback:

I've implemented a simple set of radio buttons:

![grafik](https://user-images.githubusercontent.com/458683/47664465-0679f280-db97-11e8-83b7-108445da5698.png)

When one is selected, only instructions related to that cloud are shown

![grafik](https://user-images.githubusercontent.com/458683/47664493-1560a500-db97-11e8-91b5-ba86b640dc73.png)

E.g.  with OpenStack selected

![grafik](https://user-images.githubusercontent.com/458683/47664503-1bef1c80-db97-11e8-8844-8a345d6469fc.png)

vs with DO selected:

![grafik](https://user-images.githubusercontent.com/458683/47664520-23aec100-db97-11e8-8be3-90dbb00d1f2a.png)
