### PR TITLE
Automatic archival builds of repository tags

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -87,4 +87,5 @@ after_success:
       make annotate
       make build
       bin/publish
+      bin/publish-archive
     fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -39,6 +39,7 @@ matrix:
 install:
   - sudo apt-get update
   - sudo update-ca-certificates
+  - sudo pip install awscli
   - make install-conda
   - export PATH="$HOME/miniconda3/bin:$PATH"
   - conda config --set always_yes yes --set changeps1 no

--- a/_config.yml
+++ b/_config.yml
@@ -20,6 +20,7 @@ description: A collection of tutorials generated and maintained by Galaxy Commun
 url: "https://galaxyproject.github.io/"
 baseurl: "/training-material"
 github_repository: "https://github.com/galaxyproject/training-material"
+github_repository_branch: "master"
 github_organization_name: "galaxyproject"
 gitter_url: "https://gitter.im/Galaxy-Training-Network/Lobby"
 logo: "assets/images/GTN.png"

--- a/_layouts/topic.html
+++ b/_layouts/topic.html
@@ -119,14 +119,14 @@ layout: base
                                 </td>
                                 <td>
                                     {% if material.workflows %}
-                                        <a href="{{ site.github_repository }}/tree/master/topics/{{ topic.name }}/tutorials/{{ material.tutorial_name }}/workflows/" title="{{ workflow.title }}" alt="{{ material.title }} workflows">
+                                        <a href="{{ site.github_repository }}/tree/{{ site.github_repository_branch }}/topics/{{ topic.name }}/tutorials/{{ material.tutorial_name }}/workflows/" title="{{ workflow.title }}" alt="{{ material.title }} workflows">
                                             {% icon workflow %}
                                         </a>
                                     {% endif %}
                                 </td>
                                 <td>
                                     {% if material.tours %}
-                                    <a href="{{ site.github_repository }}/tree/master/topics/{{ topic.name }}/tutorials/{{ material.tutorial_name }}/tours/">
+                                    <a href="{{ site.github_repository }}/tree/{{ site.github_repository_branch }}/topics/{{ topic.name }}/tutorials/{{ material.tutorial_name }}/tours/">
                                         {% icon interactive_tour %}
                                     </a>
                                     {% endif %}

--- a/_layouts/tutorial_hands_on.html
+++ b/_layouts/tutorial_hands_on.html
@@ -74,7 +74,7 @@ layout: base
                             </a>
                             <div class="dropdown-menu">
                                 {% if topic.docker_image %}
-                                    <a class="dropdown-item" href="{{ site.github_repository }}/tree/master/topics/{{ topic.name }}/docker" title="Docker image for this tutorial">
+                                    <a class="dropdown-item" href="{{ site.github_repository }}/tree/{{ site.github_repository_branch }}/topics/{{ topic.name }}/docker" title="Docker image for this tutorial">
                                         {% icon docker_image %} Docker image
                                     </a>
                                 {% endif %}
@@ -181,7 +181,7 @@ layout: base
             {% endif %}
         </blockquote>
 
