### PR TITLE
Fix requirement display on slides and support follow up for slides

### DIFF
--- a/_layouts/base_slides.html
+++ b/_layouts/base_slides.html
@@ -61,29 +61,16 @@ class: center, middle, inverse
 # {{ title }}
 
 {% if topic.requirements or page.requirements %}
+
 ---
 
-  ## Requirements
+## Requirements
 
-  Before diving into this slide deck, we recommend you to have a look at:
+Before diving into this slide deck, we recommend you to have a look at:
 
-  {% for requirement in topic.requirements %}
-    {% if requirement.type == "internal" %}
-  - [{{ requirement.title }}]({{ site.baseurl }}/topics{{ requirement.link }})
-    {% elsif requirement.type == "external" %}
-  - [{{ requirement.title }}]({{ requirement.link }})
-    {% endif %}
-  {% endfor %}
+{% include snippets/display_extra_training_slides.md extra_trainings=topic.requirements %}
+{% include snippets/display_extra_training_slides.md extra_trainings=page.requirements %}
 
-  {% if tutorial.requirements %}
-    {% for requirement in tutorial.requirements %}
-      {% if requirement.type == "internal" %}
-  - [{{ requirement.title }}]({{ site.baseurl }}{{ requirement.link }})
-      {% elsif requirement.type == "external" %}
-  - [{{ requirement.title }}]({{ requirement.link }})
-      {% endif %}
-    {% endfor %}
-  {% endif %}
 {% endif %}
 
 ---

--- a/_layouts/tutorial_slides.html
+++ b/_layouts/tutorial_slides.html
@@ -11,7 +11,6 @@ layout: base_slides
     {% endif %}
 {% endfor %}
 
-
 ### {% icon question %} Questions
 
 {% for question in page.questions %}
@@ -32,12 +31,24 @@ layout: base_slides
 
 {{ content }}
 
----
 
 {% if page.key_points %}
+---
 ### {% icon keypoints %} Key points
 
 {% for key_point in page.key_points %}
 - {{ key_point }}
 {% endfor %}
+{% endif %}
+
+
+{% if page.follow_up_training %}
+---
+### {% icon curriculum %} Do you want to extend your knowledge? 
+
+
+Follow one of our recommended follow-up trainings:
+
+{% include snippets/display_extra_training_slides.md extra_trainings=page.follow_up_training %}
+
 {% endif %}

--- a/snippets/display_extra_training_slides.md
+++ b/snippets/display_extra_training_slides.md
@@ -1,0 +1,33 @@
+{% capture newLine %}
+{% endcapture %}
+{% for training in include.extra_trainings %}
+    {% if training.type == "internal" %}
+        {% assign extra_topic_metadata = site.data[training.topic_name] %}
+        {% assign extra_topic = site.pages | topic_filter:training.topic_name %}
+            {% capture topic_desc %}[{{ extra_topic_metadata.title }}]({{ site.baseurl }}/topics/{{ training.topic_name }}){% endcapture %}
+        {% if training.tutorials %}
+            {% for extra_tuto in training.tutorials %}
+                {% for topic_tuto in extra_topic %}
+                    {% if extra_tuto == topic_tuto.tutorial_name %}
+                        {% assign tuto_desc = topic_tuto.title | append: ": " | prepend: "    - " | prepend: newLine %}
+                        {% if topic_tuto.slides %}
+                            {% capture tuto_slide_desc %}[{% icon slides %} slides]({{ site.baseurl }}/topics/{{ training.topic_name }}/tutorials/{{ topic_tuto.tutorial_name }}/slides.html){% endcapture %}
+                            {% assign tuto_desc = tuto_desc | append: tuto_slide_desc %}
+                            {% assign sep = " - " %}
+                        {% endif %}
+                        {% if topic_tuto.hands_on %}
+                            {% capture tuto_hands_on_desc %}{{ sep }}[{% icon tutorial %} hands-on]({{ site.baseurl }}/topics/{{ training.topic_name }}/tutorials/{{ topic_tuto.tutorial_name }}/tutorial.html){% endcapture %}
+                            {% assign tuto_desc = tuto_desc | append: tuto_hands_on_desc %}
+                        {% endif %}
+                    {% assign topic_desc = topic_desc | append: tuto_desc %}
+                    {% endif %}
+                {% endfor %}
+            {% endfor %}
+        {% endif %}
+- {{ topic_desc }}
+    {% elsif training.type == "none" %}
+- {{ training.title }}
+    {% else %}
+- [{{ training.title }}]({{ training.link }})
+    {% endif %}
+{% endfor %}

