### PR TITLE
Highlight contributors more prominently throughout the site

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -113,6 +113,7 @@ icon-tag:
   linkedin: fa-linkedin
   orcid: ai-orcid
   curriculum: fa-graduation-cap
+  hall-of-fame: fa-users
 
 # To exclude in _site
 exclude:

--- a/_includes/default-header.html
+++ b/_includes/default-header.html
@@ -12,6 +12,11 @@
             <div class="collapse navbar-collapse" id="top-navbar">
                 <ul class="navbar-nav">
                     <li class="nav-item">
+                         <a class="nav-link" href="{{ site.baseurl }}/hall-of-fame" title="Hall of Fame">
+                            {% icon hall-of-fame %} Hall of Fame
+                        </a>
+                    </li>
+                    <li class="nav-item">
                         <a class="nav-link" href="{{ site.github.repository_url }}" title="View on GitHub">
                             {% icon github %} View on GitHub
                         </a>

--- a/_includes/default-header.html
+++ b/_includes/default-header.html
@@ -13,7 +13,7 @@
                 <ul class="navbar-nav">
                     <li class="nav-item">
                          <a class="nav-link" href="{{ site.baseurl }}/hall-of-fame" title="Hall of Fame">
-                            {% icon hall-of-fame %} Hall of Fame
+                            {% icon hall-of-fame %} Contributors
                         </a>
                     </li>
                     <li class="nav-item">

--- a/_layouts/base_slides.html
+++ b/_layouts/base_slides.html
@@ -81,7 +81,7 @@ Before diving into this slide deck, we recommend you to have a look at:
 
 ## Thank you!
 
