### PR TITLE
Support learning paths

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -123,7 +123,7 @@ check-yaml: ## lint yaml files
 	)
 .PHONY: check-yaml
 
-check: check-yaml check-html-internal check-html check-slides ## run all checks
+check: check-yaml check-frontmatter check-html-internal check-html check-slides ## run all checks
 .PHONY: check
 
 check-links-gh-pages:  ## validate HTML on gh-pages branch (for daily cron job)

--- a/_config.yml
+++ b/_config.yml
@@ -109,6 +109,7 @@ icon-tag:
   twitter: fa-twitter
   linkedin: fa-linkedin
   orcid: ai-orcid
+  curriculum: fa-graduation-cap
 
 # To exclude in _site
 exclude:

--- a/_layouts/topic.html
+++ b/_layouts/topic.html
@@ -20,15 +20,7 @@ layout: base
         <p>Before diving into this topic, we recommend you to have a look at:</p>
 
         <ul>
-            {% for requirement in topic.requirements %}
-                <li>
-                    {% if requirement.type == "internal" %}
-                    <a href="{{ site.baseurl }}/topics{{ requirement.link }}">{{ requirement.title }}</a>
-                    {% elsif material.type == "external" %}
-                    <a href="{{ requirement.link }}">{{ requirement.title }}</a>
-                    {% endif %}
-                </li>
-            {% endfor %}
+            {% include snippets/display_extra_training.md extra_trainings=topic.requirements %}
         </ul>
         {% endif %}
 

--- a/_layouts/tutorial_hands_on.html
+++ b/_layouts/tutorial_hands_on.html
@@ -171,24 +171,8 @@ layout: base
             {% if topic.requirements or page.requirements %}
             <strong>{% icon requirements %} Requirements</strong>
             <ul>
-            {% for requirement in topic.requirements %}
-                <li>
-                    {% if requirement.type == "internal" %}
-                    <a href="{{ site.baseurl }}/topics{{ requirement.link }}">{{ requirement.title }}</a>
-                    {% elsif requirement.type == "external" %}
-                    <a href="{{ requirement.link }}">{{ requirement.title }}</a>
-                    {% endif %}
-                </li>
-            {% endfor %}
-            {% for requirement in page.requirements %}
-                <li>
-                    {% if requirement.type == "internal" %}
-                    <a href="{{ site.baseurl }}/topics{{ requirement.link }}">{{ requirement.title }}</a>
-                    {% elsif requirement.type == "external" %}
-                    <a href="{{ requirement.link }}">{{ requirement.title }}</a>
-                    {% endif %}
-                </li>
-            {% endfor %}
+            {% include snippets/display_extra_training.md extra_trainings=topic.requirements %}
+            {% include snippets/display_extra_training.md extra_trainings=page.requirements %}
             </ul>
             {% endif %}
 
@@ -217,6 +201,8 @@ layout: base
         <p>Further information, including links to documentation and original publications, regarding the tools, analysis techniques and the interpretation of results described in this tutorial can be found <a href="{{ site.baseurl }}/topics/{{ topic.name }}#references">here</a>.</p>
         {% endif %}
 
+        <h3>{% icon congratulations %} Congratulations on successfully completing this tutorial!</h3>
+
         {% if topic.name == "contributing" %}
         <blockquote class="agenda">
             <h3>Developing GTN training material</h3>
@@ -240,7 +226,15 @@ layout: base
         </blockquote>
         {% endif %}
 
-        <h3>{% icon congratulations %} Congratulations on successfully completing this tutorial!</h3>
+        {% if page.follow_up_training %}
+        <blockquote class="agenda follow-up">
+            <strong class="follow-up">{% icon curriculum %} Do you want to extend your knowledge? Follow one of our recommended follow-up trainings:</strong>
+            <ul>
+                {% include snippets/display_extra_training.md extra_trainings=page.follow_up_training %}
+            </ul>
+        </blockquote>
+        {% endif %}
+
         <hr>
         <br>
 

