### PR TITLE
Escape template sections

### DIFF
--- a/topics/admin/tutorials/reports/tutorial.md
+++ b/topics/admin/tutorials/reports/tutorial.md
@@ -77,6 +77,7 @@ The reports application is not complex to setup as it is included directly in th
 >
 > 3. Create `templates/galaxy/config/`, if it doesn't exist, and add create and edit `templates/galaxy/config/reports.yml` with the following contents:
 >
+>    {% raw %}
 >    ```yml
 >    uwsgi:
 >        http: 127.0.0.1:9001
@@ -105,15 +106,18 @@ The reports application is not complex to setup as it is included directly in th
 >        filter-with: proxy-prefix
 >        template_cache_path: {{ galaxy_mutable_data_dir }}/compiled_templates
 >    ```
+>    {% endraw %}
 >
 > 4. In your group variables, configure Galaxy to deploy the reports configuration file:
 >
+>    {% raw %}
 >    ```yml
 >    galaxy_template_files:
 >    ...
->    - src: files/galaxy/config/reports.yml
+>    - src: templates/galaxy/config/reports.yml
 >      dest: "{{ galaxy_config_dir }}/reports.yml"
 >    ```
+>    {% endraw %}
 >
 > 5. Run the playbook
 >


### PR DESCRIPTION
These are way too easy to miss, I wonder if there is a way Jekyll can complain about undefined variables.