### PR TITLE
Data library import snippet: update instructions

### DIFF
--- a/snippets/import_from_data_library.md
+++ b/snippets/import_from_data_library.md
@@ -7,7 +7,7 @@
 >    > * Find the correct folder (ask your instructor)
 >    > * Select the desired files
 >    > * Click on the **To History** button near the top
->    > * From the dropdown menu, select the history you want to import the files to (or create a new one)
+>    > * In the pop-up window, select the history you want to import the files to (or create a new one)
 >    > * Click on **Import**
 >    {: .tip}
 >

--- a/snippets/import_from_data_library.md
+++ b/snippets/import_from_data_library.md
@@ -1,7 +1,7 @@
 >
 >    > ### {% icon tip %} Tip: Importing data from a data library
 >    > 
->    > As an alternative to uploading the data from a url or your computer, the files may also have been made available from a *shared data library*:
+>    > As an alternative to uploading the data from a URL or your computer, the files may also have been made available from a *shared data library*:
 >    >
 >    > * Go into **Shared data** (top panel) then **Data libraries**
 >    > * Find the correct folder (ask your instructor)

--- a/snippets/import_from_data_library.md
+++ b/snippets/import_from_data_library.md
@@ -1,7 +1,7 @@
 >
 >    > ### {% icon tip %} Tip: Importing data from a data library
 >    > 
->    > As an alternative to uploading the data yourself, the files may also have been made available from a *shared data library*:
+>    > As an alternative to uploading the data from a url or your computer, the files may also have been made available from a *shared data library*:
 >    >
 >    > * Go into **Shared data** (top panel) then **Data libraries**
 >    > * Find the correct folder (ask your instructor)

--- a/snippets/import_from_data_library.md
+++ b/snippets/import_from_data_library.md
@@ -6,7 +6,7 @@
 >    > * Go into **Shared data** (top panel) then **Data libraries**
 >    > * Find the correct folder (ask your instructor)
 >    > * Select the desired files
->    > * Click on the **To History** button near the top
+>    > * Click on the **To History** button near the top and select **{{ include.astype | default: "as Datasets" }}** from the dropdown menu  
 >    > * In the pop-up window, select the history you want to import the files to (or create a new one)
 >    > * Click on **Import**
 >    {: .tip}

--- a/snippets/import_from_data_library.md
+++ b/snippets/import_from_data_library.md
@@ -1,10 +1,13 @@
 >
 >    > ### {% icon tip %} Tip: Importing data from a data library
+>    > 
+>    > As an alternative to uploading the data yourself, the files may also have been made available from a *shared data library*:
 >    >
 >    > * Go into **Shared data** (top panel) then **Data libraries**
 >    > * Find the correct folder (ask your instructor)
->    > * Select interesting files
->    > * Click on **Import selected datasets into history**
->    > * Import in the history
+>    > * Select the desired files
+>    > * Click on the **To History** button near the top
+>    > * From the dropdown menu, select the history you want to import the files to (or create a new one)
+>    > * Click on **Import**
 >    {: .tip}
 >


### PR DESCRIPTION
in my last workshop it wasn't immediately clear to a lot of the participants that this was an *alternative* to the url import rather than something they had to do *in addition*. And the instructions were a bit out of sync with the new data library UI