### PR TITLE
Allow checking specific servers for inability to support a training

### DIFF
--- a/bin/add_galaxy_instance_annotations.py
+++ b/bin/add_galaxy_instance_annotations.py
@@ -141,6 +141,10 @@ def check_tutorials(server=None):
             instance_annot[topic]['supported'] |= instance_annot[topic]['tutorials'][tutorial]['supported']
             instance_annot[topic]['tutorials'][tutorial]['instances'].update({k: {'url': v, 'supported': False} for (k, v) in unsupported.items()})
 
+    # If we're checking a single server, do not update the metadata file.
+    if server:
+        return
+
     # add the conserved servers to the metadata/instances.yaml file
     inst_file = os.path.join("metadata", "instances.yaml")
     with open(inst_file, "w") as f:

--- a/bin/add_galaxy_instance_annotations.py
+++ b/bin/add_galaxy_instance_annotations.py
@@ -103,16 +103,20 @@ def check_tutorial(topic, tutorial, tool_filepath, server_tools):
     return servers_supported, servers_unsupported
 
 
-def check_tutorials():
+def check_tutorials(server=None):
     """Check all tutorials to extract the instances on which the tutorials can
     be run and add this information to metadata/instances.yaml file"""
-    if os.path.exists('.cache.yaml'):
-        with open('.cache.yaml', 'r') as handle:
-            server_tools = yaml.load(handle)
+    if server:
+        name, server = fetch_and_extract_individual_server_tools({'url': server, 'name': 'none'})
+        server_tools = {name: server}
     else:
-        server_tools = extract_public_galaxy_servers_tools()
-        with open('.cache.yaml', 'w') as handle:
-            yaml.dump(server_tools, handle)
+        if os.path.exists('.cache.yaml'):
+            with open('.cache.yaml', 'r') as handle:
+                server_tools = yaml.load(handle)
+        else:
+            server_tools = extract_public_galaxy_servers_tools()
+            with open('.cache.yaml', 'w') as handle:
+                yaml.dump(server_tools, handle)
 
     instance_annot = {}
     for topic in os.listdir("topics"):
@@ -146,9 +150,10 @@ def check_tutorials():
 if __name__ == '__main__':
     parser = argparse.ArgumentParser(description='Extract which public Galaxy servers can run for the tutorials and add this information to a instance file')
     parser.add_argument("--verbose", action='store_true')
+    parser.add_argument("--server", help='Only check a single server, skip fetching of the public servers list.')
     args = parser.parse_args()
 
     if args.verbose:
         logging.basicConfig(level=logging.DEBUG)
 
-    check_tutorials()
+    check_tutorials(server=args.server)


### PR DESCRIPTION
@shiltemann and I were wondering why EU was marked as not supporting her mothur miseq tutorial. I've updated the annotation generation script to support checking a single server:

```console
$ python bin/add_galaxy_instance_annotations.py \
  --server https://usegalaxy.eu --verbose
...
DEBUG:root:MISSING:none:metagenomics/mothur-miseq-sop: toolshed.g2.bx.psu.edu/repos/dcorreia/newick_display
...
```

And can easily see that this tool should have its ID updated to the new IUC tool. (Or we can find out other things we're missing to support different trainings.)