### PR TITLE
Update tools.yaml for ref-based tutorial

### DIFF
--- a/topics/transcriptomics/tutorials/ref-based/tools.yaml
+++ b/topics/transcriptomics/tutorials/ref-based/tools.yaml
@@ -40,10 +40,6 @@ tools:
     owner: bgruening
     tool_panel_section_label: Text Manipulation
 
-  - name: length_and_gc_content
-    owner: iuc
-    tool_panel_section_label: Extract Features
-
   - name: cutadapt
     owner: lparsons
     tool_panel_section_label: QC and manipulation


### PR DESCRIPTION
The only use of `length_and_gc_content` tool was removed in commit e15717d8ad7ed9d20578c0d3808e29cad3efd691 .