### PR TITLE
[martenson-patch-3] Google analytics ID via travis variable

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -42,7 +42,7 @@ ACTIVATE_ENV=. $(dir ${CONDA})activate galaxy_training_material
 install: clean ## install dependencies
 	( $(ACTIVATE_ENV) && \
 	  npm install decktape && \
-	  gem install awesome_bot bundler html-proofer jekyll jekyll-feed pkg-config:'~> 1.1' && \
+	  gem install jekyll-environment-variables awesome_bot bundler html-proofer jekyll jekyll-feed pkg-config:'~> 1.1' && \
 	  gem install nokogiri:'1.8.2' -- --use-system-libraries --with-xml=$(CONDA_PREFIX)/lib \
 	)
 .PHONY: install

--- a/_config.yml
+++ b/_config.yml
@@ -135,3 +135,5 @@ include:
 # Plugins
 plugins:
   - jekyll-feed
+  - jekyll-environment-variables
+

--- a/_layouts/base.html
+++ b/_layouts/base.html
@@ -16,7 +16,7 @@
             ga('create', {{ site.env.GOOGLE_ANALYTICS_ID }} , 'auto');
             ga('send', 'pageview');
         </script>
-        {% end if %}
+        {% endif %}
         <link rel="stylesheet" href="{{ "/assets/css/bootstrap.min.css?v=3" | prepend: site.baseurl }}">
         <link rel="stylesheet" href="{{ "/assets/css/main.css?v=2" | prepend: site.baseurl }}">
         <link rel="stylesheet" href="{{ "/assets/css/font-awesome.css" | prepend: site.baseurl }}">

--- a/_layouts/base.html
+++ b/_layouts/base.html
@@ -7,14 +7,16 @@
         <meta http-equiv="x-ua-compatible" content="ie=edge">
         <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
         <title>{{ site.title }}</title>
+        {% if site.env.GOOGLE_ANALYTICS_ID %}
         <script>
             (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
             (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
             m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
             })(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
-            ga('create', 'UA-45719423-18', 'auto');
+            ga('create', {{ site.env.GOOGLE_ANALYTICS_ID }} , 'auto');
             ga('send', 'pageview');
         </script>
+        {% end if %}
         <link rel="stylesheet" href="{{ "/assets/css/bootstrap.min.css?v=3" | prepend: site.baseurl }}">
         <link rel="stylesheet" href="{{ "/assets/css/main.css?v=2" | prepend: site.baseurl }}">
         <link rel="stylesheet" href="{{ "/assets/css/font-awesome.css" | prepend: site.baseurl }}">

--- a/_layouts/base.html
+++ b/_layouts/base.html
@@ -13,7 +13,7 @@
             (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
             m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
             })(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
-            ga('create', {{ site.env.GOOGLE_ANALYTICS_ID }} , 'auto');
+            ga('create', '{{ site.env.GOOGLE_ANALYTICS_ID }}' , 'auto');
             ga('send', 'pageview');
         </script>
         {% endif %}

--- a/_layouts/base_slides.html
+++ b/_layouts/base_slides.html
@@ -12,14 +12,16 @@
   <head>
     <meta charset="utf-8">
     <title>{{ title | strip_html }}</title>
+    {% if site.env.GOOGLE_ANALYTICS_ID %}
     <script>
-      (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-      (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-      m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-      })(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
-      ga('create', 'UA-45719423-18', 'auto');
-      ga('send', 'pageview');
+        (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+        (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+        m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+        })(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
+        ga('create', {{ site.env.GOOGLE_ANALYTICS_ID }} , 'auto');
+        ga('send', 'pageview');
     </script>
+    {% end if %}
     <link rel="stylesheet" href="{{ "/assets/css/slides.css" | prepend: site.baseurl }}">
     <link rel="stylesheet" href="{{ "/assets/css/font-awesome.css" | prepend: site.baseurl }}" id="theme">
     <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.1/MathJax.js?config=TeX-AMS-MML_HTMLorMML"></script>

--- a/_layouts/base_slides.html
+++ b/_layouts/base_slides.html
@@ -18,7 +18,7 @@
         (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
         m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
         })(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
-        ga('create', {{ site.env.GOOGLE_ANALYTICS_ID }} , 'auto');
+        ga('create', '{{ site.env.GOOGLE_ANALYTICS_ID }}' , 'auto');
         ga('send', 'pageview');
     </script>
     {% endif %}

--- a/_layouts/base_slides.html
+++ b/_layouts/base_slides.html
@@ -21,7 +21,7 @@
         ga('create', {{ site.env.GOOGLE_ANALYTICS_ID }} , 'auto');
         ga('send', 'pageview');
     </script>
-    {% end if %}
+    {% endif %}
     <link rel="stylesheet" href="{{ "/assets/css/slides.css" | prepend: site.baseurl }}">
     <link rel="stylesheet" href="{{ "/assets/css/font-awesome.css" | prepend: site.baseurl }}" id="theme">
     <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.1/MathJax.js?config=TeX-AMS-MML_HTMLorMML"></script>


### PR DESCRIPTION
@martenson I think this should work to prevent people who spin up a dev instance from using our ga ID, we set an environment variable in travis and use the [jekyll-environment-variables plugin](https://github.com/ajwhite/jekyll-environment-variables)

xref: https://github.com/galaxyproject/training-material/pull/1100