-        {{ content 
+        {{ content
             | replace: '<blockquote class="hands_on">', '<blockquote class="notranslate hands_on">' }}
 
         {% if page.key_points %}

--- a/bin/publish-archive
+++ b/bin/publish-archive
@@ -11,7 +11,7 @@ check_built_version() {
 	# Only request 1 item max since we just need to know if /something/ exists there.
 	aws s3api list-objects \
 		--bucket galaxy-training \
-		--prefix "${tag}/" \
+		--prefix "archive/${tag}/" \
 		--max-items 1 \
 		| wc -l
 }

--- a/bin/publish-archive
+++ b/bin/publish-archive
@@ -1,0 +1,52 @@
+#!/bin/bash
+
+# Obtain version list
+check_built_version() {
+	tag=$1
+
+	# List all objects with the prefix matching that folder. We don't just list
+	# root because if one version has more than max files, we won't see the
+	# other versions in the list.
+	#
+	# Only request 1 item max since we just need to know if /something/ exists there.
+	aws s3api list-objects \
+		--bucket galaxy-training \
+		--prefix "${tag}/" \
+		--max-items 1 \
+		| wc -l
+}
+
+build_version() {
+	tag=$1
+	# Go into repo dir
+
+	# Checkout tag
+	git checkout $tag
+	if (( $? == 0 )); then
+		# Adjust baseurl
+		sed -i s"|^baseurl: .*|baseurl: '/archive/${tag}'|g" _config.yml
+		sed -i s"|^github_repository_branch: .*|github_repository_branch: '${tag}'|g" _config.yml
+		# Clean in order to remove anything from previous build
+		make clean
+		# And then rebuild with new version + updated _config.yml
+		make build
+		# Reset the config now that the site is built, since we no longer need
+		# it.
+		git checkout -- _config.yml
+
+		# Deploy
+		aws s3 sync _site/training-material/ s3://galaxy-training/archive/${tag}/
+	else
+		echo "Could not checkout ${tag}, probably older than Travis 50 commit clone depth."
+	fi
+}
+
+for tag in $(git tag -l); do
+	result=$(check_built_version "$tag")
+	if [[ "$result" == "0" ]]; then
+		echo "$tag needs to be built"
+		build_version "$tag"
+	else
+		echo "$tag is already built, not rebuilding [${BUILD_DIR}/${tag}]"
+	fi
+done

--- a/bin/publish-archive
+++ b/bin/publish-archive
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# Obtain version list
+# Check if a specific tag has been built. "check_built_version [tagname]"
 check_built_version() {
 	tag=$1
 
@@ -41,7 +41,9 @@ build_version() {
 	fi
 }
 
+# For all tags
 for tag in $(git tag -l); do
+	# Has it been build?
 	result=$(check_built_version "$tag")
 	if [[ "$result" == "0" ]]; then
 		echo "$tag needs to be built"

--- a/bin/publish-archive
+++ b/bin/publish-archive
@@ -50,3 +50,50 @@ for tag in $(git tag -l); do
 		echo "$tag is already built, not rebuilding [${BUILD_DIR}/${tag}]"
 	fi
 done
+
+INDEX_PAGE_DIR=$(mktemp -d)
+INDEX="${INDEX_PAGE_DIR}/index.html"
+
+# build the index page
+cat > $INDEX <<-EOF
+<!doctype html>
+<html lang="en">
+    <head>
+        <meta charset="utf-8">
+        <meta http-equiv="x-ua-compatible" content="ie=edge">
+        <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
+        <title>Galaxy Training Archive</title>
+        <link rel="stylesheet" href="https://galaxyproject.github.io/training-material/assets/css/bootstrap.min.css?v=3">
+        <link rel="stylesheet" href="https://galaxyproject.github.io/training-material/assets/css/main.css?v=2">
+    </head>
+    <body>
+        <header>
+    <nav class="navbar navbar-expand-md navbar-dark">
+        <div class="container">
+            <a class="navbar-brand" href="/">
+                Galaxy Training Archive
+            </a>
+        </div>
+    </nav>
+</header>
+<div class="container main-content">
+    <section>
+        <h1>Welcome to Galaxy Training Archive!</h1>
+        <p class="lead">
+            Access specific, historical versions of the Galaxy Training Material
+        </p>
+
+        <div class="row">
+            <div class="col">
+                <h3>Past Versions</h3><ul>
+EOF
+
+for tag in $(git tag -l); do
+	printf '<li><a href="/archive/%s/">%s</a></li>' "${tag}" "${tag}" >> $INDEX
+done
+
+
+echo "</ul></div></div></section></div></body></html>" >> $INDEX
+
+# Upload
+aws s3 sync ${INDEX_PAGE_DIR} s3://galaxy-training/

--- a/faq.md
+++ b/faq.md
@@ -40,7 +40,7 @@ We wrote an [article](https://www.biorxiv.org/content/early/2018/04/05/225680) a
 
 ## How can I advertise the training materials on my posters?
 
-We provide some QR codes and logos in the [images folder](https://github.com/galaxyproject/training-material/tree/master/assets/images).
+We provide some QR codes and logos in the [images folder]({{ site.github_repository }}/tree/{{ site.github_repository_branch }}/assets/images).
 
 # For Individual Learners
 
@@ -288,4 +288,4 @@ Yes, always! Have a look at the [Galaxy Community Events Calendar](https://galax
 
 This repository is hosted on [GitHub](https://github.com/) using git as a [DVCS](https://en.wikipedia.org/wiki/Distributed_version_control). Therefore the community is hosting backups of this
 repository in a decentralised way. The repository is self-contained and contains all needed content and all metadata.
-In addition we mirror snapshops of this repo on [Zenodo](http://zenodo.org). 
+In addition we mirror snapshops of this repo on [Zenodo](http://zenodo.org).

--- a/topics/contributing/tutorials/create-new-topic/tutorial.md
+++ b/topics/contributing/tutorials/create-new-topic/tutorial.md
@@ -73,7 +73,7 @@ Sometimes, an hands-on tutorial is not the most appropriate format for a tutoria
 
 For each topic, a flavored Docker image must integrate the tools needed for
 the tutorials. The corresponding image must be based on official Galaxy Docker
-images. We recommend to use the content of [`templates/docker`]({{ site.github_repository }}/tree/master/templates/docker) as a template.
+images. We recommend to use the content of [`templates/docker`]({{ site.github_repository }}/tree/{{ site.github_repository_branch }}/templates/docker) as a template.
 
 The `docker` image will also integrate the Galaxy tours available for each topics and the workflows.
 

--- a/topics/dev/tutorials/visualization-generic/tutorial.md
+++ b/topics/dev/tutorials/visualization-generic/tutorial.md
@@ -250,25 +250,25 @@ Let's put this all together.
 >    <!DOCTYPE HTML>
 >    <%
 >        import os
->    
+>
 >        ## Generates hash (hdadict['id']) of history item
 >        hdadict = trans.security.encode_dict_ids( hda.to_dict() )
->    
+>
 >        ## Finds the parent directory of galaxy (/, /galaxy, etc.)
 >        root     = h.url_for( '/' )
->    
+>
 >        ## Determines the exposed URL of the ./static directory
 >        app_root = root + 'plugins/visualizations/'+visualization_name+'/static/'
->    
+>
 >        ## Actual file URL:
 >        file_url = os.path.join(root, 'datasets', hdadict['id'], "display?to_ext="+hda.ext)
->    
+>
 >        ## Ensure BAI index is symlinked
 >        bai_target = hda.file_name+'.bai'
->    
+>
 >        if not os.path.isfile(bai_target):
 >            os.symlink(hda.metadata.bam_index.file_name, bai_target)
->    
+>
 >        ## Extract idxstats
 >        import pysam
 >        bam_idxstats_data = pysam.idxstats(hda.file_name)
@@ -282,19 +282,19 @@ Let's put this all together.
 >        </body>
 >    </html>
 >    ```
->    
+>
 >    We are now ready to test this very basic visualization, we just need a (small) BAM file for it.
 >
 > 3. Download [the example BAM file](https://zenodo.org/record/248730/files/tutorial.bam)
 > 4. Go the galaxy root directory and start Galaxy:
->    
+>
 >    ```bash
 >    $ cd $GALAXY_ROOT
 >    $ ./run.sh
 >    ```
 >
 > 5. Upload the example BAM file to your history
->    
+>
 >    If everything went well, our plugin has appeared as a visualization option for the dataset
 >
 >    > ### {% icon comment %} Comments
@@ -359,34 +359,34 @@ functional changes to the mako files.
 > ### {% icon hands_on %} Hands-on: Data upload
 >
 > 1. Change the mako file to the following:
->    
+>
 >    ```html
 >    <!DOCTYPE HTML>
 >    <%
 >        import os
->    
+>
 >        ## Generates hash (hdadict['id']) of history item
 >        hdadict = trans.security.encode_dict_ids( hda.to_dict() )
->    
+>
 >        ## Finds the parent directory of galaxy (/, /galaxy, etc.)
 >        root     = h.url_for( '/' )
->    
+>
 >        ## Determines the exposed URL of the ./static directory
 >        app_root = root + 'plugins/visualizations/'+visualization_name+'/static/'
->    
+>
 >        ## Actual file URL:
 >        file_url = os.path.join(root, 'datasets', hdadict['id'], "display?to_ext="+hda.ext)
->    
+>
 >        ## Ensure BAI index is symlinked
 >        bai_target = hda.file_name+'.bai'
->    
+>
 >        if not os.path.isfile(bai_target):
 >            os.symlink(hda.metadata.bam_index.file_name, bai_target)
->    
+>
 >        ## Extract idxstats
 >        import pysam
 >        bam_idxstats_data = pysam.idxstats(hda.file_name)
->    
+>
 >    %>
 >    <html>
 >        <head>
@@ -398,7 +398,7 @@ functional changes to the mako files.
 >                    for(var i = 0; i < data.length ; i++) {
 >                        var line = data[i];
 >                        var chunks = line.split("\t");
->    
+>
 >                        if(chunks[0].split("_").length == 1) { // only if it does not contain underscore
 >                            output[chunks[0]] = parseInt(chunks[2]);
 >                        }
@@ -427,7 +427,7 @@ chromosome.
 
 ![Example visualization](../../images/vis_plugins_example.png)
 
-The full contents of this plugin are provided in the [GitHub repository related to this material in `tree/master/topics/dev/files/hands_on-visualizations/alignment_rname_boxplot`]({{ site.github_repository }}/tree/master/topics/dev/files/hands_on-visualizations/alignment_rname_boxplot).
+The full contents of this plugin are provided in the [GitHub repository related to this material in `tree/master/topics/dev/files/hands_on-visualizations/alignment_rname_boxplot`]({{ site.github_repository }}/tree/{{ site.github_repository_branch }}/topics/dev/files/hands_on-visualizations/alignment_rname_boxplot).
 To try out this example, simply copy this folder to the `$GALAXY_ROOT/config/plugins/visualizations/` folder
 on your (local) Galaxy and restart Galaxy.
 

--- a/topics/instructors/tutorials/setup-galaxy-for-training/tutorial.md
+++ b/topics/instructors/tutorials/setup-galaxy-for-training/tutorial.md
@@ -125,7 +125,7 @@ To install to training requirements to our Galaxy, we will use Ephemeris, let's 
 
 # Installing tutorial requirements
 
-We have created a small bash script to automatically install all of a tutorial's requirements to an existing Galaxy. It's located in this repository under: [`bin/install_tutorial_requirements.sh`]({{ site.github_repository }}/tree/master/bin/install_tutorial_requirements.sh)
+We have created a small bash script to automatically install all of a tutorial's requirements to an existing Galaxy. It's located in this repository under: [`bin/install_tutorial_requirements.sh`]({{ site.github_repository }}/tree/{{ site.github_repository_branch }}/bin/install_tutorial_requirements.sh)
 
 In this example we will install the requirements for the [*Reference-based RNASeq*]({{ site.baseurl }}/topics/transcriptomics/tutorials/ref-based/tutorial.html) tutorial to the Galaxy instance running on localhost.
 
@@ -164,7 +164,7 @@ The only thing the script cannot currently automate is the installation of the i
 
 ### Installing an entire topic
 
-If you would like to install all the requirements for every tutorial within an entire topic, you can use the script in [`bin/install_topic_requirements.sh`]({{ site.github_repository }}/tree/master/bin/install_topic_requirements.sh)
+If you would like to install all the requirements for every tutorial within an entire topic, you can use the script in [`bin/install_topic_requirements.sh`]({{ site.github_repository }}/tree/{{ site.github_repository_branch }}/bin/install_topic_requirements.sh)
 
 
 ### Installing a subset of components


### PR DESCRIPTION
This adds a script which will check out all git tags in the repo and automatically build them if they haven't previously been built.

The results are stored http://galaxy-training.s3-website.us-east-1.amazonaws.com/ which will be proxied in the near future, so it will become something like:

```
training.galaxyproject.org/<normal website>
training.galaxyproject.org/archive/2019-01-01/<archived website>
```

Tags are fairly lightweight and easy to add as needed per-training or per-month. I propose that it is done automatically per-month, but this will be done in a separate PR. I have added an experimental tag that will show up when this is merged.

The versions currently on the S3 bucket are built from the tags in my fork and will disappear when we merge this.