### PR TITLE
Update for proxying

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -53,23 +53,23 @@ install: clean ## install dependencies
 
 serve: ## run a local server (You can specify PORT=, HOST=, and FLAGS= to set the port, host or to pass additional flags)
 	$(ACTIVATE_ENV) && \
-		${JEKYLL} serve --strict_front_matter -d _site/training-material -P ${PORT} -H ${HOST} ${FLAGS}
+		${JEKYLL} serve --strict_front_matter -d _site -P ${PORT} -H ${HOST} ${FLAGS}
 .PHONY: serve
 
 detached-serve: ## run a local server in detached mode (You can specify PORT=, HOST=, and FLAGS= to set the port, host or to pass additional flags to Jekyll)
 	$(ACTIVATE_ENV) && \
-		${JEKYLL} serve --strict_front_matter --detach -d _site/training-material -P ${PORT} -H ${HOST} ${FLAGS}
+		${JEKYLL} serve --strict_front_matter --detach -d _site -P ${PORT} -H ${HOST} ${FLAGS}
 .PHONY: detached-serve
 
 build: clean ## build files but do not run a server (You can specify FLAGS= to pass additional flags to Jekyll)
 	$(ACTIVATE_ENV) && \
-		${JEKYLL} build --strict_front_matter -d _site/training-material ${FLAGS}
+		${JEKYLL} build --strict_front_matter -d _site ${FLAGS}
 .PHONY: build
 
 check-frontmatter: build ## Validate the frontmatter
 	$(ACTIVATE_ENV) && \
 		find topics/ -name tutorial.md -or -name slides.html -or -name metadata.yaml | \
-	    xargs -n1 ruby bin/validate-frontmatter.rb 
+	    xargs -n1 ruby bin/validate-frontmatter.rb
 .PHONY: check-frontmatter
 
 check-html: build ## validate HTML
@@ -113,7 +113,7 @@ check-slides: build  ## check the markdown-formatted links in slides
 check-yaml: ## lint yaml files
 	$(ACTIVATE_ENV) && \
 		find . -name "*.yaml" | xargs -L 1 -I '{}' sh -c "yamllint {}" \
-		find topics -name '*.yml' | xargs -L 1 -I '{}' sh -c "yamllint {}" 
+		find topics -name '*.yml' | xargs -L 1 -I '{}' sh -c "yamllint {}"
 .PHONY: check-yaml
 
 check: check-yaml check-frontmatter check-html-internal check-html check-slides ## run all checks

--- a/_config.yml
+++ b/_config.yml
@@ -17,8 +17,8 @@
 title: "Galaxy Training!"
 email: galaxytrainingnetwork@gmail.com
 description: A collection of tutorials generated and maintained by Galaxy Community Members across the world
-url: "https://galaxyproject.github.io/"
-baseurl: "/training-material"
+url: "https://training.galaxyproject.org/"
+baseurl: ""
 github_repository: "https://github.com/galaxyproject/training-material"
 github_repository_branch: "master"
 github_organization_name: "galaxyproject"

--- a/_layouts/base.html
+++ b/_layouts/base.html
@@ -17,12 +17,12 @@
             ga('send', 'pageview');
         </script>
         {% endif %}
-        <link rel="stylesheet" href="{{ "/assets/css/bootstrap.min.css?v=3" | prepend: site.baseurl }}">
-        <link rel="stylesheet" href="{{ "/assets/css/main.css?v=2" | prepend: site.baseurl }}">
-        <link rel="stylesheet" href="{{ "/assets/css/font-awesome.css" | prepend: site.baseurl }}">
-        <link rel="stylesheet" href="{{ "/assets/css/academicons.css" | prepend: site.baseurl }}">
-        <link rel="stylesheet" href="{{ "/assets/css/syntax_highlighting.css" | prepend: site.baseurl }}">
-        <link rel="shortcut icon" href="{{ "/favicon.ico" | prepend: site.baseurl }}" type="image/x-icon" />
+        <link rel="stylesheet" href="{{ "/assets/css/bootstrap.min.css?v=3" | prepend: site.url }}">
+        <link rel="stylesheet" href="{{ "/assets/css/main.css?v=2" | prepend: site.url }}">
+        <link rel="stylesheet" href="{{ "/assets/css/font-awesome.css" | prepend: site.url }}">
+        <link rel="stylesheet" href="{{ "/assets/css/academicons.css" | prepend: site.url }}">
+        <link rel="stylesheet" href="{{ "/assets/css/syntax_highlighting.css" | prepend: site.url }}">
+        <link rel="shortcut icon" href="{{ "/favicon.ico" | prepend: site.url }}" type="image/x-icon" />
 
         {% assign topic = site.data[page.topic_name] %}
         {% assign og_title = topic.title %}
