### PR TITLE
Remove email address from admin tuto

### DIFF
--- a/topics/admin/tutorials/ansible-galaxy/galaxyservers.txt
+++ b/topics/admin/tutorials/ansible-galaxy/galaxyservers.txt
@@ -167,7 +167,7 @@ certbot_environment: staging
 certbot_domains:
   - "{{ hostname }}"
 certbot_agree_tos: --agree-tos
-certbot_admin_email: security@usegalaxy.eu
+certbot_admin_email: # Put YOUR email here
 certbot_share_key_users:
   - nginx
 certbot_post_renewal: |

--- a/topics/admin/tutorials/ansible-galaxy/tutorial.md
+++ b/topics/admin/tutorials/ansible-galaxy/tutorial.md
@@ -944,7 +944,7 @@ If you do not meet these requirements, you should read through them to see the c
 >    certbot_domains:
 >      - "{{ hostname }}"
 >    certbot_agree_tos: --agree-tos
->    certbot_admin_email: security@usegalaxy.eu
+>    certbot_admin_email: # Put YOUR email here
 >    certbot_share_key_users:
 >      - nginx
 >    certbot_post_renewal: |


### PR DESCRIPTION
I should not have included that originally, of course users would copy and paste it.