--- a/assets/css/main.scss
+++ b/assets/css/main.scss
@@ -107,6 +107,12 @@ footer {
     font-size: $font-size - 2;
 }
 
+.follow-up {
+    p {
+        font-size: 18px;
+    }
+}
+
 .navbar {
     background-color: $bg-color!important;
 

--- a/bin/validate-frontmatter.rb
+++ b/bin/validate-frontmatter.rb
@@ -4,11 +4,11 @@ fn = ARGV[0]
 
 # Required keys
 tutorial_required_keys = ['layout', 'title', 'time_estimation', 'contributors']
-tutorial_optional_keys = ['questions', 'zenodo_link', 'objectives', 'key_points', 'tags', 'edam_ontology', 'requirements']
+tutorial_optional_keys = ['questions', 'zenodo_link', 'objectives', 'key_points', 'tags', 'edam_ontology', 'requirements', 'follow_up_training']
 tutorial_deprecated_keys = ['topic_name', 'tutorial_name', 'type', 'name', 'galaxy_tour', 'hands_on', 'slides', 'workflows']
 
 slides_required_keys = ['layout', 'logo', 'title', 'contributors']
-slides_optional_keys = ['time_estimation', 'questions', 'zenodo_link', 'objectives', 'key_points', 'tags', 'edam_ontology', 'requirements', 'class', 'hands_on', 'hands_on_url']
+slides_optional_keys = ['time_estimation', 'questions', 'zenodo_link', 'objectives', 'key_points', 'tags', 'edam_ontology', 'requirements', 'follow_up_training', 'class', 'hands_on', 'hands_on_url']
 slides_deprecated_keys = ['topic_name', 'tutorial_name', 'type', 'name', 'galaxy_tour', 'slides', 'workflows']
 
 metadata_required_keys = ['name', 'type', 'title', 'summary', 'maintainers']

--- a/snippets/display_extra_training.md
+++ b/snippets/display_extra_training.md
@@ -1,0 +1,31 @@
+{% for training in include.extra_trainings %}
+    <li>
+    {% if training.type == "internal" %}
+        {% assign extra_topic_metadata = site.data[training.topic_name] %}
+        {% assign extra_topic = site.pages | topic_filter:training.topic_name %}
+        <a href="{{ site.baseurl }}/topics/{{ training.topic_name }}">{{ extra_topic_metadata.title }}</a>
+        {% if training.tutorials %}
+            <ul>
+                {% for extra_tuto in training.tutorials %}
+                    {% for topic_tuto in extra_topic %}
+                        {% if extra_tuto == topic_tuto.tutorial_name %}
+                            {% assign sep = "" %}
+                            <li> {{ topic_tuto.title }}:
+                            {% if topic_tuto.slides %}
+                                <a href="{{ site.baseurl }}/topics/{{ training.topic_name }}/tutorials/{{ topic_tuto.tutorial_name }}/slides.html">{% icon slides %} slides</a>
+                                {% assign sep = "-" %}
+                            {% endif %}
+                            {% if topic_tuto.hands_on %}
+                                {{ sep }} <a href="{{ site.baseurl }}/topics/{{ training.topic_name }}/tutorials/{{ topic_tuto.tutorial_name }}/tutorial.html">{% icon tutorial %} hands-on</a>
+                            {% endif %}
+                            </li>
+                        {% endif %}
+                    {% endfor %}
+                {% endfor %}
+            </ul>
+        {% endif %}
+    {% else %}
+        <a href="{{ training.link }}">{{ training.title }}</a>
+    {% endif %}
+    </li>
+{% endfor %}

--- a/topics/assembly/metadata.yaml
+++ b/topics/assembly/metadata.yaml
@@ -6,13 +6,13 @@ summary: "DNA sequence data has become an indispensable tool for Molecular Biolo
 docker_image:
 requirements:
   -
-    title: "Galaxy introduction"
     type: "internal"
-    link: "/introduction/"
+    topic_name: introduction
   -
-    title: "Quality Control"
     type: "internal"
-    link: "/sequence-analysis/"
+    topic_name: sequence-analysis
+    tutorials: 
+      - quality-control
 
 maintainers:
   - slugger70

--- a/topics/assembly/tutorials/ecoli_comparison/tutorial.md
+++ b/topics/assembly/tutorials/ecoli_comparison/tutorial.md
@@ -5,9 +5,10 @@ title: "Making sense of a newly assembled genome"
 zenodo_link: "https://doi.org/10.5281/zenodo.1306128"
 requirements:
   -
-    title: "Unicycler Assembly"
     type: "internal"
-    link: "/assembly/tutorials/unicycler-assembly/tutorial.html"
+    topic_name: assembly
+    tutorials: 
+      - unicycler-assembly
 tags:
   - prokaryote
 questions:

--- a/topics/assembly/tutorials/unicycler-assembly/tutorial.md
+++ b/topics/assembly/tutorials/unicycler-assembly/tutorial.md
@@ -12,6 +12,12 @@ objectives:
   - "Perform a Small genome Assembly with Unicycler"
   - "Evaluate the Quality of the Assembly with Quast"
   - "Annotate the assembly with Prokka"
+follow_up_training:
+  -
+    type: "internal"
+    topic_name: assembly
+    tutorials: 
+      - ecoli_comparison
 time_estimation: "4h"
 key_points:
   - "We learned about the strategies used by assemblers for hybrid assemblies"

--- a/topics/chip-seq/metadata.yaml
+++ b/topics/chip-seq/metadata.yaml
@@ -6,105 +6,127 @@ summary: ChIP-sequencing is a method used to analyze protein interactions with D
 docker_image: null
 edam_ontology: topic_3169
 requirements:
--
-  title: "Galaxy introduction"
-  type: "internal"
-  link: "/introduction/"
--
-  title: "Quality control"
-  type: "internal"
-  link: "/sequence-analysis/"
--
-  title: "Mapping"
-  type: "internal"
-  link: "/sequence-analysis/"
+  -
+    type: "internal"
+    topic_name: introduction
+  -
+    type: "internal"
+    topic_name: sequence-analysis
+    tutorials: 
+      - quality-control
+      - mapping
 
 maintainers:
-- malloryfreeberg
-- moheydarian
-- friedue
+  - malloryfreeberg
+  - moheydarian
+  - friedue
 
 references:
-- authors: Stephen G Landt et al
-  title: ChIP-seq guidelines and practices of the ENCODE and modENCODE consortia
-  link: https://www.ncbi.nlm.nih.gov/pmc/articles/PMC3431496/
-  summary: A very useful encyclopedic paper with many details about the tools the
-    (mod)ENCODE consortia use and also contains a long section about antibody validation
-- authors: Gabriel E Zentner and Steven Henikoff
-  title: Surveying the epigenomic landscape, one base at a time
-  link: http://genomebiology.biomedcentral.com/articles/10.1186/gb-2012-13-10-250
-  summary: Overview of popular sequencing techniques with very nice descriptions of
-    DNase-seq, MNase-seq, FAIRE-seq
-- authors: Benjamin L Kidder et al
-  title: 'ChIP-Seq: technical considerations for obtaining high-quality data'
-  link: http://www.nature.com/ni/journal/v12/n10/abs/ni.2117.html
-  summary: Nice, readable introduction into all aspects of ChIP-seq experiments (from
-    antibodies to cell numbers to replicates to data analysis)
-- authors: Marion Leleu et al
-  title: Processing and analyzing ChIP-seq data
-  link: http://bfg.oxfordjournals.org/content/9/5-6/466
-  summary: Fairly detailed review of key concepts of ChIP-seq data processing (less
-    detailed on analysis)
-- authors: Peter J. Park
-  title: 'ChIP-seq: Advantages and challenges of a maturing technology'
-  link: https://www.ncbi.nlm.nih.gov/pmc/articles/PMC3191340/
-  summary: ''
-- authors: Peter V Kharchenko et al
-  title: Design and analysis of ChIP-seq experiments for DNA-binding proteins
-  link: https://www.ncbi.nlm.nih.gov/pubmed/19029915
-  summary: ''
-- authors: Edison T Liu et al
-  title: 'Q&A: ChIP-seq technologies and the study of gene regulation'
-  link: http://bmcbiol.biomedcentral.com/articles/10.1186/1741-7007-8-56
-  summary: Short overview of several (typical) issues of ChIP-seq analysis
-- authors: Thomas S. Carroll et al
-  title: Impact of artifact removal on ChIP quality metrics in ChIP-seq and ChIP-exo
-    data
-  link: http://journal.frontiersin.org/article/10.3389/fgene.2014.00075/full
-  summary: ''
-- authors: Shirley Pepke et al
-  title: Computation for ChIP-seq and RNA-seq studies
-  link: https://www.ncbi.nlm.nih.gov/pmc/articles/PMC4121056/
-  summary: First comparison of peak callers, focuses on the explanation of basic principles
-    of ChIP-seq data processing and general workflows of peak calling algorithms
-- authors: Elizabeth G. Wilbanks & Marc T. Facciotti
-  title: Evaluation of Algorithm Performance in ChIP-Seq Peak Detection
-  link: http://journals.plos.org/plosone/article?id=10.1371/journal.pone.0011471
-  summary: Another comparison of peak callers - focuses more on the evaluation of
-    the peak callers performances than Shirley Pepke et al.
-- authors: Mariann Micsinai et al
-  title: Picking ChIP-seq peak detectors for analyzing chromatin modification experiments
-  link: http://nar.oxfordjournals.org/content/40/9/e70.full
-  summary: 'How to choose the best peak caller for your data set - their finding:
-    default parameters, surprisingly, yield the most reproducible results regardless
-    of the data set type'
-- authors: Jianxing Fen et al
-  title: Identifying ChIP-seq enrichment using MACS
-  link: http://www.nature.com/nprot/journal/v7/n9/abs/nprot.2012.101.html
-  summary: How to use MACS
-- authors: Yong Zhang et al
-  title: Model-based Analysis of ChIP-Seq (MACS)
-  link: http://genomebiology.biomedcentral.com/articles/10.1186/gb-2008-9-9-r137
-  summary: Original publication of MACS
-- authors: Modan K Das & Ho-Kwok Dai
-  title: A survey of DNA motif finding algorithms
-  link: http://bmcbioinformatics.biomedcentral.com/articles/10.1186/1471-2105-8-S7-S21
-  summary: Review of motif analysis tools
-- authors: Philip Machanick and Timothy L. Bailey
-  title: 'MEME-ChIP: motif analysis of large DNA datasets'
-  link: http://bioinformatics.oxfordjournals.org/content/27/12/1696.short
-  summary: MEME-ChIP-paper
-- authors: Timothy L. Bailey and Philip Machanick
-  title: Inferring direct DNA binding from ChIP-seq
-  link: http://nar.oxfordjournals.org/content/40/17/e128
-  summary: 'Centrimo: position-specific motif analysis, especially useful for ChIP-seq
-    data'
-- authors: Morgane Thomas-Chollier et al
-  title: Transcription factor binding predictions using TRAP for the analysis of ChIP-seq
-    data and regulatory SNPs
-  link: http://www.nature.com/nprot/journal/v6/n12/abs/nprot.2011.409.html
-  summary: How to use TRAP
-- authors: Helge G. Roider et al
-  title: Predicting transcription factor affinities to DNA from a biophysical model
-  link: http://bioinformatics.oxfordjournals.org/content/23/2/134.short
-  summary: Theoretical background of TRAP
+  - 
+    authors: Stephen G Landt et al
+    title: ChIP-seq guidelines and practices of the ENCODE and modENCODE consortia
+    link: https://www.ncbi.nlm.nih.gov/pmc/articles/PMC3431496/
+    summary: >
+        A very useful encyclopedic paper with many details about the tools the (mod)ENCODE consortia use 
+        and also contains a long section about antibody validation
+  - 
+    authors: Gabriel E Zentner and Steven Henikoff
+    title: Surveying the epigenomic landscape, one base at a time
+    link: http://genomebiology.biomedcentral.com/articles/10.1186/gb-2012-13-10-250
+    summary: >
+        Overview of popular sequencing techniques with very nice descriptions of DNase-seq, MNase-seq, 
+        FAIRE-seq
+  - 
+    authors: Benjamin L Kidder et al
+    title: 'ChIP-Seq: technical considerations for obtaining high-quality data'
+    link: http://www.nature.com/ni/journal/v12/n10/abs/ni.2117.html
+    summary: >
+        Nice, readable introduction into all aspects of ChIP-seq experiments (from antibodies to cell 
+        numbers to replicates to data analysis)
+  - 
+    authors: Marion Leleu et al
+    title: Processing and analyzing ChIP-seq data
+    link: http://bfg.oxfordjournals.org/content/9/5-6/466
+    summary: >
+        Fairly detailed review of key concepts of ChIP-seq data processing (less detailed on analysis)
+  - 
+    authors: Peter J. Park
+    title: 'ChIP-seq: Advantages and challenges of a maturing technology'
+    link: https://www.ncbi.nlm.nih.gov/pmc/articles/PMC3191340/
+    summary: ''
+  - 
+    authors: Peter V Kharchenko et al
+    title: Design and analysis of ChIP-seq experiments for DNA-binding proteins
+    link: https://www.ncbi.nlm.nih.gov/pubmed/19029915
+    summary: ''
+  - 
+    authors: Edison T Liu et al
+    title: 'Q&A: ChIP-seq technologies and the study of gene regulation'
+    link: http://bmcbiol.biomedcentral.com/articles/10.1186/1741-7007-8-56
+    summary: Short overview of several (typical) issues of ChIP-seq analysis
+  - 
+    authors: Thomas S. Carroll et al
+    title: Impact of artifact removal on ChIP quality metrics in ChIP-seq and ChIP-exo data
+    link: http://journal.frontiersin.org/article/10.3389/fgene.2014.00075/full
+    summary: ''
+  - 
+    authors: Shirley Pepke et al
+    title: Computation for ChIP-seq and RNA-seq studies
+    link: https://www.ncbi.nlm.nih.gov/pmc/articles/PMC4121056/
+    summary: >
+        First comparison of peak callers, focuses on the explanation of basic principles
+        of ChIP-seq data processing and general workflows of peak calling algorithms
+  - 
+    authors: Elizabeth G. Wilbanks & Marc T. Facciotti
+    title: Evaluation of Algorithm Performance in ChIP-Seq Peak Detection
+    link: http://journals.plos.org/plosone/article?id=10.1371/journal.pone.0011471
+    summary: >
+        Another comparison of peak callers - focuses more on the evaluation of the peak callers 
+        performances than Shirley Pepke et al.
+  - 
+    authors: Mariann Micsinai et al
+    title: Picking ChIP-seq peak detectors for analyzing chromatin modification experiments
+    link: http://nar.oxfordjournals.org/content/40/9/e70.full
+    summary: >
+        'How to choose the best peak caller for your data set - their finding:
+        default parameters, surprisingly, yield the most reproducible results regardless
+        of the data set type'
+  - 
+    authors: Jianxing Fen et al
+    title: Identifying ChIP-seq enrichment using MACS
+    link: http://www.nature.com/nprot/journal/v7/n9/abs/nprot.2012.101.html
+    summary: How to use MACS
+  - 
+    authors: Yong Zhang et al
+    title: Model-based Analysis of ChIP-Seq (MACS)
+    link: http://genomebiology.biomedcentral.com/articles/10.1186/gb-2008-9-9-r137
+    summary: Original publication of MACS
+  - 
+    authors: Modan K Das & Ho-Kwok Dai
+    title: A survey of DNA motif finding algorithms
+    link: http://bmcbioinformatics.biomedcentral.com/articles/10.1186/1471-2105-8-S7-S21
+    summary: Review of motif analysis tools
+  - 
+    authors: Philip Machanick and Timothy L. Bailey
+    title: 'MEME-ChIP: motif analysis of large DNA datasets'
+    link: http://bioinformatics.oxfordjournals.org/content/27/12/1696.short
+    summary: MEME-ChIP-paper
+  - 
+    authors: Timothy L. Bailey and Philip Machanick
+    title: Inferring direct DNA binding from ChIP-seq
+    link: http://nar.oxfordjournals.org/content/40/17/e128
+    summary: >
+        'Centrimo: position-specific motif analysis, especially useful for ChIP-seq
+        data'
+  - 
+    authors: Morgane Thomas-Chollier et al
+    title: >
+        Transcription factor binding predictions using TRAP for the analysis of ChIP-seq
+        data and regulatory SNPs
+    link: http://www.nature.com/nprot/journal/v6/n12/abs/nprot.2011.409.html
+    summary: How to use TRAP
+  - 
+    authors: Helge G. Roider et al
+    title: Predicting transcription factor affinities to DNA from a biophysical model
+    link: http://bioinformatics.oxfordjournals.org/content/23/2/134.short
+    summary: Theoretical background of TRAP

--- a/topics/chip-seq/tutorials/tal1-binding-site-identification/tutorial.md
+++ b/topics/chip-seq/tutorials/tal1-binding-site-identification/tutorial.md
@@ -19,8 +19,8 @@ objectives:
   - Visually inspect Tal1 peaks with Trackster
 requirements:
   -
-    title: "Trackster"
     type: "external"
+    title: "Trackster"
     link: "https://wiki.galaxyproject.org/Learn/Visualization"
 time_estimation: "3h"
 key_points:

--- a/topics/contributing/tutorials/create-new-topic/tutorial.md
+++ b/topics/contributing/tutorials/create-new-topic/tutorial.md
@@ -149,9 +149,16 @@ Several metadata are defined in `metadata.yaml` file in your topic folder to :
 - `type`: target for the topic ('use', 'admin-dev', 'instructors')
 - `summary`: summary of the focus of the topic
 - `requirements`: list of resources that the reader of the material should be familiar with before starting any tutorial in this topic:
-    - `title`
-    - `link`: relative for internal (inside training material) requirement or full for external requirement)
     - `type`: the type of link (`internal` or `external`)
