### PR TITLE
Maker: fix typo

### DIFF
--- a/topics/genome-annotation/tutorials/annotation-with-maker/tutorial.md
+++ b/topics/genome-annotation/tutorials/annotation-with-maker/tutorial.md
@@ -25,7 +25,7 @@ contributors:
 # Introduction
 {:.no_toc}
 
-Genome annotation of eukaryotes is a little mote complicated than for prokaryotes: eukaryotic genomes are usually larger than prokaryotes, with more genes. The sequences determining the beginning and the end of a gene are generally less conserved than the prokaryotic ones. Many genes also contain introns, and the limits of these introns (acceptor and donor sites) are not highly conserved.
+Genome annotation of eukaryotes is a little more complicated than for prokaryotes: eukaryotic genomes are usually larger than prokaryotes, with more genes. The sequences determining the beginning and the end of a gene are generally less conserved than the prokaryotic ones. Many genes also contain introns, and the limits of these introns (acceptor and donor sites) are not highly conserved.
 
 In this tutorial we will use a software tool called Maker to annotate the genome sequence of a small eukaryote: Schizosaccharomyces pombe (a yeast).
 


### PR DESCRIPTION
Just a little typo in the first phrase of the maker tutorial.
The funny thing is that when google translates (with the typo) it in french, it becomes exactly the opposite of what I meant (_less_ complicated instead of more complicated)