@@ -36,15 +36,15 @@
         <meta name="description" content="{{ og_desc | strip_html | truncate: 60}}" />
         <meta property="og:title" content="Galaxy Training{% if og_title %}: {{ og_title | truncate: 60}}{% endif %}" />
         <meta property="og:description" content="{{ og_desc | strip_html | truncate: 60}}" />
-        <meta property="og:image" content="{{ "/assets/images/GTNLogo1000.png" | prepend: site.baseurl }}" />
+        <meta property="og:image" content="{{ "/assets/images/GTNLogo1000.png" | prepend: site.url }}" />
     </head>
     <body>
         {{ content }}
     </body>
-    <script type="text/javascript" src="{{ "/assets/js/jquery.slim.min.js" | prepend: site.baseurl }}"></script>
-    <script type="text/javascript" src="{{ "/assets/js/popper.min.js" | prepend: site.baseurl }}"></script>
-    <script type="text/javascript" src="{{ "/assets/js/bootstrap.min.js?v=3" | prepend: site.baseurl }}"></script>
-    <script type="text/javascript" src="{{ "/assets/js/details-element-polyfill.js" | prepend: site.baseurl }}"></script>
+    <script type="text/javascript" src="{{ "/assets/js/jquery.slim.min.js" | prepend: site.url }}"></script>
+    <script type="text/javascript" src="{{ "/assets/js/popper.min.js" | prepend: site.url }}"></script>
+    <script type="text/javascript" src="{{ "/assets/js/bootstrap.min.js?v=3" | prepend: site.url }}"></script>
+    <script type="text/javascript" src="{{ "/assets/js/details-element-polyfill.js" | prepend: site.url }}"></script>
     <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.1/MathJax.js?config=TeX-AMS-MML_HTMLorMML"></script>
-    <script type="text/javascript" src="{{ "/assets/js/main.js" | prepend: site.baseurl }}"></script>
+    <script type="text/javascript" src="{{ "/assets/js/main.js" | prepend: site.url }}"></script>
 </html>

--- a/_layouts/tutorial_hands_on.html
+++ b/_layouts/tutorial_hands_on.html
@@ -22,7 +22,7 @@ layout: base
             <div class="collapse navbar-collapse" id="top-navbar">
                 <ul class="navbar-nav">
                     <li class="nav-item">
-                        <a class="nav-link" href="{{ site.baseurl }}/topics/{{ topic.name }}" title="Go back to list of tutorials">
+                        <a class="nav-link" href="{{ site.baseurl }}/topics/{{ topic.name }}/" title="Go back to list of tutorials">
                             {% icon topic %} {{ topic.title }}
                         </a>
                     </li>

--- a/bin/publish-archive
+++ b/bin/publish-archive
@@ -98,4 +98,4 @@ done
 echo "</ul></div></div></section></div></body></html>" >> $INDEX
 
 # Upload
-aws s3 sync ${INDEX_PAGE_DIR} s3://galaxy-training/
+aws s3 sync ${INDEX_PAGE_DIR} s3://galaxy-training/archive/

--- a/topics/admin/tutorials/tool-management/tutorial.md
+++ b/topics/admin/tutorials/tool-management/tutorial.md
@@ -35,7 +35,7 @@ This tutorial will introduce you to one of Galaxy's associated projects - [Ephem
 
 # Background
 