+
+    For internal, i.e. inside the Galaxy Training Material:
+    - `topic_name`: name of the topic
+    - `tutorials`: list of required tutorials inside of the topic
+
+    For external:
+    - `title`: title of the external resource
+    - `link`: URL to the external resource
+
 - `docker_image`: name of the Docker image for the topic
 
     If no Docker image exists for this topic, let this information empty

--- a/topics/contributing/tutorials/create-new-tutorial-content/tutorial.md
+++ b/topics/contributing/tutorials/create-new-tutorial-content/tutorial.md
@@ -111,9 +111,15 @@ This information is used to display the data from the topic and tutorial page. T
 We also define metadata related to the pedagogical content of the tutorial, which will appear in the top ("Overview" box) and bottom of the online tutorial:
 
 - `requirements`: list of resources that the reader of the material should be familiar with before starting this training:
-    - `title`
-    - `link`: relative for internal (inside training material) requirement or full for external requirement)
     - `type`: the type of link (`internal` or `external`)
+
+    For internal, i.e. inside the Galaxy Training Material:
+    - `topic_name`: name of the topic
+    - `tutorials`: list of required tutorials inside of the topic
+
+    For external:
+    - `title`: title of the external resource
+    - `link`: URL to the external resource
 - `time_estimation`: an estimation of the time needed to complete the hands-on
 - `questions`: list of questions that will be addressed in the tutorial
 - `objectives`: list of learning objectives for the tutorial