-This material is the result of a collaborative work. Thanks the [Galaxy Training Network](https://wiki.galaxyproject.org/Teach/GTN) and all the contributors {% if tutorial.contributors %}{% capture contributors %}{% for c in tutorial.contributors %}, {{ contributors[c].name | default: c }}{% endfor %}{% endcapture %} ({{ contributors | remove_first: ', ' }}) {% endif %}!
+This material is the result of a collaborative work. Thanks the [Galaxy Training Network](https://wiki.galaxyproject.org/Teach/GTN) and all the contributors {% if tutorial.contributors %}{% capture contributors %}{% for c in tutorial.contributors %}, [{{ contributors[c].name | default: c }}]({{ site.baseurl }}/hall-of-fame#{{ c }}){% endfor %}{% endcapture %} ({{ contributors | remove_first: ', ' }}) {% endif %}!
 
 {% if page.logo == "GTN" %}
 <img src="{{ site.baseurl }}/{{ site.logo }}" alt="Galaxy Training Network" style="height: 100px;"/>

--- a/_layouts/tutorial_hands_on.html
+++ b/_layouts/tutorial_hands_on.html
@@ -8,8 +8,8 @@ layout: base
 {% assign topic_material = site.pages | topic_filter:page.topic_name %}
 {% assign language = site.other_languages | split: ", " %}
 {% if page.contributors %}
-  {% assign contrib = page.contributors | sort %}
-  {% capture contributors %}{% for contributor in contrib %}, {% assign c = contributors[contributor].name | default: contributor %} <a href="{{ site.baseurl }}/hall-of-fame#{{ contributor }}">{{ c }}</a> {% endfor %}{% endcapture %}
+  {% assign contrib = page.contributors %}
+  {% capture contributors %}{% for contributor in contrib %}, {% assign c = contributors[contributor].name | default: contributor %} <a href="{{ site.baseurl }}/hall-of-fame#{{ contributor }}">{{ c }}</a>{% endfor %}{% endcapture %}
 {% endif %}
 
 <header>

--- a/_layouts/tutorial_hands_on.html
+++ b/_layouts/tutorial_hands_on.html
@@ -11,8 +11,8 @@ layout: base
   {% assign contrib = page.contributors %}
   {% capture contributors %}
   {% for contributor_id in contrib %}, {% assign c = contributors[contributor_id].name | default: contributor_id %}
-  <a href="{{ site.baseurl }}/hall-of-fame#{{ contributor }}" class="contributor-badge"><img src="https://avatars.githubusercontent.com/{{ contributor_id }}" alt="{{ c }}">{{ c }}</a>
-  {%- endfor %}{% endcapture %}
+  <a href="{{ site.baseurl }}/hall-of-fame#{{ contributor_id }}" class="contributor-badge"><img src="https://avatars.githubusercontent.com/{{ contributor_id }}" alt="{{ c }}">{{ c }}</a>
+  {% endfor %}{% endcapture %}
 {% endif %}
 
 <header>

--- a/_layouts/tutorial_hands_on.html
+++ b/_layouts/tutorial_hands_on.html
@@ -9,7 +9,10 @@ layout: base
 {% assign language = site.other_languages | split: ", " %}
 {% if page.contributors %}
   {% assign contrib = page.contributors %}
-  {% capture contributors %}{% for contributor in contrib %}, {% assign c = contributors[contributor].name | default: contributor %} <a href="{{ site.baseurl }}/hall-of-fame#{{ contributor }}">{{ c }}</a>{% endfor %}{% endcapture %}
+  {% capture contributors %}
+  {% for contributor_id in contrib %}, {% assign c = contributors[contributor_id].name | default: contributor_id %}
+  <a href="{{ site.baseurl }}/hall-of-fame#{{ contributor }}" class="contributor-badge"><img src="https://avatars.githubusercontent.com/{{ contributor_id }}" alt="{{ c }}">{{ c }}</a>
+  {%- endfor %}{% endcapture %}
 {% endif %}
 
 <header>

--- a/_layouts/tutorial_hands_on.html
+++ b/_layouts/tutorial_hands_on.html
@@ -12,7 +12,7 @@ layout: base
   {% capture contributors %}
   {% for contributor_id in contrib %}, {% assign c = contributors[contributor_id].name | default: contributor_id %}
   <a href="{{ site.baseurl }}/hall-of-fame#{{ contributor_id }}" class="contributor-badge"><img src="https://avatars.githubusercontent.com/{{ contributor_id }}" alt="{{ c }}">{{ c }}</a>
-  {% endfor %}{% endcapture %}
+  {%- endfor %}{% endcapture %}
 {% endif %}
 
 <header>

--- a/_layouts/tutorial_hands_on.html
+++ b/_layouts/tutorial_hands_on.html
@@ -7,6 +7,10 @@ layout: base
 {% assign instances = site.data['instances'] %}
 {% assign topic_material = site.pages | topic_filter:page.topic_name %}
 {% assign language = site.other_languages | split: ", " %}
+{% if page.contributors %}
+  {% assign contrib = page.contributors | sort %}
+  {% capture contributors %}{% for contributor in contrib %}, {% assign c = contributors[contributor].name | default: contributor %} <a href="{{ site.baseurl }}/hall-of-fame#{{ contributor }}">{{ c }}</a> {% endfor %}{% endcapture %}
+{% endif %}
 
 <header>
     <nav class="navbar navbar-expand-lg navbar-dark">
@@ -148,10 +152,10 @@ layout: base
     <script type="application/ld+json">
    {% include _includes/material.jsonld material=page %}
     </script>
-    
+
     <section class="tutorial">
         <h1 data-toc-skip>{{ page.title }}</h1>
-
+        <div class="contributors-line">By: {{ contributors | remove_first: ', ' }} </div>
         <blockquote class="overview">
             <h3>Overview</h3>
 
@@ -259,10 +263,7 @@ layout: base
     </section>
 </div>
 
-{% if page.contributors %}
-{% assign contrib = page.contributors | sort %}
-{% capture contributors %}{% for contributor in contrib %}, {{contributors[contributor].name | default: contributor }}{% endfor %}{% endcapture %}
-{% endif %}
+
 <footer>
     <div class="container">
         <p>

--- a/assets/css/main.scss
+++ b/assets/css/main.scss
@@ -536,3 +536,14 @@ nav[data-toggle='toc'] {
         max-width: 100%;
     }
 }
+
+.contributor-badge {
+    /* prevent breaking across lines */
+    white-space: nowrap;
+
+    img {
+        height: 1.25em;
+        border-radius: 50%;
+        margin: 0.25em;
+    }
+}

--- a/assets/css/main.scss
+++ b/assets/css/main.scss
@@ -202,7 +202,7 @@ footer {
 
 .tutorial {
     & > h1:first-child {
-        margin-bottom: 3rem;
+        margin-bottom: 1rem;
     }
 
     table {
@@ -322,6 +322,12 @@ footer {
             font-size: 0.7em;
         }
     }
+}
+
+.contributors-line {
+    color: $gray;
+    font-size: 1.2em;
+    margin-bottom: 5rem;
 }
 
 .hall-of-fame {
@@ -519,7 +525,7 @@ nav[data-toggle='toc'] {
 .col-sm-2 {
     padding-left: 0px;
 }
-  
+
 /* small screens */
 @media screen and (max-width: 768px) {
     nav[data-toggle='toc'] {


### PR DESCRIPTION
Because this project is only possible because of the contributions of this awesome community, @erasche and I thought they should be credited more prominently, and added an author line below the tutorial title:

![image](https://user-images.githubusercontent.com/2563865/53661838-ad63bd80-3c61-11e9-80fb-c1fb72c35c5f.png)

The names link to the hall-of-fame entry for the contributor (did same in slides)

Also added a link to the contributor hall of fame on the main page nav bar:

![image](https://user-images.githubusercontent.com/2563865/53660655-ac7d5c80-3c5e-11e9-9893-6e2b1a53d276.png)