-You are an administrator of your lab's Galaxy. A colleague has approached you with a request to run a specific [Galaxy workflow]({{ site.url }}/topics/sequence-analysis/tutorials/mapping/workflows/mapping.ga) on the lab's data. In order to run this workflow you have to accomplish several substeps first. You will need to:
+You are an administrator of your lab's Galaxy. A colleague has approached you with a request to run a specific [Galaxy workflow]({{ site.baseurl }}/topics/sequence-analysis/tutorials/mapping/workflows/mapping.ga) on the lab's data. In order to run this workflow you have to accomplish several substeps first. You will need to:
 
 - identify what tools are required for the workflow
 - and install these on your Galaxy instance
@@ -77,7 +77,7 @@ Let's try running this on a real worfklow.
 >
 > 1. Download the mapping workflow:
 >    ```console
->    $ wget {{ site.url }}/topics/sequence-analysis/tutorials/mapping/workflows/mapping.ga
+>    $ wget {{ site.url }}{{ site.baseurl }}/topics/sequence-analysis/tutorials/mapping/workflows/mapping.ga
 >    ```
 >
 > 2. Use the Ephemeris command [`workflow-to-tools`](https://ephemeris.readthedocs.io/en/latest/commands/workflow-to-tools.html) to extract the tool list from this workflow, into a file named `workflow_tools.yml`.

--- a/topics/dev/tutorials/interactive-tours/slides.html
+++ b/topics/dev/tutorials/interactive-tours/slides.html
@@ -109,7 +109,7 @@ Argument | Description
 
 - Create Tours and share them with the world!
   - on the [community collection of Interactive Tours](https://github.com/galaxyproject/galaxy-tours) or
-  - add them to the [Galaxy Training Network]({{site.url}}{{site.baseurl}})
+  - add them to the [Galaxy Training Network](https://training.galaxyproject.org/)
 - Improve the Tours implementation
 - Improve creating of Tours
   - by enhancing the [Galaxy Tour Builder](https://github.com/dannon/tourbuilder) web extension

--- a/topics/dev/tutorials/webhooks/slides.html
+++ b/topics/dev/tutorials/webhooks/slides.html
@@ -136,7 +136,7 @@ The return value can be read with a call to `/api/webhooks/WEBHOOK_NAME/get_data
   - add additional ones ...
 - Improve the documentation or training material
   - [Documentation](https://docs.galaxyproject.org/en/latest/admin/special_topics/webhooks.html)
-  - [Galaxy Training Network]({{site.url}}]{{site.baseurl}})
+  - [Galaxy Training Network](https://training.galaxyproject.org/)
 
 ---
 

--- a/topics/instructors/tutorials/setup-tiaas-for-training/tutorial.md
+++ b/topics/instructors/tutorials/setup-tiaas-for-training/tutorial.md
@@ -33,7 +33,7 @@ UseGalaxy.eu has developed Training Infrastructure as a Service (TIaaS for short
 
 Consider the requirements for your training:
 
-- Do you need really special tools that are not already available on EU? The EU server supports [most training workflows]({{ site.baseurl }}/badges/#galaxy-europe), but if you need something special you might want to [contact the admins](mailto:contact@usegalaxy.eu) to see if they can accomodate your needs.
+- Do you need really special tools that are not already available on EU? The EU server supports [most training workflows]({{ site.url }}{{ site.baseurl }}/badges/#galaxy-europe), but if you need something special you might want to [contact the admins](mailto:contact@usegalaxy.eu) to see if they can accomodate your needs.
 - Do you have special private training data that should be made public? If so the EU server is not appropriate
 - Do you need extra guarantees that the server will be online? The EU server has very good uptime for a server run by an academic group, but it cannot make promises regarding availability.
 

--- a/topics/instructors/tutorials/setup-tiaas-for-training/tutorial.md
+++ b/topics/instructors/tutorials/setup-tiaas-for-training/tutorial.md
@@ -33,7 +33,7 @@ UseGalaxy.eu has developed Training Infrastructure as a Service (TIaaS for short
 
 Consider the requirements for your training:
 
-- Do you need really special tools that are not already available on EU? The EU server supports [most training workflows]({{ site.url }}/badges/#galaxy-europe), but if you need something special you might want to [contact the admins](mailto:contact@usegalaxy.eu) to see if they can accomodate your needs.
+- Do you need really special tools that are not already available on EU? The EU server supports [most training workflows]({{ site.baseurl }}/badges/#galaxy-europe), but if you need something special you might want to [contact the admins](mailto:contact@usegalaxy.eu) to see if they can accomodate your needs.
 - Do you have special private training data that should be made public? If so the EU server is not appropriate
 - Do you need extra guarantees that the server will be online? The EU server has very good uptime for a server run by an academic group, but it cannot make promises regarding availability.
 

--- a/topics/introduction/README.md
+++ b/topics/introduction/README.md
@@ -9,7 +9,7 @@ Here, you will find some material to learn how to use Galaxy.
 
 A deck of slides is available for this topic:
 
-- [General introduction about Galaxy]({{site.url}}/topics/introduction/slides/)
+- [General introduction about Galaxy]({{site.baseurl}}/topics/introduction/slides/)
 
 # Tutorials
 

--- a/topics/proteomics/tutorials/database-handling/workflows/readme.md
+++ b/topics/proteomics/tutorials/database-handling/workflows/readme.md
@@ -1,6 +1,6 @@
 # GalaxyP Workflow: Database Handling
 
-This workflow supplements the Galaxy-P tutorial on database handling ([Link]({{site.url}}/topics/proteomics/tutorials/database-handling/tutorial.html)).
+This workflow supplements the Galaxy-P tutorial on database handling ([Link]({{site.baseurl}}/topics/proteomics/tutorials/database-handling/tutorial.html)).
 You will find two versions of the same workflow: one creates a database with only the cRAP proteins added, the other further adds the proteomes of the most common mycoplasma contaminants.
 
 An overview of the workflow is given below:
@@ -10,7 +10,7 @@ An overview of the workflow is given below:
 ## Inputs and Customization
 
 For this workflow, you need no prior inputs. You can change the database to download after starting to run the workflow (default: _Homo sapiens_). To do so, click on the `Taxonomy` option in `1: Protein Database Downloader`.
-You may also change other options about the database to download (`reviewed`, `Proteome Set` and `Include isoform data`). Please refer to the [database handling tutorial]({{site.url}}/topics/proteomics/tutorials/database-handling/tutorial.html) for details.
+You may also change other options about the database to download (`reviewed`, `Proteome Set` and `Include isoform data`). Please refer to the [database handling tutorial]({{site.baseurl}}/topics/proteomics/tutorials/database-handling/tutorial.html) for details.
 
 ![Input_options](../../../images/wf_databaseHandling_options.png)
 

--- a/topics/proteomics/tutorials/protein-id-sg-ps/workflows/readme.md
+++ b/topics/proteomics/tutorials/protein-id-sg-ps/workflows/readme.md
@@ -1,6 +1,6 @@
 # GalaxyP Workflow: Protein Identification (using Search GUI and Peptide Shaker)
 
-This workflow supplements the GalaxyP tutorial on Protein ID ([Link]({{site.url}}/topics/proteomics/tutorials/protein-id-sg-ps/tutorial.html)).
+This workflow supplements the GalaxyP tutorial on Protein ID ([Link]({{site.baseurl}}/topics/proteomics/tutorials/protein-id-sg-ps/tutorial.html)).
 You can find two versions of the same workflow: one is designed for a single MS run as an input. It can also be used for parallel analysis of multiple MS runs. Each MS run will result in a separate output file.
  The second workflow is designed for multiple MS runs to be combined into a single output file.
 
@@ -12,13 +12,13 @@ An overview of the workflow is given below:
 
 Two inputs are needed:
 
-1. A protein FASTA database to be searched against. Using the current settings, a database **without decoys** is needed. The decoys will be automatically added by ***Search GUI*** :wrench: . To learn more about databases, please consider the tutorial on [database handling]({{site.url}}/topics/proteomics/tutorials/database-handling/tutorial.html). For creating a database, you can also use a [ready-made workflow](../database-handling/).
+1. A protein FASTA database to be searched against. Using the current settings, a database **without decoys** is needed. The decoys will be automatically added by ***Search GUI*** :wrench: . To learn more about databases, please consider the tutorial on [database handling]({{site.baseurl}}/topics/proteomics/tutorials/database-handling/tutorial.html). For creating a database, you can also use a [ready-made workflow](../database-handling/).
 
 2. At least one mass spectrometry data file in the mzML format. With the current settings, you will need a non-centroided mzML (raw data, no prior peak-picking). If you have data in another format or already centroided data, please consider the section [below](#customizing-the-workflow).
 
 ## Outputs
 
-The workflow provides the identified proteins, peptides and PSMs as an output. For details on the ***Peptide Shaker*** :wrench: outputs, please consider the tutorial on [database handling]({{site.url}}/topics/proteomics/tutorials/database-handling/tutorial.html).
+The workflow provides the identified proteins, peptides and PSMs as an output. For details on the ***Peptide Shaker*** :wrench: outputs, please consider the tutorial on [database handling]({{site.baseurl}}/topics/proteomics/tutorials/database-handling/tutorial.html).
 
 ## Customizing the Workflow
 
@@ -28,5 +28,5 @@ You can customize the workflow after importing it to your Galaxy instance. Click
 - *Using another MS file format than mzML*:
 
   - For `*.mgf`: Delete the tool ***PeakPickerHiRes*** :wrench: and ***FileConverter*** :wrench: , use the mzML directly as an input for ***Search GUI*** :wrench: .
-  - For `*.raw`: Convert to mzML before running the workflow. For details, please consider the tutorial on [database handling]({{site.url}}/topics/proteomics/tutorials/database-handling/tutorial.html).
+  - For `*.raw`: Convert to mzML before running the workflow. For details, please consider the tutorial on [database handling]({{site.baseurl}}/topics/proteomics/tutorials/database-handling/tutorial.html).
   - For other formats: Use the ***FileConverter*** :wrench: to convert to mzML (profile data) or directly to mgf (centroided data).

--- a/topics/transcriptomics/README.md
+++ b/topics/transcriptomics/README.md
@@ -7,13 +7,13 @@ RNA-sequencing is a method used to reveal the presence and quantity of RNA in a 
 
 A deck of slides is available for this topic:
 
-- [General introduction about RNA seq data analysis]({{site.url}}/topics/transcriptomics/slides/)
+- [General introduction about RNA seq data analysis]({{site.baseurl}}/topics/transcriptomics/slides/)
 
 # Tutorials
 
 A tutorial with hands-on is available for this topic:
 
-- [Reference-based RNA-seq data analysis]({{site.url}}/topics/transcriptomics/tutorials/ref-based/tutorial.html)
+- [Reference-based RNA-seq data analysis]({{site.baseurl}}/topics/transcriptomics/tutorials/ref-based/tutorial.html)
 
 ## Input datasets
 


### PR DESCRIPTION
Training material will now be accessible from https://training.galaxyproject.org/ with /topics directly from the root. This is currently partially live, in an attempt to cause the minimum amount of disruption.

I've coded the assets to use the full site url so the old github pages will still render correctly. If this wasn't done, the assets would attempt loading from `/assets` instead of `/training-material/assets` and be unavailable and break.

I've also fixed some other incorrect uses of site.url instead of site.baseurl, one from an admin tuto that would break if you ran the command.

Lastly moves archive index page into /archive so that will load properly too.

With this PR merged, everything should be done, https://training.galaxyproject.org/ should have all content and browsing around on there should stay on that site. Browsing from bookmarked github.io links will, on-click, redirect to the galaxyproject.org version. Old versions will be available under https://training.galaxyproject.org/archive/