@@ -123,6 +129,20 @@ We also define metadata related to the pedagogical content of the tutorial, whic
 - `key_points`: list of take-home messages
 
     This information will appear at the end of the tutorial
+
+- `follow_up_training`: list of resources that the reader of the material could follow at the end of the tutorial
+
+    - `type`: the type of link (`internal` or `external`)
+
+    For internal, i.e. inside the Galaxy Training Material:
+    - `topic_name`: name of the topic
+    - `tutorials`: list of required tutorials inside of the topic
+
+    For external:
+    - `title`: title of the external resource
+    - `link`: URL to the external resource
+
+    They will be displayed at the end of a tutorial.
 
 For this category of metadata, we have taken inspiration from what Software Carpentry has done and particularly what they described in their [Instructor training](https://swcarpentry.github.io/instructor-training/).
 

--- a/topics/epigenetics/metadata.yaml
+++ b/topics/epigenetics/metadata.yaml
@@ -8,17 +8,14 @@ edam_ontology: "topic_3173"
 
 requirements:
   -
-    title: "Galaxy introduction"
     type: "internal"
-    link: "/introduction/"
+    topic_name: introduction
   -
-    title: "Quality control"
     type: "internal"
-    link: "/sequence-analysis/"
-  -
-    title: "Mapping"
-    type: "internal"
-    link: "/sequence-analysis/"
+    topic_name: sequence-analysis
+    tutorials:
+      - quality-control
+      - mapping
 
 maintainers:
   - joachimwolff

--- a/topics/genome-annotation/metadata.yaml
+++ b/topics/genome-annotation/metadata.yaml
@@ -9,9 +9,8 @@ summary: Genome annotation is a multi-level process that includes prediction of 
 docker_image: quay.io/galaxy/genome-annotation-training
 requirements:
   -
-    title: "Galaxy introduction"
     type: "internal"
-    link: "/introduction/"
+    topic_name: introduction
 maintainers:
   - shiltemann
   - bebatut

--- a/topics/metagenomics/metadata.yaml
+++ b/topics/metagenomics/metadata.yaml
@@ -8,9 +8,8 @@ docker_image: "quay.io/galaxy/metagenomics-training"
 
 requirements:
   -
-    title: "Galaxy introduction"
     type: "internal"
-    link: "/introduction/"
+    topic_name: introduction
 
 maintainers:
   - bebatut

--- a/topics/proteomics/metadata.yaml
+++ b/topics/proteomics/metadata.yaml
@@ -8,9 +8,8 @@ edam_ontology: "topic_0121"
 
 requirements:
   -
-    title: "Galaxy introduction"
     type: "internal"
-    link: "/introduction/"
+    topic_name: introduction
 
 maintainers:
   - stortebecker

--- a/topics/sequence-analysis/metadata.yaml
+++ b/topics/sequence-analysis/metadata.yaml
@@ -6,9 +6,8 @@ summary: "Analyses of sequences"
 docker_image: "quay.io/galaxy/sequence-analysis-training"
 requirements:
   -
-    title: "Galaxy introduction"
     type: "internal"
-    link: "/introduction/"
+    topic_name: introduction
 
 maintainers:
   - yvanlebras

--- a/topics/sequence-analysis/tutorials/mapping/tutorial.md
+++ b/topics/sequence-analysis/tutorials/mapping/tutorial.md
@@ -15,6 +15,23 @@ key_points:
   - Know your data!
   - Mapping is not trivial
   - There are many mapping algorithms, it depends on your data which one to choose
+requirements:
+  -
+    type: "internal"
+    topic_name: sequence-analysis
+    tutorials: 
+      - quality-control
+follow_up_training:
+  -
+    type: "internal"
+    topic_name: transcriptomics
+    tutorials: 
+      - ref-based
+  -
+    type: "internal"
+    topic_name: chip-seq
+    tutorials: 
+      - formation_of_super-structures_on_xi
 contributors:
   - joachimwolff
   - bebatut

--- a/topics/sequence-analysis/tutorials/quality-control/tutorial.md
+++ b/topics/sequence-analysis/tutorials/quality-control/tutorial.md
@@ -15,7 +15,12 @@ objectives:
   - Use tools for quality correction
   - Use a tool to aggregate FastQC output
   - Process single-end and paired-end data
-requirements:
+follow_up_training:
+  -
+    type: "internal"
+    topic_name: sequence-analysis
+    tutorials: 
+      - mapping
 time_estimation: "1H"
 key_points:
   - Run quality control on every dataset before running any other bioinformatics analysis

--- a/topics/statistics/metadata.yaml
+++ b/topics/statistics/metadata.yaml
@@ -7,9 +7,8 @@ docker_image: "quay.io/galaxy/statistics-training"
 
 requirements:
   -
-    title: "Galaxy introduction"
     type: "internal"
-    link: "/introduction/"
+    topic_name: introduction
 
 maintainers:
   - marziacremona

--- a/topics/transcriptomics/metadata.yaml
+++ b/topics/transcriptomics/metadata.yaml
@@ -6,13 +6,14 @@ summary: Training material for all kinds of transcriptomics analysis.
 docker_image: null
 requirements:
   -
-    title: "Galaxy introduction"
     type: "internal"
-    link: "/introduction/"
+    topic_name: introduction
   -
-    title: "Quality control"
     type: "internal"
-    link: "/sequence-analysis/"
+    topic_name: sequence-analysis
+    tutorials: 
+      - quality-control
+      - mapping
 
 maintainers:
   - bebatut

--- a/topics/variant-analysis/metadata.yaml
+++ b/topics/variant-analysis/metadata.yaml
@@ -7,17 +7,14 @@ summary: "Exome sequencing means that all protein-coding genes in a genome are s
 
 requirements:
   -
-    title: "Galaxy introduction"
     type: "internal"
-    link: "/introduction/"
+    topic_name: introduction
   -
-    title: "Quality control"
     type: "internal"
-    link: "/sequence-analysis/"
-  -
-    title: "Mapping"
-    type: "internal"
-    link: "/sequence-analysis/"
+    topic_name: sequence-analysis
+    tutorials: 
+      - quality-control
+      - mapping
 
 maintainers:
   - bebatut


### PR DESCRIPTION
This PR implements the possibility to display possible follow-up tutorials at the end of a tutorial:

![screen shot 2018-11-16 at 14 05 49](https://user-images.githubusercontent.com/1842467/48623764-e9249100-e9aa-11e8-85a1-1c5ea7894815.png)

I also restructured the requirements on the top of the tutorials and in the topic page:

![screen shot 2018-11-16 at 14 09 17](https://user-images.githubusercontent.com/1842467/48623843-2f79f000-e9ab-11e8-9c68-280db59767d8.png)

To support that, the description of requirements in metadata has been adapted and is harmonized with follow-up training description:

```
requirements:
  -
    type: "internal"
    topic_name: sequence-analysis
    tutorials: 
    - quality-control
follow_up_training:
  -
    type: "internal"
    topic_name: transcriptomics
    tutorials: 
    - ref-based
  -
    type: "internal"
    topic_name: chip-seq
    tutorials: 
    - formation_of_super-structures_on_xi
```