--- a/topics/dev/tutorials/conda/slides.html
+++ b/topics/dev/tutorials/conda/slides.html
@@ -19,13 +19,11 @@ objectives:
 time_estimation: "75m"
 requirements:
   -
-    title: "Tool development and integration into Galaxy"
     type: "internal"
-    link: "/topics/dev/tutorials/tool-integration/slides.html"
-  -
-    title: "Prerequisites for building software/conda packages"
-    type: "internal"
-    link: "/topics/dev/tutorials/conda_sys/slides.html"
+    topic_name: dev
+    tutorials:
+      - tool-integration
+      - conda_sys
 key_points:
   - "Conda and Bioconda are Galaxy best practices for connecting Galaxy tools to underlying applications and libraries."
   - "Leveraging Conda allows easy installation of your tool's dependencies by Galaxy deployers."

--- a/topics/dev/tutorials/containers/slides.html
+++ b/topics/dev/tutorials/containers/slides.html
@@ -16,9 +16,10 @@ objectives:
 time_estimation: "45m"
 requirements:
   -
-    title: "Tool development and integration into Galaxy"
     type: "internal"
-    link: "/topics/dev/tutorials/tool-integration/slides.html"
+    topic_name: dev
+    tutorials:
+        - tool-integration
 key_points:
   - "It is becoming easier, more advantageous, and more common for Galaxy admins to run all tools within their own container."
   - "You can explicitly define a container for your tool - but it is easier and more reproducible to let Galaxy find or build one using your tool's best practice requirements."

--- a/topics/dev/tutorials/tool-integration/slides.html
+++ b/topics/dev/tutorials/tool-integration/slides.html
@@ -23,6 +23,12 @@ key_points:
   - "Use GitHub"
   - "Use Travis"
   - "No more excuse to develop crappy Galaxy tools"
+follow_up_training:
+  - 
+    type: "internal"
+    topic_name: dev
+    tutorials:
+      - conda
 contributors:
   - shiltemann
   - bebatut

--- a/topics/dev/tutorials/visualization-generic/slides.html
+++ b/topics/dev/tutorials/visualization-generic/slides.html
@@ -11,8 +11,7 @@ objectives:
 requirements:
   -
     title: "Javascript knowledge"
-    type: "external"
-    link: ""
+    type: "none"
 time_estimation: "90m"
 key_points:
   - "Visualizations require a different way of thinking: server and client side; downloading files rather than system level access"

--- a/topics/dev/tutorials/visualization-generic/tutorial.md
+++ b/topics/dev/tutorials/visualization-generic/tutorial.md
@@ -10,8 +10,7 @@ objectives:
 requirements:
   -
     title: "Javascript knowledge"
-    type: "external"
-    link: ""
+    type: "none"
 time_estimation: "90m"
 key_points:
   - "Visualizations require a different way of thinking: server and client side; downloading files rather than system level access"


### PR DESCRIPTION
It should fix requirements for slides to follow the new way to represent requirements, and implement the possible follow up (as for hands-on tutorial)

![screenshot 2019-02-12 at 16 43 03](https://user-images.githubusercontent.com/1842467/52648204-6b5b1d80-2ee6-11e9-9e3a-31d6b5021b0d.png)
![screenshot 2019-02-12 at 16 45 43](https://user-images.githubusercontent.com/1842467/52648206-6b5b1d80-2ee6-11e9-87ca-283561bd3c95.png)

I also fix the metadata for some slide decks not following the new requirement declaration