### PR TITLE
updated heatmap2 field label

### DIFF
--- a/topics/transcriptomics/tutorials/ref-based/tutorial.md
+++ b/topics/transcriptomics/tutorials/ref-based/tutorial.md
@@ -914,7 +914,7 @@ We now have a table with 130 lines (the most differentially expressed genes) and
 >
 > 1. **heatmap2** {% icon tool %} to plot the heatmap:
 >    - {% icon param-file %} *"Input should have column headers"*: the generated table (output of **Cut** {% icon tool %})
->    - *"Advanced - log transformation"*: `Log2(value) transform my data`
+>    - *"Advanced - log transformation"*/*"Data transformation"*: `Log2(value) transform my data`
 >    - *"Enable data clustering"*: `Yes`
 >    - *"Labeling columns and rows"*: `Label columns and not rows`
 >    - *"Coloring groups"*: `Blue to white to red`


### PR DESCRIPTION
The ref-based RNA-Seq [hands-on](https://galaxyproject.github.io/training-material/topics/transcriptomics/tutorials/ref-based/tutorial.html) tutorial shows the heatmap2 (2.2.1) tool, and set its "Advanced - log transformation" parameter. However, [the parameter gets renamed in the latest version (2.2.1+galaxy1) as "Data transformation"](https://github.com/galaxyproject/tools-iuc/issues/2274). Since the last version is the one that gets shown by default, I propose to provide both parameter labels in the tutoral