### PR TITLE
Add an icon for repeat parameters

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -77,6 +77,7 @@ icon-tag:
   param-text: fa-pencil
   param-check: fa-check-square-o
   param-select: fa-filter
+  param-repeat: fa-plus-square-o
   galaxy-eye: fa-eye
   galaxy-gear: fa-cog
   galaxy-history: fa-archive

--- a/topics/contributing/tutorials/create-new-tutorial-content/tutorial.md
+++ b/topics/contributing/tutorials/create-new-tutorial-content/tutorial.md
@@ -393,11 +393,13 @@ The available icons are:
 > ### {% icon hands_on %} Hands-on: My Step
 >
 > 1. **My Tool** {% icon tool %} with the following parameters
->  - {% icon param-text %} *"My text parameter"*: `my value`
->  - {% icon param-file %} *"My input file"*: `my file`
->  - {% icon param-files %} *"My multiple file input or collection"*: `my collection`
->  - {% icon param-select %} *"My select menu"*: `my choice`
->  - {% icon param-check %} *"My check box"*: `yes`
+>    - {% icon param-text %} *"My text parameter"*: `my value`
+>    - {% icon param-file %} *"My input file"*: `my file`
+>    - {% icon param-files %} *"My multiple file input or collection"*: `my collection`
+>    - {% icon param-select %} *"My select menu"*: `my choice`
+>    - {% icon param-check %} *"My check box"*: `yes`
+>    - {% icon param-repeat %} **My repeat parameter**
+>      - *"param1"*: `42`
 {: .hands_on}
 ```
 {% endraw %}
@@ -407,11 +409,13 @@ which, when rendered, look like:
 > ### {% icon hands_on %} Hands-on: My Step
 >
 > 1. **My Tool** {% icon tool %} with the following parameters
->  - {% icon param-text %} *"My text parameter"*: `my value`
->  - {% icon param-file %} *"My input file"*: `my file`
->  - {% icon param-files %} *"My multiple file input or collection"*: `my collection`
->  - {% icon param-select %} *"My select menu"*: `my choice`
->  - {% icon param-check %} *"My check box"*: `yes`
+>    - {% icon param-text %} *"My text parameter"*: `my value`
+>    - {% icon param-file %} *"My input file"*: `my file`
+>    - {% icon param-files %} *"My multiple file input or collection"*: `my collection`
+>    - {% icon param-select %} *"My select menu"*: `my choice`
+>    - {% icon param-check %} *"My check box"*: `yes`
+>    - {% icon param-repeat %} **My repeat parameter**
+>      - *"param1"*: `42`
 {: .hands_on}
 
 


### PR DESCRIPTION
While reviewing a PR that included a tool with a lot of repeat parameters, I thought it would be a lot clearer if these are prefixed with a `plus` icon, as they are in Galaxy:

![image](https://user-images.githubusercontent.com/2563865/48014208-7273d200-e126-11e8-9f04-440d1990040e.png)

so I added such an icon