### PR TITLE
Add translation support

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -25,6 +25,7 @@ gitter_url: "https://gitter.im/Galaxy-Training-Network/Lobby"
 logo: "assets/images/GTN.png"
 small_logo: "assets/images/GTN-60px.png"
 biostars_url: https://biostar.usegalaxy.org/
+other_languages: "FR, JP, SP"
 
 # Where things are
 source: .

--- a/_config.yml
+++ b/_config.yml
@@ -25,7 +25,7 @@ gitter_url: "https://gitter.im/Galaxy-Training-Network/Lobby"
 logo: "assets/images/GTN.png"
 small_logo: "assets/images/GTN-60px.png"
 biostars_url: https://biostar.usegalaxy.org/
-other_languages: "FR, JP, SP"
+other_languages: "fr, ja, es, pt"
 
 # Where things are
 source: .

--- a/_layouts/topic.html
+++ b/_layouts/topic.html
@@ -8,6 +8,7 @@ layout: base
 {% assign contributors = site.data['contributors'] %}
 {% assign instances = site.data['instances'] %}
 {% assign topic_material = site.pages | topic_filter:page.topic_name %}
+{% assign language = site.other_languages | split: ", " %}
 
 <div class="container main-content">
     <section>
@@ -68,7 +69,7 @@ layout: base
                         {% if material.type == "introduction" %}
                             <td>
                                 {% if material.slides %}
-                                <a href="{{ site.baseurl }}/topics/{{ topic.name }}/slides/{{ material.tutorial_name }}.html">
+                                <a class="topic-icon" href="{{ site.baseurl }}/topics/{{ topic.name }}/slides/{{ material.tutorial_name }}.html">
                                   {% icon slides %}
                                 </a>
                                 {% endif %}
@@ -84,34 +85,42 @@ layout: base
                         {% elsif material.type == "tutorial" %}
                             <td>
                                 {% if material.slides %}
-                                <a href="{{ site.baseurl }}/topics/{{ topic.name }}/tutorials/{{ material.tutorial_name }}/slides.html">
-                                  {% icon slides %}
+                                    <a class="topic-icon" href="{{ site.baseurl }}/topics/{{ topic.name }}/tutorials/{{ material.tutorial_name }}/slides.html">
+                                    {% icon slides %}
                                 </a>
                                 {% endif %}
                             </td>
-
-
                             <td>
                                 {% if material.hands_on == "external" %}
-                                <a href="{{ material.hands_on_url }}">
-                                  {% icon tutorial %}
+                                <a class="topic-icon" href="{{ material.hands_on_url }}">
+                                    {% icon tutorial %}
                                 </a>
                                 {% elsif material.hands_on == "github" %}
                                 <a href="{{ site.github_repository }}/tree/master/topics/{{ topic.name }}/tutorials/{{ material.tutorial_name }}/tutorial.md">
-                                  {% icon tutorial %}
+                                    {% icon tutorial %}
                                 </a>
                                 {% elsif material.hands_on %}
-                                <a href="{{ site.baseurl }}/topics/{{ topic.name }}/tutorials/{{ material.tutorial_name }}/tutorial.html">
-                                  {% icon tutorial %}
-                                </a>
+                                    <a href="#" class="btn btn-default dropdown-toggle" data-toggle="dropdown" aria-expanded="false" title="Where to run the tutorial">
+                                        {% icon tutorial %}
+                                    </a>
+                                    <ul class="dropdown-menu">
+                                        <a class="dropdown-item" href="{{ site.baseurl }}/topics/{{ topic.name }}/tutorials/{{ material.tutorial_name }}/tutorial.html" title="{{ inst[0] }}">
+                                            EN
+                                        </a>
+                                    {% for lang in language %}
+                                        <a class="dropdown-item" href="https://translate.google.com/translate?sl=en&tl={{ lang }}&js=y&prev=_t&hl=fr&ie=UTF-8&u=https%3A%2F%2Ftraining.galaxyproject.org%2Ftopics%2F{{ topic.name }}%2Ftutorials%2F{{ material.tutorial_name }}%2Ftutorial.html&edit-text=&act=url" title="{{ inst[0] }}">
+                                            {{ lang }}
+                                        </a>
+                                    {% endfor %}
+                                    </ul>
                                 {% endif %}
                             </td>
 
                             {% if topic.type == "use" %}
                                 <td>
                                     {% if material.zenodo_link != nil and material.zenodo_link != "" %}
-                                    <a href="{{ material.zenodo_link }}">
-                                      {% icon zenodo_link %}
+                                    <a class="topic-icon" h href="{{ material.zenodo_link }}">
+                                        {% icon zenodo_link %}
                                     </a>
                                     {% endif %}
                                 </td>
@@ -130,6 +139,7 @@ layout: base
                                     {% endif %}
                                 </td>
                             {% endif %}
+
                             {% if instances[topic.name].supported %}
                                 <td>
                                 {% if instances[topic.name]['tutorials'][material.tutorial_name].supported %}

--- a/_layouts/topic.html
+++ b/_layouts/topic.html
@@ -100,19 +100,20 @@ layout: base
                                     {% icon tutorial %}
                                 </a>
                                 {% elsif material.hands_on %}
-                                    <a href="#" class="btn btn-default dropdown-toggle" data-toggle="dropdown" aria-expanded="false" title="Where to run the tutorial">
-                                        {% icon tutorial %}
-                                    </a>
-                                    <ul class="dropdown-menu">
-                                        <a class="dropdown-item" href="{{ site.baseurl }}/topics/{{ topic.name }}/tutorials/{{ material.tutorial_name }}/tutorial.html" title="{{ inst[0] }}">
-                                            EN
+                                    <span class="btn-group">
+                                        <a href="{{ site.baseurl }}/topics/{{ topic.name }}/tutorials/{{ material.tutorial_name }}/tutorial.html" class="btn btn-default" title="Where to run the tutorial">
+                                            {% icon tutorial %}
                                         </a>
-                                    {% for lang in language %}
-                                        <a class="dropdown-item" href="https://translate.google.com/translate?sl=en&tl={{ lang }}&js=y&prev=_t&hl=fr&ie=UTF-8&u=https%3A%2F%2Ftraining.galaxyproject.org%2Ftopics%2F{{ topic.name }}%2Ftutorials%2F{{ material.tutorial_name }}%2Ftutorial.html&edit-text=&act=url" title="{{ inst[0] }}">
-                                            {{ lang }}
+                                        <a href="#" class="btn btn-default dropdown-toggle dropdown-toggle-split" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+                                            <span class="sr-only">Toggle Dropdown</span>
                                         </a>
-                                    {% endfor %}
-                                    </ul>
+                                        <ul class="dropdown-menu">
+                                        {% for lang in language %}
+                                            <a class="dropdown-item" href="https://translate.google.com/translate?hl=jp&sl=en&tl={{ lang }}&u=https%3A%2F%2Ftraining.galaxyproject.org%2Ftopics%2F{{ topic.name }}%2Ftutorials%2F{{ material.tutorial_name }}%2Ftutorial.html&edit-text=&act=url" title="{{ inst[0] }}">
+                                                {{ lang | upcase }}
+                                            </a>
+                                        {% endfor %}
+                                    </span>
                                 {% endif %}
                             </td>
 

--- a/_layouts/tutorial_hands_on.html
+++ b/_layouts/tutorial_hands_on.html
@@ -124,8 +124,8 @@ layout: base
                         </a>
                         <div class="dropdown-menu">
                             {% for lang in language %}
-                            <a class="dropdown-item" href="https://translate.google.com/translate?sl=en&tl={{ lang }}&js=y&prev=_t&hl=fr&ie=UTF-8&u=https%3A%2F%2Ftraining.galaxyproject.org%2Ftopics%2F{{ topic.name }}%2Ftutorials%2F{{ page.tutorial_name }}%2Ftutorial.html&edit-text=&act=url" title="{{ inst[0] }}">
-                                {{ lang }}
+                            <a class="dropdown-item" href="https://translate.google.com/translate?hl=jp&sl=en&tl={{ lang }}&u=https%3A%2F%2Ftraining.galaxyproject.org%2Ftopics%2F{{ topic.name }}%2Ftutorials%2F{{ page.tutorial_name }}%2Ftutorial.html&edit-text=&act=url" title="{{ inst[0] }}">
+                                {{ lang | upcase }}
                             </a>
                             {% endfor %}
                         </div>

--- a/_layouts/tutorial_hands_on.html
+++ b/_layouts/tutorial_hands_on.html
@@ -6,6 +6,7 @@ layout: base
 {% assign contributors = site.data['contributors'] %}
 {% assign instances = site.data['instances'] %}
 {% assign topic_material = site.pages | topic_filter:page.topic_name %}
+{% assign language = site.other_languages | split: ", " %}
 
 <header>
     <nav class="navbar navbar-expand-lg navbar-dark">
@@ -117,6 +118,19 @@ layout: base
                     </li>
                     {% endif %}
 
+                    <li class="nav-item dropdown">
+                        <a href="#" class="nav-link dropdown-toggle" data-toggle="dropdown" aria-expanded="false" title="EN">
+                            EN
+                        </a>
+                        <div class="dropdown-menu">
+                            {% for lang in language %}
+                            <a class="dropdown-item" href="https://translate.google.com/translate?sl=en&tl={{ lang }}&js=y&prev=_t&hl=fr&ie=UTF-8&u=https%3A%2F%2Ftraining.galaxyproject.org%2Ftopics%2F{{ topic.name }}%2Ftutorials%2F{{ page.tutorial_name }}%2Ftutorial.html&edit-text=&act=url" title="{{ inst[0] }}">
+                                {{ lang }}
+                            </a>
+                            {% endfor %}
+                        </div>
+                    </li>
+
                     {% include _includes/help.html %}
 
                     <li class="nav-item">
@@ -183,7 +197,8 @@ layout: base
             {% endif %}
         </blockquote>
 
-        {{ content }}
+        {{ content 
+            | replace: '<blockquote class="hands_on">', '<blockquote class="notranslate hands_on">' }}
 
         {% if page.key_points %}
         <blockquote class="key_points">

--- a/assets/css/main.scss
+++ b/assets/css/main.scss
@@ -132,6 +132,10 @@ footer {
 
 }
 
+.topic-icon {
+    padding: .5rem .75rem;
+}
+
 .training-network-map {
     width: 90%;
     margin: 0 auto;


### PR DESCRIPTION
To fix (at least partially): #404 

A dropdown menu to select the language is added in the topic menu and on the top of the tutorial:

![screen shot 2018-11-13 at 16 51 52](https://user-images.githubusercontent.com/1842467/48425329-e46e9b80-e764-11e8-9d6e-4decb1fb1ad8.png)

![screen shot 2018-11-13 at 17 04 03](https://user-images.githubusercontent.com/1842467/48425991-2f3ce300-e766-11e8-8f9a-9b07d0d842d4.png)

The non english links redirect to Google translate. The hands-on boxes are not translated.
