### PR TITLE
Unflattened one-line workflows

### DIFF
--- a/topics/chip-seq/tutorials/formation_of_super-structures_on_xi/workflows/formation_of_super_structures_on_xi.ga
+++ b/topics/chip-seq/tutorials/formation_of_super-structures_on_xi/workflows/formation_of_super_structures_on_xi.ga
@@ -1,1 +1,3653 @@
-{"uuid": "8c2b398e-d873-49f5-8665-c98b4ea642db", "tags": [], "format-version": "0.1", "name": "GTN - ChIP-Seq - formation_of_super-structures_on_xi", "steps": {"0": {"tool_id": null, "tool_version": null, "outputs": [], "workflow_outputs": [{"output_name": "output", "uuid": "b9c35037-39dd-41a9-be68-4d9a93dcf91f", "label": null}], "input_connections": {}, "tool_state": "{\"name\": \"wt_input_rep1\"}", "id": 0, "uuid": "aa29cbd2-ab28-4222-990d-93040617e825", "errors": null, "name": "Input dataset", "label": "wt_input_rep1", "inputs": [{"name": "wt_input_rep1", "description": ""}], "position": {"top": 200, "left": 200}, "annotation": "", "content_id": null, "type": "data_input"}, "1": {"tool_id": null, "tool_version": null, "outputs": [], "workflow_outputs": [{"output_name": "output", "uuid": "2bd5131d-79f3-479e-9977-4f5a1f4a4e06", "label": null}], "input_connections": {}, "tool_state": "{}", "id": 1, "uuid": "8f1c713f-89b2-4c40-af1f-9022020f5e89", "errors": null, "name": "Input dataset", "label": "wt_H3K4me3_read1", "inputs": [], "position": {"top": 287, "left": 200}, "annotation": "", "content_id": null, "type": "data_input"}, "2": {"tool_id": null, "tool_version": null, "outputs": [], "workflow_outputs": [{"output_name": "output", "uuid": "50ccae0b-e051-45f6-a48e-af1bc027842c", "label": null}], "input_connections": {}, "tool_state": "{}", "id": 2, "uuid": "5ae72729-4707-41b6-99f6-436b994a3003", "errors": null, "name": "Input dataset", "label": "wt_H3K27me3_rep1", "inputs": [], "position": {"top": 392, "left": 200}, "annotation": "", "content_id": null, "type": "data_input"}, "3": {"tool_id": null, "tool_version": null, "outputs": [], "workflow_outputs": [{"output_name": "output", "uuid": "27a07d42-9ac0-427c-a37e-335032cd6a48", "label": null}], "input_connections": {}, "tool_state": "{}", "id": 3, "uuid": "03e6848c-1ed2-4025-a2bc-062b986fdf07", "errors": null, "name": "Input dataset", "label": "wt_H3K4me3_rep1", "inputs": [], "position": {"top": 689, "left": 200}, "annotation": "", "content_id": null, "type": "data_input"}, "4": {"tool_id": null, "tool_version": null, "outputs": [], "workflow_outputs": [{"output_name": "output", "uuid": "ec212d6c-3709-4fb2-b33b-21721c23a984", "label": null}], "input_connections": {}, "tool_state": "{}", "id": 4, "uuid": "bfc0e21d-1ea5-4d22-aa3e-573fc41a44e8", "errors": null, "name": "Input dataset", "label": "wt_H3K4me3_read2", "inputs": [], "position": {"top": 497, "left": 200}, "annotation": "", "content_id": null, "type": "data_input"}, "5": {"tool_id": null, "tool_version": null, "outputs": [], "workflow_outputs": [{"output_name": "output", "uuid": "335cb804-d327-4763-8173-1b08e0458758", "label": null}], "input_connections": {}, "tool_state": "{\"name\": \"wt_CTCF_rep2\"}", "id": 5, "uuid": "a3f8e4e4-d05d-4b82-84d4-a2f28f04a33a", "errors": null, "name": "Input dataset", "label": "wt_CTCF_rep2", "inputs": [{"name": "wt_CTCF_rep2", "description": ""}], "position": {"top": 602, "left": 200}, "annotation": "", "content_id": null, "type": "data_input"}, "6": {"tool_id": null, "tool_version": null, "outputs": [], "workflow_outputs": [{"output_name": "output", "uuid": "9f4bd4e8-bd77-4de5-afd6-655f0b34debb", "label": null}], "input_connections": {}, "tool_state": "{\"name\": \"wt_H3K4me3_rep2\"}", "id": 6, "uuid": "531dbbe8-4a2f-49d8-a9cf-c23abda41287", "errors": null, "name": "Input dataset", "label": "wt_H3K4me3_rep2", "inputs": [{"name": "wt_H3K4me3_rep2", "description": ""}], "position": {"top": 776, "left": 200}, "annotation": "", "content_id": null, "type": "data_input"}, "7": {"tool_id": null, "tool_version": null, "outputs": [], "workflow_outputs": [{"output_name": "output", "uuid": "5d841d48-693b-4724-bae4-10071026ae44", "label": null}], "input_connections": {}, "tool_state": "{\"name\": \"wt_H3K27me3_rep2\"}", "id": 7, "uuid": "ab56e8f1-8167-4e24-abc7-670d3f46fc4d", "errors": null, "name": "Input dataset", "label": "wt_H3K27me3_rep2", "inputs": [{"name": "wt_H3K27me3_rep2", "description": ""}], "position": {"top": 863, "left": 200}, "annotation": "", "content_id": null, "type": "data_input"}, "8": {"tool_id": null, "tool_version": null, "outputs": [], "workflow_outputs": [{"output_name": "output", "uuid": "e4d0b2fa-d718-4358-8fd0-4736e3f6e7e0", "label": null}], "input_connections": {}, "tool_state": "{\"name\": \"wt_input_rep2\"}", "id": 8, "uuid": "a7846e57-7f8a-4922-9f01-64ef71345413", "errors": null, "name": "Input dataset", "label": "wt_input_rep2", "inputs": [{"name": "wt_input_rep2", "description": ""}], "position": {"top": 968, "left": 200}, "annotation": "", "content_id": null, "type": "data_input"}, "9": {"tool_id": null, "tool_version": null, "outputs": [], "workflow_outputs": [{"output_name": "output", "uuid": "d8372f9a-eb1c-4f99-8464-353239537e56", "label": null}], "input_connections": {}, "tool_state": "{\"name\": \"wt_CTCF_rep1\"}", "id": 9, "uuid": "f0b41074-fded-4eb9-b444-531b7c93c7f8", "errors": null, "name": "Input dataset", "label": "wt_CTCF_rep1", "inputs": [{"name": "wt_CTCF_rep1", "description": ""}], "position": {"top": 1055, "left": 200}, "annotation": "", "content_id": null, "type": "data_input"}, "10": {"tool_id": "toolshed.g2.bx.psu.edu/repos/bgruening/deeptools_bam_coverage/deeptools_bam_coverage/3.0.2.0", "tool_version": "3.0.2.0", "outputs": [{"type": "bigwig", "name": "outFileName"}], "workflow_outputs": [], "input_connections": {"bamInput": {"output_name": "output", "id": 0}}, "tool_state": "{\"__page__\": null, \"outFileFormat\": \"\\\"bedgraph\\\"\", \"region\": \"\\\"chrX\\\"\", \"bamInput\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\", \"binSize\": \"\\\"25\\\"\", \"scaling\": \"{\\\"effectiveGenomeSize\\\": {\\\"effectiveGenomeSize_opt\\\": \\\"2308125349\\\", \\\"__current_case__\\\": 7}, \\\"type\\\": \\\"1x\\\", \\\"__current_case__\\\": 4}\", \"advancedOpt\": \"{\\\"showAdvancedOpt\\\": \\\"no\\\", \\\"__current_case__\\\": 0}\", \"chromInfo\": \"\\\"/usr/local/galaxy/galaxy-dist/tool-data/shared/ucsc/chrom/?.len\\\"\", \"__rerun_remap_job_id__\": null}", "id": 10, "tool_shed_repository": {"owner": "bgruening", "changeset_revision": "3033c3fba046", "name": "deeptools_bam_coverage", "tool_shed": "toolshed.g2.bx.psu.edu"}, "uuid": "583c0f65-1f9b-4162-9906-2c37f71078b2", "errors": null, "name": "bamCoverage", "post_job_actions": {"HideDatasetActionoutFileName": {"output_name": "outFileName", "action_type": "HideDatasetAction", "action_arguments": {}}}, "label": null, "inputs": [{"name": "bamInput", "description": "runtime parameter for tool bamCoverage"}], "position": {"top": 3428, "left": 458}, "annotation": "", "content_id": "toolshed.g2.bx.psu.edu/repos/bgruening/deeptools_bam_coverage/deeptools_bam_coverage/3.0.2.0", "type": "tool"}, "11": {"tool_id": "toolshed.g2.bx.psu.edu/repos/bgruening/deeptools_bam_coverage/deeptools_bam_coverage/3.0.2.0", "tool_version": "3.0.2.0", "outputs": [{"type": "bigwig", "name": "outFileName"}], "workflow_outputs": [], "input_connections": {"bamInput": {"output_name": "output", "id": 0}}, "tool_state": "{\"__page__\": null, \"outFileFormat\": \"\\\"bigwig\\\"\", \"region\": \"\\\"chrX\\\"\", \"bamInput\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\", \"binSize\": \"\\\"25\\\"\", \"scaling\": \"{\\\"effectiveGenomeSize\\\": {\\\"effectiveGenomeSize_opt\\\": \\\"2308125349\\\", \\\"__current_case__\\\": 7}, \\\"type\\\": \\\"1x\\\", \\\"__current_case__\\\": 4}\", \"advancedOpt\": \"{\\\"showAdvancedOpt\\\": \\\"no\\\", \\\"__current_case__\\\": 0}\", \"chromInfo\": \"\\\"/usr/local/galaxy/galaxy-dist/tool-data/shared/ucsc/chrom/?.len\\\"\", \"__rerun_remap_job_id__\": null}", "id": 11, "tool_shed_repository": {"owner": "bgruening", "changeset_revision": "3033c3fba046", "name": "deeptools_bam_coverage", "tool_shed": "toolshed.g2.bx.psu.edu"}, "uuid": "8c638a29-4c3b-4584-8292-846e338307f2", "errors": null, "name": "bamCoverage", "post_job_actions": {"HideDatasetActionoutFileName": {"output_name": "outFileName", "action_type": "HideDatasetAction", "action_arguments": {}}}, "label": null, "inputs": [{"name": "bamInput", "description": "runtime parameter for tool bamCoverage"}], "position": {"top": 3706, "left": 458}, "annotation": "", "content_id": "toolshed.g2.bx.psu.edu/repos/bgruening/deeptools_bam_coverage/deeptools_bam_coverage/3.0.2.0", "type": "tool"}, "12": {"tool_id": "toolshed.g2.bx.psu.edu/repos/devteam/fastqc/fastqc/0.71", "tool_version": "0.71", "outputs": [{"type": "html", "name": "html_file"}, {"type": "txt", "name": "text_file"}], "workflow_outputs": [], "input_connections": {"input_file": {"output_name": "output", "id": 1}}, "tool_state": "{\"__page__\": null, \"contaminants\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\", \"__rerun_remap_job_id__\": null, \"limits\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\", \"input_file\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\"}", "id": 12, "tool_shed_repository": {"owner": "devteam", "changeset_revision": "ff9530579d1f", "name": "fastqc", "tool_shed": "toolshed.g2.bx.psu.edu"}, "uuid": "5b1e4149-a6bf-472c-85fa-9beacff57b18", "errors": null, "name": "FastQC", "post_job_actions": {"HideDatasetActionhtml_file": {"output_name": "html_file", "action_type": "HideDatasetAction", "action_arguments": {}}, "HideDatasetActiontext_file": {"output_name": "text_file", "action_type": "HideDatasetAction", "action_arguments": {}}}, "label": null, "inputs": [{"name": "contaminants", "description": "runtime parameter for tool FastQC"}, {"name": "limits", "description": "runtime parameter for tool FastQC"}, {"name": "input_file", "description": "runtime parameter for tool FastQC"}], "position": {"top": 1420, "left": 458}, "annotation": "", "content_id": "toolshed.g2.bx.psu.edu/repos/devteam/fastqc/fastqc/0.71", "type": "tool"}, "13": {"tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/macs2/macs2_callpeak/2.1.1.20160309.4", "tool_version": "2.1.1.20160309.4", "outputs": [{"type": "tabular", "name": "output_tabular"}, {"type": "bed", "name": "output_broadpeaks"}, {"type": "bed", "name": "output_gappedpeaks"}, {"type": "bed", "name": "output_narrowpeaks"}, {"type": "bed", "name": "output_summits"}, {"type": "pdf", "name": "output_plot"}, {"type": "bedgraph", "name": "output_treat_pileup"}, {"type": "bedgraph", "name": "output_control_lambda"}, {"type": "html", "name": "output_extra_files"}], "workflow_outputs": [], "input_connections": {"control|c_multiple|input_control_file": {"output_name": "output", "id": 0}, "treatment|input_treatment_file": {"output_name": "output", "id": 2}}, "tool_state": "{\"control\": \"{\\\"c_multiple\\\": {\\\"input_control_file\\\": {\\\"__class__\\\": \\\"RuntimeValue\\\"}, \\\"c_multi_select\\\": \\\"No\\\", \\\"__current_case__\\\": 0}, \\\"__current_case__\\\": 0, \\\"c_select\\\": \\\"Yes\\\"}\", \"__page__\": null, \"effective_genome_size_options\": \"{\\\"effective_genome_size_options_selector\\\": \\\"1870000000\\\", \\\"__current_case__\\\": 1}\", \"format\": \"\\\"BAMPE\\\"\", \"outputs\": \"[\\\"html\\\"]\", \"__rerun_remap_job_id__\": null, \"cutoff_options\": \"{\\\"cutoff_options_selector\\\": \\\"qvalue\\\", \\\"qvalue\\\": \\\"0.05\\\", \\\"__current_case__\\\": 1}\", \"advanced_options\": \"{\\\"slocal\\\": \\\"\\\", \\\"ratio\\\": \\\"\\\", \\\"to_large\\\": \\\"false\\\", \\\"keep_dup_options\\\": {\\\"__current_case__\\\": 1, \\\"keep_dup_options_selector\\\": \\\"1\\\"}, \\\"broad_options\\\": {\\\"broad_options_selector\\\": \\\"nobroad\\\", \\\"call_summits\\\": \\\"false\\\", \\\"__current_case__\\\": 1}, \\\"nolambda\\\": \\\"false\\\", \\\"llocal\\\": \\\"\\\"}\", \"treatment\": \"{\\\"input_treatment_file\\\": {\\\"__class__\\\": \\\"RuntimeValue\\\"}, \\\"__current_case__\\\": 0, \\\"t_multi_select\\\": \\\"No\\\"}\", \"nomodel_type\": \"{\\\"nomodel_type_selector\\\": \\\"create_model\\\", \\\"mfold_lower\\\": \\\"5\\\", \\\"mfold_upper\\\": \\\"50\\\", \\\"band_width\\\": \\\"300\\\", \\\"__current_case__\\\": 0}\", \"chromInfo\": \"\\\"/usr/local/galaxy/galaxy-dist/tool-data/shared/ucsc/chrom/?.len\\\"\"}", "id": 13, "tool_shed_repository": {"owner": "iuc", "changeset_revision": "c16dbe4e2db2", "name": "macs2", "tool_shed": "toolshed.g2.bx.psu.edu"}, "uuid": "30aebff2-176c-4892-983b-2aeb93dc09ef", "errors": null, "name": "MACS2 callpeak", "post_job_actions": {"HideDatasetActionoutput_broadpeaks": {"output_name": "output_broadpeaks", "action_type": "HideDatasetAction", "action_arguments": {}}, "HideDatasetActionoutput_control_lambda": {"output_name": "output_control_lambda", "action_type": "HideDatasetAction", "action_arguments": {}}, "HideDatasetActionoutput_narrowpeaks": {"output_name": "output_narrowpeaks", "action_type": "HideDatasetAction", "action_arguments": {}}, "HideDatasetActionoutput_summits": {"output_name": "output_summits", "action_type": "HideDatasetAction", "action_arguments": {}}, "HideDatasetActionoutput_treat_pileup": {"output_name": "output_treat_pileup", "action_type": "HideDatasetAction", "action_arguments": {}}, "HideDatasetActionoutput_plot": {"output_name": "output_plot", "action_type": "HideDatasetAction", "action_arguments": {}}, "HideDatasetActionoutput_extra_files": {"output_name": "output_extra_files", "action_type": "HideDatasetAction", "action_arguments": {}}, "HideDatasetActionoutput_tabular": {"output_name": "output_tabular", "action_type": "HideDatasetAction", "action_arguments": {}}, "HideDatasetActionoutput_gappedpeaks": {"output_name": "output_gappedpeaks", "action_type": "HideDatasetAction", "action_arguments": {}}}, "label": null, "inputs": [{"name": "treatment", "description": "runtime parameter for tool MACS2 callpeak"}], "position": {"top": 2764, "left": 458}, "annotation": "", "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/macs2/macs2_callpeak/2.1.1.20160309.4", "type": "tool"}, "14": {"tool_id": "toolshed.g2.bx.psu.edu/repos/bgruening/deeptools_bam_compare/deeptools_bam_compare/3.0.2.0", "tool_version": "3.0.2.0", "outputs": [{"type": "bigwig", "name": "outFileName"}], "workflow_outputs": [], "input_connections": {"bamFile2": {"output_name": "output", "id": 0}, "bamFile1": {"output_name": "output", "id": 2}}, "tool_state": "{\"comparison\": \"{\\\"pseudocount\\\": \\\"1.0\\\", \\\"type\\\": \\\"log2\\\", \\\"__current_case__\\\": 0}\", \"bamFile2\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\", \"outFileFormat\": \"\\\"bigwig\\\"\", \"bamFile1\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\", \"__page__\": null, \"region\": \"\\\"chrX\\\"\", \"binSize\": \"\\\"50\\\"\", \"scaling\": \"{\\\"method\\\": \\\"readCount\\\", \\\"__current_case__\\\": 1}\", \"advancedOpt\": \"{\\\"showAdvancedOpt\\\": \\\"no\\\", \\\"__current_case__\\\": 0}\", \"__rerun_remap_job_id__\": null}", "id": 14, "tool_shed_repository": {"owner": "bgruening", "changeset_revision": "439e75416e1a", "name": "deeptools_bam_compare", "tool_shed": "toolshed.g2.bx.psu.edu"}, "uuid": "26bbb4b4-e75c-42ea-b186-e1cc922d1e90", "errors": null, "name": "bamCompare", "post_job_actions": {"HideDatasetActionoutFileName": {"output_name": "outFileName", "action_type": "HideDatasetAction", "action_arguments": {}}}, "label": null, "inputs": [{"name": "bamFile2", "description": "runtime parameter for tool bamCompare"}, {"name": "bamFile1", "description": "runtime parameter for tool bamCompare"}], "position": {"top": 3132, "left": 458}, "annotation": "", "content_id": "toolshed.g2.bx.psu.edu/repos/bgruening/deeptools_bam_compare/deeptools_bam_compare/3.0.2.0", "type": "tool"}, "15": {"tool_id": "toolshed.g2.bx.psu.edu/repos/bgruening/deeptools_bam_coverage/deeptools_bam_coverage/3.0.2.0", "tool_version": "3.0.2.0", "outputs": [{"type": "bigwig", "name": "outFileName"}], "workflow_outputs": [], "input_connections": {"bamInput": {"output_name": "output", "id": 2}}, "tool_state": "{\"__page__\": null, \"outFileFormat\": \"\\\"bigwig\\\"\", \"region\": \"\\\"chrX\\\"\", \"bamInput\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\", \"binSize\": \"\\\"25\\\"\", \"scaling\": \"{\\\"effectiveGenomeSize\\\": {\\\"effectiveGenomeSize_opt\\\": \\\"2308125349\\\", \\\"__current_case__\\\": 7}, \\\"type\\\": \\\"1x\\\", \\\"__current_case__\\\": 4}\", \"advancedOpt\": \"{\\\"showAdvancedOpt\\\": \\\"no\\\", \\\"__current_case__\\\": 0}\", \"chromInfo\": \"\\\"/usr/local/galaxy/galaxy-dist/tool-data/shared/ucsc/chrom/?.len\\\"\", \"__rerun_remap_job_id__\": null}", "id": 15, "tool_shed_repository": {"owner": "bgruening", "changeset_revision": "3033c3fba046", "name": "deeptools_bam_coverage", "tool_shed": "toolshed.g2.bx.psu.edu"}, "uuid": "115fe86a-1fd3-4c95-af30-56fe50dc10bb", "errors": null, "name": "bamCoverage", "post_job_actions": {"HideDatasetActionoutFileName": {"output_name": "outFileName", "action_type": "HideDatasetAction", "action_arguments": {}}}, "label": null, "inputs": [{"name": "bamInput", "description": "runtime parameter for tool bamCoverage"}], "position": {"top": 3312, "left": 458}, "annotation": "", "content_id": "toolshed.g2.bx.psu.edu/repos/bgruening/deeptools_bam_coverage/deeptools_bam_coverage/3.0.2.0", "type": "tool"}, "16": {"tool_id": "toolshed.g2.bx.psu.edu/repos/bgruening/deeptools_bam_compare/deeptools_bam_compare/3.0.2.0", "tool_version": "3.0.2.0", "outputs": [{"type": "bigwig", "name": "outFileName"}], "workflow_outputs": [], "input_connections": {"bamFile2": {"output_name": "output", "id": 0}, "bamFile1": {"output_name": "output", "id": 3}}, "tool_state": "{\"comparison\": \"{\\\"pseudocount\\\": \\\"1.0\\\", \\\"type\\\": \\\"log2\\\", \\\"__current_case__\\\": 0}\", \"bamFile2\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\", \"outFileFormat\": \"\\\"bedgraph\\\"\", \"bamFile1\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\", \"__page__\": null, \"region\": \"\\\"chrX\\\"\", \"binSize\": \"\\\"50\\\"\", \"scaling\": \"{\\\"method\\\": \\\"readCount\\\", \\\"__current_case__\\\": 1}\", \"advancedOpt\": \"{\\\"showAdvancedOpt\\\": \\\"no\\\", \\\"__current_case__\\\": 0}\", \"__rerun_remap_job_id__\": null}", "id": 16, "tool_shed_repository": {"owner": "bgruening", "changeset_revision": "439e75416e1a", "name": "deeptools_bam_compare", "tool_shed": "toolshed.g2.bx.psu.edu"}, "uuid": "6da76716-256b-4dac-8346-eb81087552ff", "errors": null, "name": "bamCompare", "post_job_actions": {"HideDatasetActionoutFileName": {"output_name": "outFileName", "action_type": "HideDatasetAction", "action_arguments": {}}}, "label": null, "inputs": [{"name": "bamFile2", "description": "runtime parameter for tool bamCompare"}, {"name": "bamFile1", "description": "runtime parameter for tool bamCompare"}], "position": {"top": 200, "left": 458}, "annotation": "", "content_id": "toolshed.g2.bx.psu.edu/repos/bgruening/deeptools_bam_compare/deeptools_bam_compare/3.0.2.0", "type": "tool"}, "17": {"tool_id": "toolshed.g2.bx.psu.edu/repos/bgruening/deeptools_bam_coverage/deeptools_bam_coverage/3.0.2.0", "tool_version": "3.0.2.0", "outputs": [{"type": "bigwig", "name": "outFileName"}], "workflow_outputs": [], "input_connections": {"bamInput": {"output_name": "output", "id": 3}}, "tool_state": "{\"__page__\": null, \"outFileFormat\": \"\\\"bigwig\\\"\", \"region\": \"\\\"chrX\\\"\", \"bamInput\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\", \"binSize\": \"\\\"50\\\"\", \"scaling\": \"{\\\"effectiveGenomeSize\\\": {\\\"effectiveGenomeSize_opt\\\": \\\"2308125349\\\", \\\"__current_case__\\\": 7}, \\\"type\\\": \\\"1x\\\", \\\"__current_case__\\\": 4}\", \"advancedOpt\": \"{\\\"showAdvancedOpt\\\": \\\"no\\\", \\\"__current_case__\\\": 0}\", \"__rerun_remap_job_id__\": null}", "id": 17, "tool_shed_repository": {"owner": "bgruening", "changeset_revision": "3033c3fba046", "name": "deeptools_bam_coverage", "tool_shed": "toolshed.g2.bx.psu.edu"}, "uuid": "2319b2e0-eebe-4348-b6d3-e75b9bb2c3b6", "errors": null, "name": "bamCoverage", "post_job_actions": {"HideDatasetActionoutFileName": {"output_name": "outFileName", "action_type": "HideDatasetAction", "action_arguments": {}}}, "label": null, "inputs": [{"name": "bamInput", "description": "runtime parameter for tool bamCoverage"}], "position": {"top": 380, "left": 458}, "annotation": "", "content_id": "toolshed.g2.bx.psu.edu/repos/bgruening/deeptools_bam_coverage/deeptools_bam_coverage/3.0.2.0", "type": "tool"}, "18": {"tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/macs2/macs2_callpeak/2.1.1.20160309.4", "tool_version": "2.1.1.20160309.4", "outputs": [{"type": "tabular", "name": "output_tabular"}, {"type": "bed", "name": "output_broadpeaks"}, {"type": "bed", "name": "output_gappedpeaks"}, {"type": "bed", "name": "output_narrowpeaks"}, {"type": "bed", "name": "output_summits"}, {"type": "pdf", "name": "output_plot"}, {"type": "bedgraph", "name": "output_treat_pileup"}, {"type": "bedgraph", "name": "output_control_lambda"}, {"type": "html", "name": "output_extra_files"}], "workflow_outputs": [], "input_connections": {"control|c_multiple|input_control_file": {"output_name": "output", "id": 0}, "treatment|input_treatment_file": {"output_name": "output", "id": 3}}, "tool_state": "{\"control\": \"{\\\"c_multiple\\\": {\\\"input_control_file\\\": {\\\"__class__\\\": \\\"RuntimeValue\\\"}, \\\"c_multi_select\\\": \\\"No\\\", \\\"__current_case__\\\": 0}, \\\"__current_case__\\\": 0, \\\"c_select\\\": \\\"Yes\\\"}\", \"__page__\": null, \"effective_genome_size_options\": \"{\\\"effective_genome_size_options_selector\\\": \\\"1870000000\\\", \\\"__current_case__\\\": 1}\", \"format\": \"\\\"BAMPE\\\"\", \"outputs\": \"null\", \"__rerun_remap_job_id__\": null, \"cutoff_options\": \"{\\\"cutoff_options_selector\\\": \\\"qvalue\\\", \\\"qvalue\\\": \\\"0.05\\\", \\\"__current_case__\\\": 1}\", \"advanced_options\": \"{\\\"slocal\\\": \\\"\\\", \\\"ratio\\\": \\\"\\\", \\\"to_large\\\": \\\"false\\\", \\\"keep_dup_options\\\": {\\\"__current_case__\\\": 1, \\\"keep_dup_options_selector\\\": \\\"1\\\"}, \\\"broad_options\\\": {\\\"broad_options_selector\\\": \\\"nobroad\\\", \\\"call_summits\\\": \\\"false\\\", \\\"__current_case__\\\": 1}, \\\"nolambda\\\": \\\"false\\\", \\\"llocal\\\": \\\"\\\"}\", \"treatment\": \"{\\\"input_treatment_file\\\": {\\\"__class__\\\": \\\"RuntimeValue\\\"}, \\\"__current_case__\\\": 0, \\\"t_multi_select\\\": \\\"No\\\"}\", \"nomodel_type\": \"{\\\"nomodel_type_selector\\\": \\\"create_model\\\", \\\"mfold_lower\\\": \\\"5\\\", \\\"mfold_upper\\\": \\\"50\\\", \\\"band_width\\\": \\\"300\\\", \\\"__current_case__\\\": 0}\", \"chromInfo\": \"\\\"/usr/local/galaxy/galaxy-dist/tool-data/shared/ucsc/chrom/?.len\\\"\"}", "id": 18, "tool_shed_repository": {"owner": "iuc", "changeset_revision": "c16dbe4e2db2", "name": "macs2", "tool_shed": "toolshed.g2.bx.psu.edu"}, "uuid": "47833f17-4a38-4a6f-ae0e-9b8e87a88e95", "errors": null, "name": "MACS2 callpeak", "post_job_actions": {"HideDatasetActionoutput_broadpeaks": {"output_name": "output_broadpeaks", "action_type": "HideDatasetAction", "action_arguments": {}}, "HideDatasetActionoutput_control_lambda": {"output_name": "output_control_lambda", "action_type": "HideDatasetAction", "action_arguments": {}}, "HideDatasetActionoutput_narrowpeaks": {"output_name": "output_narrowpeaks", "action_type": "HideDatasetAction", "action_arguments": {}}, "HideDatasetActionoutput_summits": {"output_name": "output_summits", "action_type": "HideDatasetAction", "action_arguments": {}}, "HideDatasetActionoutput_treat_pileup": {"output_name": "output_treat_pileup", "action_type": "HideDatasetAction", "action_arguments": {}}, "HideDatasetActionoutput_plot": {"output_name": "output_plot", "action_type": "HideDatasetAction", "action_arguments": {}}, "HideDatasetActionoutput_extra_files": {"output_name": "output_extra_files", "action_type": "HideDatasetAction", "action_arguments": {}}, "HideDatasetActionoutput_tabular": {"output_name": "output_tabular", "action_type": "HideDatasetAction", "action_arguments": {}}, "HideDatasetActionoutput_gappedpeaks": {"output_name": "output_gappedpeaks", "action_type": "HideDatasetAction", "action_arguments": {}}}, "label": null, "inputs": [{"name": "treatment", "description": "runtime parameter for tool MACS2 callpeak"}], "position": {"top": 496, "left": 458}, "annotation": "", "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/macs2/macs2_callpeak/2.1.1.20160309.4", "type": "tool"}, "19": {"tool_id": "toolshed.g2.bx.psu.edu/repos/bgruening/deeptools_bam_compare/deeptools_bam_compare/3.0.2.0", "tool_version": "3.0.2.0", "outputs": [{"type": "bigwig", "name": "outFileName"}], "workflow_outputs": [], "input_connections": {"bamFile2": {"output_name": "output", "id": 0}, "bamFile1": {"output_name": "output", "id": 3}}, "tool_state": "{\"comparison\": \"{\\\"pseudocount\\\": \\\"1.0\\\", \\\"type\\\": \\\"log2\\\", \\\"__current_case__\\\": 0}\", \"bamFile2\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\", \"outFileFormat\": \"\\\"bigwig\\\"\", \"bamFile1\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\", \"__page__\": null, \"region\": \"\\\"chrX\\\"\", \"binSize\": \"\\\"50\\\"\", \"scaling\": \"{\\\"method\\\": \\\"readCount\\\", \\\"__current_case__\\\": 1}\", \"advancedOpt\": \"{\\\"showAdvancedOpt\\\": \\\"no\\\", \\\"__current_case__\\\": 0}\", \"chromInfo\": \"\\\"/usr/local/galaxy/galaxy-dist/tool-data/shared/ucsc/chrom/?.len\\\"\", \"__rerun_remap_job_id__\": null}", "id": 19, "tool_shed_repository": {"owner": "bgruening", "changeset_revision": "439e75416e1a", "name": "deeptools_bam_compare", "tool_shed": "toolshed.g2.bx.psu.edu"}, "uuid": "ad9f8b61-7e36-4e89-a5b1-4063a4f08071", "errors": null, "name": "bamCompare", "post_job_actions": {"HideDatasetActionoutFileName": {"output_name": "outFileName", "action_type": "HideDatasetAction", "action_arguments": {}}}, "label": null, "inputs": [{"name": "bamFile2", "description": "runtime parameter for tool bamCompare"}, {"name": "bamFile1", "description": "runtime parameter for tool bamCompare"}], "position": {"top": 864, "left": 458}, "annotation": "", "content_id": "toolshed.g2.bx.psu.edu/repos/bgruening/deeptools_bam_compare/deeptools_bam_compare/3.0.2.0", "type": "tool"}, "20": {"tool_id": "toolshed.g2.bx.psu.edu/repos/bgruening/deeptools_bam_coverage/deeptools_bam_coverage/3.0.2.0", "tool_version": "3.0.2.0", "outputs": [{"type": "bigwig", "name": "outFileName"}], "workflow_outputs": [], "input_connections": {"bamInput": {"output_name": "output", "id": 3}}, "tool_state": "{\"__page__\": null, \"outFileFormat\": \"\\\"bedgraph\\\"\", \"region\": \"\\\"chrX\\\"\", \"bamInput\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\", \"binSize\": \"\\\"25\\\"\", \"scaling\": \"{\\\"effectiveGenomeSize\\\": {\\\"effectiveGenomeSize_opt\\\": \\\"2308125349\\\", \\\"__current_case__\\\": 7}, \\\"type\\\": \\\"1x\\\", \\\"__current_case__\\\": 4}\", \"advancedOpt\": \"{\\\"showAdvancedOpt\\\": \\\"no\\\", \\\"__current_case__\\\": 0}\", \"__rerun_remap_job_id__\": null}", "id": 20, "tool_shed_repository": {"owner": "bgruening", "changeset_revision": "3033c3fba046", "name": "deeptools_bam_coverage", "tool_shed": "toolshed.g2.bx.psu.edu"}, "uuid": "d9f46294-6000-4487-bb9a-2d732b431928", "errors": null, "name": "bamCoverage", "post_job_actions": {"HideDatasetActionoutFileName": {"output_name": "outFileName", "action_type": "HideDatasetAction", "action_arguments": {}}}, "label": null, "inputs": [{"name": "bamInput", "description": "runtime parameter for tool bamCoverage"}], "position": {"top": 1044, "left": 458}, "annotation": "", "content_id": "toolshed.g2.bx.psu.edu/repos/bgruening/deeptools_bam_coverage/deeptools_bam_coverage/3.0.2.0", "type": "tool"}, "21": {"tool_id": "toolshed.g2.bx.psu.edu/repos/devteam/samtools_idxstats/samtools_idxstats/2.0.1", "tool_version": "2.0.1", "outputs": [{"type": "tabular", "name": "output"}], "workflow_outputs": [], "input_connections": {"input": {"output_name": "output", "id": 3}}, "tool_state": "{\"input\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\", \"__rerun_remap_job_id__\": null, \"chromInfo\": \"\\\"/usr/local/galaxy/galaxy-dist/tool-data/shared/ucsc/chrom/?.len\\\"\", \"__page__\": null}", "id": 21, "tool_shed_repository": {"owner": "devteam", "changeset_revision": "88b8c2916784", "name": "samtools_idxstats", "tool_shed": "toolshed.g2.bx.psu.edu"}, "uuid": "f250ecb6-442e-4f53-bf3c-5ffa174accb3", "errors": null, "name": "IdxStats", "post_job_actions": {"HideDatasetActionoutput": {"output_name": "output", "action_type": "HideDatasetAction", "action_arguments": {}}}, "label": null, "inputs": [{"name": "input", "description": "runtime parameter for tool IdxStats"}], "position": {"top": 1160, "left": 458}, "annotation": "", "content_id": "toolshed.g2.bx.psu.edu/repos/devteam/samtools_idxstats/samtools_idxstats/2.0.1", "type": "tool"}, "22": {"tool_id": "toolshed.g2.bx.psu.edu/repos/bgruening/deeptools_plot_fingerprint/deeptools_plot_fingerprint/3.0.2.0", "tool_version": "3.0.2.0", "outputs": [{"type": "png", "name": "outFileName"}, {"type": "tabular", "name": "outFileRawCounts"}, {"type": "tabular", "name": "outFileQualityMetrics"}], "workflow_outputs": [], "input_connections": {"multibam_conditional|bamfiles": [{"output_name": "output", "id": 0}, {"output_name": "output", "id": 3}]}, "tool_state": "{\"__page__\": null, \"region\": \"\\\"chrX\\\"\", \"multibam_conditional\": \"{\\\"orderMatters\\\": \\\"No\\\", \\\"bamfiles\\\": {\\\"__class__\\\": \\\"RuntimeValue\\\"}, \\\"__current_case__\\\": 0}\", \"output\": \"{\\\"showOutputSettings\\\": \\\"no\\\", \\\"__current_case__\\\": 0}\", \"advancedOpt\": \"{\\\"ignoreDuplicates\\\": \\\"false\\\", \\\"centerReads\\\": \\\"false\\\", \\\"doExtendCustom\\\": {\\\"__current_case__\\\": 0, \\\"doExtend\\\": \\\"no\\\"}, \\\"minFragmentLength\\\": \\\"0\\\", \\\"samFlagExclude\\\": \\\"\\\", \\\"skipZeros\\\": \\\"false\\\", \\\"binSize\\\": \\\"500\\\", \\\"numberOfSamples\\\": \\\"10000\\\", \\\"showAdvancedOpt\\\": \\\"yes\\\", \\\"__current_case__\\\": 1, \\\"plotTitle\\\": \\\"\\\", \\\"samFlagInclude\\\": \\\"\\\", \\\"minMappingQuality\\\": \\\"1\\\", \\\"blackListFileName\\\": {\\\"__class__\\\": \\\"RuntimeValue\\\"}, \\\"maxFragmentLength\\\": \\\"0\\\"}\", \"chromInfo\": \"\\\"/usr/local/galaxy/galaxy-dist/tool-data/shared/ucsc/chrom/?.len\\\"\", \"__rerun_remap_job_id__\": null}", "id": 22, "tool_shed_repository": {"owner": "bgruening", "changeset_revision": "a064962bb6e2", "name": "deeptools_plot_fingerprint", "tool_shed": "toolshed.g2.bx.psu.edu"}, "uuid": "2d1c6ddc-17c6-4e4b-89d0-4f4424958c00", "errors": null, "name": "plotFingerprint", "post_job_actions": {"HideDatasetActionoutFileQualityMetrics": {"output_name": "outFileQualityMetrics", "action_type": "HideDatasetAction", "action_arguments": {}}, "HideDatasetActionoutFileName": {"output_name": "outFileName", "action_type": "HideDatasetAction", "action_arguments": {}}, "HideDatasetActionoutFileRawCounts": {"output_name": "outFileRawCounts", "action_type": "HideDatasetAction", "action_arguments": {}}}, "label": null, "inputs": [{"name": "multibam_conditional", "description": "runtime parameter for tool plotFingerprint"}, {"name": "advancedOpt", "description": "runtime parameter for tool plotFingerprint"}], "position": {"top": 1638, "left": 458}, "annotation": "", "content_id": "toolshed.g2.bx.psu.edu/repos/bgruening/deeptools_plot_fingerprint/deeptools_plot_fingerprint/3.0.2.0", "type": "tool"}, "23": {"tool_id": "toolshed.g2.bx.psu.edu/repos/devteam/fastqc/fastqc/0.71", "tool_version": "0.71", "outputs": [{"type": "html", "name": "html_file"}, {"type": "txt", "name": "text_file"}], "workflow_outputs": [], "input_connections": {"input_file": {"output_name": "output", "id": 4}}, "tool_state": "{\"__page__\": null, \"contaminants\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\", \"__rerun_remap_job_id__\": null, \"limits\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\", \"input_file\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\"}", "id": 23, "tool_shed_repository": {"owner": "devteam", "changeset_revision": "ff9530579d1f", "name": "fastqc", "tool_shed": "toolshed.g2.bx.psu.edu"}, "uuid": "0843bd80-453c-4908-ad94-1b7a788ee225", "errors": null, "name": "FastQC", "post_job_actions": {"HideDatasetActionhtml_file": {"output_name": "html_file", "action_type": "HideDatasetAction", "action_arguments": {}}, "HideDatasetActiontext_file": {"output_name": "text_file", "action_type": "HideDatasetAction", "action_arguments": {}}}, "label": null, "inputs": [{"name": "contaminants", "description": "runtime parameter for tool FastQC"}, {"name": "limits", "description": "runtime parameter for tool FastQC"}, {"name": "input_file", "description": "runtime parameter for tool FastQC"}], "position": {"top": 1838, "left": 458}, "annotation": "", "content_id": "toolshed.g2.bx.psu.edu/repos/devteam/fastqc/fastqc/0.71", "type": "tool"}, "24": {"tool_id": "toolshed.g2.bx.psu.edu/repos/bgruening/trim_galore/trim_galore/0.4.3.1", "tool_version": "0.4.3.1", "outputs": [{"type": "input", "name": "trimmed_reads_paired_collection"}, {"type": "input", "name": "trimmed_reads_unpaired_collection"}, {"type": "input", "name": "trimmed_reads_single"}, {"type": "input", "name": "trimmed_reads_pair1"}, {"type": "input", "name": "trimmed_reads_pair2"}, {"type": "input", "name": "unpaired_reads_1"}, {"type": "input", "name": "unpaired_reads_2"}, {"type": "txt", "name": "report_file"}], "workflow_outputs": [], "input_connections": {"singlePaired|input_mate2": {"output_name": "output", "id": 4}, "singlePaired|input_mate1": {"output_name": "output", "id": 1}}, "tool_state": "{\"__page__\": null, \"__rerun_remap_job_id__\": null, \"params\": \"{\\\"min_length\\\": \\\"20\\\", \\\"stringency\\\": \\\"3\\\", \\\"error_rate\\\": \\\"0.1\\\", \\\"retain_unpaired\\\": {\\\"retain_unpaired_select\\\": \\\"no_output\\\", \\\"__current_case__\\\": 0}, \\\"__current_case__\\\": 1, \\\"report\\\": \\\"true\\\", \\\"settingsType\\\": \\\"custom\\\", \\\"quality\\\": \\\"15\\\", \\\"clip_R1\\\": \\\"\\\", \\\"clip_R2\\\": \\\"\\\"}\", \"rrbs\": \"{\\\"settingsType\\\": \\\"default\\\", \\\"__current_case__\\\": 0}\", \"singlePaired\": \"{\\\"three_prime_clip_R1\\\": \\\"\\\", \\\"three_prime_clip_R2\\\": \\\"\\\", \\\"input_mate2\\\": {\\\"__class__\\\": \\\"RuntimeValue\\\"}, \\\"input_mate1\\\": {\\\"__class__\\\": \\\"RuntimeValue\\\"}, \\\"sPaired\\\": \\\"paired\\\", \\\"__current_case__\\\": 1, \\\"trim1\\\": \\\"false\\\", \\\"trimming\\\": {\\\"trimming_select\\\": \\\"\\\", \\\"__current_case__\\\": 0}}\"}", "id": 24, "tool_shed_repository": {"owner": "bgruening", "changeset_revision": "949f01671246", "name": "trim_galore", "tool_shed": "toolshed.g2.bx.psu.edu"}, "uuid": "3e7e49c2-1583-4c96-878b-0760558c2b43", "errors": null, "name": "Trim Galore!", "post_job_actions": {"HideDatasetActiontrimmed_reads_paired_collection": {"output_name": "trimmed_reads_paired_collection", "action_type": "HideDatasetAction", "action_arguments": {}}, "HideDatasetActiontrimmed_reads_pair2": {"output_name": "trimmed_reads_pair2", "action_type": "HideDatasetAction", "action_arguments": {}}, "HideDatasetActiontrimmed_reads_pair1": {"output_name": "trimmed_reads_pair1", "action_type": "HideDatasetAction", "action_arguments": {}}, "HideDatasetActionreport_file": {"output_name": "report_file", "action_type": "HideDatasetAction", "action_arguments": {}}, "HideDatasetActiontrimmed_reads_single": {"output_name": "trimmed_reads_single", "action_type": "HideDatasetAction", "action_arguments": {}}, "HideDatasetActionunpaired_reads_2": {"output_name": "unpaired_reads_2", "action_type": "HideDatasetAction", "action_arguments": {}}, "HideDatasetActionunpaired_reads_1": {"output_name": "unpaired_reads_1", "action_type": "HideDatasetAction", "action_arguments": {}}, "HideDatasetActiontrimmed_reads_unpaired_collection": {"output_name": "trimmed_reads_unpaired_collection", "action_type": "HideDatasetAction", "action_arguments": {}}}, "label": null, "inputs": [{"name": "singlePaired", "description": "runtime parameter for tool Trim Galore!"}, {"name": "singlePaired", "description": "runtime parameter for tool Trim Galore!"}], "position": {"top": 2056, "left": 458}, "annotation": "", "content_id": "toolshed.g2.bx.psu.edu/repos/bgruening/trim_galore/trim_galore/0.4.3.1", "type": "tool"}, "25": {"tool_id": "toolshed.g2.bx.psu.edu/repos/bgruening/deeptools_bam_compare/deeptools_bam_compare/3.0.2.0", "tool_version": "3.0.2.0", "outputs": [{"type": "bigwig", "name": "outFileName"}], "workflow_outputs": [], "input_connections": {"bamFile2": {"output_name": "output", "id": 5}, "bamFile1": {"output_name": "output", "id": 8}}, "tool_state": "{\"comparison\": \"{\\\"pseudocount\\\": \\\"1.0\\\", \\\"type\\\": \\\"log2\\\", \\\"__current_case__\\\": 0}\", \"bamFile2\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\", \"outFileFormat\": \"\\\"bigwig\\\"\", \"bamFile1\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\", \"__page__\": null, \"region\": \"\\\"chrX\\\"\", \"binSize\": \"\\\"50\\\"\", \"scaling\": \"{\\\"method\\\": \\\"readCount\\\", \\\"__current_case__\\\": 1}\", \"advancedOpt\": \"{\\\"showAdvancedOpt\\\": \\\"no\\\", \\\"__current_case__\\\": 0}\", \"chromInfo\": \"\\\"/usr/local/galaxy/galaxy-dist/tool-data/shared/ucsc/chrom/?.len\\\"\", \"__rerun_remap_job_id__\": null}", "id": 25, "tool_shed_repository": {"owner": "bgruening", "changeset_revision": "439e75416e1a", "name": "deeptools_bam_compare", "tool_shed": "toolshed.g2.bx.psu.edu"}, "uuid": "ce760066-f24e-4416-a16b-3e128b541e7d", "errors": null, "name": "bamCompare", "post_job_actions": {"HideDatasetActionoutFileName": {"output_name": "outFileName", "action_type": "HideDatasetAction", "action_arguments": {}}}, "label": null, "inputs": [{"name": "bamFile2", "description": "runtime parameter for tool bamCompare"}, {"name": "bamFile1", "description": "runtime parameter for tool bamCompare"}], "position": {"top": 4002, "left": 458}, "annotation": "", "content_id": "toolshed.g2.bx.psu.edu/repos/bgruening/deeptools_bam_compare/deeptools_bam_compare/3.0.2.0", "type": "tool"}, "26": {"tool_id": "toolshed.g2.bx.psu.edu/repos/bgruening/deeptools_bam_compare/deeptools_bam_compare/3.0.2.0", "tool_version": "3.0.2.0", "outputs": [{"type": "bigwig", "name": "outFileName"}], "workflow_outputs": [], "input_connections": {"bamFile2": {"output_name": "output", "id": 6}, "bamFile1": {"output_name": "output", "id": 8}}, "tool_state": "{\"comparison\": \"{\\\"pseudocount\\\": \\\"1.0\\\", \\\"type\\\": \\\"log2\\\", \\\"__current_case__\\\": 0}\", \"bamFile2\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\", \"outFileFormat\": \"\\\"bigwig\\\"\", \"bamFile1\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\", \"__page__\": null, \"region\": \"\\\"chrX\\\"\", \"binSize\": \"\\\"50\\\"\", \"scaling\": \"{\\\"method\\\": \\\"readCount\\\", \\\"__current_case__\\\": 1}\", \"advancedOpt\": \"{\\\"showAdvancedOpt\\\": \\\"no\\\", \\\"__current_case__\\\": 0}\", \"chromInfo\": \"\\\"/usr/local/galaxy/galaxy-dist/tool-data/shared/ucsc/chrom/?.len\\\"\", \"__rerun_remap_job_id__\": null}", "id": 26, "tool_shed_repository": {"owner": "bgruening", "changeset_revision": "439e75416e1a", "name": "deeptools_bam_compare", "tool_shed": "toolshed.g2.bx.psu.edu"}, "uuid": "f1ed2220-c932-4e7b-949c-af1159d605a4", "errors": null, "name": "bamCompare", "post_job_actions": {"HideDatasetActionoutFileName": {"output_name": "outFileName", "action_type": "HideDatasetAction", "action_arguments": {}}}, "label": null, "inputs": [{"name": "bamFile2", "description": "runtime parameter for tool bamCompare"}, {"name": "bamFile1", "description": "runtime parameter for tool bamCompare"}], "position": {"top": 4182, "left": 458}, "annotation": "", "content_id": "toolshed.g2.bx.psu.edu/repos/bgruening/deeptools_bam_compare/deeptools_bam_compare/3.0.2.0", "type": "tool"}, "27": {"tool_id": "toolshed.g2.bx.psu.edu/repos/bgruening/deeptools_bam_compare/deeptools_bam_compare/3.0.2.0", "tool_version": "3.0.2.0", "outputs": [{"type": "bigwig", "name": "outFileName"}], "workflow_outputs": [], "input_connections": {"bamFile2": {"output_name": "output", "id": 7}, "bamFile1": {"output_name": "output", "id": 8}}, "tool_state": "{\"comparison\": \"{\\\"pseudocount\\\": \\\"1.0\\\", \\\"type\\\": \\\"log2\\\", \\\"__current_case__\\\": 0}\", \"bamFile2\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\", \"outFileFormat\": \"\\\"bigwig\\\"\", \"bamFile1\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\", \"__page__\": null, \"region\": \"\\\"chrX\\\"\", \"binSize\": \"\\\"50\\\"\", \"scaling\": \"{\\\"method\\\": \\\"readCount\\\", \\\"__current_case__\\\": 1}\", \"advancedOpt\": \"{\\\"showAdvancedOpt\\\": \\\"no\\\", \\\"__current_case__\\\": 0}\", \"chromInfo\": \"\\\"/usr/local/galaxy/galaxy-dist/tool-data/shared/ucsc/chrom/?.len\\\"\", \"__rerun_remap_job_id__\": null}", "id": 27, "tool_shed_repository": {"owner": "bgruening", "changeset_revision": "439e75416e1a", "name": "deeptools_bam_compare", "tool_shed": "toolshed.g2.bx.psu.edu"}, "uuid": "dd544d91-27c3-42bc-aa3e-59d9cb1f6de0", "errors": null, "name": "bamCompare", "post_job_actions": {"HideDatasetActionoutFileName": {"output_name": "outFileName", "action_type": "HideDatasetAction", "action_arguments": {}}}, "label": null, "inputs": [{"name": "bamFile2", "description": "runtime parameter for tool bamCompare"}, {"name": "bamFile1", "description": "runtime parameter for tool bamCompare"}], "position": {"top": 4362, "left": 458}, "annotation": "", "content_id": "toolshed.g2.bx.psu.edu/repos/bgruening/deeptools_bam_compare/deeptools_bam_compare/3.0.2.0", "type": "tool"}, "28": {"tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/macs2/macs2_callpeak/2.1.1.20160309.4", "tool_version": "2.1.1.20160309.4", "outputs": [{"type": "tabular", "name": "output_tabular"}, {"type": "bed", "name": "output_broadpeaks"}, {"type": "bed", "name": "output_gappedpeaks"}, {"type": "bed", "name": "output_narrowpeaks"}, {"type": "bed", "name": "output_summits"}, {"type": "pdf", "name": "output_plot"}, {"type": "bedgraph", "name": "output_treat_pileup"}, {"type": "bedgraph", "name": "output_control_lambda"}, {"type": "html", "name": "output_extra_files"}], "workflow_outputs": [], "input_connections": {"control|c_multiple|input_control_file": {"output_name": "output", "id": 8}, "treatment|input_treatment_file": {"output_name": "output", "id": 5}}, "tool_state": "{\"control\": \"{\\\"c_multiple\\\": {\\\"input_control_file\\\": {\\\"__class__\\\": \\\"RuntimeValue\\\"}, \\\"c_multi_select\\\": \\\"No\\\", \\\"__current_case__\\\": 0}, \\\"__current_case__\\\": 0, \\\"c_select\\\": \\\"Yes\\\"}\", \"__page__\": null, \"effective_genome_size_options\": \"{\\\"effective_genome_size_options_selector\\\": \\\"1870000000\\\", \\\"__current_case__\\\": 1}\", \"format\": \"\\\"BAMPE\\\"\", \"outputs\": \"null\", \"__rerun_remap_job_id__\": null, \"cutoff_options\": \"{\\\"cutoff_options_selector\\\": \\\"qvalue\\\", \\\"qvalue\\\": \\\"0.05\\\", \\\"__current_case__\\\": 1}\", \"advanced_options\": \"{\\\"slocal\\\": \\\"\\\", \\\"ratio\\\": \\\"\\\", \\\"to_large\\\": \\\"false\\\", \\\"keep_dup_options\\\": {\\\"__current_case__\\\": 1, \\\"keep_dup_options_selector\\\": \\\"1\\\"}, \\\"broad_options\\\": {\\\"broad_options_selector\\\": \\\"nobroad\\\", \\\"call_summits\\\": \\\"false\\\", \\\"__current_case__\\\": 1}, \\\"nolambda\\\": \\\"false\\\", \\\"llocal\\\": \\\"\\\"}\", \"treatment\": \"{\\\"input_treatment_file\\\": {\\\"__class__\\\": \\\"RuntimeValue\\\"}, \\\"__current_case__\\\": 0, \\\"t_multi_select\\\": \\\"No\\\"}\", \"nomodel_type\": \"{\\\"nomodel_type_selector\\\": \\\"create_model\\\", \\\"mfold_lower\\\": \\\"5\\\", \\\"mfold_upper\\\": \\\"50\\\", \\\"band_width\\\": \\\"300\\\", \\\"__current_case__\\\": 0}\", \"chromInfo\": \"\\\"/usr/local/galaxy/galaxy-dist/tool-data/shared/ucsc/chrom/?.len\\\"\"}", "id": 28, "tool_shed_repository": {"owner": "iuc", "changeset_revision": "c16dbe4e2db2", "name": "macs2", "tool_shed": "toolshed.g2.bx.psu.edu"}, "uuid": "1e3cd8b1-babd-4d42-952b-cba44a94e6aa", "errors": null, "name": "MACS2 callpeak", "post_job_actions": {"HideDatasetActionoutput_broadpeaks": {"output_name": "output_broadpeaks", "action_type": "HideDatasetAction", "action_arguments": {}}, "HideDatasetActionoutput_control_lambda": {"output_name": "output_control_lambda", "action_type": "HideDatasetAction", "action_arguments": {}}, "HideDatasetActionoutput_narrowpeaks": {"output_name": "output_narrowpeaks", "action_type": "HideDatasetAction", "action_arguments": {}}, "HideDatasetActionoutput_summits": {"output_name": "output_summits", "action_type": "HideDatasetAction", "action_arguments": {}}, "HideDatasetActionoutput_treat_pileup": {"output_name": "output_treat_pileup", "action_type": "HideDatasetAction", "action_arguments": {}}, "HideDatasetActionoutput_plot": {"output_name": "output_plot", "action_type": "HideDatasetAction", "action_arguments": {}}, "HideDatasetActionoutput_extra_files": {"output_name": "output_extra_files", "action_type": "HideDatasetAction", "action_arguments": {}}, "HideDatasetActionoutput_tabular": {"output_name": "output_tabular", "action_type": "HideDatasetAction", "action_arguments": {}}, "HideDatasetActionoutput_gappedpeaks": {"output_name": "output_gappedpeaks", "action_type": "HideDatasetAction", "action_arguments": {}}}, "label": null, "inputs": [{"name": "treatment", "description": "runtime parameter for tool MACS2 callpeak"}], "position": {"top": 4542, "left": 458}, "annotation": "", "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/macs2/macs2_callpeak/2.1.1.20160309.4", "type": "tool"}, "29": {"tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/macs2/macs2_callpeak/2.1.1.20160309.4", "tool_version": "2.1.1.20160309.4", "outputs": [{"type": "tabular", "name": "output_tabular"}, {"type": "bed", "name": "output_broadpeaks"}, {"type": "bed", "name": "output_gappedpeaks"}, {"type": "bed", "name": "output_narrowpeaks"}, {"type": "bed", "name": "output_summits"}, {"type": "pdf", "name": "output_plot"}, {"type": "bedgraph", "name": "output_treat_pileup"}, {"type": "bedgraph", "name": "output_control_lambda"}, {"type": "html", "name": "output_extra_files"}], "workflow_outputs": [], "input_connections": {"control|c_multiple|input_control_file": {"output_name": "output", "id": 8}, "treatment|input_treatment_file": {"output_name": "output", "id": 6}}, "tool_state": "{\"control\": \"{\\\"c_multiple\\\": {\\\"input_control_file\\\": {\\\"__class__\\\": \\\"RuntimeValue\\\"}, \\\"c_multi_select\\\": \\\"No\\\", \\\"__current_case__\\\": 0}, \\\"__current_case__\\\": 0, \\\"c_select\\\": \\\"Yes\\\"}\", \"__page__\": null, \"effective_genome_size_options\": \"{\\\"effective_genome_size_options_selector\\\": \\\"1870000000\\\", \\\"__current_case__\\\": 1}\", \"format\": \"\\\"BAMPE\\\"\", \"outputs\": \"null\", \"__rerun_remap_job_id__\": null, \"cutoff_options\": \"{\\\"cutoff_options_selector\\\": \\\"qvalue\\\", \\\"qvalue\\\": \\\"0.05\\\", \\\"__current_case__\\\": 1}\", \"advanced_options\": \"{\\\"slocal\\\": \\\"\\\", \\\"ratio\\\": \\\"\\\", \\\"to_large\\\": \\\"false\\\", \\\"keep_dup_options\\\": {\\\"__current_case__\\\": 1, \\\"keep_dup_options_selector\\\": \\\"1\\\"}, \\\"broad_options\\\": {\\\"broad_options_selector\\\": \\\"nobroad\\\", \\\"call_summits\\\": \\\"false\\\", \\\"__current_case__\\\": 1}, \\\"nolambda\\\": \\\"false\\\", \\\"llocal\\\": \\\"\\\"}\", \"treatment\": \"{\\\"input_treatment_file\\\": {\\\"__class__\\\": \\\"RuntimeValue\\\"}, \\\"__current_case__\\\": 0, \\\"t_multi_select\\\": \\\"No\\\"}\", \"nomodel_type\": \"{\\\"nomodel_type_selector\\\": \\\"create_model\\\", \\\"mfold_lower\\\": \\\"5\\\", \\\"mfold_upper\\\": \\\"50\\\", \\\"band_width\\\": \\\"300\\\", \\\"__current_case__\\\": 0}\", \"chromInfo\": \"\\\"/usr/local/galaxy/galaxy-dist/tool-data/shared/ucsc/chrom/?.len\\\"\"}", "id": 29, "tool_shed_repository": {"owner": "iuc", "changeset_revision": "c16dbe4e2db2", "name": "macs2", "tool_shed": "toolshed.g2.bx.psu.edu"}, "uuid": "516eb83a-4e89-4788-8781-16d7bbff93cc", "errors": null, "name": "MACS2 callpeak", "post_job_actions": {"HideDatasetActionoutput_broadpeaks": {"output_name": "output_broadpeaks", "action_type": "HideDatasetAction", "action_arguments": {}}, "HideDatasetActionoutput_control_lambda": {"output_name": "output_control_lambda", "action_type": "HideDatasetAction", "action_arguments": {}}, "HideDatasetActionoutput_narrowpeaks": {"output_name": "output_narrowpeaks", "action_type": "HideDatasetAction", "action_arguments": {}}, "HideDatasetActionoutput_summits": {"output_name": "output_summits", "action_type": "HideDatasetAction", "action_arguments": {}}, "HideDatasetActionoutput_treat_pileup": {"output_name": "output_treat_pileup", "action_type": "HideDatasetAction", "action_arguments": {}}, "HideDatasetActionoutput_plot": {"output_name": "output_plot", "action_type": "HideDatasetAction", "action_arguments": {}}, "HideDatasetActionoutput_extra_files": {"output_name": "output_extra_files", "action_type": "HideDatasetAction", "action_arguments": {}}, "HideDatasetActionoutput_tabular": {"output_name": "output_tabular", "action_type": "HideDatasetAction", "action_arguments": {}}, "HideDatasetActionoutput_gappedpeaks": {"output_name": "output_gappedpeaks", "action_type": "HideDatasetAction", "action_arguments": {}}}, "label": null, "inputs": [{"name": "treatment", "description": "runtime parameter for tool MACS2 callpeak"}], "position": {"top": 4910, "left": 458}, "annotation": "", "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/macs2/macs2_callpeak/2.1.1.20160309.4", "type": "tool"}, "30": {"tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/macs2/macs2_callpeak/2.1.1.20160309.4", "tool_version": "2.1.1.20160309.4", "outputs": [{"type": "tabular", "name": "output_tabular"}, {"type": "bed", "name": "output_broadpeaks"}, {"type": "bed", "name": "output_gappedpeaks"}, {"type": "bed", "name": "output_narrowpeaks"}, {"type": "bed", "name": "output_summits"}, {"type": "pdf", "name": "output_plot"}, {"type": "bedgraph", "name": "output_treat_pileup"}, {"type": "bedgraph", "name": "output_control_lambda"}, {"type": "html", "name": "output_extra_files"}], "workflow_outputs": [], "input_connections": {"control|c_multiple|input_control_file": {"output_name": "output", "id": 8}, "treatment|input_treatment_file": {"output_name": "output", "id": 7}}, "tool_state": "{\"control\": \"{\\\"c_multiple\\\": {\\\"input_control_file\\\": {\\\"__class__\\\": \\\"RuntimeValue\\\"}, \\\"c_multi_select\\\": \\\"No\\\", \\\"__current_case__\\\": 0}, \\\"__current_case__\\\": 0, \\\"c_select\\\": \\\"Yes\\\"}\", \"__page__\": null, \"effective_genome_size_options\": \"{\\\"effective_genome_size_options_selector\\\": \\\"1870000000\\\", \\\"__current_case__\\\": 1}\", \"format\": \"\\\"BAMPE\\\"\", \"outputs\": \"null\", \"__rerun_remap_job_id__\": null, \"cutoff_options\": \"{\\\"cutoff_options_selector\\\": \\\"qvalue\\\", \\\"qvalue\\\": \\\"0.05\\\", \\\"__current_case__\\\": 1}\", \"advanced_options\": \"{\\\"slocal\\\": \\\"\\\", \\\"ratio\\\": \\\"\\\", \\\"to_large\\\": \\\"false\\\", \\\"keep_dup_options\\\": {\\\"__current_case__\\\": 1, \\\"keep_dup_options_selector\\\": \\\"1\\\"}, \\\"broad_options\\\": {\\\"broad_options_selector\\\": \\\"nobroad\\\", \\\"call_summits\\\": \\\"false\\\", \\\"__current_case__\\\": 1}, \\\"nolambda\\\": \\\"false\\\", \\\"llocal\\\": \\\"\\\"}\", \"treatment\": \"{\\\"input_treatment_file\\\": {\\\"__class__\\\": \\\"RuntimeValue\\\"}, \\\"__current_case__\\\": 0, \\\"t_multi_select\\\": \\\"No\\\"}\", \"nomodel_type\": \"{\\\"nomodel_type_selector\\\": \\\"create_model\\\", \\\"mfold_lower\\\": \\\"5\\\", \\\"mfold_upper\\\": \\\"50\\\", \\\"band_width\\\": \\\"300\\\", \\\"__current_case__\\\": 0}\", \"chromInfo\": \"\\\"/usr/local/galaxy/galaxy-dist/tool-data/shared/ucsc/chrom/?.len\\\"\"}", "id": 30, "tool_shed_repository": {"owner": "iuc", "changeset_revision": "c16dbe4e2db2", "name": "macs2", "tool_shed": "toolshed.g2.bx.psu.edu"}, "uuid": "5b72407b-a349-413c-8bfb-24ad00977da5", "errors": null, "name": "MACS2 callpeak", "post_job_actions": {"HideDatasetActionoutput_broadpeaks": {"output_name": "output_broadpeaks", "action_type": "HideDatasetAction", "action_arguments": {}}, "HideDatasetActionoutput_control_lambda": {"output_name": "output_control_lambda", "action_type": "HideDatasetAction", "action_arguments": {}}, "HideDatasetActionoutput_narrowpeaks": {"output_name": "output_narrowpeaks", "action_type": "HideDatasetAction", "action_arguments": {}}, "HideDatasetActionoutput_summits": {"output_name": "output_summits", "action_type": "HideDatasetAction", "action_arguments": {}}, "HideDatasetActionoutput_treat_pileup": {"output_name": "output_treat_pileup", "action_type": "HideDatasetAction", "action_arguments": {}}, "HideDatasetActionoutput_plot": {"output_name": "output_plot", "action_type": "HideDatasetAction", "action_arguments": {}}, "HideDatasetActionoutput_extra_files": {"output_name": "output_extra_files", "action_type": "HideDatasetAction", "action_arguments": {}}, "HideDatasetActionoutput_tabular": {"output_name": "output_tabular", "action_type": "HideDatasetAction", "action_arguments": {}}, "HideDatasetActionoutput_gappedpeaks": {"output_name": "output_gappedpeaks", "action_type": "HideDatasetAction", "action_arguments": {}}}, "label": null, "inputs": [{"name": "treatment", "description": "runtime parameter for tool MACS2 callpeak"}], "position": {"top": 5278, "left": 458}, "annotation": "", "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/macs2/macs2_callpeak/2.1.1.20160309.4", "type": "tool"}, "31": {"tool_id": "toolshed.g2.bx.psu.edu/repos/bgruening/deeptools_multi_bam_summary/deeptools_multi_bam_summary/3.0.2.0", "tool_version": "3.0.2.0", "outputs": [{"type": "deeptools_coverage_matrix", "name": "outFile"}, {"type": "tabular", "name": "outFileRawCounts"}], "workflow_outputs": [], "input_connections": {"multibam_conditional|bamfiles": [{"output_name": "output", "id": 0}, {"output_name": "output", "id": 8}, {"output_name": "output", "id": 5}, {"output_name": "output", "id": 6}, {"output_name": "output", "id": 9}, {"output_name": "output", "id": 3}, {"output_name": "output", "id": 8}, {"output_name": "output", "id": 7}, {"output_name": "output", "id": 2}]}, "tool_state": "{\"__page__\": null, \"region\": \"\\\"chrX\\\"\", \"mode\": \"{\\\"binSize\\\": \\\"1000\\\", \\\"distanceBetweenBins\\\": \\\"500\\\", \\\"__current_case__\\\": 0, \\\"modeOpt\\\": \\\"bins\\\"}\", \"multibam_conditional\": \"{\\\"orderMatters\\\": \\\"No\\\", \\\"bamfiles\\\": {\\\"__class__\\\": \\\"RuntimeValue\\\"}, \\\"__current_case__\\\": 0}\", \"advancedOpt\": \"{\\\"showAdvancedOpt\\\": \\\"no\\\", \\\"__current_case__\\\": 0}\", \"chromInfo\": \"\\\"/usr/local/galaxy/galaxy-dist/tool-data/shared/ucsc/chrom/?.len\\\"\", \"__rerun_remap_job_id__\": null, \"outRawCounts\": \"\\\"false\\\"\"}", "id": 31, "tool_shed_repository": {"owner": "bgruening", "changeset_revision": "6dfe9740ffc5", "name": "deeptools_multi_bam_summary", "tool_shed": "toolshed.g2.bx.psu.edu"}, "uuid": "cfa0325f-b9db-4fa9-b6e1-1c1191235e9e", "errors": null, "name": "multiBamSummary", "post_job_actions": {"HideDatasetActionoutFile": {"output_name": "outFile", "action_type": "HideDatasetAction", "action_arguments": {}}, "HideDatasetActionoutFileRawCounts": {"output_name": "outFileRawCounts", "action_type": "HideDatasetAction", "action_arguments": {}}}, "label": null, "inputs": [{"name": "multibam_conditional", "description": "runtime parameter for tool multiBamSummary"}], "position": {"top": 1276, "left": 458}, "annotation": "", "content_id": "toolshed.g2.bx.psu.edu/repos/bgruening/deeptools_multi_bam_summary/deeptools_multi_bam_summary/3.0.2.0", "type": "tool"}, "32": {"tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/macs2/macs2_callpeak/2.1.1.20160309.4", "tool_version": "2.1.1.20160309.4", "outputs": [{"type": "tabular", "name": "output_tabular"}, {"type": "bed", "name": "output_broadpeaks"}, {"type": "bed", "name": "output_gappedpeaks"}, {"type": "bed", "name": "output_narrowpeaks"}, {"type": "bed", "name": "output_summits"}, {"type": "pdf", "name": "output_plot"}, {"type": "bedgraph", "name": "output_treat_pileup"}, {"type": "bedgraph", "name": "output_control_lambda"}, {"type": "html", "name": "output_extra_files"}], "workflow_outputs": [], "input_connections": {"control|c_multiple|input_control_file": {"output_name": "output", "id": 0}, "treatment|input_treatment_file": {"output_name": "output", "id": 9}}, "tool_state": "{\"control\": \"{\\\"c_multiple\\\": {\\\"input_control_file\\\": {\\\"__class__\\\": \\\"RuntimeValue\\\"}, \\\"c_multi_select\\\": \\\"No\\\", \\\"__current_case__\\\": 0}, \\\"__current_case__\\\": 0, \\\"c_select\\\": \\\"Yes\\\"}\", \"__page__\": null, \"effective_genome_size_options\": \"{\\\"effective_genome_size_options_selector\\\": \\\"1870000000\\\", \\\"__current_case__\\\": 1}\", \"format\": \"\\\"BAMPE\\\"\", \"outputs\": \"null\", \"__rerun_remap_job_id__\": null, \"cutoff_options\": \"{\\\"cutoff_options_selector\\\": \\\"qvalue\\\", \\\"qvalue\\\": \\\"0.05\\\", \\\"__current_case__\\\": 1}\", \"advanced_options\": \"{\\\"slocal\\\": \\\"\\\", \\\"ratio\\\": \\\"\\\", \\\"to_large\\\": \\\"false\\\", \\\"keep_dup_options\\\": {\\\"__current_case__\\\": 1, \\\"keep_dup_options_selector\\\": \\\"1\\\"}, \\\"broad_options\\\": {\\\"broad_options_selector\\\": \\\"nobroad\\\", \\\"call_summits\\\": \\\"false\\\", \\\"__current_case__\\\": 1}, \\\"nolambda\\\": \\\"false\\\", \\\"llocal\\\": \\\"\\\"}\", \"treatment\": \"{\\\"input_treatment_file\\\": {\\\"__class__\\\": \\\"RuntimeValue\\\"}, \\\"__current_case__\\\": 0, \\\"t_multi_select\\\": \\\"No\\\"}\", \"nomodel_type\": \"{\\\"nomodel_type_selector\\\": \\\"create_model\\\", \\\"mfold_lower\\\": \\\"5\\\", \\\"mfold_upper\\\": \\\"50\\\", \\\"band_width\\\": \\\"300\\\", \\\"__current_case__\\\": 0}\", \"chromInfo\": \"\\\"/usr/local/galaxy/galaxy-dist/tool-data/shared/ucsc/chrom/?.len\\\"\"}", "id": 32, "tool_shed_repository": {"owner": "iuc", "changeset_revision": "c16dbe4e2db2", "name": "macs2", "tool_shed": "toolshed.g2.bx.psu.edu"}, "uuid": "6f017ce1-2627-4b2b-b2f9-fec55cb9d89a", "errors": null, "name": "MACS2 callpeak", "post_job_actions": {"HideDatasetActionoutput_broadpeaks": {"output_name": "output_broadpeaks", "action_type": "HideDatasetAction", "action_arguments": {}}, "HideDatasetActionoutput_control_lambda": {"output_name": "output_control_lambda", "action_type": "HideDatasetAction", "action_arguments": {}}, "HideDatasetActionoutput_narrowpeaks": {"output_name": "output_narrowpeaks", "action_type": "HideDatasetAction", "action_arguments": {}}, "HideDatasetActionoutput_summits": {"output_name": "output_summits", "action_type": "HideDatasetAction", "action_arguments": {}}, "HideDatasetActionoutput_treat_pileup": {"output_name": "output_treat_pileup", "action_type": "HideDatasetAction", "action_arguments": {}}, "HideDatasetActionoutput_plot": {"output_name": "output_plot", "action_type": "HideDatasetAction", "action_arguments": {}}, "HideDatasetActionoutput_extra_files": {"output_name": "output_extra_files", "action_type": "HideDatasetAction", "action_arguments": {}}, "HideDatasetActionoutput_tabular": {"output_name": "output_tabular", "action_type": "HideDatasetAction", "action_arguments": {}}, "HideDatasetActionoutput_gappedpeaks": {"output_name": "output_gappedpeaks", "action_type": "HideDatasetAction", "action_arguments": {}}}, "label": null, "inputs": [{"name": "treatment", "description": "runtime parameter for tool MACS2 callpeak"}], "position": {"top": 2396, "left": 458}, "annotation": "", "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/macs2/macs2_callpeak/2.1.1.20160309.4", "type": "tool"}, "33": {"tool_id": "toolshed.g2.bx.psu.edu/repos/bgruening/deeptools_bam_compare/deeptools_bam_compare/3.0.2.0", "tool_version": "3.0.2.0", "outputs": [{"type": "bigwig", "name": "outFileName"}], "workflow_outputs": [], "input_connections": {"bamFile2": {"output_name": "output", "id": 0}, "bamFile1": {"output_name": "output", "id": 9}}, "tool_state": "{\"comparison\": \"{\\\"pseudocount\\\": \\\"1.0\\\", \\\"type\\\": \\\"log2\\\", \\\"__current_case__\\\": 0}\", \"bamFile2\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\", \"outFileFormat\": \"\\\"bigwig\\\"\", \"bamFile1\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\", \"__page__\": null, \"region\": \"\\\"chrX\\\"\", \"binSize\": \"\\\"50\\\"\", \"scaling\": \"{\\\"method\\\": \\\"readCount\\\", \\\"__current_case__\\\": 1}\", \"advancedOpt\": \"{\\\"showAdvancedOpt\\\": \\\"no\\\", \\\"__current_case__\\\": 0}\", \"chromInfo\": \"\\\"/usr/local/galaxy/galaxy-dist/tool-data/shared/ucsc/chrom/?.len\\\"\", \"__rerun_remap_job_id__\": null}", "id": 33, "tool_shed_repository": {"owner": "bgruening", "changeset_revision": "439e75416e1a", "name": "deeptools_bam_compare", "tool_shed": "toolshed.g2.bx.psu.edu"}, "uuid": "d9c36648-8866-4373-b9ad-c69b77bd24a7", "errors": null, "name": "bamCompare", "post_job_actions": {"HideDatasetActionoutFileName": {"output_name": "outFileName", "action_type": "HideDatasetAction", "action_arguments": {}}}, "label": null, "inputs": [{"name": "bamFile2", "description": "runtime parameter for tool bamCompare"}, {"name": "bamFile1", "description": "runtime parameter for tool bamCompare"}], "position": {"top": 3822, "left": 458}, "annotation": "", "content_id": "toolshed.g2.bx.psu.edu/repos/bgruening/deeptools_bam_compare/deeptools_bam_compare/3.0.2.0", "type": "tool"}, "34": {"tool_id": "toolshed.g2.bx.psu.edu/repos/bgruening/deeptools_bam_coverage/deeptools_bam_coverage/3.0.2.0", "tool_version": "3.0.2.0", "outputs": [{"type": "bigwig", "name": "outFileName"}], "workflow_outputs": [], "input_connections": {"bamInput": {"output_name": "output", "id": 9}}, "tool_state": "{\"__page__\": null, \"outFileFormat\": \"\\\"bigwig\\\"\", \"region\": \"\\\"chrX\\\"\", \"bamInput\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\", \"binSize\": \"\\\"25\\\"\", \"scaling\": \"{\\\"effectiveGenomeSize\\\": {\\\"effectiveGenomeSize_opt\\\": \\\"2308125349\\\", \\\"__current_case__\\\": 7}, \\\"type\\\": \\\"1x\\\", \\\"__current_case__\\\": 4}\", \"advancedOpt\": \"{\\\"showAdvancedOpt\\\": \\\"no\\\", \\\"__current_case__\\\": 0}\", \"chromInfo\": \"\\\"/usr/local/galaxy/galaxy-dist/tool-data/shared/ucsc/chrom/?.len\\\"\", \"__rerun_remap_job_id__\": null}", "id": 34, "tool_shed_repository": {"owner": "bgruening", "changeset_revision": "3033c3fba046", "name": "deeptools_bam_coverage", "tool_shed": "toolshed.g2.bx.psu.edu"}, "uuid": "ac76ea6c-ac01-410d-9ef4-77b5bee1b97a", "errors": null, "name": "bamCoverage", "post_job_actions": {"HideDatasetActionoutFileName": {"output_name": "outFileName", "action_type": "HideDatasetAction", "action_arguments": {}}}, "label": null, "inputs": [{"name": "bamInput", "description": "runtime parameter for tool bamCoverage"}], "position": {"top": 5646, "left": 458}, "annotation": "", "content_id": "toolshed.g2.bx.psu.edu/repos/bgruening/deeptools_bam_coverage/deeptools_bam_coverage/3.0.2.0", "type": "tool"}, "35": {"tool_id": "toolshed.g2.bx.psu.edu/repos/bgruening/text_processing/tp_sort_header_tool/1.1.1", "tool_version": "1.1.1", "outputs": [{"type": "input", "name": "outfile"}], "workflow_outputs": [], "input_connections": {"infile": {"output_name": "outFileName", "id": 10}}, "tool_state": "{\"sortkeys\": \"[{\\\"column\\\": \\\"4\\\", \\\"__index__\\\": 0, \\\"style\\\": \\\"n\\\", \\\"order\\\": \\\"r\\\"}]\", \"__page__\": null, \"ignore_case\": \"\\\"false\\\"\", \"__rerun_remap_job_id__\": null, \"header\": \"\\\"0\\\"\", \"unique\": \"\\\"false\\\"\", \"chromInfo\": \"\\\"/usr/local/galaxy/galaxy-dist/tool-data/shared/ucsc/chrom/?.len\\\"\", \"infile\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\"}", "id": 35, "tool_shed_repository": {"owner": "bgruening", "changeset_revision": "74a8bef53a00", "name": "text_processing", "tool_shed": "toolshed.g2.bx.psu.edu"}, "uuid": "0309cc23-d2ee-4066-b706-5bee13f7ca4f", "errors": null, "name": "Sort", "post_job_actions": {"HideDatasetActionoutfile": {"output_name": "outfile", "action_type": "HideDatasetAction", "action_arguments": {}}}, "label": null, "inputs": [{"name": "infile", "description": "runtime parameter for tool Sort"}], "position": {"top": 942, "left": 786}, "annotation": "", "content_id": "toolshed.g2.bx.psu.edu/repos/bgruening/text_processing/tp_sort_header_tool/1.1.1", "type": "tool"}, "36": {"tool_id": "toolshed.g2.bx.psu.edu/repos/bgruening/text_processing/tp_sort_header_tool/1.1.1", "tool_version": "1.1.1", "outputs": [{"type": "input", "name": "outfile"}], "workflow_outputs": [], "input_connections": {"infile": {"output_name": "outFileName", "id": 16}}, "tool_state": "{\"sortkeys\": \"[{\\\"column\\\": \\\"4\\\", \\\"__index__\\\": 0, \\\"style\\\": \\\"n\\\", \\\"order\\\": \\\"r\\\"}]\", \"__page__\": null, \"ignore_case\": \"\\\"false\\\"\", \"__rerun_remap_job_id__\": null, \"header\": \"\\\"0\\\"\", \"unique\": \"\\\"false\\\"\", \"chromInfo\": \"\\\"/usr/local/galaxy/galaxy-dist/tool-data/shared/ucsc/chrom/?.len\\\"\", \"infile\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\"}", "id": 36, "tool_shed_repository": {"owner": "bgruening", "changeset_revision": "74a8bef53a00", "name": "text_processing", "tool_shed": "toolshed.g2.bx.psu.edu"}, "uuid": "a7548103-ea03-44ca-be06-b7e2db0d895c", "errors": null, "name": "Sort", "post_job_actions": {"HideDatasetActionoutfile": {"output_name": "outfile", "action_type": "HideDatasetAction", "action_arguments": {}}}, "label": null, "inputs": [{"name": "infile", "description": "runtime parameter for tool Sort"}], "position": {"top": 1434, "left": 786}, "annotation": "", "content_id": "toolshed.g2.bx.psu.edu/repos/bgruening/text_processing/tp_sort_header_tool/1.1.1", "type": "tool"}, "37": {"tool_id": "toolshed.g2.bx.psu.edu/repos/bgruening/text_processing/tp_sort_header_tool/1.1.1", "tool_version": "1.1.1", "outputs": [{"type": "input", "name": "outfile"}], "workflow_outputs": [], "input_connections": {"infile": {"output_name": "outFileName", "id": 16}}, "tool_state": "{\"sortkeys\": \"[{\\\"column\\\": \\\"4\\\", \\\"__index__\\\": 0, \\\"style\\\": \\\"n\\\", \\\"order\\\": \\\"\\\"}]\", \"__page__\": null, \"ignore_case\": \"\\\"false\\\"\", \"__rerun_remap_job_id__\": null, \"header\": \"\\\"0\\\"\", \"unique\": \"\\\"false\\\"\", \"chromInfo\": \"\\\"/usr/local/galaxy/galaxy-dist/tool-data/shared/ucsc/chrom/?.len\\\"\", \"infile\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\"}", "id": 37, "tool_shed_repository": {"owner": "bgruening", "changeset_revision": "74a8bef53a00", "name": "text_processing", "tool_shed": "toolshed.g2.bx.psu.edu"}, "uuid": "d49a9ecf-aef6-4af8-b519-001e1965dbb0", "errors": null, "name": "Sort", "post_job_actions": {"HideDatasetActionoutfile": {"output_name": "outfile", "action_type": "HideDatasetAction", "action_arguments": {}}}, "label": null, "inputs": [{"name": "infile", "description": "runtime parameter for tool Sort"}], "position": {"top": 1550, "left": 786}, "annotation": "", "content_id": "toolshed.g2.bx.psu.edu/repos/bgruening/text_processing/tp_sort_header_tool/1.1.1", "type": "tool"}, "38": {"tool_id": "toolshed.g2.bx.psu.edu/repos/bgruening/text_processing/tp_sort_header_tool/1.1.1", "tool_version": "1.1.1", "outputs": [{"type": "input", "name": "outfile"}], "workflow_outputs": [], "input_connections": {"infile": {"output_name": "output_narrowpeaks", "id": 18}}, "tool_state": "{\"sortkeys\": \"[{\\\"column\\\": \\\"9\\\", \\\"__index__\\\": 0, \\\"style\\\": \\\"n\\\", \\\"order\\\": \\\"\\\"}]\", \"__page__\": null, \"ignore_case\": \"\\\"false\\\"\", \"__rerun_remap_job_id__\": null, \"header\": \"\\\"0\\\"\", \"unique\": \"\\\"false\\\"\", \"chromInfo\": \"\\\"/usr/local/galaxy/galaxy-dist/tool-data/shared/ucsc/chrom/?.len\\\"\", \"infile\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\"}", "id": 38, "tool_shed_repository": {"owner": "bgruening", "changeset_revision": "74a8bef53a00", "name": "text_processing", "tool_shed": "toolshed.g2.bx.psu.edu"}, "uuid": "e7147f72-c44d-40a0-b7d0-8e34dc8dbd87", "errors": null, "name": "Sort", "post_job_actions": {"HideDatasetActionoutfile": {"output_name": "outfile", "action_type": "HideDatasetAction", "action_arguments": {}}}, "label": null, "inputs": [{"name": "infile", "description": "runtime parameter for tool Sort"}], "position": {"top": 710, "left": 786}, "annotation": "", "content_id": "toolshed.g2.bx.psu.edu/repos/bgruening/text_processing/tp_sort_header_tool/1.1.1", "type": "tool"}, "39": {"tool_id": "toolshed.g2.bx.psu.edu/repos/devteam/column_maker/Add_a_column1/1.1.0", "tool_version": "1.1.0", "outputs": [{"type": "input", "name": "out_file1"}], "workflow_outputs": [], "input_connections": {"input": {"output_name": "output_narrowpeaks", "id": 18}}, "tool_state": "{\"__page__\": null, \"__rerun_remap_job_id__\": null, \"cond\": \"\\\"c3-c2\\\"\", \"input\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\", \"chromInfo\": \"\\\"/usr/local/galaxy/galaxy-dist/tool-data/shared/ucsc/chrom/?.len\\\"\", \"round\": \"\\\"no\\\"\"}", "id": 39, "tool_shed_repository": {"owner": "devteam", "changeset_revision": "626658afe4cb", "name": "column_maker", "tool_shed": "toolshed.g2.bx.psu.edu"}, "uuid": "3174e622-a321-40f5-bc76-3a23261b86c3", "errors": null, "name": "Compute", "post_job_actions": {"HideDatasetActionout_file1": {"output_name": "out_file1", "action_type": "HideDatasetAction", "action_arguments": {}}}, "label": null, "inputs": [{"name": "input", "description": "runtime parameter for tool Compute"}], "position": {"top": 826, "left": 786}, "annotation": "", "content_id": "toolshed.g2.bx.psu.edu/repos/devteam/column_maker/Add_a_column1/1.1.0", "type": "tool"}, "40": {"tool_id": "toolshed.g2.bx.psu.edu/repos/bgruening/text_processing/tp_sort_header_tool/1.1.1", "tool_version": "1.1.1", "outputs": [{"type": "input", "name": "outfile"}], "workflow_outputs": [], "input_connections": {"infile": {"output_name": "outFileName", "id": 20}}, "tool_state": "{\"sortkeys\": \"[{\\\"column\\\": \\\"4\\\", \\\"__index__\\\": 0, \\\"style\\\": \\\"n\\\", \\\"order\\\": \\\"r\\\"}]\", \"__page__\": null, \"ignore_case\": \"\\\"false\\\"\", \"__rerun_remap_job_id__\": null, \"header\": \"\\\"0\\\"\", \"unique\": \"\\\"false\\\"\", \"chromInfo\": \"\\\"/usr/local/galaxy/galaxy-dist/tool-data/shared/ucsc/chrom/?.len\\\"\", \"infile\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\"}", "id": 40, "tool_shed_repository": {"owner": "bgruening", "changeset_revision": "74a8bef53a00", "name": "text_processing", "tool_shed": "toolshed.g2.bx.psu.edu"}, "uuid": "67b96a8a-01dc-4f39-a2bb-31c2a0e8b4f1", "errors": null, "name": "Sort", "post_job_actions": {"HideDatasetActionoutfile": {"output_name": "outfile", "action_type": "HideDatasetAction", "action_arguments": {}}}, "label": null, "inputs": [{"name": "infile", "description": "runtime parameter for tool Sort"}], "position": {"top": 1202, "left": 786}, "annotation": "", "content_id": "toolshed.g2.bx.psu.edu/repos/bgruening/text_processing/tp_sort_header_tool/1.1.1", "type": "tool"}, "41": {"tool_id": "toolshed.g2.bx.psu.edu/repos/devteam/bowtie2/bowtie2/2.3.4.2", "tool_version": "2.3.4.2", "outputs": [{"type": "fastqsanger", "name": "output_unaligned_reads_l"}, {"type": "fastqsanger", "name": "output_aligned_reads_l"}, {"type": "fastqsanger", "name": "output_aligned_reads_r"}, {"type": "fastqsanger", "name": "output_unaligned_reads_r"}, {"type": "bam", "name": "output"}, {"type": "sam", "name": "output_sam"}, {"type": "txt", "name": "mapping_stats"}], "workflow_outputs": [], "input_connections": {"library|input_2": {"output_name": "trimmed_reads_pair2", "id": 24}, "library|input_1": {"output_name": "trimmed_reads_pair1", "id": 24}}, "tool_state": "{\"sam_options\": \"{\\\"sam_options_selector\\\": \\\"no\\\", \\\"__current_case__\\\": 1}\", \"__page__\": null, \"__rerun_remap_job_id__\": null, \"library\": \"{\\\"aligned_file\\\": \\\"false\\\", \\\"unaligned_file\\\": \\\"false\\\", \\\"input_2\\\": {\\\"__class__\\\": \\\"RuntimeValue\\\"}, \\\"__current_case__\\\": 1, \\\"input_1\\\": {\\\"__class__\\\": \\\"RuntimeValue\\\"}, \\\"type\\\": \\\"paired\\\", \\\"paired_options\\\": {\\\"paired_options_selector\\\": \\\"no\\\", \\\"__current_case__\\\": 1}}\", \"reference_genome\": \"{\\\"source\\\": \\\"indexed\\\", \\\"__current_case__\\\": 0, \\\"index\\\": \\\"mm10\\\"}\", \"rg\": \"{\\\"rg_selector\\\": \\\"do_not_set\\\", \\\"__current_case__\\\": 3}\", \"save_mapping_stats\": \"\\\"true\\\"\", \"analysis_type\": \"{\\\"analysis_type_selector\\\": \\\"simple\\\", \\\"presets\\\": \\\"no_presets\\\", \\\"__current_case__\\\": 0}\"}", "id": 41, "tool_shed_repository": {"owner": "devteam", "changeset_revision": "c3dd1aeb7d07", "name": "bowtie2", "tool_shed": "toolshed.g2.bx.psu.edu"}, "uuid": "35b8379c-4806-4b3f-90d7-ffab08aba70c", "errors": null, "name": "Bowtie2", "post_job_actions": {"HideDatasetActionoutput_unaligned_reads_r": {"output_name": "output_unaligned_reads_r", "action_type": "HideDatasetAction", "action_arguments": {}}, "HideDatasetActionoutput": {"output_name": "output", "action_type": "HideDatasetAction", "action_arguments": {}}, "HideDatasetActionoutput_aligned_reads_l": {"output_name": "output_aligned_reads_l", "action_type": "HideDatasetAction", "action_arguments": {}}, "HideDatasetActionmapping_stats": {"output_name": "mapping_stats", "action_type": "HideDatasetAction", "action_arguments": {}}, "HideDatasetActionoutput_aligned_reads_r": {"output_name": "output_aligned_reads_r", "action_type": "HideDatasetAction", "action_arguments": {}}, "HideDatasetActionoutput_sam": {"output_name": "output_sam", "action_type": "HideDatasetAction", "action_arguments": {}}, "HideDatasetActionoutput_unaligned_reads_l": {"output_name": "output_unaligned_reads_l", "action_type": "HideDatasetAction", "action_arguments": {}}}, "label": null, "inputs": [{"name": "library", "description": "runtime parameter for tool Bowtie2"}, {"name": "library", "description": "runtime parameter for tool Bowtie2"}], "position": {"top": 200, "left": 786}, "annotation": "", "content_id": "toolshed.g2.bx.psu.edu/repos/devteam/bowtie2/bowtie2/2.3.4.2", "type": "tool"}, "42": {"tool_id": "toolshed.g2.bx.psu.edu/repos/bgruening/deeptools_plot_correlation/deeptools_plot_correlation/3.0.2.0", "tool_version": "3.0.2.0", "outputs": [{"type": "png", "name": "outFileName"}, {"type": "tabular", "name": "matrix"}], "workflow_outputs": [], "input_connections": {"corData": {"output_name": "outFile", "id": 31}}, "tool_state": "{\"__page__\": null, \"removeOutliers\": \"\\\"false\\\"\", \"outFileFormat\": \"\\\"png\\\"\", \"outFileCorMatrix\": \"\\\"false\\\"\", \"__rerun_remap_job_id__\": null, \"corMethod\": \"\\\"pearson\\\"\", \"skipZeros\": \"\\\"false\\\"\", \"plotting_type\": \"{\\\"plotWidth\\\": \\\"11.0\\\", \\\"plotTitle\\\": \\\"\\\", \\\"colorMap\\\": \\\"RdYlBu\\\", \\\"plotNumbers\\\": \\\"false\\\", \\\"zMin\\\": \\\"\\\", \\\"whatToPlot\\\": \\\"heatmap\\\", \\\"__current_case__\\\": 0, \\\"zMax\\\": \\\"\\\", \\\"plotHeight\\\": \\\"9.5\\\"}\", \"chromInfo\": \"\\\"/usr/local/galaxy/galaxy-dist/tool-data/shared/ucsc/chrom/?.len\\\"\", \"corData\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\"}", "id": 42, "tool_shed_repository": {"owner": "bgruening", "changeset_revision": "4e8b35fd2173", "name": "deeptools_plot_correlation", "tool_shed": "toolshed.g2.bx.psu.edu"}, "uuid": "660d14d2-4996-4ce6-84e5-a73b773a9e24", "errors": null, "name": "plotCorrelation", "post_job_actions": {"HideDatasetActionmatrix": {"output_name": "matrix", "action_type": "HideDatasetAction", "action_arguments": {}}, "HideDatasetActionoutFileName": {"output_name": "outFileName", "action_type": "HideDatasetAction", "action_arguments": {}}}, "label": null, "inputs": [{"name": "corData", "description": "runtime parameter for tool plotCorrelation"}], "position": {"top": 1666, "left": 786}, "annotation": "", "content_id": "toolshed.g2.bx.psu.edu/repos/bgruening/deeptools_plot_correlation/deeptools_plot_correlation/3.0.2.0", "type": "tool"}, "43": {"tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/bedtools/bedtools_intersectbed/2.27.0.2", "tool_version": "2.27.0.2", "outputs": [{"type": "input", "name": "output"}], "workflow_outputs": [], "input_connections": {"inputA": {"output_name": "output_narrowpeaks", "id": 18}, "reduce_or_iterate|inputB": {"output_name": "output_narrowpeaks", "id": 32}}, "tool_state": "{\"count\": \"\\\"false\\\"\", \"__page__\": null, \"reciprocal\": \"\\\"false\\\"\", \"overlap_mode\": \"null\", \"invert\": \"\\\"true\\\"\", \"header\": \"\\\"false\\\"\", \"inputA\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\", \"reduce_or_iterate\": \"{\\\"inputB\\\": {\\\"__class__\\\": \\\"RuntimeValue\\\"}, \\\"reduce_or_iterate_selector\\\": \\\"iterate\\\", \\\"__current_case__\\\": 0}\", \"split\": \"\\\"false\\\"\", \"fraction\": \"\\\"\\\"\", \"chromInfo\": \"\\\"/usr/local/galaxy/galaxy-dist/tool-data/shared/ucsc/chrom/?.len\\\"\", \"__rerun_remap_job_id__\": null, \"strand\": \"\\\"\\\"\", \"once\": \"\\\"false\\\"\"}", "id": 43, "tool_shed_repository": {"owner": "iuc", "changeset_revision": "6bb3cd018203", "name": "bedtools", "tool_shed": "toolshed.g2.bx.psu.edu"}, "uuid": "d9d2ca44-4a8d-4947-9bb0-11cd02473830", "errors": null, "name": "Intersect intervals", "post_job_actions": {"HideDatasetActionoutput": {"output_name": "output", "action_type": "HideDatasetAction", "action_arguments": {}}}, "label": null, "inputs": [{"name": "inputA", "description": "runtime parameter for tool Intersect intervals"}, {"name": "reduce_or_iterate", "description": "runtime parameter for tool Intersect intervals"}], "position": {"top": 566, "left": 786}, "annotation": "", "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/bedtools/bedtools_intersectbed/2.27.0.2", "type": "tool"}, "44": {"tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/bedtools/bedtools_intersectbed/2.27.0.2", "tool_version": "2.27.0.2", "outputs": [{"type": "input", "name": "output"}], "workflow_outputs": [], "input_connections": {"inputA": {"output_name": "output_narrowpeaks", "id": 32}, "reduce_or_iterate|inputB": {"output_name": "output_narrowpeaks", "id": 18}}, "tool_state": "{\"count\": \"\\\"false\\\"\", \"__page__\": null, \"reciprocal\": \"\\\"false\\\"\", \"overlap_mode\": \"null\", \"invert\": \"\\\"true\\\"\", \"header\": \"\\\"false\\\"\", \"inputA\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\", \"reduce_or_iterate\": \"{\\\"inputB\\\": {\\\"__class__\\\": \\\"RuntimeValue\\\"}, \\\"reduce_or_iterate_selector\\\": \\\"iterate\\\", \\\"__current_case__\\\": 0}\", \"split\": \"\\\"false\\\"\", \"fraction\": \"\\\"\\\"\", \"chromInfo\": \"\\\"/usr/local/galaxy/galaxy-dist/tool-data/shared/ucsc/chrom/?.len\\\"\", \"__rerun_remap_job_id__\": null, \"strand\": \"\\\"\\\"\", \"once\": \"\\\"false\\\"\"}", "id": 44, "tool_shed_repository": {"owner": "iuc", "changeset_revision": "6bb3cd018203", "name": "bedtools", "tool_shed": "toolshed.g2.bx.psu.edu"}, "uuid": "99df4865-a581-4930-8e47-5ec1ba2d65cb", "errors": null, "name": "Intersect intervals", "post_job_actions": {"HideDatasetActionoutput": {"output_name": "output", "action_type": "HideDatasetAction", "action_arguments": {}}}, "label": null, "inputs": [{"name": "inputA", "description": "runtime parameter for tool Intersect intervals"}, {"name": "reduce_or_iterate", "description": "runtime parameter for tool Intersect intervals"}], "position": {"top": 1058, "left": 786}, "annotation": "", "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/bedtools/bedtools_intersectbed/2.27.0.2", "type": "tool"}, "45": {"tool_id": "toolshed.g2.bx.psu.edu/repos/devteam/column_maker/Add_a_column1/1.1.0", "tool_version": "1.1.0", "outputs": [{"type": "input", "name": "out_file1"}], "workflow_outputs": [], "input_connections": {"input": {"output_name": "output_narrowpeaks", "id": 32}}, "tool_state": "{\"__page__\": null, \"__rerun_remap_job_id__\": null, \"cond\": \"\\\"c3-c2\\\"\", \"input\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\", \"chromInfo\": \"\\\"/usr/local/galaxy/galaxy-dist/tool-data/shared/ucsc/chrom/?.len\\\"\", \"round\": \"\\\"no\\\"\"}", "id": 45, "tool_shed_repository": {"owner": "devteam", "changeset_revision": "626658afe4cb", "name": "column_maker", "tool_shed": "toolshed.g2.bx.psu.edu"}, "uuid": "b6eed1d9-e394-4573-8a41-af02ea688553", "errors": null, "name": "Compute", "post_job_actions": {"HideDatasetActionout_file1": {"output_name": "out_file1", "action_type": "HideDatasetAction", "action_arguments": {}}}, "label": null, "inputs": [{"name": "input", "description": "runtime parameter for tool Compute"}], "position": {"top": 1318, "left": 786}, "annotation": "", "content_id": "toolshed.g2.bx.psu.edu/repos/devteam/column_maker/Add_a_column1/1.1.0", "type": "tool"}, "46": {"tool_id": "toolshed.g2.bx.psu.edu/repos/devteam/concat/gops_concat_1/1.0.1", "tool_version": "1.0.1", "outputs": [{"type": "input", "name": "output"}], "workflow_outputs": [], "input_connections": {"input2": {"output_name": "output_narrowpeaks", "id": 32}, "input1": {"output_name": "output_narrowpeaks", "id": 18}}, "tool_state": "{\"input2\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\", \"__page__\": null, \"input1\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\", \"sameformat\": \"\\\"true\\\"\", \"__rerun_remap_job_id__\": null, \"chromInfo\": \"\\\"/usr/local/galaxy/galaxy-dist/tool-data/shared/ucsc/chrom/?.len\\\"\"}", "id": 46, "tool_shed_repository": {"owner": "devteam", "changeset_revision": "d491589307e7", "name": "concat", "tool_shed": "toolshed.g2.bx.psu.edu"}, "uuid": "5484bfa5-ab4a-4768-9355-a0785d74d67d", "errors": null, "name": "Concatenate", "post_job_actions": {"HideDatasetActionoutput": {"output_name": "output", "action_type": "HideDatasetAction", "action_arguments": {}}}, "label": null, "inputs": [{"name": "input2", "description": "runtime parameter for tool Concatenate"}, {"name": "input1", "description": "runtime parameter for tool Concatenate"}], "position": {"top": 1828, "left": 786}, "annotation": "", "content_id": "toolshed.g2.bx.psu.edu/repos/devteam/concat/gops_concat_1/1.0.1", "type": "tool"}, "47": {"tool_id": "cat1", "tool_version": "1.0.0", "outputs": [{"type": "input", "name": "out_file1"}], "workflow_outputs": [], "input_connections": {"queries_2|input2": {"output_name": "output_narrowpeaks", "id": 28}, "queries_3|input2": {"output_name": "output_narrowpeaks", "id": 29}, "input1": {"output_name": "output_narrowpeaks", "id": 13}, "queries_0|input2": {"output_name": "output_narrowpeaks", "id": 32}, "queries_4|input2": {"output_name": "output_narrowpeaks", "id": 30}, "queries_1|input2": {"output_name": "output_narrowpeaks", "id": 18}}, "tool_state": "{\"__page__\": null, \"__rerun_remap_job_id__\": null, \"input1\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\", \"chromInfo\": \"\\\"/usr/local/galaxy/galaxy-dist/tool-data/shared/ucsc/chrom/?.len\\\"\", \"queries\": \"[{\\\"input2\\\": {\\\"__class__\\\": \\\"RuntimeValue\\\"}, \\\"__index__\\\": 0}, {\\\"input2\\\": {\\\"__class__\\\": \\\"RuntimeValue\\\"}, \\\"__index__\\\": 1}, {\\\"input2\\\": {\\\"__class__\\\": \\\"RuntimeValue\\\"}, \\\"__index__\\\": 2}, {\\\"input2\\\": {\\\"__class__\\\": \\\"RuntimeValue\\\"}, \\\"__index__\\\": 3}, {\\\"input2\\\": {\\\"__class__\\\": \\\"RuntimeValue\\\"}, \\\"__index__\\\": 4}]\"}", "id": 47, "uuid": "da8fcf72-6633-4cd1-85f4-f2dc7ccef315", "errors": null, "name": "Concatenate datasets", "post_job_actions": {"HideDatasetActionout_file1": {"output_name": "out_file1", "action_type": "HideDatasetAction", "action_arguments": {}}}, "label": null, "inputs": [{"name": "input1", "description": "runtime parameter for tool Concatenate datasets"}], "position": {"top": 2407, "left": 819}, "annotation": "", "content_id": "cat1", "type": "tool"}, "48": {"tool_id": "Filter1", "tool_version": "1.1.0", "outputs": [{"type": "input", "name": "out_file1"}], "workflow_outputs": [], "input_connections": {"input": {"output_name": "outfile", "id": 38}}, "tool_state": "{\"__page__\": null, \"__rerun_remap_job_id__\": null, \"cond\": \"\\\"c7>50\\\"\", \"input\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\", \"header_lines\": \"\\\"0\\\"\", \"chromInfo\": \"\\\"/usr/local/galaxy/galaxy-dist/tool-data/shared/ucsc/chrom/?.len\\\"\"}", "id": 48, "uuid": "1aba4818-de61-4759-8bdc-c7b34834e15f", "errors": null, "name": "Filter", "post_job_actions": {"HideDatasetActionout_file1": {"output_name": "out_file1", "action_type": "HideDatasetAction", "action_arguments": {}}}, "label": null, "inputs": [{"name": "input", "description": "runtime parameter for tool Filter"}], "position": {"top": 468, "left": 1114}, "annotation": "", "content_id": "Filter1", "type": "tool"}, "49": {"tool_id": "Filter1", "tool_version": "1.1.0", "outputs": [{"type": "input", "name": "out_file1"}], "workflow_outputs": [], "input_connections": {"input": {"output_name": "outfile", "id": 38}}, "tool_state": "{\"__page__\": null, \"__rerun_remap_job_id__\": null, \"cond\": \"\\\"c2>151385260 and c3<152426526\\\"\", \"input\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\", \"header_lines\": \"\\\"0\\\"\", \"chromInfo\": \"\\\"/usr/local/galaxy/galaxy-dist/tool-data/shared/ucsc/chrom/?.len\\\"\"}", "id": 49, "uuid": "069be8cf-ee7a-494f-9d3e-543a561e6fb7", "errors": null, "name": "Filter", "post_job_actions": {"HideDatasetActionout_file1": {"output_name": "out_file1", "action_type": "HideDatasetAction", "action_arguments": {}}}, "label": null, "inputs": [{"name": "input", "description": "runtime parameter for tool Filter"}], "position": {"top": 584, "left": 1114}, "annotation": "", "content_id": "Filter1", "type": "tool"}, "50": {"tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/datamash_ops/datamash_ops/datamash_ops/1.0.6", "tool_version": "1.0.6", "outputs": [{"type": "tabular", "name": "out_file"}], "workflow_outputs": [], "input_connections": {"in_file": {"output_name": "out_file1", "id": 39}}, "tool_state": "{\"operations\": \"[{\\\"__index__\\\": 0, \\\"op_name\\\": \\\"mean\\\", \\\"op_column\\\": \\\"11\\\"}]\", \"__page__\": null, \"ignore_case\": \"\\\"false\\\"\", \"header_out\": \"\\\"false\\\"\", \"__rerun_remap_job_id__\": null, \"header_in\": \"\\\"false\\\"\", \"in_file\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\", \"need_sort\": \"\\\"false\\\"\", \"print_full_line\": \"\\\"false\\\"\", \"chromInfo\": \"\\\"/usr/local/galaxy/galaxy-dist/tool-data/shared/ucsc/chrom/?.len\\\"\", \"grouping\": \"\\\"\\\"\"}", "id": 50, "tool_shed_repository": {"owner": "iuc", "changeset_revision": "2f3c6f2dcf39", "name": "datamash_ops", "tool_shed": "toolshed.g2.bx.psu.edu"}, "uuid": "f0e5143f-871f-45f1-90bb-7635bd5ae4c1", "errors": null, "name": "Datamash", "post_job_actions": {"HideDatasetActionout_file": {"output_name": "out_file", "action_type": "HideDatasetAction", "action_arguments": {}}}, "label": null, "inputs": [{"name": "in_file", "description": "runtime parameter for tool Datamash"}], "position": {"top": 700, "left": 1114}, "annotation": "", "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/datamash_ops/datamash_ops/datamash_ops/1.0.6", "type": "tool"}, "51": {"tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/datamash_ops/datamash_ops/datamash_ops/1.0.6", "tool_version": "1.0.6", "outputs": [{"type": "tabular", "name": "out_file"}], "workflow_outputs": [], "input_connections": {"in_file": {"output_name": "out_file1", "id": 45}}, "tool_state": "{\"operations\": \"[{\\\"__index__\\\": 0, \\\"op_name\\\": \\\"mean\\\", \\\"op_column\\\": \\\"11\\\"}]\", \"__page__\": null, \"ignore_case\": \"\\\"false\\\"\", \"header_out\": \"\\\"false\\\"\", \"__rerun_remap_job_id__\": null, \"header_in\": \"\\\"false\\\"\", \"in_file\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\", \"need_sort\": \"\\\"false\\\"\", \"print_full_line\": \"\\\"false\\\"\", \"chromInfo\": \"\\\"/usr/local/galaxy/galaxy-dist/tool-data/shared/ucsc/chrom/?.len\\\"\", \"grouping\": \"\\\"\\\"\"}", "id": 51, "tool_shed_repository": {"owner": "iuc", "changeset_revision": "2f3c6f2dcf39", "name": "datamash_ops", "tool_shed": "toolshed.g2.bx.psu.edu"}, "uuid": "f141779a-b768-4b5f-930d-1c47d12826ef", "errors": null, "name": "Datamash", "post_job_actions": {"HideDatasetActionout_file": {"output_name": "out_file", "action_type": "HideDatasetAction", "action_arguments": {}}}, "label": null, "inputs": [{"name": "in_file", "description": "runtime parameter for tool Datamash"}], "position": {"top": 816, "left": 1114}, "annotation": "", "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/datamash_ops/datamash_ops/datamash_ops/1.0.6", "type": "tool"}, "52": {"tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/bedtools/bedtools_sortbed/2.27.0.0", "tool_version": "2.27.0.0", "outputs": [{"type": "input", "name": "output"}], "workflow_outputs": [], "input_connections": {"input": {"output_name": "output", "id": 46}}, "tool_state": "{\"input\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\", \"__rerun_remap_job_id__\": null, \"chromInfo\": \"\\\"/usr/local/galaxy/galaxy-dist/tool-data/shared/ucsc/chrom/?.len\\\"\", \"option\": \"\\\"\\\"\", \"__page__\": null}", "id": 52, "tool_shed_repository": {"owner": "iuc", "changeset_revision": "6bb3cd018203", "name": "bedtools", "tool_shed": "toolshed.g2.bx.psu.edu"}, "uuid": "c1ac9566-e699-4d1c-85cd-0eb0eb58a047", "errors": null, "name": "SortBED", "post_job_actions": {"HideDatasetActionoutput": {"output_name": "output", "action_type": "HideDatasetAction", "action_arguments": {}}}, "label": null, "inputs": [{"name": "input", "description": "runtime parameter for tool SortBED"}], "position": {"top": 200, "left": 1114}, "annotation": "", "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/bedtools/bedtools_sortbed/2.27.0.0", "type": "tool"}, "53": {"tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/bedtools/bedtools_sortbed/2.27.0.0", "tool_version": "2.27.0.0", "outputs": [{"type": "input", "name": "output"}], "workflow_outputs": [], "input_connections": {"input": {"output_name": "out_file1", "id": 47}}, "tool_state": "{\"input\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\", \"__rerun_remap_job_id__\": null, \"chromInfo\": \"\\\"/usr/local/galaxy/galaxy-dist/tool-data/shared/ucsc/chrom/?.len\\\"\", \"option\": \"\\\"\\\"\", \"__page__\": null}", "id": 53, "tool_shed_repository": {"owner": "iuc", "changeset_revision": "6bb3cd018203", "name": "bedtools", "tool_shed": "toolshed.g2.bx.psu.edu"}, "uuid": "5f26028c-3bda-47ce-9338-4e447cc4bf4c", "errors": null, "name": "SortBED", "post_job_actions": {"HideDatasetActionoutput": {"output_name": "output", "action_type": "HideDatasetAction", "action_arguments": {}}}, "label": null, "inputs": [{"name": "input", "description": "runtime parameter for tool SortBED"}], "position": {"top": 334, "left": 1114}, "annotation": "", "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/bedtools/bedtools_sortbed/2.27.0.0", "type": "tool"}, "54": {"tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/bedtools/bedtools_mergebed/2.27.0.0", "tool_version": "2.27.0.0", "outputs": [{"type": "bed", "name": "output"}], "workflow_outputs": [], "input_connections": {"input": {"output_name": "output", "id": 52}}, "tool_state": "{\"distance\": \"\\\"0\\\"\", \"__page__\": null, \"chromInfo\": \"\\\"/usr/local/galaxy/galaxy-dist/tool-data/shared/ucsc/chrom/?.len\\\"\", \"__rerun_remap_job_id__\": null, \"header\": \"\\\"false\\\"\", \"input\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\", \"c_and_o_argument_repeat\": \"[]\", \"strand\": \"\\\"\\\"\"}", "id": 54, "tool_shed_repository": {"owner": "iuc", "changeset_revision": "6bb3cd018203", "name": "bedtools", "tool_shed": "toolshed.g2.bx.psu.edu"}, "uuid": "4010d218-df4c-43ce-ae93-0a543f84f75d", "errors": null, "name": "MergeBED", "post_job_actions": {"HideDatasetActionoutput": {"output_name": "output", "action_type": "HideDatasetAction", "action_arguments": {}}}, "label": null, "inputs": [{"name": "input", "description": "runtime parameter for tool MergeBED"}], "position": {"top": 334, "left": 1442}, "annotation": "", "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/bedtools/bedtools_mergebed/2.27.0.0", "type": "tool"}, "55": {"tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/bedtools/bedtools_mergebed/2.27.0.0", "tool_version": "2.27.0.0", "outputs": [{"type": "bed", "name": "output"}], "workflow_outputs": [], "input_connections": {"input": {"output_name": "output", "id": 53}}, "tool_state": "{\"distance\": \"\\\"0\\\"\", \"__page__\": null, \"chromInfo\": \"\\\"/usr/local/galaxy/galaxy-dist/tool-data/shared/ucsc/chrom/?.len\\\"\", \"__rerun_remap_job_id__\": null, \"header\": \"\\\"false\\\"\", \"input\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\", \"c_and_o_argument_repeat\": \"[]\", \"strand\": \"\\\"\\\"\"}", "id": 55, "tool_shed_repository": {"owner": "iuc", "changeset_revision": "6bb3cd018203", "name": "bedtools", "tool_shed": "toolshed.g2.bx.psu.edu"}, "uuid": "e42097d4-e35f-4046-a946-493866667b6c", "errors": null, "name": "MergeBED", "post_job_actions": {"HideDatasetActionoutput": {"output_name": "output", "action_type": "HideDatasetAction", "action_arguments": {}}}, "label": null, "inputs": [{"name": "input", "description": "runtime parameter for tool MergeBED"}], "position": {"top": 200, "left": 1442}, "annotation": "", "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/bedtools/bedtools_mergebed/2.27.0.0", "type": "tool"}, "56": {"tool_id": "toolshed.g2.bx.psu.edu/repos/bgruening/deeptools_compute_matrix/deeptools_compute_matrix/3.0.2.0", "tool_version": "3.0.2.0", "outputs": [{"type": "deeptools_compute_matrix_archive", "name": "outFileName"}, {"type": "bed", "name": "outFileSortedRegions"}, {"type": "tabular", "name": "outFileNameMatrix"}], "workflow_outputs": [], "input_connections": {"regionsFiles_0|regionsFile": {"output_name": "output", "id": 54}, "multibigwig_conditional|bigwigfiles": [{"output_name": "outFileName", "id": 19}, {"output_name": "outFileName", "id": 14}]}, "tool_state": "{\"__page__\": null, \"regionsFiles\": \"[{\\\"__index__\\\": 0, \\\"regionsFile\\\": {\\\"__class__\\\": \\\"RuntimeValue\\\"}}]\", \"__rerun_remap_job_id__\": null, \"multibigwig_conditional\": \"{\\\"orderMatters\\\": \\\"No\\\", \\\"bigwigfiles\\\": {\\\"__class__\\\": \\\"RuntimeValue\\\"}, \\\"__current_case__\\\": 0}\", \"mode\": \"{\\\"afterRegionStartLength\\\": \\\"3000\\\", \\\"beforeRegionStartLength\\\": \\\"3000\\\", \\\"nanAfterEnd\\\": \\\"false\\\", \\\"__current_case__\\\": 1, \\\"referencePoint\\\": \\\"center\\\", \\\"mode_select\\\": \\\"reference-point\\\"}\", \"output\": \"{\\\"showOutputSettings\\\": \\\"no\\\", \\\"__current_case__\\\": 0}\", \"advancedOpt\": \"{\\\"showAdvancedOpt\\\": \\\"no\\\", \\\"__current_case__\\\": 0}\", \"chromInfo\": \"\\\"/usr/local/galaxy/galaxy-dist/tool-data/shared/ucsc/chrom/?.len\\\"\"}", "id": 56, "tool_shed_repository": {"owner": "bgruening", "changeset_revision": "fb9cf9c97ec4", "name": "deeptools_compute_matrix", "tool_shed": "toolshed.g2.bx.psu.edu"}, "uuid": "eb044f16-7766-41d5-9251-e5983c77388c", "errors": null, "name": "computeMatrix", "post_job_actions": {"HideDatasetActionoutFileNameMatrix": {"output_name": "outFileNameMatrix", "action_type": "HideDatasetAction", "action_arguments": {}}, "HideDatasetActionoutFileSortedRegions": {"output_name": "outFileSortedRegions", "action_type": "HideDatasetAction", "action_arguments": {}}, "HideDatasetActionoutFileName": {"output_name": "outFileName", "action_type": "HideDatasetAction", "action_arguments": {}}}, "label": null, "inputs": [{"name": "multibigwig_conditional", "description": "runtime parameter for tool computeMatrix"}], "position": {"top": 200, "left": 1770}, "annotation": "", "content_id": "toolshed.g2.bx.psu.edu/repos/bgruening/deeptools_compute_matrix/deeptools_compute_matrix/3.0.2.0", "type": "tool"}, "57": {"tool_id": "toolshed.g2.bx.psu.edu/repos/bgruening/deeptools_compute_matrix/deeptools_compute_matrix/3.0.2.0", "tool_version": "3.0.2.0", "outputs": [{"type": "deeptools_compute_matrix_archive", "name": "outFileName"}, {"type": "bed", "name": "outFileSortedRegions"}, {"type": "tabular", "name": "outFileNameMatrix"}], "workflow_outputs": [], "input_connections": {"regionsFiles_0|regionsFile": {"output_name": "output", "id": 55}, "multibigwig_conditional|bigwigfiles": [{"output_name": "outFileName", "id": 14}, {"output_name": "outFileName", "id": 25}, {"output_name": "outFileName", "id": 26}, {"output_name": "outFileName", "id": 33}, {"output_name": "outFileName", "id": 27}, {"output_name": "outFileName", "id": 19}]}, "tool_state": "{\"__page__\": null, \"regionsFiles\": \"[{\\\"__index__\\\": 0, \\\"regionsFile\\\": {\\\"__class__\\\": \\\"RuntimeValue\\\"}}]\", \"__rerun_remap_job_id__\": null, \"multibigwig_conditional\": \"{\\\"orderMatters\\\": \\\"No\\\", \\\"bigwigfiles\\\": {\\\"__class__\\\": \\\"RuntimeValue\\\"}, \\\"__current_case__\\\": 0}\", \"mode\": \"{\\\"afterRegionStartLength\\\": \\\"3000\\\", \\\"beforeRegionStartLength\\\": \\\"3000\\\", \\\"nanAfterEnd\\\": \\\"false\\\", \\\"__current_case__\\\": 1, \\\"referencePoint\\\": \\\"center\\\", \\\"mode_select\\\": \\\"reference-point\\\"}\", \"output\": \"{\\\"showOutputSettings\\\": \\\"no\\\", \\\"__current_case__\\\": 0}\", \"advancedOpt\": \"{\\\"showAdvancedOpt\\\": \\\"no\\\", \\\"__current_case__\\\": 0}\", \"chromInfo\": \"\\\"/usr/local/galaxy/galaxy-dist/tool-data/shared/ucsc/chrom/?.len\\\"\"}", "id": 57, "tool_shed_repository": {"owner": "bgruening", "changeset_revision": "fb9cf9c97ec4", "name": "deeptools_compute_matrix", "tool_shed": "toolshed.g2.bx.psu.edu"}, "uuid": "37313422-889f-48c1-b52a-fdbc1774f0ba", "errors": null, "name": "computeMatrix", "post_job_actions": {"HideDatasetActionoutFileNameMatrix": {"output_name": "outFileNameMatrix", "action_type": "HideDatasetAction", "action_arguments": {}}, "HideDatasetActionoutFileSortedRegions": {"output_name": "outFileSortedRegions", "action_type": "HideDatasetAction", "action_arguments": {}}, "HideDatasetActionoutFileName": {"output_name": "outFileName", "action_type": "HideDatasetAction", "action_arguments": {}}}, "label": null, "inputs": [{"name": "multibigwig_conditional", "description": "runtime parameter for tool computeMatrix"}], "position": {"top": 418, "left": 1770}, "annotation": "", "content_id": "toolshed.g2.bx.psu.edu/repos/bgruening/deeptools_compute_matrix/deeptools_compute_matrix/3.0.2.0", "type": "tool"}, "58": {"tool_id": "toolshed.g2.bx.psu.edu/repos/bgruening/deeptools_plot_heatmap/deeptools_plot_heatmap/3.0.2.0", "tool_version": "3.0.2.0", "outputs": [{"type": "png", "name": "outFileName"}, {"type": "bed", "name": "outFileSortedRegions"}, {"type": "tabular", "name": "outFileNameMatrix"}], "workflow_outputs": [], "input_connections": {"matrixFile": {"output_name": "outFileName", "id": 56}}, "tool_state": "{\"__page__\": null, \"__rerun_remap_job_id__\": null, \"matrixFile\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\", \"output\": \"{\\\"showOutputSettings\\\": \\\"no\\\", \\\"__current_case__\\\": 0}\", \"advancedOpt\": \"{\\\"used_multiple_regions\\\": {\\\"clustering\\\": {\\\"k_kmeans\\\": \\\"2\\\", \\\"__current_case__\\\": 0, \\\"clustering_options\\\": \\\"kmeans\\\"}, \\\"__current_case__\\\": 0, \\\"used_multiple_regions_options\\\": \\\"no\\\"}, \\\"plotTitle\\\": \\\"\\\", \\\"colorMapRepeat\\\": [], \\\"alpha\\\": \\\"1.0\\\", \\\"colorList\\\": \\\"\\\", \\\"xAxisLabel\\\": \\\"distance (bp)\\\", \\\"perGroup\\\": \\\"false\\\", \\\"zMax\\\": \\\"\\\", \\\"sortUsing\\\": \\\"mean\\\", \\\"zMin\\\": \\\"\\\", \\\"startLabel\\\": \\\"\\\", \\\"averageTypeSummaryPlot\\\": \\\"mean\\\", \\\"whatToShow\\\": \\\"plot, heatmap and colorbar\\\", \\\"missingDataColor\\\": \\\"black\\\", \\\"referencePointLabel\\\": \\\"\\\", \\\"yMin\\\": \\\"\\\", \\\"regionsLabel\\\": \\\"\\\", \\\"yMax\\\": \\\"\\\", \\\"labelRotation\\\": \\\"0\\\", \\\"yAxisLabel\\\": \\\"genes\\\", \\\"endLabel\\\": \\\"\\\", \\\"sortRegions\\\": \\\"descend\\\", \\\"heatmapWidth\\\": \\\"7.5\\\", \\\"showAdvancedOpt\\\": \\\"yes\\\", \\\"__current_case__\\\": 1, \\\"heatmapHeight\\\": \\\"25.0\\\", \\\"samplesLabel\\\": \\\"\\\"}\", \"chromInfo\": \"\\\"/usr/local/galaxy/galaxy-dist/tool-data/shared/ucsc/chrom/?.len\\\"\"}", "id": 58, "tool_shed_repository": {"owner": "bgruening", "changeset_revision": "010e58e9d822", "name": "deeptools_plot_heatmap", "tool_shed": "toolshed.g2.bx.psu.edu"}, "uuid": "586a43c0-3e14-4e16-822c-953a756fb9f4", "errors": null, "name": "plotHeatmap", "post_job_actions": {"HideDatasetActionoutFileNameMatrix": {"output_name": "outFileNameMatrix", "action_type": "HideDatasetAction", "action_arguments": {}}, "HideDatasetActionoutFileSortedRegions": {"output_name": "outFileSortedRegions", "action_type": "HideDatasetAction", "action_arguments": {}}, "HideDatasetActionoutFileName": {"output_name": "outFileName", "action_type": "HideDatasetAction", "action_arguments": {}}}, "label": null, "inputs": [{"name": "matrixFile", "description": "runtime parameter for tool plotHeatmap"}], "position": {"top": 200, "left": 2098}, "annotation": "", "content_id": "toolshed.g2.bx.psu.edu/repos/bgruening/deeptools_plot_heatmap/deeptools_plot_heatmap/3.0.2.0", "type": "tool"}, "59": {"tool_id": "toolshed.g2.bx.psu.edu/repos/bgruening/deeptools_plot_heatmap/deeptools_plot_heatmap/3.0.2.0", "tool_version": "3.0.2.0", "outputs": [{"type": "png", "name": "outFileName"}, {"type": "bed", "name": "outFileSortedRegions"}, {"type": "tabular", "name": "outFileNameMatrix"}], "workflow_outputs": [], "input_connections": {"matrixFile": {"output_name": "outFileName", "id": 57}}, "tool_state": "{\"__page__\": null, \"__rerun_remap_job_id__\": null, \"matrixFile\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\", \"output\": \"{\\\"showOutputSettings\\\": \\\"no\\\", \\\"__current_case__\\\": 0}\", \"advancedOpt\": \"{\\\"used_multiple_regions\\\": {\\\"clustering\\\": {\\\"k_kmeans\\\": \\\"6\\\", \\\"__current_case__\\\": 0, \\\"clustering_options\\\": \\\"kmeans\\\"}, \\\"__current_case__\\\": 0, \\\"used_multiple_regions_options\\\": \\\"no\\\"}, \\\"plotTitle\\\": \\\"\\\", \\\"colorMapRepeat\\\": [], \\\"alpha\\\": \\\"1.0\\\", \\\"colorList\\\": \\\"\\\", \\\"xAxisLabel\\\": \\\"distance (bp)\\\", \\\"perGroup\\\": \\\"false\\\", \\\"zMax\\\": \\\"\\\", \\\"sortUsing\\\": \\\"mean\\\", \\\"zMin\\\": \\\"\\\", \\\"startLabel\\\": \\\"\\\", \\\"averageTypeSummaryPlot\\\": \\\"mean\\\", \\\"whatToShow\\\": \\\"plot, heatmap and colorbar\\\", \\\"missingDataColor\\\": \\\"black\\\", \\\"referencePointLabel\\\": \\\"\\\", \\\"yMin\\\": \\\"\\\", \\\"regionsLabel\\\": \\\"\\\", \\\"yMax\\\": \\\"\\\", \\\"labelRotation\\\": \\\"0\\\", \\\"yAxisLabel\\\": \\\"genes\\\", \\\"endLabel\\\": \\\"\\\", \\\"sortRegions\\\": \\\"descend\\\", \\\"heatmapWidth\\\": \\\"7.5\\\", \\\"showAdvancedOpt\\\": \\\"yes\\\", \\\"__current_case__\\\": 1, \\\"heatmapHeight\\\": \\\"25.0\\\", \\\"samplesLabel\\\": \\\"\\\"}\", \"chromInfo\": \"\\\"/usr/local/galaxy/galaxy-dist/tool-data/shared/ucsc/chrom/?.len\\\"\"}", "id": 59, "tool_shed_repository": {"owner": "bgruening", "changeset_revision": "010e58e9d822", "name": "deeptools_plot_heatmap", "tool_shed": "toolshed.g2.bx.psu.edu"}, "uuid": "874b0d0d-8837-42c0-8a13-cf2885598bf1", "errors": null, "name": "plotHeatmap", "post_job_actions": {"HideDatasetActionoutFileNameMatrix": {"output_name": "outFileNameMatrix", "action_type": "HideDatasetAction", "action_arguments": {}}, "HideDatasetActionoutFileSortedRegions": {"output_name": "outFileSortedRegions", "action_type": "HideDatasetAction", "action_arguments": {}}, "HideDatasetActionoutFileName": {"output_name": "outFileName", "action_type": "HideDatasetAction", "action_arguments": {}}}, "label": null, "inputs": [{"name": "matrixFile", "description": "runtime parameter for tool plotHeatmap"}], "position": {"top": 390, "left": 2098}, "annotation": "", "content_id": "toolshed.g2.bx.psu.edu/repos/bgruening/deeptools_plot_heatmap/deeptools_plot_heatmap/3.0.2.0", "type": "tool"}}, "annotation": "", "a_galaxy_workflow": "true"}
+{
+  "a_galaxy_workflow": "true",
+  "annotation": "",
+  "format-version": "0.1",
+  "name": "GTN - ChIP-Seq - formation_of_super-structures_on_xi",
+  "steps": {
+    "0": {
+      "annotation": "",
+      "content_id": null,
+      "errors": null,
+      "id": 0,
+      "input_connections": {},
+      "inputs": [
+        {
+          "description": "",
+          "name": "wt_input_rep1"
+        }
+      ],
+      "label": "wt_input_rep1",
+      "name": "Input dataset",
+      "outputs": [],
+      "position": {
+        "left": 200,
+        "top": 200
+      },
+      "tool_id": null,
+      "tool_state": "{\"name\": \"wt_input_rep1\"}",
+      "tool_version": null,
+      "type": "data_input",
+      "uuid": "aa29cbd2-ab28-4222-990d-93040617e825",
+      "workflow_outputs": [
+        {
+          "label": null,
+          "output_name": "output",
+          "uuid": "b9c35037-39dd-41a9-be68-4d9a93dcf91f"
+        }
+      ]
+    },
+    "1": {
+      "annotation": "",
+      "content_id": null,
+      "errors": null,
+      "id": 1,
+      "input_connections": {},
+      "inputs": [],
+      "label": "wt_H3K4me3_read1",
+      "name": "Input dataset",
+      "outputs": [],
+      "position": {
+        "left": 200,
+        "top": 287
+      },
+      "tool_id": null,
+      "tool_state": "{}",
+      "tool_version": null,
+      "type": "data_input",
+      "uuid": "8f1c713f-89b2-4c40-af1f-9022020f5e89",
+      "workflow_outputs": [
+        {
+          "label": null,
+          "output_name": "output",
+          "uuid": "2bd5131d-79f3-479e-9977-4f5a1f4a4e06"
+        }
+      ]
+    },
+    "10": {
+      "annotation": "",
+      "content_id": "toolshed.g2.bx.psu.edu/repos/bgruening/deeptools_bam_coverage/deeptools_bam_coverage/3.0.2.0",
+      "errors": null,
+      "id": 10,
+      "input_connections": {
+        "bamInput": {
+          "id": 0,
+          "output_name": "output"
+        }
+      },
+      "inputs": [
+        {
+          "description": "runtime parameter for tool bamCoverage",
+          "name": "bamInput"
+        }
+      ],
+      "label": null,
+      "name": "bamCoverage",
+      "outputs": [
+        {
+          "name": "outFileName",
+          "type": "bigwig"
+        }
+      ],
+      "position": {
+        "left": 458,
+        "top": 3428
+      },
+      "post_job_actions": {
+        "HideDatasetActionoutFileName": {
+          "action_arguments": {},
+          "action_type": "HideDatasetAction",
+          "output_name": "outFileName"
+        }
+      },
+      "tool_id": "toolshed.g2.bx.psu.edu/repos/bgruening/deeptools_bam_coverage/deeptools_bam_coverage/3.0.2.0",
+      "tool_shed_repository": {
+        "changeset_revision": "3033c3fba046",
+        "name": "deeptools_bam_coverage",
+        "owner": "bgruening",
+        "tool_shed": "toolshed.g2.bx.psu.edu"
+      },
+      "tool_state": "{\"__page__\": null, \"outFileFormat\": \"\\\"bedgraph\\\"\", \"region\": \"\\\"chrX\\\"\", \"bamInput\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\", \"binSize\": \"\\\"25\\\"\", \"scaling\": \"{\\\"effectiveGenomeSize\\\": {\\\"effectiveGenomeSize_opt\\\": \\\"2308125349\\\", \\\"__current_case__\\\": 7}, \\\"type\\\": \\\"1x\\\", \\\"__current_case__\\\": 4}\", \"advancedOpt\": \"{\\\"showAdvancedOpt\\\": \\\"no\\\", \\\"__current_case__\\\": 0}\", \"chromInfo\": \"\\\"/usr/local/galaxy/galaxy-dist/tool-data/shared/ucsc/chrom/?.len\\\"\", \"__rerun_remap_job_id__\": null}",
+      "tool_version": "3.0.2.0",
+      "type": "tool",
+      "uuid": "583c0f65-1f9b-4162-9906-2c37f71078b2",
+      "workflow_outputs": []
+    },
+    "11": {
+      "annotation": "",
+      "content_id": "toolshed.g2.bx.psu.edu/repos/bgruening/deeptools_bam_coverage/deeptools_bam_coverage/3.0.2.0",
+      "errors": null,
+      "id": 11,
+      "input_connections": {
+        "bamInput": {
+          "id": 0,
+          "output_name": "output"
+        }
+      },
+      "inputs": [
+        {
+          "description": "runtime parameter for tool bamCoverage",
+          "name": "bamInput"
+        }
+      ],
+      "label": null,
+      "name": "bamCoverage",
+      "outputs": [
+        {
+          "name": "outFileName",
+          "type": "bigwig"
+        }
+      ],
+      "position": {
+        "left": 458,
+        "top": 3706
+      },
+      "post_job_actions": {
+        "HideDatasetActionoutFileName": {
+          "action_arguments": {},
+          "action_type": "HideDatasetAction",
+          "output_name": "outFileName"
+        }
+      },
+      "tool_id": "toolshed.g2.bx.psu.edu/repos/bgruening/deeptools_bam_coverage/deeptools_bam_coverage/3.0.2.0",
+      "tool_shed_repository": {
+        "changeset_revision": "3033c3fba046",
+        "name": "deeptools_bam_coverage",
+        "owner": "bgruening",
+        "tool_shed": "toolshed.g2.bx.psu.edu"
+      },
+      "tool_state": "{\"__page__\": null, \"outFileFormat\": \"\\\"bigwig\\\"\", \"region\": \"\\\"chrX\\\"\", \"bamInput\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\", \"binSize\": \"\\\"25\\\"\", \"scaling\": \"{\\\"effectiveGenomeSize\\\": {\\\"effectiveGenomeSize_opt\\\": \\\"2308125349\\\", \\\"__current_case__\\\": 7}, \\\"type\\\": \\\"1x\\\", \\\"__current_case__\\\": 4}\", \"advancedOpt\": \"{\\\"showAdvancedOpt\\\": \\\"no\\\", \\\"__current_case__\\\": 0}\", \"chromInfo\": \"\\\"/usr/local/galaxy/galaxy-dist/tool-data/shared/ucsc/chrom/?.len\\\"\", \"__rerun_remap_job_id__\": null}",
+      "tool_version": "3.0.2.0",
+      "type": "tool",
+      "uuid": "8c638a29-4c3b-4584-8292-846e338307f2",
+      "workflow_outputs": []
+    },
+    "12": {
+      "annotation": "",
+      "content_id": "toolshed.g2.bx.psu.edu/repos/devteam/fastqc/fastqc/0.71",
+      "errors": null,
+      "id": 12,
+      "input_connections": {
+        "input_file": {
+          "id": 1,
+          "output_name": "output"
+        }
+      },
+      "inputs": [
+        {
+          "description": "runtime parameter for tool FastQC",
+          "name": "contaminants"
+        },
+        {
+          "description": "runtime parameter for tool FastQC",
+          "name": "limits"
+        },
+        {
+          "description": "runtime parameter for tool FastQC",
+          "name": "input_file"
+        }
+      ],
+      "label": null,
+      "name": "FastQC",
+      "outputs": [
+        {
+          "name": "html_file",
+          "type": "html"
+        },
+        {
+          "name": "text_file",
+          "type": "txt"
+        }
+      ],
+      "position": {
+        "left": 458,
+        "top": 1420
+      },
+      "post_job_actions": {
+        "HideDatasetActionhtml_file": {
+          "action_arguments": {},
+          "action_type": "HideDatasetAction",
+          "output_name": "html_file"
+        },
+        "HideDatasetActiontext_file": {
+          "action_arguments": {},
+          "action_type": "HideDatasetAction",
+          "output_name": "text_file"
+        }
+      },
+      "tool_id": "toolshed.g2.bx.psu.edu/repos/devteam/fastqc/fastqc/0.71",
+      "tool_shed_repository": {
+        "changeset_revision": "ff9530579d1f",
+        "name": "fastqc",
+        "owner": "devteam",
+        "tool_shed": "toolshed.g2.bx.psu.edu"
+      },
+      "tool_state": "{\"__page__\": null, \"contaminants\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\", \"__rerun_remap_job_id__\": null, \"limits\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\", \"input_file\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\"}",
+      "tool_version": "0.71",
+      "type": "tool",
+      "uuid": "5b1e4149-a6bf-472c-85fa-9beacff57b18",
+      "workflow_outputs": []
+    },
+    "13": {
+      "annotation": "",
+      "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/macs2/macs2_callpeak/2.1.1.20160309.4",
+      "errors": null,
+      "id": 13,
+      "input_connections": {
+        "control|c_multiple|input_control_file": {
+          "id": 0,
+          "output_name": "output"
+        },
+        "treatment|input_treatment_file": {
+          "id": 2,
+          "output_name": "output"
+        }
+      },
+      "inputs": [
+        {
+          "description": "runtime parameter for tool MACS2 callpeak",
+          "name": "treatment"
+        }
+      ],
+      "label": null,
+      "name": "MACS2 callpeak",
+      "outputs": [
+        {
+          "name": "output_tabular",
+          "type": "tabular"
+        },
+        {
+          "name": "output_broadpeaks",
+          "type": "bed"
+        },
+        {
+          "name": "output_gappedpeaks",
+          "type": "bed"
+        },
+        {
+          "name": "output_narrowpeaks",
+          "type": "bed"
+        },
+        {
+          "name": "output_summits",
+          "type": "bed"
+        },
+        {
+          "name": "output_plot",
+          "type": "pdf"
+        },
+        {
+          "name": "output_treat_pileup",
+          "type": "bedgraph"
+        },
+        {
+          "name": "output_control_lambda",
+          "type": "bedgraph"
+        },
+        {
+          "name": "output_extra_files",
+          "type": "html"
+        }
+      ],
+      "position": {
+        "left": 458,
+        "top": 2764
+      },
+      "post_job_actions": {
+        "HideDatasetActionoutput_broadpeaks": {
+          "action_arguments": {},
+          "action_type": "HideDatasetAction",
+          "output_name": "output_broadpeaks"
+        },
+        "HideDatasetActionoutput_control_lambda": {
+          "action_arguments": {},
+          "action_type": "HideDatasetAction",
+          "output_name": "output_control_lambda"
+        },
+        "HideDatasetActionoutput_extra_files": {
+          "action_arguments": {},
+          "action_type": "HideDatasetAction",
+          "output_name": "output_extra_files"
+        },
+        "HideDatasetActionoutput_gappedpeaks": {
+          "action_arguments": {},
+          "action_type": "HideDatasetAction",
+          "output_name": "output_gappedpeaks"
+        },
+        "HideDatasetActionoutput_narrowpeaks": {
+          "action_arguments": {},
+          "action_type": "HideDatasetAction",
+          "output_name": "output_narrowpeaks"
+        },
+        "HideDatasetActionoutput_plot": {
+          "action_arguments": {},
+          "action_type": "HideDatasetAction",
+          "output_name": "output_plot"
+        },
+        "HideDatasetActionoutput_summits": {
+          "action_arguments": {},
+          "action_type": "HideDatasetAction",
+          "output_name": "output_summits"
+        },
+        "HideDatasetActionoutput_tabular": {
+          "action_arguments": {},
+          "action_type": "HideDatasetAction",
+          "output_name": "output_tabular"
+        },
+        "HideDatasetActionoutput_treat_pileup": {
+          "action_arguments": {},
+          "action_type": "HideDatasetAction",
+          "output_name": "output_treat_pileup"
+        }
+      },
+      "tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/macs2/macs2_callpeak/2.1.1.20160309.4",
+      "tool_shed_repository": {
+        "changeset_revision": "c16dbe4e2db2",
+        "name": "macs2",
+        "owner": "iuc",
+        "tool_shed": "toolshed.g2.bx.psu.edu"
+      },
+      "tool_state": "{\"control\": \"{\\\"c_multiple\\\": {\\\"input_control_file\\\": {\\\"__class__\\\": \\\"RuntimeValue\\\"}, \\\"c_multi_select\\\": \\\"No\\\", \\\"__current_case__\\\": 0}, \\\"__current_case__\\\": 0, \\\"c_select\\\": \\\"Yes\\\"}\", \"__page__\": null, \"effective_genome_size_options\": \"{\\\"effective_genome_size_options_selector\\\": \\\"1870000000\\\", \\\"__current_case__\\\": 1}\", \"format\": \"\\\"BAMPE\\\"\", \"outputs\": \"[\\\"html\\\"]\", \"__rerun_remap_job_id__\": null, \"cutoff_options\": \"{\\\"cutoff_options_selector\\\": \\\"qvalue\\\", \\\"qvalue\\\": \\\"0.05\\\", \\\"__current_case__\\\": 1}\", \"advanced_options\": \"{\\\"slocal\\\": \\\"\\\", \\\"ratio\\\": \\\"\\\", \\\"to_large\\\": \\\"false\\\", \\\"keep_dup_options\\\": {\\\"__current_case__\\\": 1, \\\"keep_dup_options_selector\\\": \\\"1\\\"}, \\\"broad_options\\\": {\\\"broad_options_selector\\\": \\\"nobroad\\\", \\\"call_summits\\\": \\\"false\\\", \\\"__current_case__\\\": 1}, \\\"nolambda\\\": \\\"false\\\", \\\"llocal\\\": \\\"\\\"}\", \"treatment\": \"{\\\"input_treatment_file\\\": {\\\"__class__\\\": \\\"RuntimeValue\\\"}, \\\"__current_case__\\\": 0, \\\"t_multi_select\\\": \\\"No\\\"}\", \"nomodel_type\": \"{\\\"nomodel_type_selector\\\": \\\"create_model\\\", \\\"mfold_lower\\\": \\\"5\\\", \\\"mfold_upper\\\": \\\"50\\\", \\\"band_width\\\": \\\"300\\\", \\\"__current_case__\\\": 0}\", \"chromInfo\": \"\\\"/usr/local/galaxy/galaxy-dist/tool-data/shared/ucsc/chrom/?.len\\\"\"}",
+      "tool_version": "2.1.1.20160309.4",
+      "type": "tool",
+      "uuid": "30aebff2-176c-4892-983b-2aeb93dc09ef",
+      "workflow_outputs": []
+    },
+    "14": {
+      "annotation": "",
+      "content_id": "toolshed.g2.bx.psu.edu/repos/bgruening/deeptools_bam_compare/deeptools_bam_compare/3.0.2.0",
+      "errors": null,
+      "id": 14,
+      "input_connections": {
+        "bamFile1": {
+          "id": 2,
+          "output_name": "output"
+        },
+        "bamFile2": {
+          "id": 0,
+          "output_name": "output"
+        }
+      },
+      "inputs": [
+        {
+          "description": "runtime parameter for tool bamCompare",
+          "name": "bamFile2"
+        },
+        {
+          "description": "runtime parameter for tool bamCompare",
+          "name": "bamFile1"
+        }
+      ],
+      "label": null,
+      "name": "bamCompare",
+      "outputs": [
+        {
+          "name": "outFileName",
+          "type": "bigwig"
+        }
+      ],
+      "position": {
+        "left": 458,
+        "top": 3132
+      },
+      "post_job_actions": {
+        "HideDatasetActionoutFileName": {
+          "action_arguments": {},
+          "action_type": "HideDatasetAction",
+          "output_name": "outFileName"
+        }
+      },
+      "tool_id": "toolshed.g2.bx.psu.edu/repos/bgruening/deeptools_bam_compare/deeptools_bam_compare/3.0.2.0",
+      "tool_shed_repository": {
+        "changeset_revision": "439e75416e1a",
+        "name": "deeptools_bam_compare",
+        "owner": "bgruening",
+        "tool_shed": "toolshed.g2.bx.psu.edu"
+      },
+      "tool_state": "{\"comparison\": \"{\\\"pseudocount\\\": \\\"1.0\\\", \\\"type\\\": \\\"log2\\\", \\\"__current_case__\\\": 0}\", \"bamFile2\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\", \"outFileFormat\": \"\\\"bigwig\\\"\", \"bamFile1\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\", \"__page__\": null, \"region\": \"\\\"chrX\\\"\", \"binSize\": \"\\\"50\\\"\", \"scaling\": \"{\\\"method\\\": \\\"readCount\\\", \\\"__current_case__\\\": 1}\", \"advancedOpt\": \"{\\\"showAdvancedOpt\\\": \\\"no\\\", \\\"__current_case__\\\": 0}\", \"__rerun_remap_job_id__\": null}",
+      "tool_version": "3.0.2.0",
+      "type": "tool",
+      "uuid": "26bbb4b4-e75c-42ea-b186-e1cc922d1e90",
+      "workflow_outputs": []
+    },
+    "15": {
+      "annotation": "",
+      "content_id": "toolshed.g2.bx.psu.edu/repos/bgruening/deeptools_bam_coverage/deeptools_bam_coverage/3.0.2.0",
+      "errors": null,
+      "id": 15,
+      "input_connections": {
+        "bamInput": {
+          "id": 2,
+          "output_name": "output"
+        }
+      },
+      "inputs": [
+        {
+          "description": "runtime parameter for tool bamCoverage",
+          "name": "bamInput"
+        }
+      ],
+      "label": null,
+      "name": "bamCoverage",
+      "outputs": [
+        {
+          "name": "outFileName",
+          "type": "bigwig"
+        }
+      ],
+      "position": {
+        "left": 458,
+        "top": 3312
+      },
+      "post_job_actions": {
+        "HideDatasetActionoutFileName": {
+          "action_arguments": {},
+          "action_type": "HideDatasetAction",
+          "output_name": "outFileName"
+        }
+      },
+      "tool_id": "toolshed.g2.bx.psu.edu/repos/bgruening/deeptools_bam_coverage/deeptools_bam_coverage/3.0.2.0",
+      "tool_shed_repository": {
+        "changeset_revision": "3033c3fba046",
+        "name": "deeptools_bam_coverage",
+        "owner": "bgruening",
+        "tool_shed": "toolshed.g2.bx.psu.edu"
+      },
+      "tool_state": "{\"__page__\": null, \"outFileFormat\": \"\\\"bigwig\\\"\", \"region\": \"\\\"chrX\\\"\", \"bamInput\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\", \"binSize\": \"\\\"25\\\"\", \"scaling\": \"{\\\"effectiveGenomeSize\\\": {\\\"effectiveGenomeSize_opt\\\": \\\"2308125349\\\", \\\"__current_case__\\\": 7}, \\\"type\\\": \\\"1x\\\", \\\"__current_case__\\\": 4}\", \"advancedOpt\": \"{\\\"showAdvancedOpt\\\": \\\"no\\\", \\\"__current_case__\\\": 0}\", \"chromInfo\": \"\\\"/usr/local/galaxy/galaxy-dist/tool-data/shared/ucsc/chrom/?.len\\\"\", \"__rerun_remap_job_id__\": null}",
+      "tool_version": "3.0.2.0",
+      "type": "tool",
+      "uuid": "115fe86a-1fd3-4c95-af30-56fe50dc10bb",
+      "workflow_outputs": []
+    },
+    "16": {
+      "annotation": "",
+      "content_id": "toolshed.g2.bx.psu.edu/repos/bgruening/deeptools_bam_compare/deeptools_bam_compare/3.0.2.0",
+      "errors": null,
+      "id": 16,
+      "input_connections": {
+        "bamFile1": {
+          "id": 3,
+          "output_name": "output"
+        },
+        "bamFile2": {
+          "id": 0,
+          "output_name": "output"
+        }
+      },
+      "inputs": [
+        {
+          "description": "runtime parameter for tool bamCompare",
+          "name": "bamFile2"
+        },
+        {
+          "description": "runtime parameter for tool bamCompare",
+          "name": "bamFile1"
+        }
+      ],
+      "label": null,
+      "name": "bamCompare",
+      "outputs": [
+        {
+          "name": "outFileName",
+          "type": "bigwig"
+        }
+      ],
+      "position": {
+        "left": 458,
+        "top": 200
+      },
+      "post_job_actions": {
+        "HideDatasetActionoutFileName": {
+          "action_arguments": {},
+          "action_type": "HideDatasetAction",
+          "output_name": "outFileName"
+        }
+      },
+      "tool_id": "toolshed.g2.bx.psu.edu/repos/bgruening/deeptools_bam_compare/deeptools_bam_compare/3.0.2.0",
+      "tool_shed_repository": {
+        "changeset_revision": "439e75416e1a",
+        "name": "deeptools_bam_compare",
+        "owner": "bgruening",
+        "tool_shed": "toolshed.g2.bx.psu.edu"
+      },
+      "tool_state": "{\"comparison\": \"{\\\"pseudocount\\\": \\\"1.0\\\", \\\"type\\\": \\\"log2\\\", \\\"__current_case__\\\": 0}\", \"bamFile2\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\", \"outFileFormat\": \"\\\"bedgraph\\\"\", \"bamFile1\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\", \"__page__\": null, \"region\": \"\\\"chrX\\\"\", \"binSize\": \"\\\"50\\\"\", \"scaling\": \"{\\\"method\\\": \\\"readCount\\\", \\\"__current_case__\\\": 1}\", \"advancedOpt\": \"{\\\"showAdvancedOpt\\\": \\\"no\\\", \\\"__current_case__\\\": 0}\", \"__rerun_remap_job_id__\": null}",
+      "tool_version": "3.0.2.0",
+      "type": "tool",
+      "uuid": "6da76716-256b-4dac-8346-eb81087552ff",
+      "workflow_outputs": []
+    },
+    "17": {
+      "annotation": "",
+      "content_id": "toolshed.g2.bx.psu.edu/repos/bgruening/deeptools_bam_coverage/deeptools_bam_coverage/3.0.2.0",
+      "errors": null,
+      "id": 17,
+      "input_connections": {
+        "bamInput": {
+          "id": 3,
+          "output_name": "output"
+        }
+      },
+      "inputs": [
+        {
+          "description": "runtime parameter for tool bamCoverage",
+          "name": "bamInput"
+        }
+      ],
+      "label": null,
+      "name": "bamCoverage",
+      "outputs": [
+        {
+          "name": "outFileName",
+          "type": "bigwig"
+        }
+      ],
+      "position": {
+        "left": 458,
+        "top": 380
+      },
+      "post_job_actions": {
+        "HideDatasetActionoutFileName": {
+          "action_arguments": {},
+          "action_type": "HideDatasetAction",
+          "output_name": "outFileName"
+        }
+      },
+      "tool_id": "toolshed.g2.bx.psu.edu/repos/bgruening/deeptools_bam_coverage/deeptools_bam_coverage/3.0.2.0",
+      "tool_shed_repository": {
+        "changeset_revision": "3033c3fba046",
+        "name": "deeptools_bam_coverage",
+        "owner": "bgruening",
+        "tool_shed": "toolshed.g2.bx.psu.edu"
+      },
+      "tool_state": "{\"__page__\": null, \"outFileFormat\": \"\\\"bigwig\\\"\", \"region\": \"\\\"chrX\\\"\", \"bamInput\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\", \"binSize\": \"\\\"50\\\"\", \"scaling\": \"{\\\"effectiveGenomeSize\\\": {\\\"effectiveGenomeSize_opt\\\": \\\"2308125349\\\", \\\"__current_case__\\\": 7}, \\\"type\\\": \\\"1x\\\", \\\"__current_case__\\\": 4}\", \"advancedOpt\": \"{\\\"showAdvancedOpt\\\": \\\"no\\\", \\\"__current_case__\\\": 0}\", \"__rerun_remap_job_id__\": null}",
+      "tool_version": "3.0.2.0",
+      "type": "tool",
+      "uuid": "2319b2e0-eebe-4348-b6d3-e75b9bb2c3b6",
+      "workflow_outputs": []
+    },
+    "18": {
+      "annotation": "",
+      "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/macs2/macs2_callpeak/2.1.1.20160309.4",
+      "errors": null,
+      "id": 18,
+      "input_connections": {
+        "control|c_multiple|input_control_file": {
+          "id": 0,
+          "output_name": "output"
+        },
+        "treatment|input_treatment_file": {
+          "id": 3,
+          "output_name": "output"
+        }
+      },
+      "inputs": [
+        {
+          "description": "runtime parameter for tool MACS2 callpeak",
+          "name": "treatment"
+        }
+      ],
+      "label": null,
+      "name": "MACS2 callpeak",
+      "outputs": [
+        {
+          "name": "output_tabular",
+          "type": "tabular"
+        },
+        {
+          "name": "output_broadpeaks",
+          "type": "bed"
+        },
+        {
+          "name": "output_gappedpeaks",
+          "type": "bed"
+        },
+        {
+          "name": "output_narrowpeaks",
+          "type": "bed"
+        },
+        {
+          "name": "output_summits",
+          "type": "bed"
+        },
+        {
+          "name": "output_plot",
+          "type": "pdf"
+        },
+        {
+          "name": "output_treat_pileup",
+          "type": "bedgraph"
+        },
+        {
+          "name": "output_control_lambda",
+          "type": "bedgraph"
+        },
+        {
+          "name": "output_extra_files",
+          "type": "html"
+        }
+      ],
+      "position": {
+        "left": 458,
+        "top": 496
+      },
+      "post_job_actions": {
+        "HideDatasetActionoutput_broadpeaks": {
+          "action_arguments": {},
+          "action_type": "HideDatasetAction",
+          "output_name": "output_broadpeaks"
+        },
+        "HideDatasetActionoutput_control_lambda": {
+          "action_arguments": {},
+          "action_type": "HideDatasetAction",
+          "output_name": "output_control_lambda"
+        },
+        "HideDatasetActionoutput_extra_files": {
+          "action_arguments": {},
+          "action_type": "HideDatasetAction",
+          "output_name": "output_extra_files"
+        },
+        "HideDatasetActionoutput_gappedpeaks": {
+          "action_arguments": {},
+          "action_type": "HideDatasetAction",
+          "output_name": "output_gappedpeaks"
+        },
+        "HideDatasetActionoutput_narrowpeaks": {
+          "action_arguments": {},
+          "action_type": "HideDatasetAction",
+          "output_name": "output_narrowpeaks"
+        },
+        "HideDatasetActionoutput_plot": {
+          "action_arguments": {},
+          "action_type": "HideDatasetAction",
+          "output_name": "output_plot"
+        },
+        "HideDatasetActionoutput_summits": {
+          "action_arguments": {},
+          "action_type": "HideDatasetAction",
+          "output_name": "output_summits"
+        },
+        "HideDatasetActionoutput_tabular": {
+          "action_arguments": {},
+          "action_type": "HideDatasetAction",
+          "output_name": "output_tabular"
+        },
+        "HideDatasetActionoutput_treat_pileup": {
+          "action_arguments": {},
+          "action_type": "HideDatasetAction",
+          "output_name": "output_treat_pileup"
+        }
+      },
+      "tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/macs2/macs2_callpeak/2.1.1.20160309.4",
+      "tool_shed_repository": {
+        "changeset_revision": "c16dbe4e2db2",
+        "name": "macs2",
+        "owner": "iuc",
+        "tool_shed": "toolshed.g2.bx.psu.edu"
+      },
+      "tool_state": "{\"control\": \"{\\\"c_multiple\\\": {\\\"input_control_file\\\": {\\\"__class__\\\": \\\"RuntimeValue\\\"}, \\\"c_multi_select\\\": \\\"No\\\", \\\"__current_case__\\\": 0}, \\\"__current_case__\\\": 0, \\\"c_select\\\": \\\"Yes\\\"}\", \"__page__\": null, \"effective_genome_size_options\": \"{\\\"effective_genome_size_options_selector\\\": \\\"1870000000\\\", \\\"__current_case__\\\": 1}\", \"format\": \"\\\"BAMPE\\\"\", \"outputs\": \"null\", \"__rerun_remap_job_id__\": null, \"cutoff_options\": \"{\\\"cutoff_options_selector\\\": \\\"qvalue\\\", \\\"qvalue\\\": \\\"0.05\\\", \\\"__current_case__\\\": 1}\", \"advanced_options\": \"{\\\"slocal\\\": \\\"\\\", \\\"ratio\\\": \\\"\\\", \\\"to_large\\\": \\\"false\\\", \\\"keep_dup_options\\\": {\\\"__current_case__\\\": 1, \\\"keep_dup_options_selector\\\": \\\"1\\\"}, \\\"broad_options\\\": {\\\"broad_options_selector\\\": \\\"nobroad\\\", \\\"call_summits\\\": \\\"false\\\", \\\"__current_case__\\\": 1}, \\\"nolambda\\\": \\\"false\\\", \\\"llocal\\\": \\\"\\\"}\", \"treatment\": \"{\\\"input_treatment_file\\\": {\\\"__class__\\\": \\\"RuntimeValue\\\"}, \\\"__current_case__\\\": 0, \\\"t_multi_select\\\": \\\"No\\\"}\", \"nomodel_type\": \"{\\\"nomodel_type_selector\\\": \\\"create_model\\\", \\\"mfold_lower\\\": \\\"5\\\", \\\"mfold_upper\\\": \\\"50\\\", \\\"band_width\\\": \\\"300\\\", \\\"__current_case__\\\": 0}\", \"chromInfo\": \"\\\"/usr/local/galaxy/galaxy-dist/tool-data/shared/ucsc/chrom/?.len\\\"\"}",
+      "tool_version": "2.1.1.20160309.4",
+      "type": "tool",
+      "uuid": "47833f17-4a38-4a6f-ae0e-9b8e87a88e95",
+      "workflow_outputs": []
+    },
+    "19": {
+      "annotation": "",
+      "content_id": "toolshed.g2.bx.psu.edu/repos/bgruening/deeptools_bam_compare/deeptools_bam_compare/3.0.2.0",
+      "errors": null,
+      "id": 19,
+      "input_connections": {
+        "bamFile1": {
+          "id": 3,
+          "output_name": "output"
+        },
+        "bamFile2": {
+          "id": 0,
+          "output_name": "output"
+        }
+      },
+      "inputs": [
+        {
+          "description": "runtime parameter for tool bamCompare",
+          "name": "bamFile2"
+        },
+        {
+          "description": "runtime parameter for tool bamCompare",
+          "name": "bamFile1"
+        }
+      ],
+      "label": null,
+      "name": "bamCompare",
+      "outputs": [
+        {
+          "name": "outFileName",
+          "type": "bigwig"
+        }
+      ],
+      "position": {
+        "left": 458,
+        "top": 864
+      },
+      "post_job_actions": {
+        "HideDatasetActionoutFileName": {
+          "action_arguments": {},
+          "action_type": "HideDatasetAction",
+          "output_name": "outFileName"
+        }
+      },
+      "tool_id": "toolshed.g2.bx.psu.edu/repos/bgruening/deeptools_bam_compare/deeptools_bam_compare/3.0.2.0",
+      "tool_shed_repository": {
+        "changeset_revision": "439e75416e1a",
+        "name": "deeptools_bam_compare",
+        "owner": "bgruening",
+        "tool_shed": "toolshed.g2.bx.psu.edu"
+      },
+      "tool_state": "{\"comparison\": \"{\\\"pseudocount\\\": \\\"1.0\\\", \\\"type\\\": \\\"log2\\\", \\\"__current_case__\\\": 0}\", \"bamFile2\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\", \"outFileFormat\": \"\\\"bigwig\\\"\", \"bamFile1\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\", \"__page__\": null, \"region\": \"\\\"chrX\\\"\", \"binSize\": \"\\\"50\\\"\", \"scaling\": \"{\\\"method\\\": \\\"readCount\\\", \\\"__current_case__\\\": 1}\", \"advancedOpt\": \"{\\\"showAdvancedOpt\\\": \\\"no\\\", \\\"__current_case__\\\": 0}\", \"chromInfo\": \"\\\"/usr/local/galaxy/galaxy-dist/tool-data/shared/ucsc/chrom/?.len\\\"\", \"__rerun_remap_job_id__\": null}",
+      "tool_version": "3.0.2.0",
+      "type": "tool",
+      "uuid": "ad9f8b61-7e36-4e89-a5b1-4063a4f08071",
+      "workflow_outputs": []
+    },
+    "2": {
+      "annotation": "",
+      "content_id": null,
+      "errors": null,
+      "id": 2,
+      "input_connections": {},
+      "inputs": [],
+      "label": "wt_H3K27me3_rep1",
+      "name": "Input dataset",
+      "outputs": [],
+      "position": {
+        "left": 200,
+        "top": 392
+      },
+      "tool_id": null,
+      "tool_state": "{}",
+      "tool_version": null,
+      "type": "data_input",
+      "uuid": "5ae72729-4707-41b6-99f6-436b994a3003",
+      "workflow_outputs": [
+        {
+          "label": null,
+          "output_name": "output",
+          "uuid": "50ccae0b-e051-45f6-a48e-af1bc027842c"
+        }
+      ]
+    },
+    "20": {
+      "annotation": "",
+      "content_id": "toolshed.g2.bx.psu.edu/repos/bgruening/deeptools_bam_coverage/deeptools_bam_coverage/3.0.2.0",
+      "errors": null,
+      "id": 20,
+      "input_connections": {
+        "bamInput": {
+          "id": 3,
+          "output_name": "output"
+        }
+      },
+      "inputs": [
+        {
+          "description": "runtime parameter for tool bamCoverage",
+          "name": "bamInput"
+        }
+      ],
+      "label": null,
+      "name": "bamCoverage",
+      "outputs": [
+        {
+          "name": "outFileName",
+          "type": "bigwig"
+        }
+      ],
+      "position": {
+        "left": 458,
+        "top": 1044
+      },
+      "post_job_actions": {
+        "HideDatasetActionoutFileName": {
+          "action_arguments": {},
+          "action_type": "HideDatasetAction",
+          "output_name": "outFileName"
+        }
+      },
+      "tool_id": "toolshed.g2.bx.psu.edu/repos/bgruening/deeptools_bam_coverage/deeptools_bam_coverage/3.0.2.0",
+      "tool_shed_repository": {
+        "changeset_revision": "3033c3fba046",
+        "name": "deeptools_bam_coverage",
+        "owner": "bgruening",
+        "tool_shed": "toolshed.g2.bx.psu.edu"
+      },
+      "tool_state": "{\"__page__\": null, \"outFileFormat\": \"\\\"bedgraph\\\"\", \"region\": \"\\\"chrX\\\"\", \"bamInput\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\", \"binSize\": \"\\\"25\\\"\", \"scaling\": \"{\\\"effectiveGenomeSize\\\": {\\\"effectiveGenomeSize_opt\\\": \\\"2308125349\\\", \\\"__current_case__\\\": 7}, \\\"type\\\": \\\"1x\\\", \\\"__current_case__\\\": 4}\", \"advancedOpt\": \"{\\\"showAdvancedOpt\\\": \\\"no\\\", \\\"__current_case__\\\": 0}\", \"__rerun_remap_job_id__\": null}",
+      "tool_version": "3.0.2.0",
+      "type": "tool",
+      "uuid": "d9f46294-6000-4487-bb9a-2d732b431928",
+      "workflow_outputs": []
+    },
+    "21": {
+      "annotation": "",
+      "content_id": "toolshed.g2.bx.psu.edu/repos/devteam/samtools_idxstats/samtools_idxstats/2.0.1",
+      "errors": null,
+      "id": 21,
+      "input_connections": {
+        "input": {
+          "id": 3,
+          "output_name": "output"
+        }
+      },
+      "inputs": [
+        {
+          "description": "runtime parameter for tool IdxStats",
+          "name": "input"
+        }
+      ],
+      "label": null,
+      "name": "IdxStats",
+      "outputs": [
+        {
+          "name": "output",
+          "type": "tabular"
+        }
+      ],
+      "position": {
+        "left": 458,
+        "top": 1160
+      },
+      "post_job_actions": {
+        "HideDatasetActionoutput": {
+          "action_arguments": {},
+          "action_type": "HideDatasetAction",
+          "output_name": "output"
+        }
+      },
+      "tool_id": "toolshed.g2.bx.psu.edu/repos/devteam/samtools_idxstats/samtools_idxstats/2.0.1",
+      "tool_shed_repository": {
+        "changeset_revision": "88b8c2916784",
+        "name": "samtools_idxstats",
+        "owner": "devteam",
+        "tool_shed": "toolshed.g2.bx.psu.edu"
+      },
+      "tool_state": "{\"input\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\", \"__rerun_remap_job_id__\": null, \"chromInfo\": \"\\\"/usr/local/galaxy/galaxy-dist/tool-data/shared/ucsc/chrom/?.len\\\"\", \"__page__\": null}",
+      "tool_version": "2.0.1",
+      "type": "tool",
+      "uuid": "f250ecb6-442e-4f53-bf3c-5ffa174accb3",
+      "workflow_outputs": []
+    },
+    "22": {
+      "annotation": "",
+      "content_id": "toolshed.g2.bx.psu.edu/repos/bgruening/deeptools_plot_fingerprint/deeptools_plot_fingerprint/3.0.2.0",
+      "errors": null,
+      "id": 22,
+      "input_connections": {
+        "multibam_conditional|bamfiles": [
+          {
+            "id": 0,
+            "output_name": "output"
+          },
+          {
+            "id": 3,
+            "output_name": "output"
+          }
+        ]
+      },
+      "inputs": [
+        {
+          "description": "runtime parameter for tool plotFingerprint",
+          "name": "multibam_conditional"
+        },
+        {
+          "description": "runtime parameter for tool plotFingerprint",
+          "name": "advancedOpt"
+        }
+      ],
+      "label": null,
+      "name": "plotFingerprint",
+      "outputs": [
+        {
+          "name": "outFileName",
+          "type": "png"
+        },
+        {
+          "name": "outFileRawCounts",
+          "type": "tabular"
+        },
+        {
+          "name": "outFileQualityMetrics",
+          "type": "tabular"
+        }
+      ],
+      "position": {
+        "left": 458,
+        "top": 1638
+      },
+      "post_job_actions": {
+        "HideDatasetActionoutFileName": {
+          "action_arguments": {},
+          "action_type": "HideDatasetAction",
+          "output_name": "outFileName"
+        },
+        "HideDatasetActionoutFileQualityMetrics": {
+          "action_arguments": {},
+          "action_type": "HideDatasetAction",
+          "output_name": "outFileQualityMetrics"
+        },
+        "HideDatasetActionoutFileRawCounts": {
+          "action_arguments": {},
+          "action_type": "HideDatasetAction",
+          "output_name": "outFileRawCounts"
+        }
+      },
+      "tool_id": "toolshed.g2.bx.psu.edu/repos/bgruening/deeptools_plot_fingerprint/deeptools_plot_fingerprint/3.0.2.0",
+      "tool_shed_repository": {
+        "changeset_revision": "a064962bb6e2",
+        "name": "deeptools_plot_fingerprint",
+        "owner": "bgruening",
+        "tool_shed": "toolshed.g2.bx.psu.edu"
+      },
+      "tool_state": "{\"__page__\": null, \"region\": \"\\\"chrX\\\"\", \"multibam_conditional\": \"{\\\"orderMatters\\\": \\\"No\\\", \\\"bamfiles\\\": {\\\"__class__\\\": \\\"RuntimeValue\\\"}, \\\"__current_case__\\\": 0}\", \"output\": \"{\\\"showOutputSettings\\\": \\\"no\\\", \\\"__current_case__\\\": 0}\", \"advancedOpt\": \"{\\\"ignoreDuplicates\\\": \\\"false\\\", \\\"centerReads\\\": \\\"false\\\", \\\"doExtendCustom\\\": {\\\"__current_case__\\\": 0, \\\"doExtend\\\": \\\"no\\\"}, \\\"minFragmentLength\\\": \\\"0\\\", \\\"samFlagExclude\\\": \\\"\\\", \\\"skipZeros\\\": \\\"false\\\", \\\"binSize\\\": \\\"500\\\", \\\"numberOfSamples\\\": \\\"10000\\\", \\\"showAdvancedOpt\\\": \\\"yes\\\", \\\"__current_case__\\\": 1, \\\"plotTitle\\\": \\\"\\\", \\\"samFlagInclude\\\": \\\"\\\", \\\"minMappingQuality\\\": \\\"1\\\", \\\"blackListFileName\\\": {\\\"__class__\\\": \\\"RuntimeValue\\\"}, \\\"maxFragmentLength\\\": \\\"0\\\"}\", \"chromInfo\": \"\\\"/usr/local/galaxy/galaxy-dist/tool-data/shared/ucsc/chrom/?.len\\\"\", \"__rerun_remap_job_id__\": null}",
+      "tool_version": "3.0.2.0",
+      "type": "tool",
+      "uuid": "2d1c6ddc-17c6-4e4b-89d0-4f4424958c00",
+      "workflow_outputs": []
+    },
+    "23": {
+      "annotation": "",
+      "content_id": "toolshed.g2.bx.psu.edu/repos/devteam/fastqc/fastqc/0.71",
+      "errors": null,
+      "id": 23,
+      "input_connections": {
+        "input_file": {
+          "id": 4,
+          "output_name": "output"
+        }
+      },
+      "inputs": [
+        {
+          "description": "runtime parameter for tool FastQC",
+          "name": "contaminants"
+        },
+        {
+          "description": "runtime parameter for tool FastQC",
+          "name": "limits"
+        },
+        {
+          "description": "runtime parameter for tool FastQC",
+          "name": "input_file"
+        }
+      ],
+      "label": null,
+      "name": "FastQC",
+      "outputs": [
+        {
+          "name": "html_file",
+          "type": "html"
+        },
+        {
+          "name": "text_file",
+          "type": "txt"
+        }
+      ],
+      "position": {
+        "left": 458,
+        "top": 1838
+      },
+      "post_job_actions": {
+        "HideDatasetActionhtml_file": {
+          "action_arguments": {},
+          "action_type": "HideDatasetAction",
+          "output_name": "html_file"
+        },
+        "HideDatasetActiontext_file": {
+          "action_arguments": {},
+          "action_type": "HideDatasetAction",
+          "output_name": "text_file"
+        }
+      },
+      "tool_id": "toolshed.g2.bx.psu.edu/repos/devteam/fastqc/fastqc/0.71",
+      "tool_shed_repository": {
+        "changeset_revision": "ff9530579d1f",
+        "name": "fastqc",
+        "owner": "devteam",
+        "tool_shed": "toolshed.g2.bx.psu.edu"
+      },
+      "tool_state": "{\"__page__\": null, \"contaminants\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\", \"__rerun_remap_job_id__\": null, \"limits\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\", \"input_file\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\"}",
+      "tool_version": "0.71",
+      "type": "tool",
+      "uuid": "0843bd80-453c-4908-ad94-1b7a788ee225",
+      "workflow_outputs": []
+    },
+    "24": {
+      "annotation": "",
+      "content_id": "toolshed.g2.bx.psu.edu/repos/bgruening/trim_galore/trim_galore/0.4.3.1",
+      "errors": null,
+      "id": 24,
+      "input_connections": {
+        "singlePaired|input_mate1": {
+          "id": 1,
+          "output_name": "output"
+        },
+        "singlePaired|input_mate2": {
+          "id": 4,
+          "output_name": "output"
+        }
+      },
+      "inputs": [
+        {
+          "description": "runtime parameter for tool Trim Galore!",
+          "name": "singlePaired"
+        },
+        {
+          "description": "runtime parameter for tool Trim Galore!",
+          "name": "singlePaired"
+        }
+      ],
+      "label": null,
+      "name": "Trim Galore!",
+      "outputs": [
+        {
+          "name": "trimmed_reads_paired_collection",
+          "type": "input"
+        },
+        {
+          "name": "trimmed_reads_unpaired_collection",
+          "type": "input"
+        },
+        {
+          "name": "trimmed_reads_single",
+          "type": "input"
+        },
+        {
+          "name": "trimmed_reads_pair1",
+          "type": "input"
+        },
+        {
+          "name": "trimmed_reads_pair2",
+          "type": "input"
+        },
+        {
+          "name": "unpaired_reads_1",
+          "type": "input"
+        },
+        {
+          "name": "unpaired_reads_2",
+          "type": "input"
+        },
+        {
+          "name": "report_file",
+          "type": "txt"
+        }
+      ],
+      "position": {
+        "left": 458,
+        "top": 2056
+      },
+      "post_job_actions": {
+        "HideDatasetActionreport_file": {
+          "action_arguments": {},
+          "action_type": "HideDatasetAction",
+          "output_name": "report_file"
+        },
+        "HideDatasetActiontrimmed_reads_pair1": {
+          "action_arguments": {},
+          "action_type": "HideDatasetAction",
+          "output_name": "trimmed_reads_pair1"
+        },
+        "HideDatasetActiontrimmed_reads_pair2": {
+          "action_arguments": {},
+          "action_type": "HideDatasetAction",
+          "output_name": "trimmed_reads_pair2"
+        },
+        "HideDatasetActiontrimmed_reads_paired_collection": {
+          "action_arguments": {},
+          "action_type": "HideDatasetAction",
+          "output_name": "trimmed_reads_paired_collection"
+        },
+        "HideDatasetActiontrimmed_reads_single": {
+          "action_arguments": {},
+          "action_type": "HideDatasetAction",
+          "output_name": "trimmed_reads_single"
+        },
+        "HideDatasetActiontrimmed_reads_unpaired_collection": {
+          "action_arguments": {},
+          "action_type": "HideDatasetAction",
+          "output_name": "trimmed_reads_unpaired_collection"
+        },
+        "HideDatasetActionunpaired_reads_1": {
+          "action_arguments": {},
+          "action_type": "HideDatasetAction",
+          "output_name": "unpaired_reads_1"
+        },
+        "HideDatasetActionunpaired_reads_2": {
+          "action_arguments": {},
+          "action_type": "HideDatasetAction",
+          "output_name": "unpaired_reads_2"
+        }
+      },
+      "tool_id": "toolshed.g2.bx.psu.edu/repos/bgruening/trim_galore/trim_galore/0.4.3.1",
+      "tool_shed_repository": {
+        "changeset_revision": "949f01671246",
+        "name": "trim_galore",
+        "owner": "bgruening",
+        "tool_shed": "toolshed.g2.bx.psu.edu"
+      },
+      "tool_state": "{\"__page__\": null, \"__rerun_remap_job_id__\": null, \"params\": \"{\\\"min_length\\\": \\\"20\\\", \\\"stringency\\\": \\\"3\\\", \\\"error_rate\\\": \\\"0.1\\\", \\\"retain_unpaired\\\": {\\\"retain_unpaired_select\\\": \\\"no_output\\\", \\\"__current_case__\\\": 0}, \\\"__current_case__\\\": 1, \\\"report\\\": \\\"true\\\", \\\"settingsType\\\": \\\"custom\\\", \\\"quality\\\": \\\"15\\\", \\\"clip_R1\\\": \\\"\\\", \\\"clip_R2\\\": \\\"\\\"}\", \"rrbs\": \"{\\\"settingsType\\\": \\\"default\\\", \\\"__current_case__\\\": 0}\", \"singlePaired\": \"{\\\"three_prime_clip_R1\\\": \\\"\\\", \\\"three_prime_clip_R2\\\": \\\"\\\", \\\"input_mate2\\\": {\\\"__class__\\\": \\\"RuntimeValue\\\"}, \\\"input_mate1\\\": {\\\"__class__\\\": \\\"RuntimeValue\\\"}, \\\"sPaired\\\": \\\"paired\\\", \\\"__current_case__\\\": 1, \\\"trim1\\\": \\\"false\\\", \\\"trimming\\\": {\\\"trimming_select\\\": \\\"\\\", \\\"__current_case__\\\": 0}}\"}",
+      "tool_version": "0.4.3.1",
+      "type": "tool",
+      "uuid": "3e7e49c2-1583-4c96-878b-0760558c2b43",
+      "workflow_outputs": []
+    },
+    "25": {
+      "annotation": "",
+      "content_id": "toolshed.g2.bx.psu.edu/repos/bgruening/deeptools_bam_compare/deeptools_bam_compare/3.0.2.0",
+      "errors": null,
+      "id": 25,
+      "input_connections": {
+        "bamFile1": {
+          "id": 8,
+          "output_name": "output"
+        },
+        "bamFile2": {
+          "id": 5,
+          "output_name": "output"
+        }
+      },
+      "inputs": [
+        {
+          "description": "runtime parameter for tool bamCompare",
+          "name": "bamFile2"
+        },
+        {
+          "description": "runtime parameter for tool bamCompare",
+          "name": "bamFile1"
+        }
+      ],
+      "label": null,
+      "name": "bamCompare",
+      "outputs": [
+        {
+          "name": "outFileName",
+          "type": "bigwig"
+        }
+      ],
+      "position": {
+        "left": 458,
+        "top": 4002
+      },
+      "post_job_actions": {
+        "HideDatasetActionoutFileName": {
+          "action_arguments": {},
+          "action_type": "HideDatasetAction",
+          "output_name": "outFileName"
+        }
+      },
+      "tool_id": "toolshed.g2.bx.psu.edu/repos/bgruening/deeptools_bam_compare/deeptools_bam_compare/3.0.2.0",
+      "tool_shed_repository": {
+        "changeset_revision": "439e75416e1a",
+        "name": "deeptools_bam_compare",
+        "owner": "bgruening",
+        "tool_shed": "toolshed.g2.bx.psu.edu"
+      },
+      "tool_state": "{\"comparison\": \"{\\\"pseudocount\\\": \\\"1.0\\\", \\\"type\\\": \\\"log2\\\", \\\"__current_case__\\\": 0}\", \"bamFile2\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\", \"outFileFormat\": \"\\\"bigwig\\\"\", \"bamFile1\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\", \"__page__\": null, \"region\": \"\\\"chrX\\\"\", \"binSize\": \"\\\"50\\\"\", \"scaling\": \"{\\\"method\\\": \\\"readCount\\\", \\\"__current_case__\\\": 1}\", \"advancedOpt\": \"{\\\"showAdvancedOpt\\\": \\\"no\\\", \\\"__current_case__\\\": 0}\", \"chromInfo\": \"\\\"/usr/local/galaxy/galaxy-dist/tool-data/shared/ucsc/chrom/?.len\\\"\", \"__rerun_remap_job_id__\": null}",
+      "tool_version": "3.0.2.0",
+      "type": "tool",
+      "uuid": "ce760066-f24e-4416-a16b-3e128b541e7d",
+      "workflow_outputs": []
+    },
+    "26": {
+      "annotation": "",
+      "content_id": "toolshed.g2.bx.psu.edu/repos/bgruening/deeptools_bam_compare/deeptools_bam_compare/3.0.2.0",
+      "errors": null,
+      "id": 26,
+      "input_connections": {
+        "bamFile1": {
+          "id": 8,
+          "output_name": "output"
+        },
+        "bamFile2": {
+          "id": 6,
+          "output_name": "output"
+        }
+      },
+      "inputs": [
+        {
+          "description": "runtime parameter for tool bamCompare",
+          "name": "bamFile2"
+        },
+        {
+          "description": "runtime parameter for tool bamCompare",
+          "name": "bamFile1"
+        }
+      ],
+      "label": null,
+      "name": "bamCompare",
+      "outputs": [
+        {
+          "name": "outFileName",
+          "type": "bigwig"
+        }
+      ],
+      "position": {
+        "left": 458,
+        "top": 4182
+      },
+      "post_job_actions": {
+        "HideDatasetActionoutFileName": {
+          "action_arguments": {},
+          "action_type": "HideDatasetAction",
+          "output_name": "outFileName"
+        }
+      },
+      "tool_id": "toolshed.g2.bx.psu.edu/repos/bgruening/deeptools_bam_compare/deeptools_bam_compare/3.0.2.0",
+      "tool_shed_repository": {
+        "changeset_revision": "439e75416e1a",
+        "name": "deeptools_bam_compare",
+        "owner": "bgruening",
+        "tool_shed": "toolshed.g2.bx.psu.edu"
+      },
+      "tool_state": "{\"comparison\": \"{\\\"pseudocount\\\": \\\"1.0\\\", \\\"type\\\": \\\"log2\\\", \\\"__current_case__\\\": 0}\", \"bamFile2\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\", \"outFileFormat\": \"\\\"bigwig\\\"\", \"bamFile1\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\", \"__page__\": null, \"region\": \"\\\"chrX\\\"\", \"binSize\": \"\\\"50\\\"\", \"scaling\": \"{\\\"method\\\": \\\"readCount\\\", \\\"__current_case__\\\": 1}\", \"advancedOpt\": \"{\\\"showAdvancedOpt\\\": \\\"no\\\", \\\"__current_case__\\\": 0}\", \"chromInfo\": \"\\\"/usr/local/galaxy/galaxy-dist/tool-data/shared/ucsc/chrom/?.len\\\"\", \"__rerun_remap_job_id__\": null}",
+      "tool_version": "3.0.2.0",
+      "type": "tool",
+      "uuid": "f1ed2220-c932-4e7b-949c-af1159d605a4",
+      "workflow_outputs": []
+    },
+    "27": {
+      "annotation": "",
+      "content_id": "toolshed.g2.bx.psu.edu/repos/bgruening/deeptools_bam_compare/deeptools_bam_compare/3.0.2.0",
+      "errors": null,
+      "id": 27,
+      "input_connections": {
+        "bamFile1": {
+          "id": 8,
+          "output_name": "output"
+        },
+        "bamFile2": {
+          "id": 7,
+          "output_name": "output"
+        }
+      },
+      "inputs": [
+        {
+          "description": "runtime parameter for tool bamCompare",
+          "name": "bamFile2"
+        },
+        {
+          "description": "runtime parameter for tool bamCompare",
+          "name": "bamFile1"
+        }
+      ],
+      "label": null,
+      "name": "bamCompare",
+      "outputs": [
+        {
+          "name": "outFileName",
+          "type": "bigwig"
+        }
+      ],
+      "position": {
+        "left": 458,
+        "top": 4362
+      },
+      "post_job_actions": {
+        "HideDatasetActionoutFileName": {
+          "action_arguments": {},
+          "action_type": "HideDatasetAction",
+          "output_name": "outFileName"
+        }
+      },
+      "tool_id": "toolshed.g2.bx.psu.edu/repos/bgruening/deeptools_bam_compare/deeptools_bam_compare/3.0.2.0",
+      "tool_shed_repository": {
+        "changeset_revision": "439e75416e1a",
+        "name": "deeptools_bam_compare",
+        "owner": "bgruening",
+        "tool_shed": "toolshed.g2.bx.psu.edu"
+      },
+      "tool_state": "{\"comparison\": \"{\\\"pseudocount\\\": \\\"1.0\\\", \\\"type\\\": \\\"log2\\\", \\\"__current_case__\\\": 0}\", \"bamFile2\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\", \"outFileFormat\": \"\\\"bigwig\\\"\", \"bamFile1\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\", \"__page__\": null, \"region\": \"\\\"chrX\\\"\", \"binSize\": \"\\\"50\\\"\", \"scaling\": \"{\\\"method\\\": \\\"readCount\\\", \\\"__current_case__\\\": 1}\", \"advancedOpt\": \"{\\\"showAdvancedOpt\\\": \\\"no\\\", \\\"__current_case__\\\": 0}\", \"chromInfo\": \"\\\"/usr/local/galaxy/galaxy-dist/tool-data/shared/ucsc/chrom/?.len\\\"\", \"__rerun_remap_job_id__\": null}",
+      "tool_version": "3.0.2.0",
+      "type": "tool",
+      "uuid": "dd544d91-27c3-42bc-aa3e-59d9cb1f6de0",
+      "workflow_outputs": []
+    },
+    "28": {
+      "annotation": "",
+      "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/macs2/macs2_callpeak/2.1.1.20160309.4",
+      "errors": null,
+      "id": 28,
+      "input_connections": {
+        "control|c_multiple|input_control_file": {
+          "id": 8,
+          "output_name": "output"
+        },
+        "treatment|input_treatment_file": {
+          "id": 5,
+          "output_name": "output"
+        }
+      },
+      "inputs": [
+        {
+          "description": "runtime parameter for tool MACS2 callpeak",
+          "name": "treatment"
+        }
+      ],
+      "label": null,
+      "name": "MACS2 callpeak",
+      "outputs": [
+        {
+          "name": "output_tabular",
+          "type": "tabular"
+        },
+        {
+          "name": "output_broadpeaks",
+          "type": "bed"
+        },
+        {
+          "name": "output_gappedpeaks",
+          "type": "bed"
+        },
+        {
+          "name": "output_narrowpeaks",
+          "type": "bed"
+        },
+        {
+          "name": "output_summits",
+          "type": "bed"
+        },
+        {
+          "name": "output_plot",
+          "type": "pdf"
+        },
+        {
+          "name": "output_treat_pileup",
+          "type": "bedgraph"
+        },
+        {
+          "name": "output_control_lambda",
+          "type": "bedgraph"
+        },
+        {
+          "name": "output_extra_files",
+          "type": "html"
+        }
+      ],
+      "position": {
+        "left": 458,
+        "top": 4542
+      },
+      "post_job_actions": {
+        "HideDatasetActionoutput_broadpeaks": {
+          "action_arguments": {},
+          "action_type": "HideDatasetAction",
+          "output_name": "output_broadpeaks"
+        },
+        "HideDatasetActionoutput_control_lambda": {
+          "action_arguments": {},
+          "action_type": "HideDatasetAction",
+          "output_name": "output_control_lambda"
+        },
+        "HideDatasetActionoutput_extra_files": {
+          "action_arguments": {},
+          "action_type": "HideDatasetAction",
+          "output_name": "output_extra_files"
+        },
+        "HideDatasetActionoutput_gappedpeaks": {
+          "action_arguments": {},
+          "action_type": "HideDatasetAction",
+          "output_name": "output_gappedpeaks"
+        },
+        "HideDatasetActionoutput_narrowpeaks": {
+          "action_arguments": {},
+          "action_type": "HideDatasetAction",
+          "output_name": "output_narrowpeaks"
+        },
+        "HideDatasetActionoutput_plot": {
+          "action_arguments": {},
+          "action_type": "HideDatasetAction",
+          "output_name": "output_plot"
+        },
+        "HideDatasetActionoutput_summits": {
+          "action_arguments": {},
+          "action_type": "HideDatasetAction",
+          "output_name": "output_summits"
+        },
+        "HideDatasetActionoutput_tabular": {
+          "action_arguments": {},
+          "action_type": "HideDatasetAction",
+          "output_name": "output_tabular"
+        },
+        "HideDatasetActionoutput_treat_pileup": {
+          "action_arguments": {},
+          "action_type": "HideDatasetAction",
+          "output_name": "output_treat_pileup"
+        }
+      },
+      "tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/macs2/macs2_callpeak/2.1.1.20160309.4",
+      "tool_shed_repository": {
+        "changeset_revision": "c16dbe4e2db2",
+        "name": "macs2",
+        "owner": "iuc",
+        "tool_shed": "toolshed.g2.bx.psu.edu"
+      },
+      "tool_state": "{\"control\": \"{\\\"c_multiple\\\": {\\\"input_control_file\\\": {\\\"__class__\\\": \\\"RuntimeValue\\\"}, \\\"c_multi_select\\\": \\\"No\\\", \\\"__current_case__\\\": 0}, \\\"__current_case__\\\": 0, \\\"c_select\\\": \\\"Yes\\\"}\", \"__page__\": null, \"effective_genome_size_options\": \"{\\\"effective_genome_size_options_selector\\\": \\\"1870000000\\\", \\\"__current_case__\\\": 1}\", \"format\": \"\\\"BAMPE\\\"\", \"outputs\": \"null\", \"__rerun_remap_job_id__\": null, \"cutoff_options\": \"{\\\"cutoff_options_selector\\\": \\\"qvalue\\\", \\\"qvalue\\\": \\\"0.05\\\", \\\"__current_case__\\\": 1}\", \"advanced_options\": \"{\\\"slocal\\\": \\\"\\\", \\\"ratio\\\": \\\"\\\", \\\"to_large\\\": \\\"false\\\", \\\"keep_dup_options\\\": {\\\"__current_case__\\\": 1, \\\"keep_dup_options_selector\\\": \\\"1\\\"}, \\\"broad_options\\\": {\\\"broad_options_selector\\\": \\\"nobroad\\\", \\\"call_summits\\\": \\\"false\\\", \\\"__current_case__\\\": 1}, \\\"nolambda\\\": \\\"false\\\", \\\"llocal\\\": \\\"\\\"}\", \"treatment\": \"{\\\"input_treatment_file\\\": {\\\"__class__\\\": \\\"RuntimeValue\\\"}, \\\"__current_case__\\\": 0, \\\"t_multi_select\\\": \\\"No\\\"}\", \"nomodel_type\": \"{\\\"nomodel_type_selector\\\": \\\"create_model\\\", \\\"mfold_lower\\\": \\\"5\\\", \\\"mfold_upper\\\": \\\"50\\\", \\\"band_width\\\": \\\"300\\\", \\\"__current_case__\\\": 0}\", \"chromInfo\": \"\\\"/usr/local/galaxy/galaxy-dist/tool-data/shared/ucsc/chrom/?.len\\\"\"}",
+      "tool_version": "2.1.1.20160309.4",
+      "type": "tool",
+      "uuid": "1e3cd8b1-babd-4d42-952b-cba44a94e6aa",
+      "workflow_outputs": []
+    },
+    "29": {
+      "annotation": "",
+      "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/macs2/macs2_callpeak/2.1.1.20160309.4",
+      "errors": null,
+      "id": 29,
+      "input_connections": {
+        "control|c_multiple|input_control_file": {
+          "id": 8,
+          "output_name": "output"
+        },
+        "treatment|input_treatment_file": {
+          "id": 6,
+          "output_name": "output"
+        }
+      },
+      "inputs": [
+        {
+          "description": "runtime parameter for tool MACS2 callpeak",
+          "name": "treatment"
+        }
+      ],
+      "label": null,
+      "name": "MACS2 callpeak",
+      "outputs": [
+        {
+          "name": "output_tabular",
+          "type": "tabular"
+        },
+        {
+          "name": "output_broadpeaks",
+          "type": "bed"
+        },
+        {
+          "name": "output_gappedpeaks",
+          "type": "bed"
+        },
+        {
+          "name": "output_narrowpeaks",
+          "type": "bed"
+        },
+        {
+          "name": "output_summits",
+          "type": "bed"
+        },
+        {
+          "name": "output_plot",
+          "type": "pdf"
+        },
+        {
+          "name": "output_treat_pileup",
+          "type": "bedgraph"
+        },
+        {
+          "name": "output_control_lambda",
+          "type": "bedgraph"
+        },
+        {
+          "name": "output_extra_files",
+          "type": "html"
+        }
+      ],
+      "position": {
+        "left": 458,
+        "top": 4910
+      },
+      "post_job_actions": {
+        "HideDatasetActionoutput_broadpeaks": {
+          "action_arguments": {},
+          "action_type": "HideDatasetAction",
+          "output_name": "output_broadpeaks"
+        },
+        "HideDatasetActionoutput_control_lambda": {
+          "action_arguments": {},
+          "action_type": "HideDatasetAction",
+          "output_name": "output_control_lambda"
+        },
+        "HideDatasetActionoutput_extra_files": {
+          "action_arguments": {},
+          "action_type": "HideDatasetAction",
+          "output_name": "output_extra_files"
+        },
+        "HideDatasetActionoutput_gappedpeaks": {
+          "action_arguments": {},
+          "action_type": "HideDatasetAction",
+          "output_name": "output_gappedpeaks"
+        },
+        "HideDatasetActionoutput_narrowpeaks": {
+          "action_arguments": {},
+          "action_type": "HideDatasetAction",
+          "output_name": "output_narrowpeaks"
+        },
+        "HideDatasetActionoutput_plot": {
+          "action_arguments": {},
+          "action_type": "HideDatasetAction",
+          "output_name": "output_plot"
+        },
+        "HideDatasetActionoutput_summits": {
+          "action_arguments": {},
+          "action_type": "HideDatasetAction",
+          "output_name": "output_summits"
+        },
+        "HideDatasetActionoutput_tabular": {
+          "action_arguments": {},
+          "action_type": "HideDatasetAction",
+          "output_name": "output_tabular"
+        },
+        "HideDatasetActionoutput_treat_pileup": {
+          "action_arguments": {},
+          "action_type": "HideDatasetAction",
+          "output_name": "output_treat_pileup"
+        }
+      },
+      "tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/macs2/macs2_callpeak/2.1.1.20160309.4",
+      "tool_shed_repository": {
+        "changeset_revision": "c16dbe4e2db2",
+        "name": "macs2",
+        "owner": "iuc",
+        "tool_shed": "toolshed.g2.bx.psu.edu"
+      },
+      "tool_state": "{\"control\": \"{\\\"c_multiple\\\": {\\\"input_control_file\\\": {\\\"__class__\\\": \\\"RuntimeValue\\\"}, \\\"c_multi_select\\\": \\\"No\\\", \\\"__current_case__\\\": 0}, \\\"__current_case__\\\": 0, \\\"c_select\\\": \\\"Yes\\\"}\", \"__page__\": null, \"effective_genome_size_options\": \"{\\\"effective_genome_size_options_selector\\\": \\\"1870000000\\\", \\\"__current_case__\\\": 1}\", \"format\": \"\\\"BAMPE\\\"\", \"outputs\": \"null\", \"__rerun_remap_job_id__\": null, \"cutoff_options\": \"{\\\"cutoff_options_selector\\\": \\\"qvalue\\\", \\\"qvalue\\\": \\\"0.05\\\", \\\"__current_case__\\\": 1}\", \"advanced_options\": \"{\\\"slocal\\\": \\\"\\\", \\\"ratio\\\": \\\"\\\", \\\"to_large\\\": \\\"false\\\", \\\"keep_dup_options\\\": {\\\"__current_case__\\\": 1, \\\"keep_dup_options_selector\\\": \\\"1\\\"}, \\\"broad_options\\\": {\\\"broad_options_selector\\\": \\\"nobroad\\\", \\\"call_summits\\\": \\\"false\\\", \\\"__current_case__\\\": 1}, \\\"nolambda\\\": \\\"false\\\", \\\"llocal\\\": \\\"\\\"}\", \"treatment\": \"{\\\"input_treatment_file\\\": {\\\"__class__\\\": \\\"RuntimeValue\\\"}, \\\"__current_case__\\\": 0, \\\"t_multi_select\\\": \\\"No\\\"}\", \"nomodel_type\": \"{\\\"nomodel_type_selector\\\": \\\"create_model\\\", \\\"mfold_lower\\\": \\\"5\\\", \\\"mfold_upper\\\": \\\"50\\\", \\\"band_width\\\": \\\"300\\\", \\\"__current_case__\\\": 0}\", \"chromInfo\": \"\\\"/usr/local/galaxy/galaxy-dist/tool-data/shared/ucsc/chrom/?.len\\\"\"}",
+      "tool_version": "2.1.1.20160309.4",
+      "type": "tool",
+      "uuid": "516eb83a-4e89-4788-8781-16d7bbff93cc",
+      "workflow_outputs": []
+    },
+    "3": {
+      "annotation": "",
+      "content_id": null,
+      "errors": null,
+      "id": 3,
+      "input_connections": {},
+      "inputs": [],
+      "label": "wt_H3K4me3_rep1",
+      "name": "Input dataset",
+      "outputs": [],
+      "position": {
+        "left": 200,
+        "top": 689
+      },
+      "tool_id": null,
+      "tool_state": "{}",
+      "tool_version": null,
+      "type": "data_input",
+      "uuid": "03e6848c-1ed2-4025-a2bc-062b986fdf07",
+      "workflow_outputs": [
+        {
+          "label": null,
+          "output_name": "output",
+          "uuid": "27a07d42-9ac0-427c-a37e-335032cd6a48"
+        }
+      ]
+    },
+    "30": {
+      "annotation": "",
+      "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/macs2/macs2_callpeak/2.1.1.20160309.4",
+      "errors": null,
+      "id": 30,
+      "input_connections": {
+        "control|c_multiple|input_control_file": {
+          "id": 8,
+          "output_name": "output"
+        },
+        "treatment|input_treatment_file": {
+          "id": 7,
+          "output_name": "output"
+        }
+      },
+      "inputs": [
+        {
+          "description": "runtime parameter for tool MACS2 callpeak",
+          "name": "treatment"
+        }
+      ],
+      "label": null,
+      "name": "MACS2 callpeak",
+      "outputs": [
+        {
+          "name": "output_tabular",
+          "type": "tabular"
+        },
+        {
+          "name": "output_broadpeaks",
+          "type": "bed"
+        },
+        {
+          "name": "output_gappedpeaks",
+          "type": "bed"
+        },
+        {
+          "name": "output_narrowpeaks",
+          "type": "bed"
+        },
+        {
+          "name": "output_summits",
+          "type": "bed"
+        },
+        {
+          "name": "output_plot",
+          "type": "pdf"
+        },
+        {
+          "name": "output_treat_pileup",
+          "type": "bedgraph"
+        },
+        {
+          "name": "output_control_lambda",
+          "type": "bedgraph"
+        },
+        {
+          "name": "output_extra_files",
+          "type": "html"
+        }
+      ],
+      "position": {
+        "left": 458,
+        "top": 5278
+      },
+      "post_job_actions": {
+        "HideDatasetActionoutput_broadpeaks": {
+          "action_arguments": {},
+          "action_type": "HideDatasetAction",
+          "output_name": "output_broadpeaks"
+        },
+        "HideDatasetActionoutput_control_lambda": {
+          "action_arguments": {},
+          "action_type": "HideDatasetAction",
+          "output_name": "output_control_lambda"
+        },
+        "HideDatasetActionoutput_extra_files": {
+          "action_arguments": {},
+          "action_type": "HideDatasetAction",
+          "output_name": "output_extra_files"
+        },
+        "HideDatasetActionoutput_gappedpeaks": {
+          "action_arguments": {},
+          "action_type": "HideDatasetAction",
+          "output_name": "output_gappedpeaks"
+        },
+        "HideDatasetActionoutput_narrowpeaks": {
+          "action_arguments": {},
+          "action_type": "HideDatasetAction",
+          "output_name": "output_narrowpeaks"
+        },
+        "HideDatasetActionoutput_plot": {
+          "action_arguments": {},
+          "action_type": "HideDatasetAction",
+          "output_name": "output_plot"
+        },
+        "HideDatasetActionoutput_summits": {
+          "action_arguments": {},
+          "action_type": "HideDatasetAction",
+          "output_name": "output_summits"
+        },
+        "HideDatasetActionoutput_tabular": {
+          "action_arguments": {},
+          "action_type": "HideDatasetAction",
+          "output_name": "output_tabular"
+        },
+        "HideDatasetActionoutput_treat_pileup": {
+          "action_arguments": {},
+          "action_type": "HideDatasetAction",
+          "output_name": "output_treat_pileup"
+        }
+      },
+      "tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/macs2/macs2_callpeak/2.1.1.20160309.4",
+      "tool_shed_repository": {
+        "changeset_revision": "c16dbe4e2db2",
+        "name": "macs2",
+        "owner": "iuc",
+        "tool_shed": "toolshed.g2.bx.psu.edu"
+      },
+      "tool_state": "{\"control\": \"{\\\"c_multiple\\\": {\\\"input_control_file\\\": {\\\"__class__\\\": \\\"RuntimeValue\\\"}, \\\"c_multi_select\\\": \\\"No\\\", \\\"__current_case__\\\": 0}, \\\"__current_case__\\\": 0, \\\"c_select\\\": \\\"Yes\\\"}\", \"__page__\": null, \"effective_genome_size_options\": \"{\\\"effective_genome_size_options_selector\\\": \\\"1870000000\\\", \\\"__current_case__\\\": 1}\", \"format\": \"\\\"BAMPE\\\"\", \"outputs\": \"null\", \"__rerun_remap_job_id__\": null, \"cutoff_options\": \"{\\\"cutoff_options_selector\\\": \\\"qvalue\\\", \\\"qvalue\\\": \\\"0.05\\\", \\\"__current_case__\\\": 1}\", \"advanced_options\": \"{\\\"slocal\\\": \\\"\\\", \\\"ratio\\\": \\\"\\\", \\\"to_large\\\": \\\"false\\\", \\\"keep_dup_options\\\": {\\\"__current_case__\\\": 1, \\\"keep_dup_options_selector\\\": \\\"1\\\"}, \\\"broad_options\\\": {\\\"broad_options_selector\\\": \\\"nobroad\\\", \\\"call_summits\\\": \\\"false\\\", \\\"__current_case__\\\": 1}, \\\"nolambda\\\": \\\"false\\\", \\\"llocal\\\": \\\"\\\"}\", \"treatment\": \"{\\\"input_treatment_file\\\": {\\\"__class__\\\": \\\"RuntimeValue\\\"}, \\\"__current_case__\\\": 0, \\\"t_multi_select\\\": \\\"No\\\"}\", \"nomodel_type\": \"{\\\"nomodel_type_selector\\\": \\\"create_model\\\", \\\"mfold_lower\\\": \\\"5\\\", \\\"mfold_upper\\\": \\\"50\\\", \\\"band_width\\\": \\\"300\\\", \\\"__current_case__\\\": 0}\", \"chromInfo\": \"\\\"/usr/local/galaxy/galaxy-dist/tool-data/shared/ucsc/chrom/?.len\\\"\"}",
+      "tool_version": "2.1.1.20160309.4",
+      "type": "tool",
+      "uuid": "5b72407b-a349-413c-8bfb-24ad00977da5",
+      "workflow_outputs": []
+    },
+    "31": {
+      "annotation": "",
+      "content_id": "toolshed.g2.bx.psu.edu/repos/bgruening/deeptools_multi_bam_summary/deeptools_multi_bam_summary/3.0.2.0",
+      "errors": null,
+      "id": 31,
+      "input_connections": {
+        "multibam_conditional|bamfiles": [
+          {
+            "id": 0,
+            "output_name": "output"
+          },
+          {
+            "id": 8,
+            "output_name": "output"
+          },
+          {
+            "id": 5,
+            "output_name": "output"
+          },
+          {
+            "id": 6,
+            "output_name": "output"
+          },
+          {
+            "id": 9,
+            "output_name": "output"
+          },
+          {
+            "id": 3,
+            "output_name": "output"
+          },
+          {
+            "id": 8,
+            "output_name": "output"
+          },
+          {
+            "id": 7,
+            "output_name": "output"
+          },
+          {
+            "id": 2,
+            "output_name": "output"
+          }
+        ]
+      },
+      "inputs": [
+        {
+          "description": "runtime parameter for tool multiBamSummary",
+          "name": "multibam_conditional"
+        }
+      ],
+      "label": null,
+      "name": "multiBamSummary",
+      "outputs": [
+        {
+          "name": "outFile",
+          "type": "deeptools_coverage_matrix"
+        },
+        {
+          "name": "outFileRawCounts",
+          "type": "tabular"
+        }
+      ],
+      "position": {
+        "left": 458,
+        "top": 1276
+      },
+      "post_job_actions": {
+        "HideDatasetActionoutFile": {
+          "action_arguments": {},
+          "action_type": "HideDatasetAction",
+          "output_name": "outFile"
+        },
+        "HideDatasetActionoutFileRawCounts": {
+          "action_arguments": {},
+          "action_type": "HideDatasetAction",
+          "output_name": "outFileRawCounts"
+        }
+      },
+      "tool_id": "toolshed.g2.bx.psu.edu/repos/bgruening/deeptools_multi_bam_summary/deeptools_multi_bam_summary/3.0.2.0",
+      "tool_shed_repository": {
+        "changeset_revision": "6dfe9740ffc5",
+        "name": "deeptools_multi_bam_summary",
+        "owner": "bgruening",
+        "tool_shed": "toolshed.g2.bx.psu.edu"
+      },
+      "tool_state": "{\"__page__\": null, \"region\": \"\\\"chrX\\\"\", \"mode\": \"{\\\"binSize\\\": \\\"1000\\\", \\\"distanceBetweenBins\\\": \\\"500\\\", \\\"__current_case__\\\": 0, \\\"modeOpt\\\": \\\"bins\\\"}\", \"multibam_conditional\": \"{\\\"orderMatters\\\": \\\"No\\\", \\\"bamfiles\\\": {\\\"__class__\\\": \\\"RuntimeValue\\\"}, \\\"__current_case__\\\": 0}\", \"advancedOpt\": \"{\\\"showAdvancedOpt\\\": \\\"no\\\", \\\"__current_case__\\\": 0}\", \"chromInfo\": \"\\\"/usr/local/galaxy/galaxy-dist/tool-data/shared/ucsc/chrom/?.len\\\"\", \"__rerun_remap_job_id__\": null, \"outRawCounts\": \"\\\"false\\\"\"}",
+      "tool_version": "3.0.2.0",
+      "type": "tool",
+      "uuid": "cfa0325f-b9db-4fa9-b6e1-1c1191235e9e",
+      "workflow_outputs": []
+    },
+    "32": {
+      "annotation": "",
+      "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/macs2/macs2_callpeak/2.1.1.20160309.4",
+      "errors": null,
+      "id": 32,
+      "input_connections": {
+        "control|c_multiple|input_control_file": {
+          "id": 0,
+          "output_name": "output"
+        },
+        "treatment|input_treatment_file": {
+          "id": 9,
+          "output_name": "output"
+        }
+      },
+      "inputs": [
+        {
+          "description": "runtime parameter for tool MACS2 callpeak",
+          "name": "treatment"
+        }
+      ],
+      "label": null,
+      "name": "MACS2 callpeak",
+      "outputs": [
+        {
+          "name": "output_tabular",
+          "type": "tabular"
+        },
+        {
+          "name": "output_broadpeaks",
+          "type": "bed"
+        },
+        {
+          "name": "output_gappedpeaks",
+          "type": "bed"
+        },
+        {
+          "name": "output_narrowpeaks",
+          "type": "bed"
+        },
+        {
+          "name": "output_summits",
+          "type": "bed"
+        },
+        {
+          "name": "output_plot",
+          "type": "pdf"
+        },
+        {
+          "name": "output_treat_pileup",
+          "type": "bedgraph"
+        },
+        {
+          "name": "output_control_lambda",
+          "type": "bedgraph"
+        },
+        {
+          "name": "output_extra_files",
+          "type": "html"
+        }
+      ],
+      "position": {
+        "left": 458,
+        "top": 2396
+      },
+      "post_job_actions": {
+        "HideDatasetActionoutput_broadpeaks": {
+          "action_arguments": {},
+          "action_type": "HideDatasetAction",
+          "output_name": "output_broadpeaks"
+        },
+        "HideDatasetActionoutput_control_lambda": {
+          "action_arguments": {},
+          "action_type": "HideDatasetAction",
+          "output_name": "output_control_lambda"
+        },
+        "HideDatasetActionoutput_extra_files": {
+          "action_arguments": {},
+          "action_type": "HideDatasetAction",
+          "output_name": "output_extra_files"
+        },
+        "HideDatasetActionoutput_gappedpeaks": {
+          "action_arguments": {},
+          "action_type": "HideDatasetAction",
+          "output_name": "output_gappedpeaks"
+        },
+        "HideDatasetActionoutput_narrowpeaks": {
+          "action_arguments": {},
+          "action_type": "HideDatasetAction",
+          "output_name": "output_narrowpeaks"
+        },
+        "HideDatasetActionoutput_plot": {
+          "action_arguments": {},
+          "action_type": "HideDatasetAction",
+          "output_name": "output_plot"
+        },
+        "HideDatasetActionoutput_summits": {
+          "action_arguments": {},
+          "action_type": "HideDatasetAction",
+          "output_name": "output_summits"
+        },
+        "HideDatasetActionoutput_tabular": {
+          "action_arguments": {},
+          "action_type": "HideDatasetAction",
+          "output_name": "output_tabular"
+        },
+        "HideDatasetActionoutput_treat_pileup": {
+          "action_arguments": {},
+          "action_type": "HideDatasetAction",
+          "output_name": "output_treat_pileup"
+        }
+      },
+      "tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/macs2/macs2_callpeak/2.1.1.20160309.4",
+      "tool_shed_repository": {
+        "changeset_revision": "c16dbe4e2db2",
+        "name": "macs2",
+        "owner": "iuc",
+        "tool_shed": "toolshed.g2.bx.psu.edu"
+      },
+      "tool_state": "{\"control\": \"{\\\"c_multiple\\\": {\\\"input_control_file\\\": {\\\"__class__\\\": \\\"RuntimeValue\\\"}, \\\"c_multi_select\\\": \\\"No\\\", \\\"__current_case__\\\": 0}, \\\"__current_case__\\\": 0, \\\"c_select\\\": \\\"Yes\\\"}\", \"__page__\": null, \"effective_genome_size_options\": \"{\\\"effective_genome_size_options_selector\\\": \\\"1870000000\\\", \\\"__current_case__\\\": 1}\", \"format\": \"\\\"BAMPE\\\"\", \"outputs\": \"null\", \"__rerun_remap_job_id__\": null, \"cutoff_options\": \"{\\\"cutoff_options_selector\\\": \\\"qvalue\\\", \\\"qvalue\\\": \\\"0.05\\\", \\\"__current_case__\\\": 1}\", \"advanced_options\": \"{\\\"slocal\\\": \\\"\\\", \\\"ratio\\\": \\\"\\\", \\\"to_large\\\": \\\"false\\\", \\\"keep_dup_options\\\": {\\\"__current_case__\\\": 1, \\\"keep_dup_options_selector\\\": \\\"1\\\"}, \\\"broad_options\\\": {\\\"broad_options_selector\\\": \\\"nobroad\\\", \\\"call_summits\\\": \\\"false\\\", \\\"__current_case__\\\": 1}, \\\"nolambda\\\": \\\"false\\\", \\\"llocal\\\": \\\"\\\"}\", \"treatment\": \"{\\\"input_treatment_file\\\": {\\\"__class__\\\": \\\"RuntimeValue\\\"}, \\\"__current_case__\\\": 0, \\\"t_multi_select\\\": \\\"No\\\"}\", \"nomodel_type\": \"{\\\"nomodel_type_selector\\\": \\\"create_model\\\", \\\"mfold_lower\\\": \\\"5\\\", \\\"mfold_upper\\\": \\\"50\\\", \\\"band_width\\\": \\\"300\\\", \\\"__current_case__\\\": 0}\", \"chromInfo\": \"\\\"/usr/local/galaxy/galaxy-dist/tool-data/shared/ucsc/chrom/?.len\\\"\"}",
+      "tool_version": "2.1.1.20160309.4",
+      "type": "tool",
+      "uuid": "6f017ce1-2627-4b2b-b2f9-fec55cb9d89a",
+      "workflow_outputs": []
+    },
+    "33": {
+      "annotation": "",
+      "content_id": "toolshed.g2.bx.psu.edu/repos/bgruening/deeptools_bam_compare/deeptools_bam_compare/3.0.2.0",
+      "errors": null,
+      "id": 33,
+      "input_connections": {
+        "bamFile1": {
+          "id": 9,
+          "output_name": "output"
+        },
+        "bamFile2": {
+          "id": 0,
+          "output_name": "output"
+        }
+      },
+      "inputs": [
+        {
+          "description": "runtime parameter for tool bamCompare",
+          "name": "bamFile2"
+        },
+        {
+          "description": "runtime parameter for tool bamCompare",
+          "name": "bamFile1"
+        }
+      ],
+      "label": null,
+      "name": "bamCompare",
+      "outputs": [
+        {
+          "name": "outFileName",
+          "type": "bigwig"
+        }
+      ],
+      "position": {
+        "left": 458,
+        "top": 3822
+      },
+      "post_job_actions": {
+        "HideDatasetActionoutFileName": {
+          "action_arguments": {},
+          "action_type": "HideDatasetAction",
+          "output_name": "outFileName"
+        }
+      },
+      "tool_id": "toolshed.g2.bx.psu.edu/repos/bgruening/deeptools_bam_compare/deeptools_bam_compare/3.0.2.0",
+      "tool_shed_repository": {
+        "changeset_revision": "439e75416e1a",
+        "name": "deeptools_bam_compare",
+        "owner": "bgruening",
+        "tool_shed": "toolshed.g2.bx.psu.edu"
+      },
+      "tool_state": "{\"comparison\": \"{\\\"pseudocount\\\": \\\"1.0\\\", \\\"type\\\": \\\"log2\\\", \\\"__current_case__\\\": 0}\", \"bamFile2\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\", \"outFileFormat\": \"\\\"bigwig\\\"\", \"bamFile1\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\", \"__page__\": null, \"region\": \"\\\"chrX\\\"\", \"binSize\": \"\\\"50\\\"\", \"scaling\": \"{\\\"method\\\": \\\"readCount\\\", \\\"__current_case__\\\": 1}\", \"advancedOpt\": \"{\\\"showAdvancedOpt\\\": \\\"no\\\", \\\"__current_case__\\\": 0}\", \"chromInfo\": \"\\\"/usr/local/galaxy/galaxy-dist/tool-data/shared/ucsc/chrom/?.len\\\"\", \"__rerun_remap_job_id__\": null}",
+      "tool_version": "3.0.2.0",
+      "type": "tool",
+      "uuid": "d9c36648-8866-4373-b9ad-c69b77bd24a7",
+      "workflow_outputs": []
+    },
+    "34": {
+      "annotation": "",
+      "content_id": "toolshed.g2.bx.psu.edu/repos/bgruening/deeptools_bam_coverage/deeptools_bam_coverage/3.0.2.0",
+      "errors": null,
+      "id": 34,
+      "input_connections": {
+        "bamInput": {
+          "id": 9,
+          "output_name": "output"
+        }
+      },
+      "inputs": [
+        {
+          "description": "runtime parameter for tool bamCoverage",
+          "name": "bamInput"
+        }
+      ],
+      "label": null,
+      "name": "bamCoverage",
+      "outputs": [
+        {
+          "name": "outFileName",
+          "type": "bigwig"
+        }
+      ],
+      "position": {
+        "left": 458,
+        "top": 5646
+      },
+      "post_job_actions": {
+        "HideDatasetActionoutFileName": {
+          "action_arguments": {},
+          "action_type": "HideDatasetAction",
+          "output_name": "outFileName"
+        }
+      },
+      "tool_id": "toolshed.g2.bx.psu.edu/repos/bgruening/deeptools_bam_coverage/deeptools_bam_coverage/3.0.2.0",
+      "tool_shed_repository": {
+        "changeset_revision": "3033c3fba046",
+        "name": "deeptools_bam_coverage",
+        "owner": "bgruening",
+        "tool_shed": "toolshed.g2.bx.psu.edu"
+      },
+      "tool_state": "{\"__page__\": null, \"outFileFormat\": \"\\\"bigwig\\\"\", \"region\": \"\\\"chrX\\\"\", \"bamInput\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\", \"binSize\": \"\\\"25\\\"\", \"scaling\": \"{\\\"effectiveGenomeSize\\\": {\\\"effectiveGenomeSize_opt\\\": \\\"2308125349\\\", \\\"__current_case__\\\": 7}, \\\"type\\\": \\\"1x\\\", \\\"__current_case__\\\": 4}\", \"advancedOpt\": \"{\\\"showAdvancedOpt\\\": \\\"no\\\", \\\"__current_case__\\\": 0}\", \"chromInfo\": \"\\\"/usr/local/galaxy/galaxy-dist/tool-data/shared/ucsc/chrom/?.len\\\"\", \"__rerun_remap_job_id__\": null}",
+      "tool_version": "3.0.2.0",
+      "type": "tool",
+      "uuid": "ac76ea6c-ac01-410d-9ef4-77b5bee1b97a",
+      "workflow_outputs": []
+    },
+    "35": {
+      "annotation": "",
+      "content_id": "toolshed.g2.bx.psu.edu/repos/bgruening/text_processing/tp_sort_header_tool/1.1.1",
+      "errors": null,
+      "id": 35,
+      "input_connections": {
+        "infile": {
+          "id": 10,
+          "output_name": "outFileName"
+        }
+      },
+      "inputs": [
+        {
+          "description": "runtime parameter for tool Sort",
+          "name": "infile"
+        }
+      ],
+      "label": null,
+      "name": "Sort",
+      "outputs": [
+        {
+          "name": "outfile",
+          "type": "input"
+        }
+      ],
+      "position": {
+        "left": 786,
+        "top": 942
+      },
+      "post_job_actions": {
+        "HideDatasetActionoutfile": {
+          "action_arguments": {},
+          "action_type": "HideDatasetAction",
+          "output_name": "outfile"
+        }
+      },
+      "tool_id": "toolshed.g2.bx.psu.edu/repos/bgruening/text_processing/tp_sort_header_tool/1.1.1",
+      "tool_shed_repository": {
+        "changeset_revision": "74a8bef53a00",
+        "name": "text_processing",
+        "owner": "bgruening",
+        "tool_shed": "toolshed.g2.bx.psu.edu"
+      },
+      "tool_state": "{\"sortkeys\": \"[{\\\"column\\\": \\\"4\\\", \\\"__index__\\\": 0, \\\"style\\\": \\\"n\\\", \\\"order\\\": \\\"r\\\"}]\", \"__page__\": null, \"ignore_case\": \"\\\"false\\\"\", \"__rerun_remap_job_id__\": null, \"header\": \"\\\"0\\\"\", \"unique\": \"\\\"false\\\"\", \"chromInfo\": \"\\\"/usr/local/galaxy/galaxy-dist/tool-data/shared/ucsc/chrom/?.len\\\"\", \"infile\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\"}",
+      "tool_version": "1.1.1",
+      "type": "tool",
+      "uuid": "0309cc23-d2ee-4066-b706-5bee13f7ca4f",
+      "workflow_outputs": []
+    },
+    "36": {
+      "annotation": "",
+      "content_id": "toolshed.g2.bx.psu.edu/repos/bgruening/text_processing/tp_sort_header_tool/1.1.1",
+      "errors": null,
+      "id": 36,
+      "input_connections": {
+        "infile": {
+          "id": 16,
+          "output_name": "outFileName"
+        }
+      },
+      "inputs": [
+        {
+          "description": "runtime parameter for tool Sort",
+          "name": "infile"
+        }
+      ],
+      "label": null,
+      "name": "Sort",
+      "outputs": [
+        {
+          "name": "outfile",
+          "type": "input"
+        }
+      ],
+      "position": {
+        "left": 786,
+        "top": 1434
+      },
+      "post_job_actions": {
+        "HideDatasetActionoutfile": {
+          "action_arguments": {},
+          "action_type": "HideDatasetAction",
+          "output_name": "outfile"
+        }
+      },
+      "tool_id": "toolshed.g2.bx.psu.edu/repos/bgruening/text_processing/tp_sort_header_tool/1.1.1",
+      "tool_shed_repository": {
+        "changeset_revision": "74a8bef53a00",
+        "name": "text_processing",
+        "owner": "bgruening",
+        "tool_shed": "toolshed.g2.bx.psu.edu"
+      },
+      "tool_state": "{\"sortkeys\": \"[{\\\"column\\\": \\\"4\\\", \\\"__index__\\\": 0, \\\"style\\\": \\\"n\\\", \\\"order\\\": \\\"r\\\"}]\", \"__page__\": null, \"ignore_case\": \"\\\"false\\\"\", \"__rerun_remap_job_id__\": null, \"header\": \"\\\"0\\\"\", \"unique\": \"\\\"false\\\"\", \"chromInfo\": \"\\\"/usr/local/galaxy/galaxy-dist/tool-data/shared/ucsc/chrom/?.len\\\"\", \"infile\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\"}",
+      "tool_version": "1.1.1",
+      "type": "tool",
+      "uuid": "a7548103-ea03-44ca-be06-b7e2db0d895c",
+      "workflow_outputs": []
+    },
+    "37": {
+      "annotation": "",
+      "content_id": "toolshed.g2.bx.psu.edu/repos/bgruening/text_processing/tp_sort_header_tool/1.1.1",
+      "errors": null,
+      "id": 37,
+      "input_connections": {
+        "infile": {
+          "id": 16,
+          "output_name": "outFileName"
+        }
+      },
+      "inputs": [
+        {
+          "description": "runtime parameter for tool Sort",
+          "name": "infile"
+        }
+      ],
+      "label": null,
+      "name": "Sort",
+      "outputs": [
+        {
+          "name": "outfile",
+          "type": "input"
+        }
+      ],
+      "position": {
+        "left": 786,
+        "top": 1550
+      },
+      "post_job_actions": {
+        "HideDatasetActionoutfile": {
+          "action_arguments": {},
+          "action_type": "HideDatasetAction",
+          "output_name": "outfile"
+        }
+      },
+      "tool_id": "toolshed.g2.bx.psu.edu/repos/bgruening/text_processing/tp_sort_header_tool/1.1.1",
+      "tool_shed_repository": {
+        "changeset_revision": "74a8bef53a00",
+        "name": "text_processing",
+        "owner": "bgruening",
+        "tool_shed": "toolshed.g2.bx.psu.edu"
+      },
+      "tool_state": "{\"sortkeys\": \"[{\\\"column\\\": \\\"4\\\", \\\"__index__\\\": 0, \\\"style\\\": \\\"n\\\", \\\"order\\\": \\\"\\\"}]\", \"__page__\": null, \"ignore_case\": \"\\\"false\\\"\", \"__rerun_remap_job_id__\": null, \"header\": \"\\\"0\\\"\", \"unique\": \"\\\"false\\\"\", \"chromInfo\": \"\\\"/usr/local/galaxy/galaxy-dist/tool-data/shared/ucsc/chrom/?.len\\\"\", \"infile\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\"}",
+      "tool_version": "1.1.1",
+      "type": "tool",
+      "uuid": "d49a9ecf-aef6-4af8-b519-001e1965dbb0",
+      "workflow_outputs": []
+    },
+    "38": {
+      "annotation": "",
+      "content_id": "toolshed.g2.bx.psu.edu/repos/bgruening/text_processing/tp_sort_header_tool/1.1.1",
+      "errors": null,
+      "id": 38,
+      "input_connections": {
+        "infile": {
+          "id": 18,
+          "output_name": "output_narrowpeaks"
+        }
+      },
+      "inputs": [
+        {
+          "description": "runtime parameter for tool Sort",
+          "name": "infile"
+        }
+      ],
+      "label": null,
+      "name": "Sort",
+      "outputs": [
+        {
+          "name": "outfile",
+          "type": "input"
+        }
+      ],
+      "position": {
+        "left": 786,
+        "top": 710
+      },
+      "post_job_actions": {
+        "HideDatasetActionoutfile": {
+          "action_arguments": {},
+          "action_type": "HideDatasetAction",
+          "output_name": "outfile"
+        }
+      },
+      "tool_id": "toolshed.g2.bx.psu.edu/repos/bgruening/text_processing/tp_sort_header_tool/1.1.1",
+      "tool_shed_repository": {
+        "changeset_revision": "74a8bef53a00",
+        "name": "text_processing",
+        "owner": "bgruening",
+        "tool_shed": "toolshed.g2.bx.psu.edu"
+      },
+      "tool_state": "{\"sortkeys\": \"[{\\\"column\\\": \\\"9\\\", \\\"__index__\\\": 0, \\\"style\\\": \\\"n\\\", \\\"order\\\": \\\"\\\"}]\", \"__page__\": null, \"ignore_case\": \"\\\"false\\\"\", \"__rerun_remap_job_id__\": null, \"header\": \"\\\"0\\\"\", \"unique\": \"\\\"false\\\"\", \"chromInfo\": \"\\\"/usr/local/galaxy/galaxy-dist/tool-data/shared/ucsc/chrom/?.len\\\"\", \"infile\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\"}",
+      "tool_version": "1.1.1",
+      "type": "tool",
+      "uuid": "e7147f72-c44d-40a0-b7d0-8e34dc8dbd87",
+      "workflow_outputs": []
+    },
+    "39": {
+      "annotation": "",
+      "content_id": "toolshed.g2.bx.psu.edu/repos/devteam/column_maker/Add_a_column1/1.1.0",
+      "errors": null,
+      "id": 39,
+      "input_connections": {
+        "input": {
+          "id": 18,
+          "output_name": "output_narrowpeaks"
+        }
+      },
+      "inputs": [
+        {
+          "description": "runtime parameter for tool Compute",
+          "name": "input"
+        }
+      ],
+      "label": null,
+      "name": "Compute",
+      "outputs": [
+        {
+          "name": "out_file1",
+          "type": "input"
+        }
+      ],
+      "position": {
+        "left": 786,
+        "top": 826
+      },
+      "post_job_actions": {
+        "HideDatasetActionout_file1": {
+          "action_arguments": {},
+          "action_type": "HideDatasetAction",
+          "output_name": "out_file1"
+        }
+      },
+      "tool_id": "toolshed.g2.bx.psu.edu/repos/devteam/column_maker/Add_a_column1/1.1.0",
+      "tool_shed_repository": {
+        "changeset_revision": "626658afe4cb",
+        "name": "column_maker",
+        "owner": "devteam",
+        "tool_shed": "toolshed.g2.bx.psu.edu"
+      },
+      "tool_state": "{\"__page__\": null, \"__rerun_remap_job_id__\": null, \"cond\": \"\\\"c3-c2\\\"\", \"input\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\", \"chromInfo\": \"\\\"/usr/local/galaxy/galaxy-dist/tool-data/shared/ucsc/chrom/?.len\\\"\", \"round\": \"\\\"no\\\"\"}",
+      "tool_version": "1.1.0",
+      "type": "tool",
+      "uuid": "3174e622-a321-40f5-bc76-3a23261b86c3",
+      "workflow_outputs": []
+    },
+    "4": {
+      "annotation": "",
+      "content_id": null,
+      "errors": null,
+      "id": 4,
+      "input_connections": {},
+      "inputs": [],
+      "label": "wt_H3K4me3_read2",
+      "name": "Input dataset",
+      "outputs": [],
+      "position": {
+        "left": 200,
+        "top": 497
+      },
+      "tool_id": null,
+      "tool_state": "{}",
+      "tool_version": null,
+      "type": "data_input",
+      "uuid": "bfc0e21d-1ea5-4d22-aa3e-573fc41a44e8",
+      "workflow_outputs": [
+        {
+          "label": null,
+          "output_name": "output",
+          "uuid": "ec212d6c-3709-4fb2-b33b-21721c23a984"
+        }
+      ]
+    },
+    "40": {
+      "annotation": "",
+      "content_id": "toolshed.g2.bx.psu.edu/repos/bgruening/text_processing/tp_sort_header_tool/1.1.1",
+      "errors": null,
+      "id": 40,
+      "input_connections": {
+        "infile": {
+          "id": 20,
+          "output_name": "outFileName"
+        }
+      },
+      "inputs": [
+        {
+          "description": "runtime parameter for tool Sort",
+          "name": "infile"
+        }
+      ],
+      "label": null,
+      "name": "Sort",
+      "outputs": [
+        {
+          "name": "outfile",
+          "type": "input"
+        }
+      ],
+      "position": {
+        "left": 786,
+        "top": 1202
+      },
+      "post_job_actions": {
+        "HideDatasetActionoutfile": {
+          "action_arguments": {},
+          "action_type": "HideDatasetAction",
+          "output_name": "outfile"
+        }
+      },
+      "tool_id": "toolshed.g2.bx.psu.edu/repos/bgruening/text_processing/tp_sort_header_tool/1.1.1",
+      "tool_shed_repository": {
+        "changeset_revision": "74a8bef53a00",
+        "name": "text_processing",
+        "owner": "bgruening",
+        "tool_shed": "toolshed.g2.bx.psu.edu"
+      },
+      "tool_state": "{\"sortkeys\": \"[{\\\"column\\\": \\\"4\\\", \\\"__index__\\\": 0, \\\"style\\\": \\\"n\\\", \\\"order\\\": \\\"r\\\"}]\", \"__page__\": null, \"ignore_case\": \"\\\"false\\\"\", \"__rerun_remap_job_id__\": null, \"header\": \"\\\"0\\\"\", \"unique\": \"\\\"false\\\"\", \"chromInfo\": \"\\\"/usr/local/galaxy/galaxy-dist/tool-data/shared/ucsc/chrom/?.len\\\"\", \"infile\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\"}",
+      "tool_version": "1.1.1",
+      "type": "tool",
+      "uuid": "67b96a8a-01dc-4f39-a2bb-31c2a0e8b4f1",
+      "workflow_outputs": []
+    },
+    "41": {
+      "annotation": "",
+      "content_id": "toolshed.g2.bx.psu.edu/repos/devteam/bowtie2/bowtie2/2.3.4.2",
+      "errors": null,
+      "id": 41,
+      "input_connections": {
+        "library|input_1": {
+          "id": 24,
+          "output_name": "trimmed_reads_pair1"
+        },
+        "library|input_2": {
+          "id": 24,
+          "output_name": "trimmed_reads_pair2"
+        }
+      },
+      "inputs": [
+        {
+          "description": "runtime parameter for tool Bowtie2",
+          "name": "library"
+        },
+        {
+          "description": "runtime parameter for tool Bowtie2",
+          "name": "library"
+        }
+      ],
+      "label": null,
+      "name": "Bowtie2",
+      "outputs": [
+        {
+          "name": "output_unaligned_reads_l",
+          "type": "fastqsanger"
+        },
+        {
+          "name": "output_aligned_reads_l",
+          "type": "fastqsanger"
+        },
+        {
+          "name": "output_aligned_reads_r",
+          "type": "fastqsanger"
+        },
+        {
+          "name": "output_unaligned_reads_r",
+          "type": "fastqsanger"
+        },
+        {
+          "name": "output",
+          "type": "bam"
+        },
+        {
+          "name": "output_sam",
+          "type": "sam"
+        },
+        {
+          "name": "mapping_stats",
+          "type": "txt"
+        }
+      ],
+      "position": {
+        "left": 786,
+        "top": 200
+      },
+      "post_job_actions": {
+        "HideDatasetActionmapping_stats": {
+          "action_arguments": {},
+          "action_type": "HideDatasetAction",
+          "output_name": "mapping_stats"
+        },
+        "HideDatasetActionoutput": {
+          "action_arguments": {},
+          "action_type": "HideDatasetAction",
+          "output_name": "output"
+        },
+        "HideDatasetActionoutput_aligned_reads_l": {
+          "action_arguments": {},
+          "action_type": "HideDatasetAction",
+          "output_name": "output_aligned_reads_l"
+        },
+        "HideDatasetActionoutput_aligned_reads_r": {
+          "action_arguments": {},
+          "action_type": "HideDatasetAction",
+          "output_name": "output_aligned_reads_r"
+        },
+        "HideDatasetActionoutput_sam": {
+          "action_arguments": {},
+          "action_type": "HideDatasetAction",
+          "output_name": "output_sam"
+        },
+        "HideDatasetActionoutput_unaligned_reads_l": {
+          "action_arguments": {},
+          "action_type": "HideDatasetAction",
+          "output_name": "output_unaligned_reads_l"
+        },
+        "HideDatasetActionoutput_unaligned_reads_r": {
+          "action_arguments": {},
+          "action_type": "HideDatasetAction",
+          "output_name": "output_unaligned_reads_r"
+        }
+      },
+      "tool_id": "toolshed.g2.bx.psu.edu/repos/devteam/bowtie2/bowtie2/2.3.4.2",
+      "tool_shed_repository": {
+        "changeset_revision": "c3dd1aeb7d07",
+        "name": "bowtie2",
+        "owner": "devteam",
+        "tool_shed": "toolshed.g2.bx.psu.edu"
+      },
+      "tool_state": "{\"sam_options\": \"{\\\"sam_options_selector\\\": \\\"no\\\", \\\"__current_case__\\\": 1}\", \"__page__\": null, \"__rerun_remap_job_id__\": null, \"library\": \"{\\\"aligned_file\\\": \\\"false\\\", \\\"unaligned_file\\\": \\\"false\\\", \\\"input_2\\\": {\\\"__class__\\\": \\\"RuntimeValue\\\"}, \\\"__current_case__\\\": 1, \\\"input_1\\\": {\\\"__class__\\\": \\\"RuntimeValue\\\"}, \\\"type\\\": \\\"paired\\\", \\\"paired_options\\\": {\\\"paired_options_selector\\\": \\\"no\\\", \\\"__current_case__\\\": 1}}\", \"reference_genome\": \"{\\\"source\\\": \\\"indexed\\\", \\\"__current_case__\\\": 0, \\\"index\\\": \\\"mm10\\\"}\", \"rg\": \"{\\\"rg_selector\\\": \\\"do_not_set\\\", \\\"__current_case__\\\": 3}\", \"save_mapping_stats\": \"\\\"true\\\"\", \"analysis_type\": \"{\\\"analysis_type_selector\\\": \\\"simple\\\", \\\"presets\\\": \\\"no_presets\\\", \\\"__current_case__\\\": 0}\"}",
+      "tool_version": "2.3.4.2",
+      "type": "tool",
+      "uuid": "35b8379c-4806-4b3f-90d7-ffab08aba70c",
+      "workflow_outputs": []
+    },
+    "42": {
+      "annotation": "",
+      "content_id": "toolshed.g2.bx.psu.edu/repos/bgruening/deeptools_plot_correlation/deeptools_plot_correlation/3.0.2.0",
+      "errors": null,
+      "id": 42,
+      "input_connections": {
+        "corData": {
+          "id": 31,
+          "output_name": "outFile"
+        }
+      },
+      "inputs": [
+        {
+          "description": "runtime parameter for tool plotCorrelation",
+          "name": "corData"
+        }
+      ],
+      "label": null,
+      "name": "plotCorrelation",
+      "outputs": [
+        {
+          "name": "outFileName",
+          "type": "png"
+        },
+        {
+          "name": "matrix",
+          "type": "tabular"
+        }
+      ],
+      "position": {
+        "left": 786,
+        "top": 1666
+      },
+      "post_job_actions": {
+        "HideDatasetActionmatrix": {
+          "action_arguments": {},
+          "action_type": "HideDatasetAction",
+          "output_name": "matrix"
+        },
+        "HideDatasetActionoutFileName": {
+          "action_arguments": {},
+          "action_type": "HideDatasetAction",
+          "output_name": "outFileName"
+        }
+      },
+      "tool_id": "toolshed.g2.bx.psu.edu/repos/bgruening/deeptools_plot_correlation/deeptools_plot_correlation/3.0.2.0",
+      "tool_shed_repository": {
+        "changeset_revision": "4e8b35fd2173",
+        "name": "deeptools_plot_correlation",
+        "owner": "bgruening",
+        "tool_shed": "toolshed.g2.bx.psu.edu"
+      },
+      "tool_state": "{\"__page__\": null, \"removeOutliers\": \"\\\"false\\\"\", \"outFileFormat\": \"\\\"png\\\"\", \"outFileCorMatrix\": \"\\\"false\\\"\", \"__rerun_remap_job_id__\": null, \"corMethod\": \"\\\"pearson\\\"\", \"skipZeros\": \"\\\"false\\\"\", \"plotting_type\": \"{\\\"plotWidth\\\": \\\"11.0\\\", \\\"plotTitle\\\": \\\"\\\", \\\"colorMap\\\": \\\"RdYlBu\\\", \\\"plotNumbers\\\": \\\"false\\\", \\\"zMin\\\": \\\"\\\", \\\"whatToPlot\\\": \\\"heatmap\\\", \\\"__current_case__\\\": 0, \\\"zMax\\\": \\\"\\\", \\\"plotHeight\\\": \\\"9.5\\\"}\", \"chromInfo\": \"\\\"/usr/local/galaxy/galaxy-dist/tool-data/shared/ucsc/chrom/?.len\\\"\", \"corData\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\"}",
+      "tool_version": "3.0.2.0",
+      "type": "tool",
+      "uuid": "660d14d2-4996-4ce6-84e5-a73b773a9e24",
+      "workflow_outputs": []
+    },
+    "43": {
+      "annotation": "",
+      "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/bedtools/bedtools_intersectbed/2.27.0.2",
+      "errors": null,
+      "id": 43,
+      "input_connections": {
+        "inputA": {
+          "id": 18,
+          "output_name": "output_narrowpeaks"
+        },
+        "reduce_or_iterate|inputB": {
+          "id": 32,
+          "output_name": "output_narrowpeaks"
+        }
+      },
+      "inputs": [
+        {
+          "description": "runtime parameter for tool Intersect intervals",
+          "name": "inputA"
+        },
+        {
+          "description": "runtime parameter for tool Intersect intervals",
+          "name": "reduce_or_iterate"
+        }
+      ],
+      "label": null,
+      "name": "Intersect intervals",
+      "outputs": [
+        {
+          "name": "output",
+          "type": "input"
+        }
+      ],
+      "position": {
+        "left": 786,
+        "top": 566
+      },
+      "post_job_actions": {
+        "HideDatasetActionoutput": {
+          "action_arguments": {},
+          "action_type": "HideDatasetAction",
+          "output_name": "output"
+        }
+      },
+      "tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/bedtools/bedtools_intersectbed/2.27.0.2",
+      "tool_shed_repository": {
+        "changeset_revision": "6bb3cd018203",
+        "name": "bedtools",
+        "owner": "iuc",
+        "tool_shed": "toolshed.g2.bx.psu.edu"
+      },
+      "tool_state": "{\"count\": \"\\\"false\\\"\", \"__page__\": null, \"reciprocal\": \"\\\"false\\\"\", \"overlap_mode\": \"null\", \"invert\": \"\\\"true\\\"\", \"header\": \"\\\"false\\\"\", \"inputA\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\", \"reduce_or_iterate\": \"{\\\"inputB\\\": {\\\"__class__\\\": \\\"RuntimeValue\\\"}, \\\"reduce_or_iterate_selector\\\": \\\"iterate\\\", \\\"__current_case__\\\": 0}\", \"split\": \"\\\"false\\\"\", \"fraction\": \"\\\"\\\"\", \"chromInfo\": \"\\\"/usr/local/galaxy/galaxy-dist/tool-data/shared/ucsc/chrom/?.len\\\"\", \"__rerun_remap_job_id__\": null, \"strand\": \"\\\"\\\"\", \"once\": \"\\\"false\\\"\"}",
+      "tool_version": "2.27.0.2",
+      "type": "tool",
+      "uuid": "d9d2ca44-4a8d-4947-9bb0-11cd02473830",
+      "workflow_outputs": []
+    },
+    "44": {
+      "annotation": "",
+      "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/bedtools/bedtools_intersectbed/2.27.0.2",
+      "errors": null,
+      "id": 44,
+      "input_connections": {
+        "inputA": {
+          "id": 32,
+          "output_name": "output_narrowpeaks"
+        },
+        "reduce_or_iterate|inputB": {
+          "id": 18,
+          "output_name": "output_narrowpeaks"
+        }
+      },
+      "inputs": [
+        {
+          "description": "runtime parameter for tool Intersect intervals",
+          "name": "inputA"
+        },
+        {
+          "description": "runtime parameter for tool Intersect intervals",
+          "name": "reduce_or_iterate"
+        }
+      ],
+      "label": null,
+      "name": "Intersect intervals",
+      "outputs": [
+        {
+          "name": "output",
+          "type": "input"
+        }
+      ],
+      "position": {
+        "left": 786,
+        "top": 1058
+      },
+      "post_job_actions": {
+        "HideDatasetActionoutput": {
+          "action_arguments": {},
+          "action_type": "HideDatasetAction",
+          "output_name": "output"
+        }
+      },
+      "tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/bedtools/bedtools_intersectbed/2.27.0.2",
+      "tool_shed_repository": {
+        "changeset_revision": "6bb3cd018203",
+        "name": "bedtools",
+        "owner": "iuc",
+        "tool_shed": "toolshed.g2.bx.psu.edu"
+      },
+      "tool_state": "{\"count\": \"\\\"false\\\"\", \"__page__\": null, \"reciprocal\": \"\\\"false\\\"\", \"overlap_mode\": \"null\", \"invert\": \"\\\"true\\\"\", \"header\": \"\\\"false\\\"\", \"inputA\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\", \"reduce_or_iterate\": \"{\\\"inputB\\\": {\\\"__class__\\\": \\\"RuntimeValue\\\"}, \\\"reduce_or_iterate_selector\\\": \\\"iterate\\\", \\\"__current_case__\\\": 0}\", \"split\": \"\\\"false\\\"\", \"fraction\": \"\\\"\\\"\", \"chromInfo\": \"\\\"/usr/local/galaxy/galaxy-dist/tool-data/shared/ucsc/chrom/?.len\\\"\", \"__rerun_remap_job_id__\": null, \"strand\": \"\\\"\\\"\", \"once\": \"\\\"false\\\"\"}",
+      "tool_version": "2.27.0.2",
+      "type": "tool",
+      "uuid": "99df4865-a581-4930-8e47-5ec1ba2d65cb",
+      "workflow_outputs": []
+    },
+    "45": {
+      "annotation": "",
+      "content_id": "toolshed.g2.bx.psu.edu/repos/devteam/column_maker/Add_a_column1/1.1.0",
+      "errors": null,
+      "id": 45,
+      "input_connections": {
+        "input": {
+          "id": 32,
+          "output_name": "output_narrowpeaks"
+        }
+      },
+      "inputs": [
+        {
+          "description": "runtime parameter for tool Compute",
+          "name": "input"
+        }
+      ],
+      "label": null,
+      "name": "Compute",
+      "outputs": [
+        {
+          "name": "out_file1",
+          "type": "input"
+        }
+      ],
+      "position": {
+        "left": 786,
+        "top": 1318
+      },
+      "post_job_actions": {
+        "HideDatasetActionout_file1": {
+          "action_arguments": {},
+          "action_type": "HideDatasetAction",
+          "output_name": "out_file1"
+        }
+      },
+      "tool_id": "toolshed.g2.bx.psu.edu/repos/devteam/column_maker/Add_a_column1/1.1.0",
+      "tool_shed_repository": {
+        "changeset_revision": "626658afe4cb",
+        "name": "column_maker",
+        "owner": "devteam",
+        "tool_shed": "toolshed.g2.bx.psu.edu"
+      },
+      "tool_state": "{\"__page__\": null, \"__rerun_remap_job_id__\": null, \"cond\": \"\\\"c3-c2\\\"\", \"input\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\", \"chromInfo\": \"\\\"/usr/local/galaxy/galaxy-dist/tool-data/shared/ucsc/chrom/?.len\\\"\", \"round\": \"\\\"no\\\"\"}",
+      "tool_version": "1.1.0",
+      "type": "tool",
+      "uuid": "b6eed1d9-e394-4573-8a41-af02ea688553",
+      "workflow_outputs": []
+    },
+    "46": {
+      "annotation": "",
+      "content_id": "toolshed.g2.bx.psu.edu/repos/devteam/concat/gops_concat_1/1.0.1",
+      "errors": null,
+      "id": 46,
+      "input_connections": {
+        "input1": {
+          "id": 18,
+          "output_name": "output_narrowpeaks"
+        },
+        "input2": {
+          "id": 32,
+          "output_name": "output_narrowpeaks"
+        }
+      },
+      "inputs": [
+        {
+          "description": "runtime parameter for tool Concatenate",
+          "name": "input2"
+        },
+        {
+          "description": "runtime parameter for tool Concatenate",
+          "name": "input1"
+        }
+      ],
+      "label": null,
+      "name": "Concatenate",
+      "outputs": [
+        {
+          "name": "output",
+          "type": "input"
+        }
+      ],
+      "position": {
+        "left": 786,
+        "top": 1828
+      },
+      "post_job_actions": {
+        "HideDatasetActionoutput": {
+          "action_arguments": {},
+          "action_type": "HideDatasetAction",
+          "output_name": "output"
+        }
+      },
+      "tool_id": "toolshed.g2.bx.psu.edu/repos/devteam/concat/gops_concat_1/1.0.1",
+      "tool_shed_repository": {
+        "changeset_revision": "d491589307e7",
+        "name": "concat",
+        "owner": "devteam",
+        "tool_shed": "toolshed.g2.bx.psu.edu"
+      },
+      "tool_state": "{\"input2\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\", \"__page__\": null, \"input1\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\", \"sameformat\": \"\\\"true\\\"\", \"__rerun_remap_job_id__\": null, \"chromInfo\": \"\\\"/usr/local/galaxy/galaxy-dist/tool-data/shared/ucsc/chrom/?.len\\\"\"}",
+      "tool_version": "1.0.1",
+      "type": "tool",
+      "uuid": "5484bfa5-ab4a-4768-9355-a0785d74d67d",
+      "workflow_outputs": []
+    },
+    "47": {
+      "annotation": "",
+      "content_id": "cat1",
+      "errors": null,
+      "id": 47,
+      "input_connections": {
+        "input1": {
+          "id": 13,
+          "output_name": "output_narrowpeaks"
+        },
+        "queries_0|input2": {
+          "id": 32,
+          "output_name": "output_narrowpeaks"
+        },
+        "queries_1|input2": {
+          "id": 18,
+          "output_name": "output_narrowpeaks"
+        },
+        "queries_2|input2": {
+          "id": 28,
+          "output_name": "output_narrowpeaks"
+        },
+        "queries_3|input2": {
+          "id": 29,
+          "output_name": "output_narrowpeaks"
+        },
+        "queries_4|input2": {
+          "id": 30,
+          "output_name": "output_narrowpeaks"
+        }
+      },
+      "inputs": [
+        {
+          "description": "runtime parameter for tool Concatenate datasets",
+          "name": "input1"
+        }
+      ],
+      "label": null,
+      "name": "Concatenate datasets",
+      "outputs": [
+        {
+          "name": "out_file1",
+          "type": "input"
+        }
+      ],
+      "position": {
+        "left": 819,
+        "top": 2407
+      },
+      "post_job_actions": {
+        "HideDatasetActionout_file1": {
+          "action_arguments": {},
+          "action_type": "HideDatasetAction",
+          "output_name": "out_file1"
+        }
+      },
+      "tool_id": "cat1",
+      "tool_state": "{\"__page__\": null, \"__rerun_remap_job_id__\": null, \"input1\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\", \"chromInfo\": \"\\\"/usr/local/galaxy/galaxy-dist/tool-data/shared/ucsc/chrom/?.len\\\"\", \"queries\": \"[{\\\"input2\\\": {\\\"__class__\\\": \\\"RuntimeValue\\\"}, \\\"__index__\\\": 0}, {\\\"input2\\\": {\\\"__class__\\\": \\\"RuntimeValue\\\"}, \\\"__index__\\\": 1}, {\\\"input2\\\": {\\\"__class__\\\": \\\"RuntimeValue\\\"}, \\\"__index__\\\": 2}, {\\\"input2\\\": {\\\"__class__\\\": \\\"RuntimeValue\\\"}, \\\"__index__\\\": 3}, {\\\"input2\\\": {\\\"__class__\\\": \\\"RuntimeValue\\\"}, \\\"__index__\\\": 4}]\"}",
+      "tool_version": "1.0.0",
+      "type": "tool",
+      "uuid": "da8fcf72-6633-4cd1-85f4-f2dc7ccef315",
+      "workflow_outputs": []
+    },
+    "48": {
+      "annotation": "",
+      "content_id": "Filter1",
+      "errors": null,
+      "id": 48,
+      "input_connections": {
+        "input": {
+          "id": 38,
+          "output_name": "outfile"
+        }
+      },
+      "inputs": [
+        {
+          "description": "runtime parameter for tool Filter",
+          "name": "input"
+        }
+      ],
+      "label": null,
+      "name": "Filter",
+      "outputs": [
+        {
+          "name": "out_file1",
+          "type": "input"
+        }
+      ],
+      "position": {
+        "left": 1114,
+        "top": 468
+      },
+      "post_job_actions": {
+        "HideDatasetActionout_file1": {
+          "action_arguments": {},
+          "action_type": "HideDatasetAction",
+          "output_name": "out_file1"
+        }
+      },
+      "tool_id": "Filter1",
+      "tool_state": "{\"__page__\": null, \"__rerun_remap_job_id__\": null, \"cond\": \"\\\"c7>50\\\"\", \"input\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\", \"header_lines\": \"\\\"0\\\"\", \"chromInfo\": \"\\\"/usr/local/galaxy/galaxy-dist/tool-data/shared/ucsc/chrom/?.len\\\"\"}",
+      "tool_version": "1.1.0",
+      "type": "tool",
+      "uuid": "1aba4818-de61-4759-8bdc-c7b34834e15f",
+      "workflow_outputs": []
+    },
+    "49": {
+      "annotation": "",
+      "content_id": "Filter1",
+      "errors": null,
+      "id": 49,
+      "input_connections": {
+        "input": {
+          "id": 38,
+          "output_name": "outfile"
+        }
+      },
+      "inputs": [
+        {
+          "description": "runtime parameter for tool Filter",
+          "name": "input"
+        }
+      ],
+      "label": null,
+      "name": "Filter",
+      "outputs": [
+        {
+          "name": "out_file1",
+          "type": "input"
+        }
+      ],
+      "position": {
+        "left": 1114,
+        "top": 584
+      },
+      "post_job_actions": {
+        "HideDatasetActionout_file1": {
+          "action_arguments": {},
+          "action_type": "HideDatasetAction",
+          "output_name": "out_file1"
+        }
+      },
+      "tool_id": "Filter1",
+      "tool_state": "{\"__page__\": null, \"__rerun_remap_job_id__\": null, \"cond\": \"\\\"c2>151385260 and c3<152426526\\\"\", \"input\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\", \"header_lines\": \"\\\"0\\\"\", \"chromInfo\": \"\\\"/usr/local/galaxy/galaxy-dist/tool-data/shared/ucsc/chrom/?.len\\\"\"}",
+      "tool_version": "1.1.0",
+      "type": "tool",
+      "uuid": "069be8cf-ee7a-494f-9d3e-543a561e6fb7",
+      "workflow_outputs": []
+    },
+    "5": {
+      "annotation": "",
+      "content_id": null,
+      "errors": null,
+      "id": 5,
+      "input_connections": {},
+      "inputs": [
+        {
+          "description": "",
+          "name": "wt_CTCF_rep2"
+        }
+      ],
+      "label": "wt_CTCF_rep2",
+      "name": "Input dataset",
+      "outputs": [],
+      "position": {
+        "left": 200,
+        "top": 602
+      },
+      "tool_id": null,
+      "tool_state": "{\"name\": \"wt_CTCF_rep2\"}",
+      "tool_version": null,
+      "type": "data_input",
+      "uuid": "a3f8e4e4-d05d-4b82-84d4-a2f28f04a33a",
+      "workflow_outputs": [
+        {
+          "label": null,
+          "output_name": "output",
+          "uuid": "335cb804-d327-4763-8173-1b08e0458758"
+        }
+      ]
+    },
+    "50": {
+      "annotation": "",
+      "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/datamash_ops/datamash_ops/datamash_ops/1.0.6",
+      "errors": null,
+      "id": 50,
+      "input_connections": {
+        "in_file": {
+          "id": 39,
+          "output_name": "out_file1"
+        }
+      },
+      "inputs": [
+        {
+          "description": "runtime parameter for tool Datamash",
+          "name": "in_file"
+        }
+      ],
+      "label": null,
+      "name": "Datamash",
+      "outputs": [
+        {
+          "name": "out_file",
+          "type": "tabular"
+        }
+      ],
+      "position": {
+        "left": 1114,
+        "top": 700
+      },
+      "post_job_actions": {
+        "HideDatasetActionout_file": {
+          "action_arguments": {},
+          "action_type": "HideDatasetAction",
+          "output_name": "out_file"
+        }
+      },
+      "tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/datamash_ops/datamash_ops/datamash_ops/1.0.6",
+      "tool_shed_repository": {
+        "changeset_revision": "2f3c6f2dcf39",
+        "name": "datamash_ops",
+        "owner": "iuc",
+        "tool_shed": "toolshed.g2.bx.psu.edu"
+      },
+      "tool_state": "{\"operations\": \"[{\\\"__index__\\\": 0, \\\"op_name\\\": \\\"mean\\\", \\\"op_column\\\": \\\"11\\\"}]\", \"__page__\": null, \"ignore_case\": \"\\\"false\\\"\", \"header_out\": \"\\\"false\\\"\", \"__rerun_remap_job_id__\": null, \"header_in\": \"\\\"false\\\"\", \"in_file\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\", \"need_sort\": \"\\\"false\\\"\", \"print_full_line\": \"\\\"false\\\"\", \"chromInfo\": \"\\\"/usr/local/galaxy/galaxy-dist/tool-data/shared/ucsc/chrom/?.len\\\"\", \"grouping\": \"\\\"\\\"\"}",
+      "tool_version": "1.0.6",
+      "type": "tool",
+      "uuid": "f0e5143f-871f-45f1-90bb-7635bd5ae4c1",
+      "workflow_outputs": []
+    },
+    "51": {
+      "annotation": "",
+      "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/datamash_ops/datamash_ops/datamash_ops/1.0.6",
+      "errors": null,
+      "id": 51,
+      "input_connections": {
+        "in_file": {
+          "id": 45,
+          "output_name": "out_file1"
+        }
+      },
+      "inputs": [
+        {
+          "description": "runtime parameter for tool Datamash",
+          "name": "in_file"
+        }
+      ],
+      "label": null,
+      "name": "Datamash",
+      "outputs": [
+        {
+          "name": "out_file",
+          "type": "tabular"
+        }
+      ],
+      "position": {
+        "left": 1114,
+        "top": 816
+      },
+      "post_job_actions": {
+        "HideDatasetActionout_file": {
+          "action_arguments": {},
+          "action_type": "HideDatasetAction",
+          "output_name": "out_file"
+        }
+      },
+      "tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/datamash_ops/datamash_ops/datamash_ops/1.0.6",
+      "tool_shed_repository": {
+        "changeset_revision": "2f3c6f2dcf39",
+        "name": "datamash_ops",
+        "owner": "iuc",
+        "tool_shed": "toolshed.g2.bx.psu.edu"
+      },
+      "tool_state": "{\"operations\": \"[{\\\"__index__\\\": 0, \\\"op_name\\\": \\\"mean\\\", \\\"op_column\\\": \\\"11\\\"}]\", \"__page__\": null, \"ignore_case\": \"\\\"false\\\"\", \"header_out\": \"\\\"false\\\"\", \"__rerun_remap_job_id__\": null, \"header_in\": \"\\\"false\\\"\", \"in_file\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\", \"need_sort\": \"\\\"false\\\"\", \"print_full_line\": \"\\\"false\\\"\", \"chromInfo\": \"\\\"/usr/local/galaxy/galaxy-dist/tool-data/shared/ucsc/chrom/?.len\\\"\", \"grouping\": \"\\\"\\\"\"}",
+      "tool_version": "1.0.6",
+      "type": "tool",
+      "uuid": "f141779a-b768-4b5f-930d-1c47d12826ef",
+      "workflow_outputs": []
+    },
+    "52": {
+      "annotation": "",
+      "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/bedtools/bedtools_sortbed/2.27.0.0",
+      "errors": null,
+      "id": 52,
+      "input_connections": {
+        "input": {
+          "id": 46,
+          "output_name": "output"
+        }
+      },
+      "inputs": [
+        {
+          "description": "runtime parameter for tool SortBED",
+          "name": "input"
+        }
+      ],
+      "label": null,
+      "name": "SortBED",
+      "outputs": [
+        {
+          "name": "output",
+          "type": "input"
+        }
+      ],
+      "position": {
+        "left": 1114,
+        "top": 200
+      },
+      "post_job_actions": {
+        "HideDatasetActionoutput": {
+          "action_arguments": {},
+          "action_type": "HideDatasetAction",
+          "output_name": "output"
+        }
+      },
+      "tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/bedtools/bedtools_sortbed/2.27.0.0",
+      "tool_shed_repository": {
+        "changeset_revision": "6bb3cd018203",
+        "name": "bedtools",
+        "owner": "iuc",
+        "tool_shed": "toolshed.g2.bx.psu.edu"
+      },
+      "tool_state": "{\"input\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\", \"__rerun_remap_job_id__\": null, \"chromInfo\": \"\\\"/usr/local/galaxy/galaxy-dist/tool-data/shared/ucsc/chrom/?.len\\\"\", \"option\": \"\\\"\\\"\", \"__page__\": null}",
+      "tool_version": "2.27.0.0",
+      "type": "tool",
+      "uuid": "c1ac9566-e699-4d1c-85cd-0eb0eb58a047",
+      "workflow_outputs": []
+    },
+    "53": {
+      "annotation": "",
+      "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/bedtools/bedtools_sortbed/2.27.0.0",
+      "errors": null,
+      "id": 53,
+      "input_connections": {
+        "input": {
+          "id": 47,
+          "output_name": "out_file1"
+        }
+      },
+      "inputs": [
+        {
+          "description": "runtime parameter for tool SortBED",
+          "name": "input"
+        }
+      ],
+      "label": null,
+      "name": "SortBED",
+      "outputs": [
+        {
+          "name": "output",
+          "type": "input"
+        }
+      ],
+      "position": {
+        "left": 1114,
+        "top": 334
+      },
+      "post_job_actions": {
+        "HideDatasetActionoutput": {
+          "action_arguments": {},
+          "action_type": "HideDatasetAction",
+          "output_name": "output"
+        }
+      },
+      "tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/bedtools/bedtools_sortbed/2.27.0.0",
+      "tool_shed_repository": {
+        "changeset_revision": "6bb3cd018203",
+        "name": "bedtools",
+        "owner": "iuc",
+        "tool_shed": "toolshed.g2.bx.psu.edu"
+      },
+      "tool_state": "{\"input\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\", \"__rerun_remap_job_id__\": null, \"chromInfo\": \"\\\"/usr/local/galaxy/galaxy-dist/tool-data/shared/ucsc/chrom/?.len\\\"\", \"option\": \"\\\"\\\"\", \"__page__\": null}",
+      "tool_version": "2.27.0.0",
+      "type": "tool",
+      "uuid": "5f26028c-3bda-47ce-9338-4e447cc4bf4c",
+      "workflow_outputs": []
+    },
+    "54": {
+      "annotation": "",
+      "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/bedtools/bedtools_mergebed/2.27.0.0",
+      "errors": null,
+      "id": 54,
+      "input_connections": {
+        "input": {
+          "id": 52,
+          "output_name": "output"
+        }
+      },
+      "inputs": [
+        {
+          "description": "runtime parameter for tool MergeBED",
+          "name": "input"
+        }
+      ],
+      "label": null,
+      "name": "MergeBED",
+      "outputs": [
+        {
+          "name": "output",
+          "type": "bed"
+        }
+      ],
+      "position": {
+        "left": 1442,
+        "top": 334
+      },
+      "post_job_actions": {
+        "HideDatasetActionoutput": {
+          "action_arguments": {},
+          "action_type": "HideDatasetAction",
+          "output_name": "output"
+        }
+      },
+      "tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/bedtools/bedtools_mergebed/2.27.0.0",
+      "tool_shed_repository": {
+        "changeset_revision": "6bb3cd018203",
+        "name": "bedtools",
+        "owner": "iuc",
+        "tool_shed": "toolshed.g2.bx.psu.edu"
+      },
+      "tool_state": "{\"distance\": \"\\\"0\\\"\", \"__page__\": null, \"chromInfo\": \"\\\"/usr/local/galaxy/galaxy-dist/tool-data/shared/ucsc/chrom/?.len\\\"\", \"__rerun_remap_job_id__\": null, \"header\": \"\\\"false\\\"\", \"input\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\", \"c_and_o_argument_repeat\": \"[]\", \"strand\": \"\\\"\\\"\"}",
+      "tool_version": "2.27.0.0",
+      "type": "tool",
+      "uuid": "4010d218-df4c-43ce-ae93-0a543f84f75d",
+      "workflow_outputs": []
+    },
+    "55": {
+      "annotation": "",
+      "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/bedtools/bedtools_mergebed/2.27.0.0",
+      "errors": null,
+      "id": 55,
+      "input_connections": {
+        "input": {
+          "id": 53,
+          "output_name": "output"
+        }
+      },
+      "inputs": [
+        {
+          "description": "runtime parameter for tool MergeBED",
+          "name": "input"
+        }
+      ],
+      "label": null,
+      "name": "MergeBED",
+      "outputs": [
+        {
+          "name": "output",
+          "type": "bed"
+        }
+      ],
+      "position": {
+        "left": 1442,
+        "top": 200
+      },
+      "post_job_actions": {
+        "HideDatasetActionoutput": {
+          "action_arguments": {},
+          "action_type": "HideDatasetAction",
+          "output_name": "output"
+        }
+      },
+      "tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/bedtools/bedtools_mergebed/2.27.0.0",
+      "tool_shed_repository": {
+        "changeset_revision": "6bb3cd018203",
+        "name": "bedtools",
+        "owner": "iuc",
+        "tool_shed": "toolshed.g2.bx.psu.edu"
+      },
+      "tool_state": "{\"distance\": \"\\\"0\\\"\", \"__page__\": null, \"chromInfo\": \"\\\"/usr/local/galaxy/galaxy-dist/tool-data/shared/ucsc/chrom/?.len\\\"\", \"__rerun_remap_job_id__\": null, \"header\": \"\\\"false\\\"\", \"input\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\", \"c_and_o_argument_repeat\": \"[]\", \"strand\": \"\\\"\\\"\"}",
+      "tool_version": "2.27.0.0",
+      "type": "tool",
+      "uuid": "e42097d4-e35f-4046-a946-493866667b6c",
+      "workflow_outputs": []
+    },
+    "56": {
+      "annotation": "",
+      "content_id": "toolshed.g2.bx.psu.edu/repos/bgruening/deeptools_compute_matrix/deeptools_compute_matrix/3.0.2.0",
+      "errors": null,
+      "id": 56,
+      "input_connections": {
+        "multibigwig_conditional|bigwigfiles": [
+          {
+            "id": 19,
+            "output_name": "outFileName"
+          },
+          {
+            "id": 14,
+            "output_name": "outFileName"
+          }
+        ],
+        "regionsFiles_0|regionsFile": {
+          "id": 54,
+          "output_name": "output"
+        }
+      },
+      "inputs": [
+        {
+          "description": "runtime parameter for tool computeMatrix",
+          "name": "multibigwig_conditional"
+        }
+      ],
+      "label": null,
+      "name": "computeMatrix",
+      "outputs": [
+        {
+          "name": "outFileName",
+          "type": "deeptools_compute_matrix_archive"
+        },
+        {
+          "name": "outFileSortedRegions",
+          "type": "bed"
+        },
+        {
+          "name": "outFileNameMatrix",
+          "type": "tabular"
+        }
+      ],
+      "position": {
+        "left": 1770,
+        "top": 200
+      },
+      "post_job_actions": {
+        "HideDatasetActionoutFileName": {
+          "action_arguments": {},
+          "action_type": "HideDatasetAction",
+          "output_name": "outFileName"
+        },
+        "HideDatasetActionoutFileNameMatrix": {
+          "action_arguments": {},
+          "action_type": "HideDatasetAction",
+          "output_name": "outFileNameMatrix"
+        },
+        "HideDatasetActionoutFileSortedRegions": {
+          "action_arguments": {},
+          "action_type": "HideDatasetAction",
+          "output_name": "outFileSortedRegions"
+        }
+      },
+      "tool_id": "toolshed.g2.bx.psu.edu/repos/bgruening/deeptools_compute_matrix/deeptools_compute_matrix/3.0.2.0",
+      "tool_shed_repository": {
+        "changeset_revision": "fb9cf9c97ec4",
+        "name": "deeptools_compute_matrix",
+        "owner": "bgruening",
+        "tool_shed": "toolshed.g2.bx.psu.edu"
+      },
+      "tool_state": "{\"__page__\": null, \"regionsFiles\": \"[{\\\"__index__\\\": 0, \\\"regionsFile\\\": {\\\"__class__\\\": \\\"RuntimeValue\\\"}}]\", \"__rerun_remap_job_id__\": null, \"multibigwig_conditional\": \"{\\\"orderMatters\\\": \\\"No\\\", \\\"bigwigfiles\\\": {\\\"__class__\\\": \\\"RuntimeValue\\\"}, \\\"__current_case__\\\": 0}\", \"mode\": \"{\\\"afterRegionStartLength\\\": \\\"3000\\\", \\\"beforeRegionStartLength\\\": \\\"3000\\\", \\\"nanAfterEnd\\\": \\\"false\\\", \\\"__current_case__\\\": 1, \\\"referencePoint\\\": \\\"center\\\", \\\"mode_select\\\": \\\"reference-point\\\"}\", \"output\": \"{\\\"showOutputSettings\\\": \\\"no\\\", \\\"__current_case__\\\": 0}\", \"advancedOpt\": \"{\\\"showAdvancedOpt\\\": \\\"no\\\", \\\"__current_case__\\\": 0}\", \"chromInfo\": \"\\\"/usr/local/galaxy/galaxy-dist/tool-data/shared/ucsc/chrom/?.len\\\"\"}",
+      "tool_version": "3.0.2.0",
+      "type": "tool",
+      "uuid": "eb044f16-7766-41d5-9251-e5983c77388c",
+      "workflow_outputs": []
+    },
+    "57": {
+      "annotation": "",
+      "content_id": "toolshed.g2.bx.psu.edu/repos/bgruening/deeptools_compute_matrix/deeptools_compute_matrix/3.0.2.0",
+      "errors": null,
+      "id": 57,
+      "input_connections": {
+        "multibigwig_conditional|bigwigfiles": [
+          {
+            "id": 14,
+            "output_name": "outFileName"
+          },
+          {
+            "id": 25,
+            "output_name": "outFileName"
+          },
+          {
+            "id": 26,
+            "output_name": "outFileName"
+          },
+          {
+            "id": 33,
+            "output_name": "outFileName"
+          },
+          {
+            "id": 27,
+            "output_name": "outFileName"
+          },
+          {
+            "id": 19,
+            "output_name": "outFileName"
+          }
+        ],
+        "regionsFiles_0|regionsFile": {
+          "id": 55,
+          "output_name": "output"
+        }
+      },
+      "inputs": [
+        {
+          "description": "runtime parameter for tool computeMatrix",
+          "name": "multibigwig_conditional"
+        }
+      ],
+      "label": null,
+      "name": "computeMatrix",
+      "outputs": [
+        {
+          "name": "outFileName",
+          "type": "deeptools_compute_matrix_archive"
+        },
+        {
+          "name": "outFileSortedRegions",
+          "type": "bed"
+        },
+        {
+          "name": "outFileNameMatrix",
+          "type": "tabular"
+        }
+      ],
+      "position": {
+        "left": 1770,
+        "top": 418
+      },
+      "post_job_actions": {
+        "HideDatasetActionoutFileName": {
+          "action_arguments": {},
+          "action_type": "HideDatasetAction",
+          "output_name": "outFileName"
+        },
+        "HideDatasetActionoutFileNameMatrix": {
+          "action_arguments": {},
+          "action_type": "HideDatasetAction",
+          "output_name": "outFileNameMatrix"
+        },
+        "HideDatasetActionoutFileSortedRegions": {
+          "action_arguments": {},
+          "action_type": "HideDatasetAction",
+          "output_name": "outFileSortedRegions"
+        }
+      },
+      "tool_id": "toolshed.g2.bx.psu.edu/repos/bgruening/deeptools_compute_matrix/deeptools_compute_matrix/3.0.2.0",
+      "tool_shed_repository": {
+        "changeset_revision": "fb9cf9c97ec4",
+        "name": "deeptools_compute_matrix",
+        "owner": "bgruening",
+        "tool_shed": "toolshed.g2.bx.psu.edu"
+      },
+      "tool_state": "{\"__page__\": null, \"regionsFiles\": \"[{\\\"__index__\\\": 0, \\\"regionsFile\\\": {\\\"__class__\\\": \\\"RuntimeValue\\\"}}]\", \"__rerun_remap_job_id__\": null, \"multibigwig_conditional\": \"{\\\"orderMatters\\\": \\\"No\\\", \\\"bigwigfiles\\\": {\\\"__class__\\\": \\\"RuntimeValue\\\"}, \\\"__current_case__\\\": 0}\", \"mode\": \"{\\\"afterRegionStartLength\\\": \\\"3000\\\", \\\"beforeRegionStartLength\\\": \\\"3000\\\", \\\"nanAfterEnd\\\": \\\"false\\\", \\\"__current_case__\\\": 1, \\\"referencePoint\\\": \\\"center\\\", \\\"mode_select\\\": \\\"reference-point\\\"}\", \"output\": \"{\\\"showOutputSettings\\\": \\\"no\\\", \\\"__current_case__\\\": 0}\", \"advancedOpt\": \"{\\\"showAdvancedOpt\\\": \\\"no\\\", \\\"__current_case__\\\": 0}\", \"chromInfo\": \"\\\"/usr/local/galaxy/galaxy-dist/tool-data/shared/ucsc/chrom/?.len\\\"\"}",
+      "tool_version": "3.0.2.0",
+      "type": "tool",
+      "uuid": "37313422-889f-48c1-b52a-fdbc1774f0ba",
+      "workflow_outputs": []
+    },
+    "58": {
+      "annotation": "",
+      "content_id": "toolshed.g2.bx.psu.edu/repos/bgruening/deeptools_plot_heatmap/deeptools_plot_heatmap/3.0.2.0",
+      "errors": null,
+      "id": 58,
+      "input_connections": {
+        "matrixFile": {
+          "id": 56,
+          "output_name": "outFileName"
+        }
+      },
+      "inputs": [
+        {
+          "description": "runtime parameter for tool plotHeatmap",
+          "name": "matrixFile"
+        }
+      ],
+      "label": null,
+      "name": "plotHeatmap",
+      "outputs": [
+        {
+          "name": "outFileName",
+          "type": "png"
+        },
+        {
+          "name": "outFileSortedRegions",
+          "type": "bed"
+        },
+        {
+          "name": "outFileNameMatrix",
+          "type": "tabular"
+        }
+      ],
+      "position": {
+        "left": 2098,
+        "top": 200
+      },
+      "post_job_actions": {
+        "HideDatasetActionoutFileName": {
+          "action_arguments": {},
+          "action_type": "HideDatasetAction",
+          "output_name": "outFileName"
+        },
+        "HideDatasetActionoutFileNameMatrix": {
+          "action_arguments": {},
+          "action_type": "HideDatasetAction",
+          "output_name": "outFileNameMatrix"
+        },
+        "HideDatasetActionoutFileSortedRegions": {
+          "action_arguments": {},
+          "action_type": "HideDatasetAction",
+          "output_name": "outFileSortedRegions"
+        }
+      },
+      "tool_id": "toolshed.g2.bx.psu.edu/repos/bgruening/deeptools_plot_heatmap/deeptools_plot_heatmap/3.0.2.0",
+      "tool_shed_repository": {
+        "changeset_revision": "010e58e9d822",
+        "name": "deeptools_plot_heatmap",
+        "owner": "bgruening",
+        "tool_shed": "toolshed.g2.bx.psu.edu"
+      },
+      "tool_state": "{\"__page__\": null, \"__rerun_remap_job_id__\": null, \"matrixFile\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\", \"output\": \"{\\\"showOutputSettings\\\": \\\"no\\\", \\\"__current_case__\\\": 0}\", \"advancedOpt\": \"{\\\"used_multiple_regions\\\": {\\\"clustering\\\": {\\\"k_kmeans\\\": \\\"2\\\", \\\"__current_case__\\\": 0, \\\"clustering_options\\\": \\\"kmeans\\\"}, \\\"__current_case__\\\": 0, \\\"used_multiple_regions_options\\\": \\\"no\\\"}, \\\"plotTitle\\\": \\\"\\\", \\\"colorMapRepeat\\\": [], \\\"alpha\\\": \\\"1.0\\\", \\\"colorList\\\": \\\"\\\", \\\"xAxisLabel\\\": \\\"distance (bp)\\\", \\\"perGroup\\\": \\\"false\\\", \\\"zMax\\\": \\\"\\\", \\\"sortUsing\\\": \\\"mean\\\", \\\"zMin\\\": \\\"\\\", \\\"startLabel\\\": \\\"\\\", \\\"averageTypeSummaryPlot\\\": \\\"mean\\\", \\\"whatToShow\\\": \\\"plot, heatmap and colorbar\\\", \\\"missingDataColor\\\": \\\"black\\\", \\\"referencePointLabel\\\": \\\"\\\", \\\"yMin\\\": \\\"\\\", \\\"regionsLabel\\\": \\\"\\\", \\\"yMax\\\": \\\"\\\", \\\"labelRotation\\\": \\\"0\\\", \\\"yAxisLabel\\\": \\\"genes\\\", \\\"endLabel\\\": \\\"\\\", \\\"sortRegions\\\": \\\"descend\\\", \\\"heatmapWidth\\\": \\\"7.5\\\", \\\"showAdvancedOpt\\\": \\\"yes\\\", \\\"__current_case__\\\": 1, \\\"heatmapHeight\\\": \\\"25.0\\\", \\\"samplesLabel\\\": \\\"\\\"}\", \"chromInfo\": \"\\\"/usr/local/galaxy/galaxy-dist/tool-data/shared/ucsc/chrom/?.len\\\"\"}",
+      "tool_version": "3.0.2.0",
+      "type": "tool",
+      "uuid": "586a43c0-3e14-4e16-822c-953a756fb9f4",
+      "workflow_outputs": []
+    },
+    "59": {
+      "annotation": "",
+      "content_id": "toolshed.g2.bx.psu.edu/repos/bgruening/deeptools_plot_heatmap/deeptools_plot_heatmap/3.0.2.0",
+      "errors": null,
+      "id": 59,
+      "input_connections": {
+        "matrixFile": {
+          "id": 57,
+          "output_name": "outFileName"
+        }
+      },
+      "inputs": [
+        {
+          "description": "runtime parameter for tool plotHeatmap",
+          "name": "matrixFile"
+        }
+      ],
+      "label": null,
+      "name": "plotHeatmap",
+      "outputs": [
+        {
+          "name": "outFileName",
+          "type": "png"
+        },
+        {
+          "name": "outFileSortedRegions",
+          "type": "bed"
+        },
+        {
+          "name": "outFileNameMatrix",
+          "type": "tabular"
+        }
+      ],
+      "position": {
+        "left": 2098,
+        "top": 390
+      },
+      "post_job_actions": {
+        "HideDatasetActionoutFileName": {
+          "action_arguments": {},
+          "action_type": "HideDatasetAction",
+          "output_name": "outFileName"
+        },
+        "HideDatasetActionoutFileNameMatrix": {
+          "action_arguments": {},
+          "action_type": "HideDatasetAction",
+          "output_name": "outFileNameMatrix"
+        },
+        "HideDatasetActionoutFileSortedRegions": {
+          "action_arguments": {},
+          "action_type": "HideDatasetAction",
+          "output_name": "outFileSortedRegions"
+        }
+      },
+      "tool_id": "toolshed.g2.bx.psu.edu/repos/bgruening/deeptools_plot_heatmap/deeptools_plot_heatmap/3.0.2.0",
+      "tool_shed_repository": {
+        "changeset_revision": "010e58e9d822",
+        "name": "deeptools_plot_heatmap",
+        "owner": "bgruening",
+        "tool_shed": "toolshed.g2.bx.psu.edu"
+      },
+      "tool_state": "{\"__page__\": null, \"__rerun_remap_job_id__\": null, \"matrixFile\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\", \"output\": \"{\\\"showOutputSettings\\\": \\\"no\\\", \\\"__current_case__\\\": 0}\", \"advancedOpt\": \"{\\\"used_multiple_regions\\\": {\\\"clustering\\\": {\\\"k_kmeans\\\": \\\"6\\\", \\\"__current_case__\\\": 0, \\\"clustering_options\\\": \\\"kmeans\\\"}, \\\"__current_case__\\\": 0, \\\"used_multiple_regions_options\\\": \\\"no\\\"}, \\\"plotTitle\\\": \\\"\\\", \\\"colorMapRepeat\\\": [], \\\"alpha\\\": \\\"1.0\\\", \\\"colorList\\\": \\\"\\\", \\\"xAxisLabel\\\": \\\"distance (bp)\\\", \\\"perGroup\\\": \\\"false\\\", \\\"zMax\\\": \\\"\\\", \\\"sortUsing\\\": \\\"mean\\\", \\\"zMin\\\": \\\"\\\", \\\"startLabel\\\": \\\"\\\", \\\"averageTypeSummaryPlot\\\": \\\"mean\\\", \\\"whatToShow\\\": \\\"plot, heatmap and colorbar\\\", \\\"missingDataColor\\\": \\\"black\\\", \\\"referencePointLabel\\\": \\\"\\\", \\\"yMin\\\": \\\"\\\", \\\"regionsLabel\\\": \\\"\\\", \\\"yMax\\\": \\\"\\\", \\\"labelRotation\\\": \\\"0\\\", \\\"yAxisLabel\\\": \\\"genes\\\", \\\"endLabel\\\": \\\"\\\", \\\"sortRegions\\\": \\\"descend\\\", \\\"heatmapWidth\\\": \\\"7.5\\\", \\\"showAdvancedOpt\\\": \\\"yes\\\", \\\"__current_case__\\\": 1, \\\"heatmapHeight\\\": \\\"25.0\\\", \\\"samplesLabel\\\": \\\"\\\"}\", \"chromInfo\": \"\\\"/usr/local/galaxy/galaxy-dist/tool-data/shared/ucsc/chrom/?.len\\\"\"}",
+      "tool_version": "3.0.2.0",
+      "type": "tool",
+      "uuid": "874b0d0d-8837-42c0-8a13-cf2885598bf1",
+      "workflow_outputs": []
+    },
+    "6": {
+      "annotation": "",
+      "content_id": null,
+      "errors": null,
+      "id": 6,
+      "input_connections": {},
+      "inputs": [
+        {
+          "description": "",
+          "name": "wt_H3K4me3_rep2"
+        }
+      ],
+      "label": "wt_H3K4me3_rep2",
+      "name": "Input dataset",
+      "outputs": [],
+      "position": {
+        "left": 200,
+        "top": 776
+      },
+      "tool_id": null,
+      "tool_state": "{\"name\": \"wt_H3K4me3_rep2\"}",
+      "tool_version": null,
+      "type": "data_input",
+      "uuid": "531dbbe8-4a2f-49d8-a9cf-c23abda41287",
+      "workflow_outputs": [
+        {
+          "label": null,
+          "output_name": "output",
+          "uuid": "9f4bd4e8-bd77-4de5-afd6-655f0b34debb"
+        }
+      ]
+    },
+    "7": {
+      "annotation": "",
+      "content_id": null,
+      "errors": null,
+      "id": 7,
+      "input_connections": {},
+      "inputs": [
+        {
+          "description": "",
+          "name": "wt_H3K27me3_rep2"
+        }
+      ],
+      "label": "wt_H3K27me3_rep2",
+      "name": "Input dataset",
+      "outputs": [],
+      "position": {
+        "left": 200,
+        "top": 863
+      },
+      "tool_id": null,
+      "tool_state": "{\"name\": \"wt_H3K27me3_rep2\"}",
+      "tool_version": null,
+      "type": "data_input",
+      "uuid": "ab56e8f1-8167-4e24-abc7-670d3f46fc4d",
+      "workflow_outputs": [
+        {
+          "label": null,
+          "output_name": "output",
+          "uuid": "5d841d48-693b-4724-bae4-10071026ae44"
+        }
+      ]
+    },
+    "8": {
+      "annotation": "",
+      "content_id": null,
+      "errors": null,
+      "id": 8,
+      "input_connections": {},
+      "inputs": [
+        {
+          "description": "",
+          "name": "wt_input_rep2"
+        }
+      ],
+      "label": "wt_input_rep2",
+      "name": "Input dataset",
+      "outputs": [],
+      "position": {
+        "left": 200,
+        "top": 968
+      },
+      "tool_id": null,
+      "tool_state": "{\"name\": \"wt_input_rep2\"}",
+      "tool_version": null,
+      "type": "data_input",
+      "uuid": "a7846e57-7f8a-4922-9f01-64ef71345413",
+      "workflow_outputs": [
+        {
+          "label": null,
+          "output_name": "output",
+          "uuid": "e4d0b2fa-d718-4358-8fd0-4736e3f6e7e0"
+        }
+      ]
+    },
+    "9": {
+      "annotation": "",
+      "content_id": null,
+      "errors": null,
+      "id": 9,
+      "input_connections": {},
+      "inputs": [
+        {
+          "description": "",
+          "name": "wt_CTCF_rep1"
+        }
+      ],
+      "label": "wt_CTCF_rep1",
+      "name": "Input dataset",
+      "outputs": [],
+      "position": {
+        "left": 200,
+        "top": 1055
+      },
+      "tool_id": null,
+      "tool_state": "{\"name\": \"wt_CTCF_rep1\"}",
+      "tool_version": null,
+      "type": "data_input",
+      "uuid": "f0b41074-fded-4eb9-b444-531b7c93c7f8",
+      "workflow_outputs": [
+        {
+          "label": null,
+          "output_name": "output",
+          "uuid": "d8372f9a-eb1c-4f99-8464-353239537e56"
+        }
+      ]
+    }
+  },
+  "tags": [],
+  "uuid": "8c2b398e-d873-49f5-8665-c98b4ea642db"
+}

--- a/topics/genome-annotation/tutorials/annotation-with-maker/workflows/main_workflow.ga
+++ b/topics/genome-annotation/tutorials/annotation-with-maker/workflows/main_workflow.ga
@@ -1,1 +1,1672 @@
-{"uuid": "245fa7cb-ae4e-4d3a-90a9-f0d3aedb0b93", "tags": [], "format-version": "0.1", "name": "Genome annotation with Maker", "steps": {"0": {"tool_id": null, "tool_version": null, "outputs": [], "workflow_outputs": [{"output_name": "output", "uuid": "ccb7418d-3c9b-4edf-900b-c9a263928665", "label": null}], "input_connections": {}, "tool_state": "{}", "id": 0, "uuid": "a361a75e-5fa4-44ca-a4b7-cc9054a73054", "errors": null, "name": "Input dataset", "label": "Genome sequence", "inputs": [], "position": {"top": 347, "left": 200}, "annotation": "", "content_id": null, "type": "data_input"}, "1": {"tool_id": null, "tool_version": null, "outputs": [], "workflow_outputs": [{"output_name": "output", "uuid": "21526dae-ff77-496a-81b9-e1c1117022d4", "label": null}], "input_connections": {}, "tool_state": "{}", "id": 1, "uuid": "6b3edbe9-085d-46ae-9ae3-96e876c003e0", "errors": null, "name": "Input dataset", "label": "EST and/or cDNA", "inputs": [], "position": {"top": 458, "left": 201}, "annotation": "", "content_id": null, "type": "data_input"}, "2": {"tool_id": null, "tool_version": null, "outputs": [], "workflow_outputs": [{"output_name": "output", "uuid": "9894240a-e8a5-4bdd-b767-c50739a19872", "label": null}], "input_connections": {}, "tool_state": "{}", "id": 2, "uuid": "ce4ee756-1713-4e6a-898c-b85a834712bc", "errors": null, "name": "Input dataset", "label": "Proteins", "inputs": [], "position": {"top": 550, "left": 200}, "annotation": "", "content_id": null, "type": "data_input"}, "3": {"tool_id": "toolshed.g2.bx.psu.edu/repos/simon-gladman/fasta_stats/fasta-stats/1.0.0", "tool_version": "1.0.0", "outputs": [{"type": "tabular", "name": "stats"}], "workflow_outputs": [{"output_name": "stats", "uuid": "df3cbf21-6f4a-4622-bee0-4d0197a8ae9a", "label": null}], "input_connections": {"dataset": {"output_name": "output", "id": 0}}, "tool_state": "{\"__page__\": null, \"__rerun_remap_job_id__\": null, \"dataset\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\"}", "id": 3, "tool_shed_repository": {"owner": "simon-gladman", "changeset_revision": "20ca2574216a", "name": "fasta_stats", "tool_shed": "toolshed.g2.bx.psu.edu"}, "uuid": "43cab601-f700-4278-bd0a-7f0997cf75cf", "errors": null, "name": "Fasta Statistics", "post_job_actions": {}, "label": null, "inputs": [{"name": "dataset", "description": "runtime parameter for tool Fasta Statistics"}], "position": {"top": 936.5, "left": 499}, "annotation": "", "content_id": "toolshed.g2.bx.psu.edu/repos/simon-gladman/fasta_stats/fasta-stats/1.0.0", "type": "tool"}, "4": {"tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/busco/busco/3.0.2+galaxy0", "tool_version": "3.0.2+galaxy0", "outputs": [{"type": "txt", "name": "busco_sum"}, {"type": "tabular", "name": "busco_table"}, {"type": "tabular", "name": "busco_missing"}], "workflow_outputs": [{"output_name": "busco_missing", "uuid": "f01b9a5d-68f5-4626-bfda-7f0fdcf4bf96", "label": null}, {"output_name": "busco_sum", "uuid": "43b9f11d-dcf0-401d-8ee2-d31643734bcc", "label": null}, {"output_name": "busco_table", "uuid": "afae7071-669c-4697-aaf3-13e3c3faa605", "label": null}], "input_connections": {"input": {"output_name": "output", "id": 0}}, "tool_state": "{\"adv\": \"{\\\"aug_prediction\\\": {\\\"augustus_mode\\\": \\\"no\\\", \\\"__current_case__\\\": 0}, \\\"evalue\\\": \\\"0.01\\\", \\\"limit\\\": \\\"3\\\", \\\"long\\\": \\\"false\\\"}\", \"__page__\": null, \"__rerun_remap_job_id__\": null, \"mode\": \"\\\"geno\\\"\", \"input\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\", \"lineage_path\": \"\\\"fungi_odb9\\\"\"}", "id": 4, "tool_shed_repository": {"owner": "iuc", "changeset_revision": "5ecdeca79a0d", "name": "busco", "tool_shed": "toolshed.g2.bx.psu.edu"}, "uuid": "1e9daffc-7c82-48a8-a2a9-304738d095d0", "errors": null, "name": "Busco", "post_job_actions": {}, "label": null, "inputs": [{"name": "input", "description": "runtime parameter for tool Busco"}], "position": {"top": 1036, "left": 497}, "annotation": "", "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/busco/busco/3.0.2+galaxy0", "type": "tool"}, "5": {"tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/maker/maker/2.31.9.1", "tool_version": "2.31.9.1", "outputs": [{"type": "gff3", "name": "output_gff"}, {"type": "gff3", "name": "output_evidences"}, {"type": "gff3", "name": "output_full"}], "workflow_outputs": [], "input_connections": {"protein_evidences|protein": {"output_name": "output", "id": 2}, "genome": {"output_name": "output", "id": 0}, "est_evidences|est": {"output_name": "output", "id": 1}}, "tool_state": "{\"reannotation\": \"{\\\"reannotate\\\": \\\"no\\\", \\\"__current_case__\\\": 0}\", \"__page__\": null, \"organism_type\": \"\\\"eukaryotic\\\"\", \"gene_prediction\": \"{\\\"model_gff\\\": {\\\"__class__\\\": \\\"RuntimeValue\\\"}, \\\"trna\\\": \\\"false\\\", \\\"snoscan_rrna\\\": {\\\"__class__\\\": \\\"RuntimeValue\\\"}, \\\"pred_gff\\\": {\\\"__class__\\\": \\\"RuntimeValue\\\"}}\", \"__rerun_remap_job_id__\": null, \"repeat_masking\": \"{\\\"repeat_source\\\": {\\\"source_type\\\": \\\"no\\\", \\\"__current_case__\\\": 2}}\", \"abinitio_gene_prediction\": \"{\\\"snaphmm\\\": {\\\"__class__\\\": \\\"RuntimeValue\\\"}, \\\"unmask\\\": \\\"false\\\", \\\"aug_prediction\\\": {\\\"augustus_mode\\\": \\\"no\\\", \\\"__current_case__\\\": 0}}\", \"est_evidences\": \"{\\\"altest\\\": {\\\"__class__\\\": \\\"RuntimeValue\\\"}, \\\"est2genome\\\": \\\"true\\\", \\\"est\\\": {\\\"__class__\\\": \\\"RuntimeValue\\\"}, \\\"altest_gff\\\": {\\\"__class__\\\": \\\"RuntimeValue\\\"}, \\\"est_gff\\\": {\\\"__class__\\\": \\\"RuntimeValue\\\"}}\", \"genome\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\", \"protein_evidences\": \"{\\\"protein2genome\\\": \\\"true\\\", \\\"protein\\\": {\\\"__class__\\\": \\\"RuntimeValue\\\"}, \\\"protein_gff\\\": {\\\"__class__\\\": \\\"RuntimeValue\\\"}}\", \"advanced\": \"{\\\"pred_stats\\\": \\\"false\\\", \\\"pred_flank\\\": \\\"200\\\", \\\"AED_threshold\\\": \\\"1.0\\\", \\\"keep_preds\\\": \\\"0.0\\\", \\\"other_gff\\\": {\\\"__class__\\\": \\\"RuntimeValue\\\"}, \\\"alt_splice\\\": \\\"false\\\", \\\"split_hit\\\": \\\"10000\\\", \\\"always_complete\\\": \\\"false\\\", \\\"single_exon\\\": {\\\"single_exon\\\": \\\"0\\\", \\\"__current_case__\\\": 0}, \\\"max_dna_len\\\": \\\"100000\\\", \\\"alt_peptide\\\": \\\"C\\\", \\\"map_forward\\\": \\\"false\\\", \\\"correct_est_fusion\\\": \\\"false\\\", \\\"min_contig\\\": \\\"1\\\", \\\"min_protein\\\": \\\"0\\\"}\"}", "id": 5, "tool_shed_repository": {"owner": "iuc", "changeset_revision": "73a79dec987b", "name": "maker", "tool_shed": "toolshed.g2.bx.psu.edu"}, "uuid": "6c96618f-d6d0-43bd-83a1-65ec6cb960ba", "errors": null, "name": "Maker", "post_job_actions": {"HideDatasetActionoutput_gff": {"output_name": "output_gff", "action_type": "HideDatasetAction", "action_arguments": {}}, "HideDatasetActionoutput_evidences": {"output_name": "output_evidences", "action_type": "HideDatasetAction", "action_arguments": {}}, "HideDatasetActionoutput_full": {"output_name": "output_full", "action_type": "HideDatasetAction", "action_arguments": {}}}, "label": null, "inputs": [{"name": "gene_prediction", "description": "runtime parameter for tool Maker"}, {"name": "gene_prediction", "description": "runtime parameter for tool Maker"}, {"name": "gene_prediction", "description": "runtime parameter for tool Maker"}, {"name": "abinitio_gene_prediction", "description": "runtime parameter for tool Maker"}, {"name": "est_evidences", "description": "runtime parameter for tool Maker"}, {"name": "est_evidences", "description": "runtime parameter for tool Maker"}, {"name": "est_evidences", "description": "runtime parameter for tool Maker"}, {"name": "est_evidences", "description": "runtime parameter for tool Maker"}, {"name": "genome", "description": "runtime parameter for tool Maker"}, {"name": "protein_evidences", "description": "runtime parameter for tool Maker"}, {"name": "protein_evidences", "description": "runtime parameter for tool Maker"}, {"name": "advanced", "description": "runtime parameter for tool Maker"}], "position": {"top": 402.1166687011719, "left": 474.86669921875}, "annotation": "", "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/maker/maker/2.31.9.1", "type": "tool"}, "6": {"tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/snap_training/snap_training/2013_11_29", "tool_version": "2013_11_29", "outputs": [{"type": "snaphmm", "name": "output"}], "workflow_outputs": [], "input_connections": {"genome": {"output_name": "output", "id": 0}, "maker_gff": {"output_name": "output_gff", "id": 5}}, "tool_state": "{\"__page__\": null, \"gene_num\": \"\\\"1000\\\"\", \"__rerun_remap_job_id__\": null, \"genome\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\", \"maker_gff\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\"}", "id": 6, "tool_shed_repository": {"owner": "iuc", "changeset_revision": "821bf8bc5623", "name": "snap_training", "tool_shed": "toolshed.g2.bx.psu.edu"}, "uuid": "6cf74e8a-5896-42a3-91aa-1be2f24bf1c3", "errors": null, "name": "Train SNAP", "post_job_actions": {"HideDatasetActionoutput": {"output_name": "output", "action_type": "HideDatasetAction", "action_arguments": {}}}, "label": null, "inputs": [{"name": "genome", "description": "runtime parameter for tool Train SNAP"}, {"name": "maker_gff", "description": "runtime parameter for tool Train SNAP"}], "position": {"top": 411.6166687011719, "left": 803.8666687011719}, "annotation": "", "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/snap_training/snap_training/2013_11_29", "type": "tool"}, "7": {"tool_id": "toolshed.g2.bx.psu.edu/repos/bgruening/augustus_training/augustus_training/3.2.3", "tool_version": "3.2.3", "outputs": [{"type": "augustus", "name": "output_tar"}], "workflow_outputs": [], "input_connections": {"genome": {"output_name": "output", "id": 0}, "maker_gff": {"output_name": "output_gff", "id": 5}}, "tool_state": "{\"__page__\": null, \"__rerun_remap_job_id__\": null, \"genome\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\", \"maker_gff\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\"}", "id": 7, "tool_shed_repository": {"owner": "bgruening", "changeset_revision": "86c89c3bd99d", "name": "augustus_training", "tool_shed": "toolshed.g2.bx.psu.edu"}, "uuid": "cb95420d-5347-4d34-9b0e-752113eb48d8", "errors": null, "name": "Train Augustus", "post_job_actions": {"HideDatasetActionoutput_tar": {"output_name": "output_tar", "action_type": "HideDatasetAction", "action_arguments": {}}}, "label": null, "inputs": [{"name": "genome", "description": "runtime parameter for tool Train Augustus"}, {"name": "maker_gff", "description": "runtime parameter for tool Train Augustus"}], "position": {"top": 589.61669921875, "left": 818.8666687011719}, "annotation": "", "content_id": "toolshed.g2.bx.psu.edu/repos/bgruening/augustus_training/augustus_training/3.2.3", "type": "tool"}, "8": {"tool_id": "toolshed.g2.bx.psu.edu/repos/devteam/gffread/gffread/2.2.1.1", "tool_version": "2.2.1.1", "outputs": [{"type": "gff3", "name": "output_gff"}, {"type": "gtf", "name": "output_gtf"}, {"type": "fasta", "name": "output_exons"}, {"type": "fasta", "name": "output_cds"}, {"type": "fasta", "name": "output_pep"}, {"type": "txt", "name": "output_dupinfo"}], "workflow_outputs": [], "input_connections": {"input": {"output_name": "output_gff", "id": 5}, "reference_genome|genome_fasta": {"output_name": "output", "id": 0}}, "tool_state": "{\"__page__\": null, \"filtering\": \"null\", \"gffs\": \"{\\\"gff_fmt\\\": \\\"none\\\", \\\"__current_case__\\\": 0}\", \"full_gff_attribute_preservation\": \"\\\"false\\\"\", \"reference_genome\": \"{\\\"source\\\": \\\"history\\\", \\\"fa_outputs\\\": [\\\"-w exons.fa\\\"], \\\"genome_fasta\\\": {\\\"__class__\\\": \\\"RuntimeValue\\\"}, \\\"__current_case__\\\": 2, \\\"ref_filtering\\\": null}\", \"merging\": \"{\\\"merge_sel\\\": \\\"none\\\", \\\"__current_case__\\\": 0}\", \"__rerun_remap_job_id__\": null, \"input\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\", \"decode_url\": \"\\\"false\\\"\", \"maxintron\": \"\\\"\\\"\", \"expose\": \"\\\"false\\\"\", \"region\": \"{\\\"region_filter\\\": \\\"none\\\", \\\"__current_case__\\\": 0}\", \"chr_replace\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\"}", "id": 8, "tool_shed_repository": {"owner": "devteam", "changeset_revision": "0232f19d300f", "name": "gffread", "tool_shed": "toolshed.g2.bx.psu.edu"}, "uuid": "73918785-0727-4cb4-a963-35837819616a", "errors": null, "name": "gffread", "post_job_actions": {"HideDatasetActionoutput_pep": {"output_name": "output_pep", "action_type": "HideDatasetAction", "action_arguments": {}}, "HideDatasetActionoutput_gff": {"output_name": "output_gff", "action_type": "HideDatasetAction", "action_arguments": {}}, "HideDatasetActionoutput_gtf": {"output_name": "output_gtf", "action_type": "HideDatasetAction", "action_arguments": {}}, "HideDatasetActionoutput_dupinfo": {"output_name": "output_dupinfo", "action_type": "HideDatasetAction", "action_arguments": {}}, "HideDatasetActionoutput_exons": {"output_name": "output_exons", "action_type": "HideDatasetAction", "action_arguments": {}}, "HideDatasetActionoutput_cds": {"output_name": "output_cds", "action_type": "HideDatasetAction", "action_arguments": {}}}, "label": null, "inputs": [{"name": "chr_replace", "description": "runtime parameter for tool gffread"}, {"name": "reference_genome", "description": "runtime parameter for tool gffread"}, {"name": "input", "description": "runtime parameter for tool gffread"}], "position": {"top": 988, "left": 787}, "annotation": "", "content_id": "toolshed.g2.bx.psu.edu/repos/devteam/gffread/gffread/2.2.1.1", "type": "tool"}, "9": {"tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/jcvi_gff_stats/jcvi_gff_stats/0.8.4", "tool_version": "0.8.4", "outputs": [{"type": "txt", "name": "summary"}, {"type": "pdf", "name": "graphs"}], "workflow_outputs": [{"output_name": "graphs", "uuid": "c6240f71-0bb9-465c-a3ac-dc720113b54c", "label": null}, {"output_name": "summary", "uuid": "8af52c03-600f-4d4b-ba50-d30dadbba278", "label": null}], "input_connections": {"gff": {"output_name": "output_gff", "id": 5}, "ref_genome|genome": {"output_name": "output", "id": 0}}, "tool_state": "{\"__page__\": null, \"__rerun_remap_job_id__\": null, \"ref_genome\": \"{\\\"genome\\\": {\\\"__class__\\\": \\\"RuntimeValue\\\"}, \\\"__current_case__\\\": 1, \\\"genome_type_select\\\": \\\"history\\\"}\", \"gff\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\"}", "id": 9, "tool_shed_repository": {"owner": "iuc", "changeset_revision": "8cffbd184762", "name": "jcvi_gff_stats", "tool_shed": "toolshed.g2.bx.psu.edu"}, "uuid": "673e51c8-a909-481b-ae45-6dc98072a249", "errors": null, "name": "Genome annotation statistics", "post_job_actions": {}, "label": null, "inputs": [{"name": "ref_genome", "description": "runtime parameter for tool Genome annotation statistics"}, {"name": "gff", "description": "runtime parameter for tool Genome annotation statistics"}], "position": {"top": 1281.5, "left": 791.5}, "annotation": "", "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/jcvi_gff_stats/jcvi_gff_stats/0.8.4", "type": "tool"}, "10": {"tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/maker/maker/2.31.9.1", "tool_version": "2.31.9.1", "outputs": [{"type": "gff3", "name": "output_gff"}, {"type": "gff3", "name": "output_evidences"}, {"type": "gff3", "name": "output_full"}], "workflow_outputs": [], "input_connections": {"reannotation|maker_gff": {"output_name": "output_full", "id": 5}, "abinitio_gene_prediction|aug_prediction|augustus_model": {"output_name": "output_tar", "id": 7}, "genome": {"output_name": "output", "id": 0}, "abinitio_gene_prediction|snaphmm": {"output_name": "output", "id": 6}}, "tool_state": "{\"reannotation\": \"{\\\"pred_pass\\\": \\\"false\\\", \\\"__current_case__\\\": 1, \\\"model_pass\\\": \\\"false\\\", \\\"rm_pass\\\": \\\"true\\\", \\\"maker_gff\\\": {\\\"__class__\\\": \\\"RuntimeValue\\\"}, \\\"other_pass\\\": \\\"false\\\", \\\"reannotate\\\": \\\"yes\\\", \\\"altest_pass\\\": \\\"true\\\", \\\"protein_pass\\\": \\\"true\\\", \\\"est_pass\\\": \\\"true\\\"}\", \"__page__\": null, \"organism_type\": \"\\\"eukaryotic\\\"\", \"gene_prediction\": \"{\\\"model_gff\\\": {\\\"__class__\\\": \\\"RuntimeValue\\\"}, \\\"trna\\\": \\\"false\\\", \\\"snoscan_rrna\\\": {\\\"__class__\\\": \\\"RuntimeValue\\\"}, \\\"pred_gff\\\": {\\\"__class__\\\": \\\"RuntimeValue\\\"}}\", \"__rerun_remap_job_id__\": null, \"repeat_masking\": \"{\\\"repeat_source\\\": {\\\"source_type\\\": \\\"no\\\", \\\"__current_case__\\\": 2}}\", \"abinitio_gene_prediction\": \"{\\\"snaphmm\\\": {\\\"__class__\\\": \\\"RuntimeValue\\\"}, \\\"unmask\\\": \\\"false\\\", \\\"aug_prediction\\\": {\\\"augustus_mode\\\": \\\"history\\\", \\\"__current_case__\\\": 1, \\\"augustus_model\\\": {\\\"__class__\\\": \\\"RuntimeValue\\\"}}}\", \"est_evidences\": \"{\\\"altest\\\": {\\\"__class__\\\": \\\"RuntimeValue\\\"}, \\\"est2genome\\\": \\\"false\\\", \\\"est\\\": {\\\"__class__\\\": \\\"RuntimeValue\\\"}, \\\"altest_gff\\\": {\\\"__class__\\\": \\\"RuntimeValue\\\"}, \\\"est_gff\\\": {\\\"__class__\\\": \\\"RuntimeValue\\\"}}\", \"genome\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\", \"protein_evidences\": \"{\\\"protein2genome\\\": \\\"false\\\", \\\"protein\\\": {\\\"__class__\\\": \\\"RuntimeValue\\\"}, \\\"protein_gff\\\": {\\\"__class__\\\": \\\"RuntimeValue\\\"}}\", \"advanced\": \"{\\\"pred_stats\\\": \\\"false\\\", \\\"pred_flank\\\": \\\"200\\\", \\\"AED_threshold\\\": \\\"1.0\\\", \\\"keep_preds\\\": \\\"0.0\\\", \\\"other_gff\\\": {\\\"__class__\\\": \\\"RuntimeValue\\\"}, \\\"alt_splice\\\": \\\"false\\\", \\\"split_hit\\\": \\\"10000\\\", \\\"always_complete\\\": \\\"false\\\", \\\"single_exon\\\": {\\\"single_exon\\\": \\\"0\\\", \\\"__current_case__\\\": 0}, \\\"max_dna_len\\\": \\\"100000\\\", \\\"alt_peptide\\\": \\\"C\\\", \\\"map_forward\\\": \\\"false\\\", \\\"correct_est_fusion\\\": \\\"false\\\", \\\"min_contig\\\": \\\"1\\\", \\\"min_protein\\\": \\\"0\\\"}\"}", "id": 10, "tool_shed_repository": {"owner": "iuc", "changeset_revision": "73a79dec987b", "name": "maker", "tool_shed": "toolshed.g2.bx.psu.edu"}, "uuid": "b0455510-745c-45fb-a99e-b0ef1cbd34a0", "errors": null, "name": "Maker", "post_job_actions": {"HideDatasetActionoutput_gff": {"output_name": "output_gff", "action_type": "HideDatasetAction", "action_arguments": {}}, "HideDatasetActionoutput_evidences": {"output_name": "output_evidences", "action_type": "HideDatasetAction", "action_arguments": {}}, "HideDatasetActionoutput_full": {"output_name": "output_full", "action_type": "HideDatasetAction", "action_arguments": {}}}, "label": null, "inputs": [{"name": "reannotation", "description": "runtime parameter for tool Maker"}, {"name": "gene_prediction", "description": "runtime parameter for tool Maker"}, {"name": "gene_prediction", "description": "runtime parameter for tool Maker"}, {"name": "gene_prediction", "description": "runtime parameter for tool Maker"}, {"name": "abinitio_gene_prediction", "description": "runtime parameter for tool Maker"}, {"name": "est_evidences", "description": "runtime parameter for tool Maker"}, {"name": "est_evidences", "description": "runtime parameter for tool Maker"}, {"name": "est_evidences", "description": "runtime parameter for tool Maker"}, {"name": "est_evidences", "description": "runtime parameter for tool Maker"}, {"name": "genome", "description": "runtime parameter for tool Maker"}, {"name": "protein_evidences", "description": "runtime parameter for tool Maker"}, {"name": "protein_evidences", "description": "runtime parameter for tool Maker"}, {"name": "advanced", "description": "runtime parameter for tool Maker"}], "position": {"top": 413.1166687011719, "left": 1090.8666687011719}, "annotation": "", "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/maker/maker/2.31.9.1", "type": "tool"}, "11": {"tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/busco/busco/3.0.2+galaxy0", "tool_version": "3.0.2+galaxy0", "outputs": [{"type": "txt", "name": "busco_sum"}, {"type": "tabular", "name": "busco_table"}, {"type": "tabular", "name": "busco_missing"}], "workflow_outputs": [{"output_name": "busco_sum", "uuid": "fb7d0b41-92b0-4839-aa4f-b65897eae521", "label": "Busco summary first round"}], "input_connections": {"input": {"output_name": "output_exons", "id": 8}}, "tool_state": "{\"adv\": \"{\\\"aug_prediction\\\": {\\\"augustus_mode\\\": \\\"no\\\", \\\"__current_case__\\\": 0}, \\\"evalue\\\": \\\"0.01\\\", \\\"limit\\\": \\\"3\\\", \\\"long\\\": \\\"false\\\"}\", \"__page__\": null, \"__rerun_remap_job_id__\": null, \"mode\": \"\\\"tran\\\"\", \"input\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\", \"lineage_path\": \"\\\"fungi_odb9\\\"\"}", "id": 11, "tool_shed_repository": {"owner": "iuc", "changeset_revision": "5ecdeca79a0d", "name": "busco", "tool_shed": "toolshed.g2.bx.psu.edu"}, "uuid": "baf6fb29-d3d6-42c6-9859-21b0378caf44", "errors": null, "name": "Busco", "post_job_actions": {"HideDatasetActionbusco_table": {"output_name": "busco_table", "action_type": "HideDatasetAction", "action_arguments": {}}, "HideDatasetActionbusco_missing": {"output_name": "busco_missing", "action_type": "HideDatasetAction", "action_arguments": {}}}, "label": null, "inputs": [{"name": "input", "description": "runtime parameter for tool Busco"}], "position": {"top": 1052, "left": 1077}, "annotation": "", "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/busco/busco/3.0.2+galaxy0", "type": "tool"}, "12": {"tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/snap_training/snap_training/2013_11_29", "tool_version": "2013_11_29", "outputs": [{"type": "snaphmm", "name": "output"}], "workflow_outputs": [{"output_name": "output", "uuid": "d124e154-8e5e-4588-a714-2a48c4db3872", "label": null}], "input_connections": {"genome": {"output_name": "output", "id": 0}, "maker_gff": {"output_name": "output_gff", "id": 10}}, "tool_state": "{\"__page__\": null, \"gene_num\": \"\\\"1000\\\"\", \"__rerun_remap_job_id__\": null, \"genome\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\", \"maker_gff\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\"}", "id": 12, "tool_shed_repository": {"owner": "iuc", "changeset_revision": "821bf8bc5623", "name": "snap_training", "tool_shed": "toolshed.g2.bx.psu.edu"}, "uuid": "100ef17b-1337-4727-9ccb-c847e0e290f7", "errors": null, "name": "Train SNAP", "post_job_actions": {}, "label": null, "inputs": [{"name": "genome", "description": "runtime parameter for tool Train SNAP"}, {"name": "maker_gff", "description": "runtime parameter for tool Train SNAP"}], "position": {"top": 407.6166687011719, "left": 1384.8666687011719}, "annotation": "", "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/snap_training/snap_training/2013_11_29", "type": "tool"}, "13": {"tool_id": "toolshed.g2.bx.psu.edu/repos/bgruening/augustus_training/augustus_training/3.2.3", "tool_version": "3.2.3", "outputs": [{"type": "augustus", "name": "output_tar"}], "workflow_outputs": [{"output_name": "output_tar", "uuid": "eaeb1ed6-0d75-4411-91aa-40fd3ea9b646", "label": null}], "input_connections": {"genome": {"output_name": "output", "id": 0}, "maker_gff": {"output_name": "output_gff", "id": 10}}, "tool_state": "{\"__page__\": null, \"__rerun_remap_job_id__\": null, \"genome\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\", \"maker_gff\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\"}", "id": 13, "tool_shed_repository": {"owner": "bgruening", "changeset_revision": "86c89c3bd99d", "name": "augustus_training", "tool_shed": "toolshed.g2.bx.psu.edu"}, "uuid": "e6c27b8d-4da9-4ff6-a6cb-5202db8abd0e", "errors": null, "name": "Train Augustus", "post_job_actions": {}, "label": null, "inputs": [{"name": "genome", "description": "runtime parameter for tool Train Augustus"}, {"name": "maker_gff", "description": "runtime parameter for tool Train Augustus"}], "position": {"top": 593.61669921875, "left": 1403.8666687011719}, "annotation": "", "content_id": "toolshed.g2.bx.psu.edu/repos/bgruening/augustus_training/augustus_training/3.2.3", "type": "tool"}, "14": {"tool_id": "toolshed.g2.bx.psu.edu/repos/devteam/gffread/gffread/2.2.1.1", "tool_version": "2.2.1.1", "outputs": [{"type": "gff3", "name": "output_gff"}, {"type": "gtf", "name": "output_gtf"}, {"type": "fasta", "name": "output_exons"}, {"type": "fasta", "name": "output_cds"}, {"type": "fasta", "name": "output_pep"}, {"type": "txt", "name": "output_dupinfo"}], "workflow_outputs": [], "input_connections": {"input": {"output_name": "output_gff", "id": 10}, "reference_genome|genome_fasta": {"output_name": "output", "id": 0}}, "tool_state": "{\"__page__\": null, \"filtering\": \"null\", \"gffs\": \"{\\\"gff_fmt\\\": \\\"none\\\", \\\"__current_case__\\\": 0}\", \"full_gff_attribute_preservation\": \"\\\"false\\\"\", \"reference_genome\": \"{\\\"source\\\": \\\"history\\\", \\\"fa_outputs\\\": [\\\"-w exons.fa\\\"], \\\"genome_fasta\\\": {\\\"__class__\\\": \\\"RuntimeValue\\\"}, \\\"__current_case__\\\": 2, \\\"ref_filtering\\\": null}\", \"merging\": \"{\\\"merge_sel\\\": \\\"none\\\", \\\"__current_case__\\\": 0}\", \"__rerun_remap_job_id__\": null, \"input\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\", \"decode_url\": \"\\\"false\\\"\", \"maxintron\": \"\\\"\\\"\", \"expose\": \"\\\"false\\\"\", \"region\": \"{\\\"region_filter\\\": \\\"none\\\", \\\"__current_case__\\\": 0}\", \"chr_replace\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\"}", "id": 14, "tool_shed_repository": {"owner": "devteam", "changeset_revision": "0232f19d300f", "name": "gffread", "tool_shed": "toolshed.g2.bx.psu.edu"}, "uuid": "3a501dca-fa6a-4604-afd4-ee046bbb62cd", "errors": null, "name": "gffread", "post_job_actions": {"HideDatasetActionoutput_pep": {"output_name": "output_pep", "action_type": "HideDatasetAction", "action_arguments": {}}, "HideDatasetActionoutput_dupinfo": {"output_name": "output_dupinfo", "action_type": "HideDatasetAction", "action_arguments": {}}, "HideDatasetActionoutput_gtf": {"output_name": "output_gtf", "action_type": "HideDatasetAction", "action_arguments": {}}, "HideDatasetActionoutput_gff": {"output_name": "output_gff", "action_type": "HideDatasetAction", "action_arguments": {}}, "HideDatasetActionoutput_exons": {"output_name": "output_exons", "action_type": "HideDatasetAction", "action_arguments": {}}, "HideDatasetActionoutput_cds": {"output_name": "output_cds", "action_type": "HideDatasetAction", "action_arguments": {}}}, "label": null, "inputs": [{"name": "chr_replace", "description": "runtime parameter for tool gffread"}, {"name": "reference_genome", "description": "runtime parameter for tool gffread"}, {"name": "input", "description": "runtime parameter for tool gffread"}], "position": {"top": 1052, "left": 1535}, "annotation": "", "content_id": "toolshed.g2.bx.psu.edu/repos/devteam/gffread/gffread/2.2.1.1", "type": "tool"}, "15": {"tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/jcvi_gff_stats/jcvi_gff_stats/0.8.4", "tool_version": "0.8.4", "outputs": [{"type": "txt", "name": "summary"}, {"type": "pdf", "name": "graphs"}], "workflow_outputs": [{"output_name": "graphs", "uuid": "64627062-2ee8-43d8-adc5-cc8cb57ad999", "label": null}, {"output_name": "summary", "uuid": "d58e3714-a1dc-43c9-8799-9221776bb63d", "label": null}], "input_connections": {"gff": {"output_name": "output_gff", "id": 10}, "ref_genome|genome": {"output_name": "output", "id": 0}}, "tool_state": "{\"__page__\": null, \"__rerun_remap_job_id__\": null, \"ref_genome\": \"{\\\"genome\\\": {\\\"__class__\\\": \\\"RuntimeValue\\\"}, \\\"__current_case__\\\": 1, \\\"genome_type_select\\\": \\\"history\\\"}\", \"gff\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\"}", "id": 15, "tool_shed_repository": {"owner": "iuc", "changeset_revision": "8cffbd184762", "name": "jcvi_gff_stats", "tool_shed": "toolshed.g2.bx.psu.edu"}, "uuid": "d0ec8ae3-a384-4b5f-aac8-31fa9f4d6490", "errors": null, "name": "Genome annotation statistics", "post_job_actions": {}, "label": null, "inputs": [{"name": "ref_genome", "description": "runtime parameter for tool Genome annotation statistics"}, {"name": "gff", "description": "runtime parameter for tool Genome annotation statistics"}], "position": {"top": 1340.5, "left": 1534.5}, "annotation": "", "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/jcvi_gff_stats/jcvi_gff_stats/0.8.4", "type": "tool"}, "16": {"tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/maker/maker/2.31.9.1", "tool_version": "2.31.9.1", "outputs": [{"type": "gff3", "name": "output_gff"}, {"type": "gff3", "name": "output_evidences"}, {"type": "gff3", "name": "output_full"}], "workflow_outputs": [], "input_connections": {"reannotation|maker_gff": {"output_name": "output_full", "id": 10}, "abinitio_gene_prediction|aug_prediction|augustus_model": {"output_name": "output_tar", "id": 13}, "genome": {"output_name": "output", "id": 0}, "abinitio_gene_prediction|snaphmm": {"output_name": "output", "id": 12}}, "tool_state": "{\"reannotation\": \"{\\\"pred_pass\\\": \\\"false\\\", \\\"__current_case__\\\": 1, \\\"model_pass\\\": \\\"false\\\", \\\"rm_pass\\\": \\\"true\\\", \\\"maker_gff\\\": {\\\"__class__\\\": \\\"RuntimeValue\\\"}, \\\"other_pass\\\": \\\"false\\\", \\\"reannotate\\\": \\\"yes\\\", \\\"altest_pass\\\": \\\"true\\\", \\\"protein_pass\\\": \\\"true\\\", \\\"est_pass\\\": \\\"true\\\"}\", \"__page__\": null, \"organism_type\": \"\\\"eukaryotic\\\"\", \"gene_prediction\": \"{\\\"model_gff\\\": {\\\"__class__\\\": \\\"RuntimeValue\\\"}, \\\"trna\\\": \\\"false\\\", \\\"snoscan_rrna\\\": {\\\"__class__\\\": \\\"RuntimeValue\\\"}, \\\"pred_gff\\\": {\\\"__class__\\\": \\\"RuntimeValue\\\"}}\", \"__rerun_remap_job_id__\": null, \"repeat_masking\": \"{\\\"repeat_source\\\": {\\\"source_type\\\": \\\"no\\\", \\\"__current_case__\\\": 2}}\", \"abinitio_gene_prediction\": \"{\\\"snaphmm\\\": {\\\"__class__\\\": \\\"RuntimeValue\\\"}, \\\"unmask\\\": \\\"false\\\", \\\"aug_prediction\\\": {\\\"augustus_mode\\\": \\\"history\\\", \\\"__current_case__\\\": 1, \\\"augustus_model\\\": {\\\"__class__\\\": \\\"RuntimeValue\\\"}}}\", \"est_evidences\": \"{\\\"altest\\\": {\\\"__class__\\\": \\\"RuntimeValue\\\"}, \\\"est2genome\\\": \\\"false\\\", \\\"est\\\": {\\\"__class__\\\": \\\"RuntimeValue\\\"}, \\\"altest_gff\\\": {\\\"__class__\\\": \\\"RuntimeValue\\\"}, \\\"est_gff\\\": {\\\"__class__\\\": \\\"RuntimeValue\\\"}}\", \"genome\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\", \"protein_evidences\": \"{\\\"protein2genome\\\": \\\"false\\\", \\\"protein\\\": {\\\"__class__\\\": \\\"RuntimeValue\\\"}, \\\"protein_gff\\\": {\\\"__class__\\\": \\\"RuntimeValue\\\"}}\", \"advanced\": \"{\\\"pred_stats\\\": \\\"false\\\", \\\"pred_flank\\\": \\\"200\\\", \\\"AED_threshold\\\": \\\"1.0\\\", \\\"keep_preds\\\": \\\"0.0\\\", \\\"other_gff\\\": {\\\"__class__\\\": \\\"RuntimeValue\\\"}, \\\"alt_splice\\\": \\\"false\\\", \\\"split_hit\\\": \\\"10000\\\", \\\"always_complete\\\": \\\"false\\\", \\\"single_exon\\\": {\\\"single_exon\\\": \\\"0\\\", \\\"__current_case__\\\": 0}, \\\"max_dna_len\\\": \\\"100000\\\", \\\"alt_peptide\\\": \\\"C\\\", \\\"map_forward\\\": \\\"false\\\", \\\"correct_est_fusion\\\": \\\"false\\\", \\\"min_contig\\\": \\\"1\\\", \\\"min_protein\\\": \\\"0\\\"}\"}", "id": 16, "tool_shed_repository": {"owner": "iuc", "changeset_revision": "73a79dec987b", "name": "maker", "tool_shed": "toolshed.g2.bx.psu.edu"}, "uuid": "591d90b2-aee1-418e-9f1e-96ad16d15bb3", "errors": null, "name": "Maker", "post_job_actions": {"HideDatasetActionoutput_gff": {"output_name": "output_gff", "action_type": "HideDatasetAction", "action_arguments": {}}, "HideDatasetActionoutput_evidences": {"output_name": "output_evidences", "action_type": "HideDatasetAction", "action_arguments": {}}, "HideDatasetActionoutput_full": {"output_name": "output_full", "action_type": "HideDatasetAction", "action_arguments": {}}}, "label": null, "inputs": [{"name": "reannotation", "description": "runtime parameter for tool Maker"}, {"name": "gene_prediction", "description": "runtime parameter for tool Maker"}, {"name": "gene_prediction", "description": "runtime parameter for tool Maker"}, {"name": "gene_prediction", "description": "runtime parameter for tool Maker"}, {"name": "abinitio_gene_prediction", "description": "runtime parameter for tool Maker"}, {"name": "est_evidences", "description": "runtime parameter for tool Maker"}, {"name": "est_evidences", "description": "runtime parameter for tool Maker"}, {"name": "est_evidences", "description": "runtime parameter for tool Maker"}, {"name": "est_evidences", "description": "runtime parameter for tool Maker"}, {"name": "genome", "description": "runtime parameter for tool Maker"}, {"name": "protein_evidences", "description": "runtime parameter for tool Maker"}, {"name": "protein_evidences", "description": "runtime parameter for tool Maker"}, {"name": "advanced", "description": "runtime parameter for tool Maker"}], "position": {"top": 399.1166687011719, "left": 1639.8666687011719}, "annotation": "", "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/maker/maker/2.31.9.1", "type": "tool"}, "17": {"tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/busco/busco/3.0.2+galaxy0", "tool_version": "3.0.2+galaxy0", "outputs": [{"type": "txt", "name": "busco_sum"}, {"type": "tabular", "name": "busco_table"}, {"type": "tabular", "name": "busco_missing"}], "workflow_outputs": [{"output_name": "busco_sum", "uuid": "0e5b73a6-a82a-42e0-9e79-389f87b32755", "label": "Busco summary second round"}], "input_connections": {"input": {"output_name": "output_exons", "id": 14}}, "tool_state": "{\"adv\": \"{\\\"aug_prediction\\\": {\\\"augustus_mode\\\": \\\"no\\\", \\\"__current_case__\\\": 0}, \\\"evalue\\\": \\\"0.01\\\", \\\"limit\\\": \\\"3\\\", \\\"long\\\": \\\"false\\\"}\", \"__page__\": null, \"__rerun_remap_job_id__\": null, \"mode\": \"\\\"tran\\\"\", \"input\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\", \"lineage_path\": \"\\\"fungi_odb9\\\"\"}", "id": 17, "tool_shed_repository": {"owner": "iuc", "changeset_revision": "5ecdeca79a0d", "name": "busco", "tool_shed": "toolshed.g2.bx.psu.edu"}, "uuid": "0287ea88-f129-40c7-a98e-3f7c843cf60b", "errors": null, "name": "Busco", "post_job_actions": {"HideDatasetActionbusco_table": {"output_name": "busco_table", "action_type": "HideDatasetAction", "action_arguments": {}}, "HideDatasetActionbusco_missing": {"output_name": "busco_missing", "action_type": "HideDatasetAction", "action_arguments": {}}}, "label": null, "inputs": [{"name": "input", "description": "runtime parameter for tool Busco"}], "position": {"top": 1073, "left": 1812}, "annotation": "", "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/busco/busco/3.0.2+galaxy0", "type": "tool"}, "18": {"tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/maker_map_ids/maker_map_ids/2.31.9", "tool_version": "2.31.9", "outputs": [{"type": "gff", "name": "renamed"}, {"type": "tabular", "name": "id_map"}], "workflow_outputs": [{"output_name": "renamed", "uuid": "e6c1d04b-5ff9-43a2-9b1e-119b2e34ae0c", "label": null}], "input_connections": {"maker_gff": {"output_name": "output_gff", "id": 16}}, "tool_state": "{\"__page__\": null, \"prefix\": \"\\\"TEST\\\"\", \"maker_gff\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\", \"__rerun_remap_job_id__\": null, \"justify\": \"\\\"6\\\"\"}", "id": 18, "tool_shed_repository": {"owner": "iuc", "changeset_revision": "1b3626164087", "name": "maker_map_ids", "tool_shed": "toolshed.g2.bx.psu.edu"}, "uuid": "ce5cdd61-afb1-4652-8630-6f7a43256784", "errors": null, "name": "Map annotation ids", "post_job_actions": {"ChangeDatatypeActionrenamed": {"output_name": "renamed", "action_type": "ChangeDatatypeAction", "action_arguments": {"newtype": "gff3"}}, "HideDatasetActionid_map": {"output_name": "id_map", "action_type": "HideDatasetAction", "action_arguments": {}}}, "label": null, "inputs": [{"name": "maker_gff", "description": "runtime parameter for tool Map annotation ids"}], "position": {"top": 426.6166687011719, "left": 1991.36669921875}, "annotation": "", "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/maker_map_ids/maker_map_ids/2.31.9", "type": "tool"}, "19": {"tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/jbrowse/jbrowse/1.12.5+galaxy1", "tool_version": "1.12.5+galaxy1", "outputs": [{"type": "html", "name": "output"}], "workflow_outputs": [{"output_name": "output", "uuid": "67d05250-ab0e-407f-a82a-8aa39d6b4923", "label": null}], "input_connections": {"track_groups_1|data_tracks_0|data_format|annotation": [{"output_name": "output_evidences", "id": 10}, {"output_name": "output_evidences", "id": 16}, {"output_name": "output_evidences", "id": 5}], "track_groups_0|data_tracks_0|data_format|annotation": [{"output_name": "output_gff", "id": 10}, {"output_name": "output_gff", "id": 5}, {"output_name": "renamed", "id": 18}], "reference_genome|genomes": {"output_name": "output", "id": 0}}, "tool_state": "{\"__page__\": null, \"standalone\": \"\\\"true\\\"\", \"__rerun_remap_job_id__\": null, \"reference_genome\": \"{\\\"genomes\\\": {\\\"__class__\\\": \\\"RuntimeValue\\\"}, \\\"__current_case__\\\": 1, \\\"genome_type_select\\\": \\\"history\\\"}\", \"track_groups\": \"[{\\\"category\\\": \\\"Maker annotation\\\", \\\"__index__\\\": 0, \\\"data_tracks\\\": [{\\\"__index__\\\": 0, \\\"data_format\\\": {\\\"index\\\": \\\"false\\\", \\\"match_part\\\": {\\\"match_part_select\\\": \\\"false\\\", \\\"__current_case__\\\": 1}, \\\"jbstyle\\\": {\\\"style_classname\\\": \\\"feature\\\", \\\"style_description\\\": \\\"note,description\\\", \\\"style_height\\\": \\\"10px\\\", \\\"max_height\\\": \\\"600\\\", \\\"style_label\\\": \\\"product,name,id\\\"}, \\\"track_visibility\\\": \\\"default_off\\\", \\\"track_config\\\": {\\\"track_class\\\": \\\"JBrowse/View/Track/CanvasFeatures\\\", \\\"canvas_options\\\": {\\\"transcriptType\\\": \\\"\\\", \\\"subParts\\\": \\\"\\\", \\\"impliedUTRs\\\": \\\"false\\\"}, \\\"__current_case__\\\": 0}, \\\"jbcolor_scale\\\": {\\\"color_score\\\": {\\\"color\\\": {\\\"color_select\\\": \\\"automatic\\\", \\\"__current_case__\\\": 0}, \\\"__current_case__\\\": 0, \\\"color_score_select\\\": \\\"none\\\"}}, \\\"override_apollo_drag\\\": \\\"False\\\", \\\"__current_case__\\\": 2, \\\"override_apollo_plugins\\\": \\\"False\\\", \\\"jbmenu\\\": {\\\"track_menu\\\": []}, \\\"annotation\\\": {\\\"__class__\\\": \\\"RuntimeValue\\\"}, \\\"data_format_select\\\": \\\"gene_calls\\\"}}]}, {\\\"category\\\": \\\"Maker evidences\\\", \\\"__index__\\\": 1, \\\"data_tracks\\\": [{\\\"__index__\\\": 0, \\\"data_format\\\": {\\\"index\\\": \\\"false\\\", \\\"match_part\\\": {\\\"match_part_select\\\": \\\"true\\\", \\\"__current_case__\\\": 0, \\\"name\\\": {\\\"__class__\\\": \\\"RuntimeValue\\\"}}, \\\"jbstyle\\\": {\\\"style_classname\\\": \\\"feature\\\", \\\"style_description\\\": \\\"note,description\\\", \\\"style_height\\\": \\\"10px\\\", \\\"max_height\\\": \\\"600\\\", \\\"style_label\\\": \\\"product,name,id\\\"}, \\\"track_visibility\\\": \\\"default_off\\\", \\\"track_config\\\": {\\\"track_class\\\": \\\"JBrowse/View/Track/CanvasFeatures\\\", \\\"canvas_options\\\": {\\\"transcriptType\\\": \\\"\\\", \\\"subParts\\\": \\\"\\\", \\\"impliedUTRs\\\": \\\"false\\\"}, \\\"__current_case__\\\": 0}, \\\"jbcolor_scale\\\": {\\\"color_score\\\": {\\\"color\\\": {\\\"color_select\\\": \\\"automatic\\\", \\\"__current_case__\\\": 0}, \\\"__current_case__\\\": 0, \\\"color_score_select\\\": \\\"none\\\"}}, \\\"override_apollo_drag\\\": \\\"False\\\", \\\"__current_case__\\\": 2, \\\"override_apollo_plugins\\\": \\\"False\\\", \\\"jbmenu\\\": {\\\"track_menu\\\": []}, \\\"annotation\\\": {\\\"__class__\\\": \\\"RuntimeValue\\\"}, \\\"data_format_select\\\": \\\"gene_calls\\\"}}]}]\", \"plugins\": \"{\\\"GCContent\\\": \\\"false\\\", \\\"Bookmarks\\\": \\\"false\\\", \\\"theme\\\": \\\"\\\", \\\"ComboTrackSelector\\\": \\\"false\\\"}\", \"action\": \"{\\\"action_select\\\": \\\"create\\\", \\\"__current_case__\\\": 0}\", \"gencode\": \"\\\"1\\\"\", \"uglyTestingHack\": \"\\\"\\\"\", \"jbgen\": \"{\\\"trackPadding\\\": \\\"20\\\", \\\"show_tracklist\\\": \\\"true\\\", \\\"show_overview\\\": \\\"true\\\", \\\"show_nav\\\": \\\"true\\\", \\\"aboutDescription\\\": \\\"\\\", \\\"defaultLocation\\\": \\\"\\\", \\\"hideGenomeOptions\\\": \\\"false\\\", \\\"shareLink\\\": \\\"true\\\", \\\"show_menu\\\": \\\"true\\\"}\"}", "id": 19, "tool_shed_repository": {"owner": "iuc", "changeset_revision": "1c718d8b3532", "name": "jbrowse", "tool_shed": "toolshed.g2.bx.psu.edu"}, "uuid": "adfadef1-3024-499c-9850-34f4f038d822", "errors": null, "name": "JBrowse", "post_job_actions": {}, "label": null, "inputs": [{"name": "reference_genome", "description": "runtime parameter for tool JBrowse"}], "position": {"top": 230, "left": 2283}, "annotation": "", "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/jbrowse/jbrowse/1.12.5+galaxy1", "type": "tool"}, "20": {"tool_id": "toolshed.g2.bx.psu.edu/repos/devteam/gffread/gffread/2.2.1.1", "tool_version": "2.2.1.1", "outputs": [{"type": "gff3", "name": "output_gff"}, {"type": "gtf", "name": "output_gtf"}, {"type": "fasta", "name": "output_exons"}, {"type": "fasta", "name": "output_cds"}, {"type": "fasta", "name": "output_pep"}, {"type": "txt", "name": "output_dupinfo"}], "workflow_outputs": [{"output_name": "output_cds", "uuid": "58574cae-de5a-4bf1-8071-b23f3fde9519", "label": null}, {"output_name": "output_exons", "uuid": "6deb9839-5d60-4834-9c9d-219b470db959", "label": null}, {"output_name": "output_pep", "uuid": "41835dec-563c-4f4d-8d04-26f993b4df7f", "label": null}], "input_connections": {"input": {"output_name": "renamed", "id": 18}, "reference_genome|genome_fasta": {"output_name": "output", "id": 0}}, "tool_state": "{\"__page__\": null, \"filtering\": \"null\", \"gffs\": \"{\\\"gff_fmt\\\": \\\"none\\\", \\\"__current_case__\\\": 0}\", \"full_gff_attribute_preservation\": \"\\\"false\\\"\", \"reference_genome\": \"{\\\"source\\\": \\\"history\\\", \\\"fa_outputs\\\": [\\\"-w exons.fa\\\", \\\"-x cds.fa\\\", \\\"-y pep.fa\\\"], \\\"genome_fasta\\\": {\\\"__class__\\\": \\\"RuntimeValue\\\"}, \\\"__current_case__\\\": 2, \\\"ref_filtering\\\": null}\", \"merging\": \"{\\\"merge_sel\\\": \\\"none\\\", \\\"__current_case__\\\": 0}\", \"__rerun_remap_job_id__\": null, \"input\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\", \"decode_url\": \"\\\"false\\\"\", \"maxintron\": \"\\\"\\\"\", \"expose\": \"\\\"false\\\"\", \"region\": \"{\\\"region_filter\\\": \\\"none\\\", \\\"__current_case__\\\": 0}\", \"chr_replace\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\"}", "id": 20, "tool_shed_repository": {"owner": "devteam", "changeset_revision": "0232f19d300f", "name": "gffread", "tool_shed": "toolshed.g2.bx.psu.edu"}, "uuid": "3b5ecaf4-2d08-42f8-a6f0-f05ad9e5fe92", "errors": null, "name": "gffread", "post_job_actions": {"HideDatasetActionoutput_dupinfo": {"output_name": "output_dupinfo", "action_type": "HideDatasetAction", "action_arguments": {}}, "HideDatasetActionoutput_gff": {"output_name": "output_gff", "action_type": "HideDatasetAction", "action_arguments": {}}, "HideDatasetActionoutput_gtf": {"output_name": "output_gtf", "action_type": "HideDatasetAction", "action_arguments": {}}}, "label": null, "inputs": [{"name": "chr_replace", "description": "runtime parameter for tool gffread"}, {"name": "reference_genome", "description": "runtime parameter for tool gffread"}, {"name": "input", "description": "runtime parameter for tool gffread"}], "position": {"top": 626, "left": 2290}, "annotation": "", "content_id": "toolshed.g2.bx.psu.edu/repos/devteam/gffread/gffread/2.2.1.1", "type": "tool"}, "21": {"tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/jcvi_gff_stats/jcvi_gff_stats/0.8.4", "tool_version": "0.8.4", "outputs": [{"type": "txt", "name": "summary"}, {"type": "pdf", "name": "graphs"}], "workflow_outputs": [{"output_name": "graphs", "uuid": "5a86e4d9-a402-494f-b4f5-b2c2b049b96f", "label": null}, {"output_name": "summary", "uuid": "3b73d282-51ab-4997-9124-e1e5db62b849", "label": null}], "input_connections": {"gff": {"output_name": "renamed", "id": 18}, "ref_genome|genome": {"output_name": "output", "id": 0}}, "tool_state": "{\"__page__\": null, \"__rerun_remap_job_id__\": null, \"ref_genome\": \"{\\\"genome\\\": {\\\"__class__\\\": \\\"RuntimeValue\\\"}, \\\"__current_case__\\\": 1, \\\"genome_type_select\\\": \\\"history\\\"}\", \"gff\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\"}", "id": 21, "tool_shed_repository": {"owner": "iuc", "changeset_revision": "8cffbd184762", "name": "jcvi_gff_stats", "tool_shed": "toolshed.g2.bx.psu.edu"}, "uuid": "14236032-ec57-4beb-ab0a-e44bf845643c", "errors": null, "name": "Genome annotation statistics", "post_job_actions": {}, "label": null, "inputs": [{"name": "ref_genome", "description": "runtime parameter for tool Genome annotation statistics"}, {"name": "gff", "description": "runtime parameter for tool Genome annotation statistics"}], "position": {"top": 916.5, "left": 2292.5}, "annotation": "", "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/jcvi_gff_stats/jcvi_gff_stats/0.8.4", "type": "tool"}, "22": {"tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/busco/busco/3.0.2+galaxy0", "tool_version": "3.0.2+galaxy0", "outputs": [{"type": "txt", "name": "busco_sum"}, {"type": "tabular", "name": "busco_table"}, {"type": "tabular", "name": "busco_missing"}], "workflow_outputs": [{"output_name": "busco_sum", "uuid": "c0c9f74e-7de1-4602-bc33-7b87cab6ae80", "label": "Busco summary final round"}], "input_connections": {"input": {"output_name": "output_exons", "id": 20}}, "tool_state": "{\"adv\": \"{\\\"aug_prediction\\\": {\\\"augustus_mode\\\": \\\"no\\\", \\\"__current_case__\\\": 0}, \\\"evalue\\\": \\\"0.01\\\", \\\"limit\\\": \\\"3\\\", \\\"long\\\": \\\"false\\\"}\", \"__page__\": null, \"__rerun_remap_job_id__\": null, \"mode\": \"\\\"tran\\\"\", \"input\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\", \"lineage_path\": \"\\\"fungi_odb9\\\"\"}", "id": 22, "tool_shed_repository": {"owner": "iuc", "changeset_revision": "5ecdeca79a0d", "name": "busco", "tool_shed": "toolshed.g2.bx.psu.edu"}, "uuid": "186dc61b-e9c2-4292-b80f-29db38d5f247", "errors": null, "name": "Busco", "post_job_actions": {"HideDatasetActionbusco_table": {"output_name": "busco_table", "action_type": "HideDatasetAction", "action_arguments": {}}, "HideDatasetActionbusco_missing": {"output_name": "busco_missing", "action_type": "HideDatasetAction", "action_arguments": {}}}, "label": null, "inputs": [{"name": "input", "description": "runtime parameter for tool Busco"}], "position": {"top": 659, "left": 2590}, "annotation": "", "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/busco/busco/3.0.2+galaxy0", "type": "tool"}}, "annotation": "", "a_galaxy_workflow": "true"}
+{
+  "a_galaxy_workflow": "true",
+  "annotation": "",
+  "format-version": "0.1",
+  "name": "Genome annotation with Maker",
+  "steps": {
+    "0": {
+      "annotation": "",
+      "content_id": null,
+      "errors": null,
+      "id": 0,
+      "input_connections": {},
+      "inputs": [],
+      "label": "Genome sequence",
+      "name": "Input dataset",
+      "outputs": [],
+      "position": {
+        "left": 200,
+        "top": 347
+      },
+      "tool_id": null,
+      "tool_state": "{}",
+      "tool_version": null,
+      "type": "data_input",
+      "uuid": "a361a75e-5fa4-44ca-a4b7-cc9054a73054",
+      "workflow_outputs": [
+        {
+          "label": null,
+          "output_name": "output",
+          "uuid": "ccb7418d-3c9b-4edf-900b-c9a263928665"
+        }
+      ]
+    },
+    "1": {
+      "annotation": "",
+      "content_id": null,
+      "errors": null,
+      "id": 1,
+      "input_connections": {},
+      "inputs": [],
+      "label": "EST and/or cDNA",
+      "name": "Input dataset",
+      "outputs": [],
+      "position": {
+        "left": 201,
+        "top": 458
+      },
+      "tool_id": null,
+      "tool_state": "{}",
+      "tool_version": null,
+      "type": "data_input",
+      "uuid": "6b3edbe9-085d-46ae-9ae3-96e876c003e0",
+      "workflow_outputs": [
+        {
+          "label": null,
+          "output_name": "output",
+          "uuid": "21526dae-ff77-496a-81b9-e1c1117022d4"
+        }
+      ]
+    },
+    "10": {
+      "annotation": "",
+      "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/maker/maker/2.31.9.1",
+      "errors": null,
+      "id": 10,
+      "input_connections": {
+        "abinitio_gene_prediction|aug_prediction|augustus_model": {
+          "id": 7,
+          "output_name": "output_tar"
+        },
+        "abinitio_gene_prediction|snaphmm": {
+          "id": 6,
+          "output_name": "output"
+        },
+        "genome": {
+          "id": 0,
+          "output_name": "output"
+        },
+        "reannotation|maker_gff": {
+          "id": 5,
+          "output_name": "output_full"
+        }
+      },
+      "inputs": [
+        {
+          "description": "runtime parameter for tool Maker",
+          "name": "reannotation"
+        },
+        {
+          "description": "runtime parameter for tool Maker",
+          "name": "gene_prediction"
+        },
+        {
+          "description": "runtime parameter for tool Maker",
+          "name": "gene_prediction"
+        },
+        {
+          "description": "runtime parameter for tool Maker",
+          "name": "gene_prediction"
+        },
+        {
+          "description": "runtime parameter for tool Maker",
+          "name": "abinitio_gene_prediction"
+        },
+        {
+          "description": "runtime parameter for tool Maker",
+          "name": "est_evidences"
+        },
+        {
+          "description": "runtime parameter for tool Maker",
+          "name": "est_evidences"
+        },
+        {
+          "description": "runtime parameter for tool Maker",
+          "name": "est_evidences"
+        },
+        {
+          "description": "runtime parameter for tool Maker",
+          "name": "est_evidences"
+        },
+        {
+          "description": "runtime parameter for tool Maker",
+          "name": "genome"
+        },
+        {
+          "description": "runtime parameter for tool Maker",
+          "name": "protein_evidences"
+        },
+        {
+          "description": "runtime parameter for tool Maker",
+          "name": "protein_evidences"
+        },
+        {
+          "description": "runtime parameter for tool Maker",
+          "name": "advanced"
+        }
+      ],
+      "label": null,
+      "name": "Maker",
+      "outputs": [
+        {
+          "name": "output_gff",
+          "type": "gff3"
+        },
+        {
+          "name": "output_evidences",
+          "type": "gff3"
+        },
+        {
+          "name": "output_full",
+          "type": "gff3"
+        }
+      ],
+      "position": {
+        "left": 1090.8666687011719,
+        "top": 413.1166687011719
+      },
+      "post_job_actions": {
+        "HideDatasetActionoutput_evidences": {
+          "action_arguments": {},
+          "action_type": "HideDatasetAction",
+          "output_name": "output_evidences"
+        },
+        "HideDatasetActionoutput_full": {
+          "action_arguments": {},
+          "action_type": "HideDatasetAction",
+          "output_name": "output_full"
+        },
+        "HideDatasetActionoutput_gff": {
+          "action_arguments": {},
+          "action_type": "HideDatasetAction",
+          "output_name": "output_gff"
+        }
+      },
+      "tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/maker/maker/2.31.9.1",
+      "tool_shed_repository": {
+        "changeset_revision": "73a79dec987b",
+        "name": "maker",
+        "owner": "iuc",
+        "tool_shed": "toolshed.g2.bx.psu.edu"
+      },
+      "tool_state": "{\"reannotation\": \"{\\\"pred_pass\\\": \\\"false\\\", \\\"__current_case__\\\": 1, \\\"model_pass\\\": \\\"false\\\", \\\"rm_pass\\\": \\\"true\\\", \\\"maker_gff\\\": {\\\"__class__\\\": \\\"RuntimeValue\\\"}, \\\"other_pass\\\": \\\"false\\\", \\\"reannotate\\\": \\\"yes\\\", \\\"altest_pass\\\": \\\"true\\\", \\\"protein_pass\\\": \\\"true\\\", \\\"est_pass\\\": \\\"true\\\"}\", \"__page__\": null, \"organism_type\": \"\\\"eukaryotic\\\"\", \"gene_prediction\": \"{\\\"model_gff\\\": {\\\"__class__\\\": \\\"RuntimeValue\\\"}, \\\"trna\\\": \\\"false\\\", \\\"snoscan_rrna\\\": {\\\"__class__\\\": \\\"RuntimeValue\\\"}, \\\"pred_gff\\\": {\\\"__class__\\\": \\\"RuntimeValue\\\"}}\", \"__rerun_remap_job_id__\": null, \"repeat_masking\": \"{\\\"repeat_source\\\": {\\\"source_type\\\": \\\"no\\\", \\\"__current_case__\\\": 2}}\", \"abinitio_gene_prediction\": \"{\\\"snaphmm\\\": {\\\"__class__\\\": \\\"RuntimeValue\\\"}, \\\"unmask\\\": \\\"false\\\", \\\"aug_prediction\\\": {\\\"augustus_mode\\\": \\\"history\\\", \\\"__current_case__\\\": 1, \\\"augustus_model\\\": {\\\"__class__\\\": \\\"RuntimeValue\\\"}}}\", \"est_evidences\": \"{\\\"altest\\\": {\\\"__class__\\\": \\\"RuntimeValue\\\"}, \\\"est2genome\\\": \\\"false\\\", \\\"est\\\": {\\\"__class__\\\": \\\"RuntimeValue\\\"}, \\\"altest_gff\\\": {\\\"__class__\\\": \\\"RuntimeValue\\\"}, \\\"est_gff\\\": {\\\"__class__\\\": \\\"RuntimeValue\\\"}}\", \"genome\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\", \"protein_evidences\": \"{\\\"protein2genome\\\": \\\"false\\\", \\\"protein\\\": {\\\"__class__\\\": \\\"RuntimeValue\\\"}, \\\"protein_gff\\\": {\\\"__class__\\\": \\\"RuntimeValue\\\"}}\", \"advanced\": \"{\\\"pred_stats\\\": \\\"false\\\", \\\"pred_flank\\\": \\\"200\\\", \\\"AED_threshold\\\": \\\"1.0\\\", \\\"keep_preds\\\": \\\"0.0\\\", \\\"other_gff\\\": {\\\"__class__\\\": \\\"RuntimeValue\\\"}, \\\"alt_splice\\\": \\\"false\\\", \\\"split_hit\\\": \\\"10000\\\", \\\"always_complete\\\": \\\"false\\\", \\\"single_exon\\\": {\\\"single_exon\\\": \\\"0\\\", \\\"__current_case__\\\": 0}, \\\"max_dna_len\\\": \\\"100000\\\", \\\"alt_peptide\\\": \\\"C\\\", \\\"map_forward\\\": \\\"false\\\", \\\"correct_est_fusion\\\": \\\"false\\\", \\\"min_contig\\\": \\\"1\\\", \\\"min_protein\\\": \\\"0\\\"}\"}",
+      "tool_version": "2.31.9.1",
+      "type": "tool",
+      "uuid": "b0455510-745c-45fb-a99e-b0ef1cbd34a0",
+      "workflow_outputs": []
+    },
+    "11": {
+      "annotation": "",
+      "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/busco/busco/3.0.2+galaxy0",
+      "errors": null,
+      "id": 11,
+      "input_connections": {
+        "input": {
+          "id": 8,
+          "output_name": "output_exons"
+        }
+      },
+      "inputs": [
+        {
+          "description": "runtime parameter for tool Busco",
+          "name": "input"
+        }
+      ],
+      "label": null,
+      "name": "Busco",
+      "outputs": [
+        {
+          "name": "busco_sum",
+          "type": "txt"
+        },
+        {
+          "name": "busco_table",
+          "type": "tabular"
+        },
+        {
+          "name": "busco_missing",
+          "type": "tabular"
+        }
+      ],
+      "position": {
+        "left": 1077,
+        "top": 1052
+      },
+      "post_job_actions": {
+        "HideDatasetActionbusco_missing": {
+          "action_arguments": {},
+          "action_type": "HideDatasetAction",
+          "output_name": "busco_missing"
+        },
+        "HideDatasetActionbusco_table": {
+          "action_arguments": {},
+          "action_type": "HideDatasetAction",
+          "output_name": "busco_table"
+        }
+      },
+      "tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/busco/busco/3.0.2+galaxy0",
+      "tool_shed_repository": {
+        "changeset_revision": "5ecdeca79a0d",
+        "name": "busco",
+        "owner": "iuc",
+        "tool_shed": "toolshed.g2.bx.psu.edu"
+      },
+      "tool_state": "{\"adv\": \"{\\\"aug_prediction\\\": {\\\"augustus_mode\\\": \\\"no\\\", \\\"__current_case__\\\": 0}, \\\"evalue\\\": \\\"0.01\\\", \\\"limit\\\": \\\"3\\\", \\\"long\\\": \\\"false\\\"}\", \"__page__\": null, \"__rerun_remap_job_id__\": null, \"mode\": \"\\\"tran\\\"\", \"input\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\", \"lineage_path\": \"\\\"fungi_odb9\\\"\"}",
+      "tool_version": "3.0.2+galaxy0",
+      "type": "tool",
+      "uuid": "baf6fb29-d3d6-42c6-9859-21b0378caf44",
+      "workflow_outputs": [
+        {
+          "label": "Busco summary first round",
+          "output_name": "busco_sum",
+          "uuid": "fb7d0b41-92b0-4839-aa4f-b65897eae521"
+        }
+      ]
+    },
+    "12": {
+      "annotation": "",
+      "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/snap_training/snap_training/2013_11_29",
+      "errors": null,
+      "id": 12,
+      "input_connections": {
+        "genome": {
+          "id": 0,
+          "output_name": "output"
+        },
+        "maker_gff": {
+          "id": 10,
+          "output_name": "output_gff"
+        }
+      },
+      "inputs": [
+        {
+          "description": "runtime parameter for tool Train SNAP",
+          "name": "genome"
+        },
+        {
+          "description": "runtime parameter for tool Train SNAP",
+          "name": "maker_gff"
+        }
+      ],
+      "label": null,
+      "name": "Train SNAP",
+      "outputs": [
+        {
+          "name": "output",
+          "type": "snaphmm"
+        }
+      ],
+      "position": {
+        "left": 1384.8666687011719,
+        "top": 407.6166687011719
+      },
+      "post_job_actions": {},
+      "tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/snap_training/snap_training/2013_11_29",
+      "tool_shed_repository": {
+        "changeset_revision": "821bf8bc5623",
+        "name": "snap_training",
+        "owner": "iuc",
+        "tool_shed": "toolshed.g2.bx.psu.edu"
+      },
+      "tool_state": "{\"__page__\": null, \"gene_num\": \"\\\"1000\\\"\", \"__rerun_remap_job_id__\": null, \"genome\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\", \"maker_gff\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\"}",
+      "tool_version": "2013_11_29",
+      "type": "tool",
+      "uuid": "100ef17b-1337-4727-9ccb-c847e0e290f7",
+      "workflow_outputs": [
+        {
+          "label": null,
+          "output_name": "output",
+          "uuid": "d124e154-8e5e-4588-a714-2a48c4db3872"
+        }
+      ]
+    },
+    "13": {
+      "annotation": "",
+      "content_id": "toolshed.g2.bx.psu.edu/repos/bgruening/augustus_training/augustus_training/3.2.3",
+      "errors": null,
+      "id": 13,
+      "input_connections": {
+        "genome": {
+          "id": 0,
+          "output_name": "output"
+        },
+        "maker_gff": {
+          "id": 10,
+          "output_name": "output_gff"
+        }
+      },
+      "inputs": [
+        {
+          "description": "runtime parameter for tool Train Augustus",
+          "name": "genome"
+        },
+        {
+          "description": "runtime parameter for tool Train Augustus",
+          "name": "maker_gff"
+        }
+      ],
+      "label": null,
+      "name": "Train Augustus",
+      "outputs": [
+        {
+          "name": "output_tar",
+          "type": "augustus"
+        }
+      ],
+      "position": {
+        "left": 1403.8666687011719,
+        "top": 593.61669921875
+      },
+      "post_job_actions": {},
+      "tool_id": "toolshed.g2.bx.psu.edu/repos/bgruening/augustus_training/augustus_training/3.2.3",
+      "tool_shed_repository": {
+        "changeset_revision": "86c89c3bd99d",
+        "name": "augustus_training",
+        "owner": "bgruening",
+        "tool_shed": "toolshed.g2.bx.psu.edu"
+      },
+      "tool_state": "{\"__page__\": null, \"__rerun_remap_job_id__\": null, \"genome\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\", \"maker_gff\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\"}",
+      "tool_version": "3.2.3",
+      "type": "tool",
+      "uuid": "e6c27b8d-4da9-4ff6-a6cb-5202db8abd0e",
+      "workflow_outputs": [
+        {
+          "label": null,
+          "output_name": "output_tar",
+          "uuid": "eaeb1ed6-0d75-4411-91aa-40fd3ea9b646"
+        }
+      ]
+    },
+    "14": {
+      "annotation": "",
+      "content_id": "toolshed.g2.bx.psu.edu/repos/devteam/gffread/gffread/2.2.1.1",
+      "errors": null,
+      "id": 14,
+      "input_connections": {
+        "input": {
+          "id": 10,
+          "output_name": "output_gff"
+        },
+        "reference_genome|genome_fasta": {
+          "id": 0,
+          "output_name": "output"
+        }
+      },
+      "inputs": [
+        {
+          "description": "runtime parameter for tool gffread",
+          "name": "chr_replace"
+        },
+        {
+          "description": "runtime parameter for tool gffread",
+          "name": "reference_genome"
+        },
+        {
+          "description": "runtime parameter for tool gffread",
+          "name": "input"
+        }
+      ],
+      "label": null,
+      "name": "gffread",
+      "outputs": [
+        {
+          "name": "output_gff",
+          "type": "gff3"
+        },
+        {
+          "name": "output_gtf",
+          "type": "gtf"
+        },
+        {
+          "name": "output_exons",
+          "type": "fasta"
+        },
+        {
+          "name": "output_cds",
+          "type": "fasta"
+        },
+        {
+          "name": "output_pep",
+          "type": "fasta"
+        },
+        {
+          "name": "output_dupinfo",
+          "type": "txt"
+        }
+      ],
+      "position": {
+        "left": 1535,
+        "top": 1052
+      },
+      "post_job_actions": {
+        "HideDatasetActionoutput_cds": {
+          "action_arguments": {},
+          "action_type": "HideDatasetAction",
+          "output_name": "output_cds"
+        },
+        "HideDatasetActionoutput_dupinfo": {
+          "action_arguments": {},
+          "action_type": "HideDatasetAction",
+          "output_name": "output_dupinfo"
+        },
+        "HideDatasetActionoutput_exons": {
+          "action_arguments": {},
+          "action_type": "HideDatasetAction",
+          "output_name": "output_exons"
+        },
+        "HideDatasetActionoutput_gff": {
+          "action_arguments": {},
+          "action_type": "HideDatasetAction",
+          "output_name": "output_gff"
+        },
+        "HideDatasetActionoutput_gtf": {
+          "action_arguments": {},
+          "action_type": "HideDatasetAction",
+          "output_name": "output_gtf"
+        },
+        "HideDatasetActionoutput_pep": {
+          "action_arguments": {},
+          "action_type": "HideDatasetAction",
+          "output_name": "output_pep"
+        }
+      },
+      "tool_id": "toolshed.g2.bx.psu.edu/repos/devteam/gffread/gffread/2.2.1.1",
+      "tool_shed_repository": {
+        "changeset_revision": "0232f19d300f",
+        "name": "gffread",
+        "owner": "devteam",
+        "tool_shed": "toolshed.g2.bx.psu.edu"
+      },
+      "tool_state": "{\"__page__\": null, \"filtering\": \"null\", \"gffs\": \"{\\\"gff_fmt\\\": \\\"none\\\", \\\"__current_case__\\\": 0}\", \"full_gff_attribute_preservation\": \"\\\"false\\\"\", \"reference_genome\": \"{\\\"source\\\": \\\"history\\\", \\\"fa_outputs\\\": [\\\"-w exons.fa\\\"], \\\"genome_fasta\\\": {\\\"__class__\\\": \\\"RuntimeValue\\\"}, \\\"__current_case__\\\": 2, \\\"ref_filtering\\\": null}\", \"merging\": \"{\\\"merge_sel\\\": \\\"none\\\", \\\"__current_case__\\\": 0}\", \"__rerun_remap_job_id__\": null, \"input\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\", \"decode_url\": \"\\\"false\\\"\", \"maxintron\": \"\\\"\\\"\", \"expose\": \"\\\"false\\\"\", \"region\": \"{\\\"region_filter\\\": \\\"none\\\", \\\"__current_case__\\\": 0}\", \"chr_replace\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\"}",
+      "tool_version": "2.2.1.1",
+      "type": "tool",
+      "uuid": "3a501dca-fa6a-4604-afd4-ee046bbb62cd",
+      "workflow_outputs": []
+    },
+    "15": {
+      "annotation": "",
+      "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/jcvi_gff_stats/jcvi_gff_stats/0.8.4",
+      "errors": null,
+      "id": 15,
+      "input_connections": {
+        "gff": {
+          "id": 10,
+          "output_name": "output_gff"
+        },
+        "ref_genome|genome": {
+          "id": 0,
+          "output_name": "output"
+        }
+      },
+      "inputs": [
+        {
+          "description": "runtime parameter for tool Genome annotation statistics",
+          "name": "ref_genome"
+        },
+        {
+          "description": "runtime parameter for tool Genome annotation statistics",
+          "name": "gff"
+        }
+      ],
+      "label": null,
+      "name": "Genome annotation statistics",
+      "outputs": [
+        {
+          "name": "summary",
+          "type": "txt"
+        },
+        {
+          "name": "graphs",
+          "type": "pdf"
+        }
+      ],
+      "position": {
+        "left": 1534.5,
+        "top": 1340.5
+      },
+      "post_job_actions": {},
+      "tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/jcvi_gff_stats/jcvi_gff_stats/0.8.4",
+      "tool_shed_repository": {
+        "changeset_revision": "8cffbd184762",
+        "name": "jcvi_gff_stats",
+        "owner": "iuc",
+        "tool_shed": "toolshed.g2.bx.psu.edu"
+      },
+      "tool_state": "{\"__page__\": null, \"__rerun_remap_job_id__\": null, \"ref_genome\": \"{\\\"genome\\\": {\\\"__class__\\\": \\\"RuntimeValue\\\"}, \\\"__current_case__\\\": 1, \\\"genome_type_select\\\": \\\"history\\\"}\", \"gff\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\"}",
+      "tool_version": "0.8.4",
+      "type": "tool",
+      "uuid": "d0ec8ae3-a384-4b5f-aac8-31fa9f4d6490",
+      "workflow_outputs": [
+        {
+          "label": null,
+          "output_name": "graphs",
+          "uuid": "64627062-2ee8-43d8-adc5-cc8cb57ad999"
+        },
+        {
+          "label": null,
+          "output_name": "summary",
+          "uuid": "d58e3714-a1dc-43c9-8799-9221776bb63d"
+        }
+      ]
+    },
+    "16": {
+      "annotation": "",
+      "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/maker/maker/2.31.9.1",
+      "errors": null,
+      "id": 16,
+      "input_connections": {
+        "abinitio_gene_prediction|aug_prediction|augustus_model": {
+          "id": 13,
+          "output_name": "output_tar"
+        },
+        "abinitio_gene_prediction|snaphmm": {
+          "id": 12,
+          "output_name": "output"
+        },
+        "genome": {
+          "id": 0,
+          "output_name": "output"
+        },
+        "reannotation|maker_gff": {
+          "id": 10,
+          "output_name": "output_full"
+        }
+      },
+      "inputs": [
+        {
+          "description": "runtime parameter for tool Maker",
+          "name": "reannotation"
+        },
+        {
+          "description": "runtime parameter for tool Maker",
+          "name": "gene_prediction"
+        },
+        {
+          "description": "runtime parameter for tool Maker",
+          "name": "gene_prediction"
+        },
+        {
+          "description": "runtime parameter for tool Maker",
+          "name": "gene_prediction"
+        },
+        {
+          "description": "runtime parameter for tool Maker",
+          "name": "abinitio_gene_prediction"
+        },
+        {
+          "description": "runtime parameter for tool Maker",
+          "name": "est_evidences"
+        },
+        {
+          "description": "runtime parameter for tool Maker",
+          "name": "est_evidences"
+        },
+        {
+          "description": "runtime parameter for tool Maker",
+          "name": "est_evidences"
+        },
+        {
+          "description": "runtime parameter for tool Maker",
+          "name": "est_evidences"
+        },
+        {
+          "description": "runtime parameter for tool Maker",
+          "name": "genome"
+        },
+        {
+          "description": "runtime parameter for tool Maker",
+          "name": "protein_evidences"
+        },
+        {
+          "description": "runtime parameter for tool Maker",
+          "name": "protein_evidences"
+        },
+        {
+          "description": "runtime parameter for tool Maker",
+          "name": "advanced"
+        }
+      ],
+      "label": null,
+      "name": "Maker",
+      "outputs": [
+        {
+          "name": "output_gff",
+          "type": "gff3"
+        },
+        {
+          "name": "output_evidences",
+          "type": "gff3"
+        },
+        {
+          "name": "output_full",
+          "type": "gff3"
+        }
+      ],
+      "position": {
+        "left": 1639.8666687011719,
+        "top": 399.1166687011719
+      },
+      "post_job_actions": {
+        "HideDatasetActionoutput_evidences": {
+          "action_arguments": {},
+          "action_type": "HideDatasetAction",
+          "output_name": "output_evidences"
+        },
+        "HideDatasetActionoutput_full": {
+          "action_arguments": {},
+          "action_type": "HideDatasetAction",
+          "output_name": "output_full"
+        },
+        "HideDatasetActionoutput_gff": {
+          "action_arguments": {},
+          "action_type": "HideDatasetAction",
+          "output_name": "output_gff"
+        }
+      },
+      "tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/maker/maker/2.31.9.1",
+      "tool_shed_repository": {
+        "changeset_revision": "73a79dec987b",
+        "name": "maker",
+        "owner": "iuc",
+        "tool_shed": "toolshed.g2.bx.psu.edu"
+      },
+      "tool_state": "{\"reannotation\": \"{\\\"pred_pass\\\": \\\"false\\\", \\\"__current_case__\\\": 1, \\\"model_pass\\\": \\\"false\\\", \\\"rm_pass\\\": \\\"true\\\", \\\"maker_gff\\\": {\\\"__class__\\\": \\\"RuntimeValue\\\"}, \\\"other_pass\\\": \\\"false\\\", \\\"reannotate\\\": \\\"yes\\\", \\\"altest_pass\\\": \\\"true\\\", \\\"protein_pass\\\": \\\"true\\\", \\\"est_pass\\\": \\\"true\\\"}\", \"__page__\": null, \"organism_type\": \"\\\"eukaryotic\\\"\", \"gene_prediction\": \"{\\\"model_gff\\\": {\\\"__class__\\\": \\\"RuntimeValue\\\"}, \\\"trna\\\": \\\"false\\\", \\\"snoscan_rrna\\\": {\\\"__class__\\\": \\\"RuntimeValue\\\"}, \\\"pred_gff\\\": {\\\"__class__\\\": \\\"RuntimeValue\\\"}}\", \"__rerun_remap_job_id__\": null, \"repeat_masking\": \"{\\\"repeat_source\\\": {\\\"source_type\\\": \\\"no\\\", \\\"__current_case__\\\": 2}}\", \"abinitio_gene_prediction\": \"{\\\"snaphmm\\\": {\\\"__class__\\\": \\\"RuntimeValue\\\"}, \\\"unmask\\\": \\\"false\\\", \\\"aug_prediction\\\": {\\\"augustus_mode\\\": \\\"history\\\", \\\"__current_case__\\\": 1, \\\"augustus_model\\\": {\\\"__class__\\\": \\\"RuntimeValue\\\"}}}\", \"est_evidences\": \"{\\\"altest\\\": {\\\"__class__\\\": \\\"RuntimeValue\\\"}, \\\"est2genome\\\": \\\"false\\\", \\\"est\\\": {\\\"__class__\\\": \\\"RuntimeValue\\\"}, \\\"altest_gff\\\": {\\\"__class__\\\": \\\"RuntimeValue\\\"}, \\\"est_gff\\\": {\\\"__class__\\\": \\\"RuntimeValue\\\"}}\", \"genome\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\", \"protein_evidences\": \"{\\\"protein2genome\\\": \\\"false\\\", \\\"protein\\\": {\\\"__class__\\\": \\\"RuntimeValue\\\"}, \\\"protein_gff\\\": {\\\"__class__\\\": \\\"RuntimeValue\\\"}}\", \"advanced\": \"{\\\"pred_stats\\\": \\\"false\\\", \\\"pred_flank\\\": \\\"200\\\", \\\"AED_threshold\\\": \\\"1.0\\\", \\\"keep_preds\\\": \\\"0.0\\\", \\\"other_gff\\\": {\\\"__class__\\\": \\\"RuntimeValue\\\"}, \\\"alt_splice\\\": \\\"false\\\", \\\"split_hit\\\": \\\"10000\\\", \\\"always_complete\\\": \\\"false\\\", \\\"single_exon\\\": {\\\"single_exon\\\": \\\"0\\\", \\\"__current_case__\\\": 0}, \\\"max_dna_len\\\": \\\"100000\\\", \\\"alt_peptide\\\": \\\"C\\\", \\\"map_forward\\\": \\\"false\\\", \\\"correct_est_fusion\\\": \\\"false\\\", \\\"min_contig\\\": \\\"1\\\", \\\"min_protein\\\": \\\"0\\\"}\"}",
+      "tool_version": "2.31.9.1",
+      "type": "tool",
+      "uuid": "591d90b2-aee1-418e-9f1e-96ad16d15bb3",
+      "workflow_outputs": []
+    },
+    "17": {
+      "annotation": "",
+      "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/busco/busco/3.0.2+galaxy0",
+      "errors": null,
+      "id": 17,
+      "input_connections": {
+        "input": {
+          "id": 14,
+          "output_name": "output_exons"
+        }
+      },
+      "inputs": [
+        {
+          "description": "runtime parameter for tool Busco",
+          "name": "input"
+        }
+      ],
+      "label": null,
+      "name": "Busco",
+      "outputs": [
+        {
+          "name": "busco_sum",
+          "type": "txt"
+        },
+        {
+          "name": "busco_table",
+          "type": "tabular"
+        },
+        {
+          "name": "busco_missing",
+          "type": "tabular"
+        }
+      ],
+      "position": {
+        "left": 1812,
+        "top": 1073
+      },
+      "post_job_actions": {
+        "HideDatasetActionbusco_missing": {
+          "action_arguments": {},
+          "action_type": "HideDatasetAction",
+          "output_name": "busco_missing"
+        },
+        "HideDatasetActionbusco_table": {
+          "action_arguments": {},
+          "action_type": "HideDatasetAction",
+          "output_name": "busco_table"
+        }
+      },
+      "tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/busco/busco/3.0.2+galaxy0",
+      "tool_shed_repository": {
+        "changeset_revision": "5ecdeca79a0d",
+        "name": "busco",
+        "owner": "iuc",
+        "tool_shed": "toolshed.g2.bx.psu.edu"
+      },
+      "tool_state": "{\"adv\": \"{\\\"aug_prediction\\\": {\\\"augustus_mode\\\": \\\"no\\\", \\\"__current_case__\\\": 0}, \\\"evalue\\\": \\\"0.01\\\", \\\"limit\\\": \\\"3\\\", \\\"long\\\": \\\"false\\\"}\", \"__page__\": null, \"__rerun_remap_job_id__\": null, \"mode\": \"\\\"tran\\\"\", \"input\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\", \"lineage_path\": \"\\\"fungi_odb9\\\"\"}",
+      "tool_version": "3.0.2+galaxy0",
+      "type": "tool",
+      "uuid": "0287ea88-f129-40c7-a98e-3f7c843cf60b",
+      "workflow_outputs": [
+        {
+          "label": "Busco summary second round",
+          "output_name": "busco_sum",
+          "uuid": "0e5b73a6-a82a-42e0-9e79-389f87b32755"
+        }
+      ]
+    },
+    "18": {
+      "annotation": "",
+      "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/maker_map_ids/maker_map_ids/2.31.9",
+      "errors": null,
+      "id": 18,
+      "input_connections": {
+        "maker_gff": {
+          "id": 16,
+          "output_name": "output_gff"
+        }
+      },
+      "inputs": [
+        {
+          "description": "runtime parameter for tool Map annotation ids",
+          "name": "maker_gff"
+        }
+      ],
+      "label": null,
+      "name": "Map annotation ids",
+      "outputs": [
+        {
+          "name": "renamed",
+          "type": "gff"
+        },
+        {
+          "name": "id_map",
+          "type": "tabular"
+        }
+      ],
+      "position": {
+        "left": 1991.36669921875,
+        "top": 426.6166687011719
+      },
+      "post_job_actions": {
+        "ChangeDatatypeActionrenamed": {
+          "action_arguments": {
+            "newtype": "gff3"
+          },
+          "action_type": "ChangeDatatypeAction",
+          "output_name": "renamed"
+        },
+        "HideDatasetActionid_map": {
+          "action_arguments": {},
+          "action_type": "HideDatasetAction",
+          "output_name": "id_map"
+        }
+      },
+      "tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/maker_map_ids/maker_map_ids/2.31.9",
+      "tool_shed_repository": {
+        "changeset_revision": "1b3626164087",
+        "name": "maker_map_ids",
+        "owner": "iuc",
+        "tool_shed": "toolshed.g2.bx.psu.edu"
+      },
+      "tool_state": "{\"__page__\": null, \"prefix\": \"\\\"TEST\\\"\", \"maker_gff\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\", \"__rerun_remap_job_id__\": null, \"justify\": \"\\\"6\\\"\"}",
+      "tool_version": "2.31.9",
+      "type": "tool",
+      "uuid": "ce5cdd61-afb1-4652-8630-6f7a43256784",
+      "workflow_outputs": [
+        {
+          "label": null,
+          "output_name": "renamed",
+          "uuid": "e6c1d04b-5ff9-43a2-9b1e-119b2e34ae0c"
+        }
+      ]
+    },
+    "19": {
+      "annotation": "",
+      "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/jbrowse/jbrowse/1.12.5+galaxy1",
+      "errors": null,
+      "id": 19,
+      "input_connections": {
+        "reference_genome|genomes": {
+          "id": 0,
+          "output_name": "output"
+        },
+        "track_groups_0|data_tracks_0|data_format|annotation": [
+          {
+            "id": 10,
+            "output_name": "output_gff"
+          },
+          {
+            "id": 5,
+            "output_name": "output_gff"
+          },
+          {
+            "id": 18,
+            "output_name": "renamed"
+          }
+        ],
+        "track_groups_1|data_tracks_0|data_format|annotation": [
+          {
+            "id": 10,
+            "output_name": "output_evidences"
+          },
+          {
+            "id": 16,
+            "output_name": "output_evidences"
+          },
+          {
+            "id": 5,
+            "output_name": "output_evidences"
+          }
+        ]
+      },
+      "inputs": [
+        {
+          "description": "runtime parameter for tool JBrowse",
+          "name": "reference_genome"
+        }
+      ],
+      "label": null,
+      "name": "JBrowse",
+      "outputs": [
+        {
+          "name": "output",
+          "type": "html"
+        }
+      ],
+      "position": {
+        "left": 2283,
+        "top": 230
+      },
+      "post_job_actions": {},
+      "tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/jbrowse/jbrowse/1.12.5+galaxy1",
+      "tool_shed_repository": {
+        "changeset_revision": "1c718d8b3532",
+        "name": "jbrowse",
+        "owner": "iuc",
+        "tool_shed": "toolshed.g2.bx.psu.edu"
+      },
+      "tool_state": "{\"__page__\": null, \"standalone\": \"\\\"true\\\"\", \"__rerun_remap_job_id__\": null, \"reference_genome\": \"{\\\"genomes\\\": {\\\"__class__\\\": \\\"RuntimeValue\\\"}, \\\"__current_case__\\\": 1, \\\"genome_type_select\\\": \\\"history\\\"}\", \"track_groups\": \"[{\\\"category\\\": \\\"Maker annotation\\\", \\\"__index__\\\": 0, \\\"data_tracks\\\": [{\\\"__index__\\\": 0, \\\"data_format\\\": {\\\"index\\\": \\\"false\\\", \\\"match_part\\\": {\\\"match_part_select\\\": \\\"false\\\", \\\"__current_case__\\\": 1}, \\\"jbstyle\\\": {\\\"style_classname\\\": \\\"feature\\\", \\\"style_description\\\": \\\"note,description\\\", \\\"style_height\\\": \\\"10px\\\", \\\"max_height\\\": \\\"600\\\", \\\"style_label\\\": \\\"product,name,id\\\"}, \\\"track_visibility\\\": \\\"default_off\\\", \\\"track_config\\\": {\\\"track_class\\\": \\\"JBrowse/View/Track/CanvasFeatures\\\", \\\"canvas_options\\\": {\\\"transcriptType\\\": \\\"\\\", \\\"subParts\\\": \\\"\\\", \\\"impliedUTRs\\\": \\\"false\\\"}, \\\"__current_case__\\\": 0}, \\\"jbcolor_scale\\\": {\\\"color_score\\\": {\\\"color\\\": {\\\"color_select\\\": \\\"automatic\\\", \\\"__current_case__\\\": 0}, \\\"__current_case__\\\": 0, \\\"color_score_select\\\": \\\"none\\\"}}, \\\"override_apollo_drag\\\": \\\"False\\\", \\\"__current_case__\\\": 2, \\\"override_apollo_plugins\\\": \\\"False\\\", \\\"jbmenu\\\": {\\\"track_menu\\\": []}, \\\"annotation\\\": {\\\"__class__\\\": \\\"RuntimeValue\\\"}, \\\"data_format_select\\\": \\\"gene_calls\\\"}}]}, {\\\"category\\\": \\\"Maker evidences\\\", \\\"__index__\\\": 1, \\\"data_tracks\\\": [{\\\"__index__\\\": 0, \\\"data_format\\\": {\\\"index\\\": \\\"false\\\", \\\"match_part\\\": {\\\"match_part_select\\\": \\\"true\\\", \\\"__current_case__\\\": 0, \\\"name\\\": {\\\"__class__\\\": \\\"RuntimeValue\\\"}}, \\\"jbstyle\\\": {\\\"style_classname\\\": \\\"feature\\\", \\\"style_description\\\": \\\"note,description\\\", \\\"style_height\\\": \\\"10px\\\", \\\"max_height\\\": \\\"600\\\", \\\"style_label\\\": \\\"product,name,id\\\"}, \\\"track_visibility\\\": \\\"default_off\\\", \\\"track_config\\\": {\\\"track_class\\\": \\\"JBrowse/View/Track/CanvasFeatures\\\", \\\"canvas_options\\\": {\\\"transcriptType\\\": \\\"\\\", \\\"subParts\\\": \\\"\\\", \\\"impliedUTRs\\\": \\\"false\\\"}, \\\"__current_case__\\\": 0}, \\\"jbcolor_scale\\\": {\\\"color_score\\\": {\\\"color\\\": {\\\"color_select\\\": \\\"automatic\\\", \\\"__current_case__\\\": 0}, \\\"__current_case__\\\": 0, \\\"color_score_select\\\": \\\"none\\\"}}, \\\"override_apollo_drag\\\": \\\"False\\\", \\\"__current_case__\\\": 2, \\\"override_apollo_plugins\\\": \\\"False\\\", \\\"jbmenu\\\": {\\\"track_menu\\\": []}, \\\"annotation\\\": {\\\"__class__\\\": \\\"RuntimeValue\\\"}, \\\"data_format_select\\\": \\\"gene_calls\\\"}}]}]\", \"plugins\": \"{\\\"GCContent\\\": \\\"false\\\", \\\"Bookmarks\\\": \\\"false\\\", \\\"theme\\\": \\\"\\\", \\\"ComboTrackSelector\\\": \\\"false\\\"}\", \"action\": \"{\\\"action_select\\\": \\\"create\\\", \\\"__current_case__\\\": 0}\", \"gencode\": \"\\\"1\\\"\", \"uglyTestingHack\": \"\\\"\\\"\", \"jbgen\": \"{\\\"trackPadding\\\": \\\"20\\\", \\\"show_tracklist\\\": \\\"true\\\", \\\"show_overview\\\": \\\"true\\\", \\\"show_nav\\\": \\\"true\\\", \\\"aboutDescription\\\": \\\"\\\", \\\"defaultLocation\\\": \\\"\\\", \\\"hideGenomeOptions\\\": \\\"false\\\", \\\"shareLink\\\": \\\"true\\\", \\\"show_menu\\\": \\\"true\\\"}\"}",
+      "tool_version": "1.12.5+galaxy1",
+      "type": "tool",
+      "uuid": "adfadef1-3024-499c-9850-34f4f038d822",
+      "workflow_outputs": [
+        {
+          "label": null,
+          "output_name": "output",
+          "uuid": "67d05250-ab0e-407f-a82a-8aa39d6b4923"
+        }
+      ]
+    },
+    "2": {
+      "annotation": "",
+      "content_id": null,
+      "errors": null,
+      "id": 2,
+      "input_connections": {},
+      "inputs": [],
+      "label": "Proteins",
+      "name": "Input dataset",
+      "outputs": [],
+      "position": {
+        "left": 200,
+        "top": 550
+      },
+      "tool_id": null,
+      "tool_state": "{}",
+      "tool_version": null,
+      "type": "data_input",
+      "uuid": "ce4ee756-1713-4e6a-898c-b85a834712bc",
+      "workflow_outputs": [
+        {
+          "label": null,
+          "output_name": "output",
+          "uuid": "9894240a-e8a5-4bdd-b767-c50739a19872"
+        }
+      ]
+    },
+    "20": {
+      "annotation": "",
+      "content_id": "toolshed.g2.bx.psu.edu/repos/devteam/gffread/gffread/2.2.1.1",
+      "errors": null,
+      "id": 20,
+      "input_connections": {
+        "input": {
+          "id": 18,
+          "output_name": "renamed"
+        },
+        "reference_genome|genome_fasta": {
+          "id": 0,
+          "output_name": "output"
+        }
+      },
+      "inputs": [
+        {
+          "description": "runtime parameter for tool gffread",
+          "name": "chr_replace"
+        },
+        {
+          "description": "runtime parameter for tool gffread",
+          "name": "reference_genome"
+        },
+        {
+          "description": "runtime parameter for tool gffread",
+          "name": "input"
+        }
+      ],
+      "label": null,
+      "name": "gffread",
+      "outputs": [
+        {
+          "name": "output_gff",
+          "type": "gff3"
+        },
+        {
+          "name": "output_gtf",
+          "type": "gtf"
+        },
+        {
+          "name": "output_exons",
+          "type": "fasta"
+        },
+        {
+          "name": "output_cds",
+          "type": "fasta"
+        },
+        {
+          "name": "output_pep",
+          "type": "fasta"
+        },
+        {
+          "name": "output_dupinfo",
+          "type": "txt"
+        }
+      ],
+      "position": {
+        "left": 2290,
+        "top": 626
+      },
+      "post_job_actions": {
+        "HideDatasetActionoutput_dupinfo": {
+          "action_arguments": {},
+          "action_type": "HideDatasetAction",
+          "output_name": "output_dupinfo"
+        },
+        "HideDatasetActionoutput_gff": {
+          "action_arguments": {},
+          "action_type": "HideDatasetAction",
+          "output_name": "output_gff"
+        },
+        "HideDatasetActionoutput_gtf": {
+          "action_arguments": {},
+          "action_type": "HideDatasetAction",
+          "output_name": "output_gtf"
+        }
+      },
+      "tool_id": "toolshed.g2.bx.psu.edu/repos/devteam/gffread/gffread/2.2.1.1",
+      "tool_shed_repository": {
+        "changeset_revision": "0232f19d300f",
+        "name": "gffread",
+        "owner": "devteam",
+        "tool_shed": "toolshed.g2.bx.psu.edu"
+      },
+      "tool_state": "{\"__page__\": null, \"filtering\": \"null\", \"gffs\": \"{\\\"gff_fmt\\\": \\\"none\\\", \\\"__current_case__\\\": 0}\", \"full_gff_attribute_preservation\": \"\\\"false\\\"\", \"reference_genome\": \"{\\\"source\\\": \\\"history\\\", \\\"fa_outputs\\\": [\\\"-w exons.fa\\\", \\\"-x cds.fa\\\", \\\"-y pep.fa\\\"], \\\"genome_fasta\\\": {\\\"__class__\\\": \\\"RuntimeValue\\\"}, \\\"__current_case__\\\": 2, \\\"ref_filtering\\\": null}\", \"merging\": \"{\\\"merge_sel\\\": \\\"none\\\", \\\"__current_case__\\\": 0}\", \"__rerun_remap_job_id__\": null, \"input\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\", \"decode_url\": \"\\\"false\\\"\", \"maxintron\": \"\\\"\\\"\", \"expose\": \"\\\"false\\\"\", \"region\": \"{\\\"region_filter\\\": \\\"none\\\", \\\"__current_case__\\\": 0}\", \"chr_replace\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\"}",
+      "tool_version": "2.2.1.1",
+      "type": "tool",
+      "uuid": "3b5ecaf4-2d08-42f8-a6f0-f05ad9e5fe92",
+      "workflow_outputs": [
+        {
+          "label": null,
+          "output_name": "output_cds",
+          "uuid": "58574cae-de5a-4bf1-8071-b23f3fde9519"
+        },
+        {
+          "label": null,
+          "output_name": "output_exons",
+          "uuid": "6deb9839-5d60-4834-9c9d-219b470db959"
+        },
+        {
+          "label": null,
+          "output_name": "output_pep",
+          "uuid": "41835dec-563c-4f4d-8d04-26f993b4df7f"
+        }
+      ]
+    },
+    "21": {
+      "annotation": "",
+      "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/jcvi_gff_stats/jcvi_gff_stats/0.8.4",
+      "errors": null,
+      "id": 21,
+      "input_connections": {
+        "gff": {
+          "id": 18,
+          "output_name": "renamed"
+        },
+        "ref_genome|genome": {
+          "id": 0,
+          "output_name": "output"
+        }
+      },
+      "inputs": [
+        {
+          "description": "runtime parameter for tool Genome annotation statistics",
+          "name": "ref_genome"
+        },
+        {
+          "description": "runtime parameter for tool Genome annotation statistics",
+          "name": "gff"
+        }
+      ],
+      "label": null,
+      "name": "Genome annotation statistics",
+      "outputs": [
+        {
+          "name": "summary",
+          "type": "txt"
+        },
+        {
+          "name": "graphs",
+          "type": "pdf"
+        }
+      ],
+      "position": {
+        "left": 2292.5,
+        "top": 916.5
+      },
+      "post_job_actions": {},
+      "tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/jcvi_gff_stats/jcvi_gff_stats/0.8.4",
+      "tool_shed_repository": {
+        "changeset_revision": "8cffbd184762",
+        "name": "jcvi_gff_stats",
+        "owner": "iuc",
+        "tool_shed": "toolshed.g2.bx.psu.edu"
+      },
+      "tool_state": "{\"__page__\": null, \"__rerun_remap_job_id__\": null, \"ref_genome\": \"{\\\"genome\\\": {\\\"__class__\\\": \\\"RuntimeValue\\\"}, \\\"__current_case__\\\": 1, \\\"genome_type_select\\\": \\\"history\\\"}\", \"gff\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\"}",
+      "tool_version": "0.8.4",
+      "type": "tool",
+      "uuid": "14236032-ec57-4beb-ab0a-e44bf845643c",
+      "workflow_outputs": [
+        {
+          "label": null,
+          "output_name": "graphs",
+          "uuid": "5a86e4d9-a402-494f-b4f5-b2c2b049b96f"
+        },
+        {
+          "label": null,
+          "output_name": "summary",
+          "uuid": "3b73d282-51ab-4997-9124-e1e5db62b849"
+        }
+      ]
+    },
+    "22": {
+      "annotation": "",
+      "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/busco/busco/3.0.2+galaxy0",
+      "errors": null,
+      "id": 22,
+      "input_connections": {
+        "input": {
+          "id": 20,
+          "output_name": "output_exons"
+        }
+      },
+      "inputs": [
+        {
+          "description": "runtime parameter for tool Busco",
+          "name": "input"
+        }
+      ],
+      "label": null,
+      "name": "Busco",
+      "outputs": [
+        {
+          "name": "busco_sum",
+          "type": "txt"
+        },
+        {
+          "name": "busco_table",
+          "type": "tabular"
+        },
+        {
+          "name": "busco_missing",
+          "type": "tabular"
+        }
+      ],
+      "position": {
+        "left": 2590,
+        "top": 659
+      },
+      "post_job_actions": {
+        "HideDatasetActionbusco_missing": {
+          "action_arguments": {},
+          "action_type": "HideDatasetAction",
+          "output_name": "busco_missing"
+        },
+        "HideDatasetActionbusco_table": {
+          "action_arguments": {},
+          "action_type": "HideDatasetAction",
+          "output_name": "busco_table"
+        }
+      },
+      "tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/busco/busco/3.0.2+galaxy0",
+      "tool_shed_repository": {
+        "changeset_revision": "5ecdeca79a0d",
+        "name": "busco",
+        "owner": "iuc",
+        "tool_shed": "toolshed.g2.bx.psu.edu"
+      },
+      "tool_state": "{\"adv\": \"{\\\"aug_prediction\\\": {\\\"augustus_mode\\\": \\\"no\\\", \\\"__current_case__\\\": 0}, \\\"evalue\\\": \\\"0.01\\\", \\\"limit\\\": \\\"3\\\", \\\"long\\\": \\\"false\\\"}\", \"__page__\": null, \"__rerun_remap_job_id__\": null, \"mode\": \"\\\"tran\\\"\", \"input\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\", \"lineage_path\": \"\\\"fungi_odb9\\\"\"}",
+      "tool_version": "3.0.2+galaxy0",
+      "type": "tool",
+      "uuid": "186dc61b-e9c2-4292-b80f-29db38d5f247",
+      "workflow_outputs": [
+        {
+          "label": "Busco summary final round",
+          "output_name": "busco_sum",
+          "uuid": "c0c9f74e-7de1-4602-bc33-7b87cab6ae80"
+        }
+      ]
+    },
+    "3": {
+      "annotation": "",
+      "content_id": "toolshed.g2.bx.psu.edu/repos/simon-gladman/fasta_stats/fasta-stats/1.0.0",
+      "errors": null,
+      "id": 3,
+      "input_connections": {
+        "dataset": {
+          "id": 0,
+          "output_name": "output"
+        }
+      },
+      "inputs": [
+        {
+          "description": "runtime parameter for tool Fasta Statistics",
+          "name": "dataset"
+        }
+      ],
+      "label": null,
+      "name": "Fasta Statistics",
+      "outputs": [
+        {
+          "name": "stats",
+          "type": "tabular"
+        }
+      ],
+      "position": {
+        "left": 499,
+        "top": 936.5
+      },
+      "post_job_actions": {},
+      "tool_id": "toolshed.g2.bx.psu.edu/repos/simon-gladman/fasta_stats/fasta-stats/1.0.0",
+      "tool_shed_repository": {
+        "changeset_revision": "20ca2574216a",
+        "name": "fasta_stats",
+        "owner": "simon-gladman",
+        "tool_shed": "toolshed.g2.bx.psu.edu"
+      },
+      "tool_state": "{\"__page__\": null, \"__rerun_remap_job_id__\": null, \"dataset\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\"}",
+      "tool_version": "1.0.0",
+      "type": "tool",
+      "uuid": "43cab601-f700-4278-bd0a-7f0997cf75cf",
+      "workflow_outputs": [
+        {
+          "label": null,
+          "output_name": "stats",
+          "uuid": "df3cbf21-6f4a-4622-bee0-4d0197a8ae9a"
+        }
+      ]
+    },
+    "4": {
+      "annotation": "",
+      "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/busco/busco/3.0.2+galaxy0",
+      "errors": null,
+      "id": 4,
+      "input_connections": {
+        "input": {
+          "id": 0,
+          "output_name": "output"
+        }
+      },
+      "inputs": [
+        {
+          "description": "runtime parameter for tool Busco",
+          "name": "input"
+        }
+      ],
+      "label": null,
+      "name": "Busco",
+      "outputs": [
+        {
+          "name": "busco_sum",
+          "type": "txt"
+        },
+        {
+          "name": "busco_table",
+          "type": "tabular"
+        },
+        {
+          "name": "busco_missing",
+          "type": "tabular"
+        }
+      ],
+      "position": {
+        "left": 497,
+        "top": 1036
+      },
+      "post_job_actions": {},
+      "tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/busco/busco/3.0.2+galaxy0",
+      "tool_shed_repository": {
+        "changeset_revision": "5ecdeca79a0d",
+        "name": "busco",
+        "owner": "iuc",
+        "tool_shed": "toolshed.g2.bx.psu.edu"
+      },
+      "tool_state": "{\"adv\": \"{\\\"aug_prediction\\\": {\\\"augustus_mode\\\": \\\"no\\\", \\\"__current_case__\\\": 0}, \\\"evalue\\\": \\\"0.01\\\", \\\"limit\\\": \\\"3\\\", \\\"long\\\": \\\"false\\\"}\", \"__page__\": null, \"__rerun_remap_job_id__\": null, \"mode\": \"\\\"geno\\\"\", \"input\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\", \"lineage_path\": \"\\\"fungi_odb9\\\"\"}",
+      "tool_version": "3.0.2+galaxy0",
+      "type": "tool",
+      "uuid": "1e9daffc-7c82-48a8-a2a9-304738d095d0",
+      "workflow_outputs": [
+        {
+          "label": null,
+          "output_name": "busco_missing",
+          "uuid": "f01b9a5d-68f5-4626-bfda-7f0fdcf4bf96"
+        },
+        {
+          "label": null,
+          "output_name": "busco_sum",
+          "uuid": "43b9f11d-dcf0-401d-8ee2-d31643734bcc"
+        },
+        {
+          "label": null,
+          "output_name": "busco_table",
+          "uuid": "afae7071-669c-4697-aaf3-13e3c3faa605"
+        }
+      ]
+    },
+    "5": {
+      "annotation": "",
+      "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/maker/maker/2.31.9.1",
+      "errors": null,
+      "id": 5,
+      "input_connections": {
+        "est_evidences|est": {
+          "id": 1,
+          "output_name": "output"
+        },
+        "genome": {
+          "id": 0,
+          "output_name": "output"
+        },
+        "protein_evidences|protein": {
+          "id": 2,
+          "output_name": "output"
+        }
+      },
+      "inputs": [
+        {
+          "description": "runtime parameter for tool Maker",
+          "name": "gene_prediction"
+        },
+        {
+          "description": "runtime parameter for tool Maker",
+          "name": "gene_prediction"
+        },
+        {
+          "description": "runtime parameter for tool Maker",
+          "name": "gene_prediction"
+        },
+        {
+          "description": "runtime parameter for tool Maker",
+          "name": "abinitio_gene_prediction"
+        },
+        {
+          "description": "runtime parameter for tool Maker",
+          "name": "est_evidences"
+        },
+        {
+          "description": "runtime parameter for tool Maker",
+          "name": "est_evidences"
+        },
+        {
+          "description": "runtime parameter for tool Maker",
+          "name": "est_evidences"
+        },
+        {
+          "description": "runtime parameter for tool Maker",
+          "name": "est_evidences"
+        },
+        {
+          "description": "runtime parameter for tool Maker",
+          "name": "genome"
+        },
+        {
+          "description": "runtime parameter for tool Maker",
+          "name": "protein_evidences"
+        },
+        {
+          "description": "runtime parameter for tool Maker",
+          "name": "protein_evidences"
+        },
+        {
+          "description": "runtime parameter for tool Maker",
+          "name": "advanced"
+        }
+      ],
+      "label": null,
+      "name": "Maker",
+      "outputs": [
+        {
+          "name": "output_gff",
+          "type": "gff3"
+        },
+        {
+          "name": "output_evidences",
+          "type": "gff3"
+        },
+        {
+          "name": "output_full",
+          "type": "gff3"
+        }
+      ],
+      "position": {
+        "left": 474.86669921875,
+        "top": 402.1166687011719
+      },
+      "post_job_actions": {
+        "HideDatasetActionoutput_evidences": {
+          "action_arguments": {},
+          "action_type": "HideDatasetAction",
+          "output_name": "output_evidences"
+        },
+        "HideDatasetActionoutput_full": {
+          "action_arguments": {},
+          "action_type": "HideDatasetAction",
+          "output_name": "output_full"
+        },
+        "HideDatasetActionoutput_gff": {
+          "action_arguments": {},
+          "action_type": "HideDatasetAction",
+          "output_name": "output_gff"
+        }
+      },
+      "tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/maker/maker/2.31.9.1",
+      "tool_shed_repository": {
+        "changeset_revision": "73a79dec987b",
+        "name": "maker",
+        "owner": "iuc",
+        "tool_shed": "toolshed.g2.bx.psu.edu"
+      },
+      "tool_state": "{\"reannotation\": \"{\\\"reannotate\\\": \\\"no\\\", \\\"__current_case__\\\": 0}\", \"__page__\": null, \"organism_type\": \"\\\"eukaryotic\\\"\", \"gene_prediction\": \"{\\\"model_gff\\\": {\\\"__class__\\\": \\\"RuntimeValue\\\"}, \\\"trna\\\": \\\"false\\\", \\\"snoscan_rrna\\\": {\\\"__class__\\\": \\\"RuntimeValue\\\"}, \\\"pred_gff\\\": {\\\"__class__\\\": \\\"RuntimeValue\\\"}}\", \"__rerun_remap_job_id__\": null, \"repeat_masking\": \"{\\\"repeat_source\\\": {\\\"source_type\\\": \\\"no\\\", \\\"__current_case__\\\": 2}}\", \"abinitio_gene_prediction\": \"{\\\"snaphmm\\\": {\\\"__class__\\\": \\\"RuntimeValue\\\"}, \\\"unmask\\\": \\\"false\\\", \\\"aug_prediction\\\": {\\\"augustus_mode\\\": \\\"no\\\", \\\"__current_case__\\\": 0}}\", \"est_evidences\": \"{\\\"altest\\\": {\\\"__class__\\\": \\\"RuntimeValue\\\"}, \\\"est2genome\\\": \\\"true\\\", \\\"est\\\": {\\\"__class__\\\": \\\"RuntimeValue\\\"}, \\\"altest_gff\\\": {\\\"__class__\\\": \\\"RuntimeValue\\\"}, \\\"est_gff\\\": {\\\"__class__\\\": \\\"RuntimeValue\\\"}}\", \"genome\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\", \"protein_evidences\": \"{\\\"protein2genome\\\": \\\"true\\\", \\\"protein\\\": {\\\"__class__\\\": \\\"RuntimeValue\\\"}, \\\"protein_gff\\\": {\\\"__class__\\\": \\\"RuntimeValue\\\"}}\", \"advanced\": \"{\\\"pred_stats\\\": \\\"false\\\", \\\"pred_flank\\\": \\\"200\\\", \\\"AED_threshold\\\": \\\"1.0\\\", \\\"keep_preds\\\": \\\"0.0\\\", \\\"other_gff\\\": {\\\"__class__\\\": \\\"RuntimeValue\\\"}, \\\"alt_splice\\\": \\\"false\\\", \\\"split_hit\\\": \\\"10000\\\", \\\"always_complete\\\": \\\"false\\\", \\\"single_exon\\\": {\\\"single_exon\\\": \\\"0\\\", \\\"__current_case__\\\": 0}, \\\"max_dna_len\\\": \\\"100000\\\", \\\"alt_peptide\\\": \\\"C\\\", \\\"map_forward\\\": \\\"false\\\", \\\"correct_est_fusion\\\": \\\"false\\\", \\\"min_contig\\\": \\\"1\\\", \\\"min_protein\\\": \\\"0\\\"}\"}",
+      "tool_version": "2.31.9.1",
+      "type": "tool",
+      "uuid": "6c96618f-d6d0-43bd-83a1-65ec6cb960ba",
+      "workflow_outputs": []
+    },
+    "6": {
+      "annotation": "",
+      "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/snap_training/snap_training/2013_11_29",
+      "errors": null,
+      "id": 6,
+      "input_connections": {
+        "genome": {
+          "id": 0,
+          "output_name": "output"
+        },
+        "maker_gff": {
+          "id": 5,
+          "output_name": "output_gff"
+        }
+      },
+      "inputs": [
+        {
+          "description": "runtime parameter for tool Train SNAP",
+          "name": "genome"
+        },
+        {
+          "description": "runtime parameter for tool Train SNAP",
+          "name": "maker_gff"
+        }
+      ],
+      "label": null,
+      "name": "Train SNAP",
+      "outputs": [
+        {
+          "name": "output",
+          "type": "snaphmm"
+        }
+      ],
+      "position": {
+        "left": 803.8666687011719,
+        "top": 411.6166687011719
+      },
+      "post_job_actions": {
+        "HideDatasetActionoutput": {
+          "action_arguments": {},
+          "action_type": "HideDatasetAction",
+          "output_name": "output"
+        }
+      },
+      "tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/snap_training/snap_training/2013_11_29",
+      "tool_shed_repository": {
+        "changeset_revision": "821bf8bc5623",
+        "name": "snap_training",
+        "owner": "iuc",
+        "tool_shed": "toolshed.g2.bx.psu.edu"
+      },
+      "tool_state": "{\"__page__\": null, \"gene_num\": \"\\\"1000\\\"\", \"__rerun_remap_job_id__\": null, \"genome\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\", \"maker_gff\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\"}",
+      "tool_version": "2013_11_29",
+      "type": "tool",
+      "uuid": "6cf74e8a-5896-42a3-91aa-1be2f24bf1c3",
+      "workflow_outputs": []
+    },
+    "7": {
+      "annotation": "",
+      "content_id": "toolshed.g2.bx.psu.edu/repos/bgruening/augustus_training/augustus_training/3.2.3",
+      "errors": null,
+      "id": 7,
+      "input_connections": {
+        "genome": {
+          "id": 0,
+          "output_name": "output"
+        },
+        "maker_gff": {
+          "id": 5,
+          "output_name": "output_gff"
+        }
+      },
+      "inputs": [
+        {
+          "description": "runtime parameter for tool Train Augustus",
+          "name": "genome"
+        },
+        {
+          "description": "runtime parameter for tool Train Augustus",
+          "name": "maker_gff"
+        }
+      ],
+      "label": null,
+      "name": "Train Augustus",
+      "outputs": [
+        {
+          "name": "output_tar",
+          "type": "augustus"
+        }
+      ],
+      "position": {
+        "left": 818.8666687011719,
+        "top": 589.61669921875
+      },
+      "post_job_actions": {
+        "HideDatasetActionoutput_tar": {
+          "action_arguments": {},
+          "action_type": "HideDatasetAction",
+          "output_name": "output_tar"
+        }
+      },
+      "tool_id": "toolshed.g2.bx.psu.edu/repos/bgruening/augustus_training/augustus_training/3.2.3",
+      "tool_shed_repository": {
+        "changeset_revision": "86c89c3bd99d",
+        "name": "augustus_training",
+        "owner": "bgruening",
+        "tool_shed": "toolshed.g2.bx.psu.edu"
+      },
+      "tool_state": "{\"__page__\": null, \"__rerun_remap_job_id__\": null, \"genome\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\", \"maker_gff\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\"}",
+      "tool_version": "3.2.3",
+      "type": "tool",
+      "uuid": "cb95420d-5347-4d34-9b0e-752113eb48d8",
+      "workflow_outputs": []
+    },
+    "8": {
+      "annotation": "",
+      "content_id": "toolshed.g2.bx.psu.edu/repos/devteam/gffread/gffread/2.2.1.1",
+      "errors": null,
+      "id": 8,
+      "input_connections": {
+        "input": {
+          "id": 5,
+          "output_name": "output_gff"
+        },
+        "reference_genome|genome_fasta": {
+          "id": 0,
+          "output_name": "output"
+        }
+      },
+      "inputs": [
+        {
+          "description": "runtime parameter for tool gffread",
+          "name": "chr_replace"
+        },
+        {
+          "description": "runtime parameter for tool gffread",
+          "name": "reference_genome"
+        },
+        {
+          "description": "runtime parameter for tool gffread",
+          "name": "input"
+        }
+      ],
+      "label": null,
+      "name": "gffread",
+      "outputs": [
+        {
+          "name": "output_gff",
+          "type": "gff3"
+        },
+        {
+          "name": "output_gtf",
+          "type": "gtf"
+        },
+        {
+          "name": "output_exons",
+          "type": "fasta"
+        },
+        {
+          "name": "output_cds",
+          "type": "fasta"
+        },
+        {
+          "name": "output_pep",
+          "type": "fasta"
+        },
+        {
+          "name": "output_dupinfo",
+          "type": "txt"
+        }
+      ],
+      "position": {
+        "left": 787,
+        "top": 988
+      },
+      "post_job_actions": {
+        "HideDatasetActionoutput_cds": {
+          "action_arguments": {},
+          "action_type": "HideDatasetAction",
+          "output_name": "output_cds"
+        },
+        "HideDatasetActionoutput_dupinfo": {
+          "action_arguments": {},
+          "action_type": "HideDatasetAction",
+          "output_name": "output_dupinfo"
+        },
+        "HideDatasetActionoutput_exons": {
+          "action_arguments": {},
+          "action_type": "HideDatasetAction",
+          "output_name": "output_exons"
+        },
+        "HideDatasetActionoutput_gff": {
+          "action_arguments": {},
+          "action_type": "HideDatasetAction",
+          "output_name": "output_gff"
+        },
+        "HideDatasetActionoutput_gtf": {
+          "action_arguments": {},
+          "action_type": "HideDatasetAction",
+          "output_name": "output_gtf"
+        },
+        "HideDatasetActionoutput_pep": {
+          "action_arguments": {},
+          "action_type": "HideDatasetAction",
+          "output_name": "output_pep"
+        }
+      },
+      "tool_id": "toolshed.g2.bx.psu.edu/repos/devteam/gffread/gffread/2.2.1.1",
+      "tool_shed_repository": {
+        "changeset_revision": "0232f19d300f",
+        "name": "gffread",
+        "owner": "devteam",
+        "tool_shed": "toolshed.g2.bx.psu.edu"
+      },
+      "tool_state": "{\"__page__\": null, \"filtering\": \"null\", \"gffs\": \"{\\\"gff_fmt\\\": \\\"none\\\", \\\"__current_case__\\\": 0}\", \"full_gff_attribute_preservation\": \"\\\"false\\\"\", \"reference_genome\": \"{\\\"source\\\": \\\"history\\\", \\\"fa_outputs\\\": [\\\"-w exons.fa\\\"], \\\"genome_fasta\\\": {\\\"__class__\\\": \\\"RuntimeValue\\\"}, \\\"__current_case__\\\": 2, \\\"ref_filtering\\\": null}\", \"merging\": \"{\\\"merge_sel\\\": \\\"none\\\", \\\"__current_case__\\\": 0}\", \"__rerun_remap_job_id__\": null, \"input\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\", \"decode_url\": \"\\\"false\\\"\", \"maxintron\": \"\\\"\\\"\", \"expose\": \"\\\"false\\\"\", \"region\": \"{\\\"region_filter\\\": \\\"none\\\", \\\"__current_case__\\\": 0}\", \"chr_replace\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\"}",
+      "tool_version": "2.2.1.1",
+      "type": "tool",
+      "uuid": "73918785-0727-4cb4-a963-35837819616a",
+      "workflow_outputs": []
+    },
+    "9": {
+      "annotation": "",
+      "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/jcvi_gff_stats/jcvi_gff_stats/0.8.4",
+      "errors": null,
+      "id": 9,
+      "input_connections": {
+        "gff": {
+          "id": 5,
+          "output_name": "output_gff"
+        },
+        "ref_genome|genome": {
+          "id": 0,
+          "output_name": "output"
+        }
+      },
+      "inputs": [
+        {
+          "description": "runtime parameter for tool Genome annotation statistics",
+          "name": "ref_genome"
+        },
+        {
+          "description": "runtime parameter for tool Genome annotation statistics",
+          "name": "gff"
+        }
+      ],
+      "label": null,
+      "name": "Genome annotation statistics",
+      "outputs": [
+        {
+          "name": "summary",
+          "type": "txt"
+        },
+        {
+          "name": "graphs",
+          "type": "pdf"
+        }
+      ],
+      "position": {
+        "left": 791.5,
+        "top": 1281.5
+      },
+      "post_job_actions": {},
+      "tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/jcvi_gff_stats/jcvi_gff_stats/0.8.4",
+      "tool_shed_repository": {
+        "changeset_revision": "8cffbd184762",
+        "name": "jcvi_gff_stats",
+        "owner": "iuc",
+        "tool_shed": "toolshed.g2.bx.psu.edu"
+      },
+      "tool_state": "{\"__page__\": null, \"__rerun_remap_job_id__\": null, \"ref_genome\": \"{\\\"genome\\\": {\\\"__class__\\\": \\\"RuntimeValue\\\"}, \\\"__current_case__\\\": 1, \\\"genome_type_select\\\": \\\"history\\\"}\", \"gff\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\"}",
+      "tool_version": "0.8.4",
+      "type": "tool",
+      "uuid": "673e51c8-a909-481b-ae45-6dc98072a249",
+      "workflow_outputs": [
+        {
+          "label": null,
+          "output_name": "graphs",
+          "uuid": "c6240f71-0bb9-465c-a3ac-dc720113b54c"
+        },
+        {
+          "label": null,
+          "output_name": "summary",
+          "uuid": "8af52c03-600f-4d4b-ba50-d30dadbba278"
+        }
+      ]
+    }
+  },
+  "tags": [],
+  "uuid": "245fa7cb-ae4e-4d3a-90a9-f0d3aedb0b93"
+}

--- a/topics/introduction/tutorials/galaxy-intro-short/workflows/Galaxy-Workflow-galaxy-intro-short.ga
+++ b/topics/introduction/tutorials/galaxy-intro-short/workflows/Galaxy-Workflow-galaxy-intro-short.ga
@@ -1,1 +1,155 @@
-{"uuid": "58bcce73-f061-4298-9d44-5ffac39dc1b8", "tags": [], "format-version": "0.1", "name": "galaxy-intro-short", "version": 0, "steps": {"0": {"tool_id": null, "tool_version": null, "outputs": [], "workflow_outputs": [], "input_connections": {}, "tool_state": "{\"name\": \"https://zenodo.org/record/582600/files/mutant_R1.fastq\"}", "id": 0, "uuid": "e271eee4-bfb8-40b4-b691-a25cb9932327", "errors": null, "name": "Input dataset", "label": null, "inputs": [{"name": "https://zenodo.org/record/582600/files/mutant_R1.fastq", "description": ""}], "position": {"top": 10, "left": 10}, "annotation": "", "content_id": null, "type": "data_input"}, "1": {"tool_id": "toolshed.g2.bx.psu.edu/repos/devteam/fastqc/fastqc/0.72", "tool_version": "0.72", "outputs": [{"type": "html", "name": "html_file"}, {"type": "txt", "name": "text_file"}], "workflow_outputs": [], "input_connections": {"input_file": {"output_name": "output", "id": 0}}, "tool_state": "{\"__page__\": null, \"limits\": \"null\", \"input_file\": \"null\", \"__rerun_remap_job_id__\": null, \"contaminants\": \"null\", \"chromInfo\": \"\\\"/cvmfs/data.galaxyproject.org/managed/len/ucsc/?.len\\\"\"}", "id": 1, "tool_shed_repository": {"owner": "devteam", "changeset_revision": "c15237684a01", "name": "fastqc", "tool_shed": "toolshed.g2.bx.psu.edu"}, "uuid": "c6a231d9-786d-4fdf-bc25-8e3db1c16bfa", "errors": null, "name": "FastQC", "post_job_actions": {}, "label": null, "inputs": [], "position": {"top": 10, "left": 230}, "annotation": "", "content_id": "toolshed.g2.bx.psu.edu/repos/devteam/fastqc/fastqc/0.72", "type": "tool"}, "2": {"tool_id": "toolshed.g2.bx.psu.edu/repos/devteam/fastq_quality_filter/cshl_fastq_quality_filter/1.0.1", "tool_version": "1.0.1", "outputs": [{"type": "input", "name": "output"}], "workflow_outputs": [], "input_connections": {"input": {"output_name": "output", "id": 0}}, "tool_state": "{\"__page__\": null, \"chromInfo\": \"\\\"/cvmfs/data.galaxyproject.org/managed/len/ucsc/?.len\\\"\", \"__rerun_remap_job_id__\": null, \"percent\": \"\\\"80\\\"\", \"input\": \"null\", \"quality\": \"\\\"35\\\"\"}", "id": 2, "tool_shed_repository": {"owner": "devteam", "changeset_revision": "43a7370aa010", "name": "fastq_quality_filter", "tool_shed": "toolshed.g2.bx.psu.edu"}, "uuid": "3a3ec769-355d-488a-984b-78462a794ef9", "errors": null, "name": "Filter by quality", "post_job_actions": {}, "label": null, "inputs": [], "position": {"top": 130, "left": 230}, "annotation": "", "content_id": "toolshed.g2.bx.psu.edu/repos/devteam/fastq_quality_filter/cshl_fastq_quality_filter/1.0.1", "type": "tool"}, "3": {"tool_id": "toolshed.g2.bx.psu.edu/repos/devteam/fastq_quality_filter/cshl_fastq_quality_filter/1.0.1", "tool_version": "1.0.1", "outputs": [{"type": "input", "name": "output"}], "workflow_outputs": [], "input_connections": {"input": {"output_name": "output", "id": 0}}, "tool_state": "{\"__page__\": null, \"chromInfo\": \"\\\"/cvmfs/data.galaxyproject.org/managed/len/ucsc/?.len\\\"\", \"__rerun_remap_job_id__\": null, \"percent\": \"\\\"80\\\"\", \"input\": \"null\", \"quality\": \"\\\"36\\\"\"}", "id": 3, "tool_shed_repository": {"owner": "devteam", "changeset_revision": "43a7370aa010", "name": "fastq_quality_filter", "tool_shed": "toolshed.g2.bx.psu.edu"}, "uuid": "df2f009c-d3e5-4ccc-bf0f-10b8e44947da", "errors": null, "name": "Filter by quality", "post_job_actions": {}, "label": null, "inputs": [], "position": {"top": 250, "left": 230}, "annotation": "", "content_id": "toolshed.g2.bx.psu.edu/repos/devteam/fastq_quality_filter/cshl_fastq_quality_filter/1.0.1", "type": "tool"}}, "annotation": "", "a_galaxy_workflow": "true"}
+{
+  "a_galaxy_workflow": "true",
+  "annotation": "",
+  "format-version": "0.1",
+  "name": "galaxy-intro-short",
+  "steps": {
+    "0": {
+      "annotation": "",
+      "content_id": null,
+      "errors": null,
+      "id": 0,
+      "input_connections": {},
+      "inputs": [
+        {
+          "description": "",
+          "name": "https://zenodo.org/record/582600/files/mutant_R1.fastq"
+        }
+      ],
+      "label": null,
+      "name": "Input dataset",
+      "outputs": [],
+      "position": {
+        "left": 10,
+        "top": 10
+      },
+      "tool_id": null,
+      "tool_state": "{\"name\": \"https://zenodo.org/record/582600/files/mutant_R1.fastq\"}",
+      "tool_version": null,
+      "type": "data_input",
+      "uuid": "e271eee4-bfb8-40b4-b691-a25cb9932327",
+      "workflow_outputs": []
+    },
+    "1": {
+      "annotation": "",
+      "content_id": "toolshed.g2.bx.psu.edu/repos/devteam/fastqc/fastqc/0.72",
+      "errors": null,
+      "id": 1,
+      "input_connections": {
+        "input_file": {
+          "id": 0,
+          "output_name": "output"
+        }
+      },
+      "inputs": [],
+      "label": null,
+      "name": "FastQC",
+      "outputs": [
+        {
+          "name": "html_file",
+          "type": "html"
+        },
+        {
+          "name": "text_file",
+          "type": "txt"
+        }
+      ],
+      "position": {
+        "left": 230,
+        "top": 10
+      },
+      "post_job_actions": {},
+      "tool_id": "toolshed.g2.bx.psu.edu/repos/devteam/fastqc/fastqc/0.72",
+      "tool_shed_repository": {
+        "changeset_revision": "c15237684a01",
+        "name": "fastqc",
+        "owner": "devteam",
+        "tool_shed": "toolshed.g2.bx.psu.edu"
+      },
+      "tool_state": "{\"__page__\": null, \"limits\": \"null\", \"input_file\": \"null\", \"__rerun_remap_job_id__\": null, \"contaminants\": \"null\", \"chromInfo\": \"\\\"/cvmfs/data.galaxyproject.org/managed/len/ucsc/?.len\\\"\"}",
+      "tool_version": "0.72",
+      "type": "tool",
+      "uuid": "c6a231d9-786d-4fdf-bc25-8e3db1c16bfa",
+      "workflow_outputs": []
+    },
+    "2": {
+      "annotation": "",
+      "content_id": "toolshed.g2.bx.psu.edu/repos/devteam/fastq_quality_filter/cshl_fastq_quality_filter/1.0.1",
+      "errors": null,
+      "id": 2,
+      "input_connections": {
+        "input": {
+          "id": 0,
+          "output_name": "output"
+        }
+      },
+      "inputs": [],
+      "label": null,
+      "name": "Filter by quality",
+      "outputs": [
+        {
+          "name": "output",
+          "type": "input"
+        }
+      ],
+      "position": {
+        "left": 230,
+        "top": 130
+      },
+      "post_job_actions": {},
+      "tool_id": "toolshed.g2.bx.psu.edu/repos/devteam/fastq_quality_filter/cshl_fastq_quality_filter/1.0.1",
+      "tool_shed_repository": {
+        "changeset_revision": "43a7370aa010",
+        "name": "fastq_quality_filter",
+        "owner": "devteam",
+        "tool_shed": "toolshed.g2.bx.psu.edu"
+      },
+      "tool_state": "{\"__page__\": null, \"chromInfo\": \"\\\"/cvmfs/data.galaxyproject.org/managed/len/ucsc/?.len\\\"\", \"__rerun_remap_job_id__\": null, \"percent\": \"\\\"80\\\"\", \"input\": \"null\", \"quality\": \"\\\"35\\\"\"}",
+      "tool_version": "1.0.1",
+      "type": "tool",
+      "uuid": "3a3ec769-355d-488a-984b-78462a794ef9",
+      "workflow_outputs": []
+    },
+    "3": {
+      "annotation": "",
+      "content_id": "toolshed.g2.bx.psu.edu/repos/devteam/fastq_quality_filter/cshl_fastq_quality_filter/1.0.1",
+      "errors": null,
+      "id": 3,
+      "input_connections": {
+        "input": {
+          "id": 0,
+          "output_name": "output"
+        }
+      },
+      "inputs": [],
+      "label": null,
+      "name": "Filter by quality",
+      "outputs": [
+        {
+          "name": "output",
+          "type": "input"
+        }
+      ],
+      "position": {
+        "left": 230,
+        "top": 250
+      },
+      "post_job_actions": {},
+      "tool_id": "toolshed.g2.bx.psu.edu/repos/devteam/fastq_quality_filter/cshl_fastq_quality_filter/1.0.1",
+      "tool_shed_repository": {
+        "changeset_revision": "43a7370aa010",
+        "name": "fastq_quality_filter",
+        "owner": "devteam",
+        "tool_shed": "toolshed.g2.bx.psu.edu"
+      },
+      "tool_state": "{\"__page__\": null, \"chromInfo\": \"\\\"/cvmfs/data.galaxyproject.org/managed/len/ucsc/?.len\\\"\", \"__rerun_remap_job_id__\": null, \"percent\": \"\\\"80\\\"\", \"input\": \"null\", \"quality\": \"\\\"36\\\"\"}",
+      "tool_version": "1.0.1",
+      "type": "tool",
+      "uuid": "df2f009c-d3e5-4ccc-bf0f-10b8e44947da",
+      "workflow_outputs": []
+    }
+  },
+  "tags": [],
+  "uuid": "58bcce73-f061-4298-9d44-5ffac39dc1b8",
+  "version": 0
+}

--- a/topics/introduction/tutorials/galaxy-intro-strands/workflows/Galaxy-Workflow-galaxy-intro-strands-2.ga
+++ b/topics/introduction/tutorials/galaxy-intro-strands/workflows/Galaxy-Workflow-galaxy-intro-strands-2.ga
@@ -1,1 +1,258 @@
-{"uuid": "4211a2fa-833f-49f9-a0fb-151db5491730", "tags": [], "format-version": "0.1", "name": "galaxy-intro-strands-2", "steps": {"0": {"tool_id": null, "tool_version": null, "outputs": [], "workflow_outputs": [], "input_connections": {}, "tool_state": "{\"name\": \"Genes\"}", "id": 0, "uuid": "286c5925-431f-432d-a658-515befa7c6d3", "errors": null, "name": "Input dataset", "label": null, "inputs": [{"name": "Genes", "description": ""}], "position": {"top": 10, "left": 10}, "annotation": "", "content_id": null, "type": "data_input"}, "1": {"tool_id": "gene2exon1", "tool_version": "1.0.0", "outputs": [{"type": "bed", "name": "out_file1"}], "workflow_outputs": [], "input_connections": {"input1": {"output_name": "output", "id": 0}}, "tool_state": "{\"__page__\": null, \"region\": \"\\\"coding\\\"\", \"input1\": \"null\", \"chromInfo\": \"\\\"/usr/local/galaxy/galaxy-dist/tool-data/shared/ucsc/chrom/hg38.len\\\"\", \"__rerun_remap_job_id__\": null}", "id": 1, "uuid": "876165cb-ae9d-432b-ba84-adb4ce2fbf71", "errors": null, "name": "Gene BED To Exon/Intron/Codon BED", "post_job_actions": {}, "label": null, "inputs": [], "position": {"top": 10, "left": 230}, "annotation": "", "content_id": "gene2exon1", "type": "tool"}, "2": {"tool_id": "Filter1", "tool_version": "1.1.0", "outputs": [{"type": "input", "name": "out_file1"}], "workflow_outputs": [], "input_connections": {"input": {"output_name": "out_file1", "id": 1}}, "tool_state": "{\"__page__\": null, \"__rerun_remap_job_id__\": null, \"cond\": \"\\\"c6=='+'\\\"\", \"input\": \"null\", \"header_lines\": \"\\\"0\\\"\", \"chromInfo\": \"\\\"/usr/local/galaxy/galaxy-dist/tool-data/shared/ucsc/chrom/hg38.len\\\"\"}", "id": 2, "uuid": "6f97b25d-fb6c-49bf-aa8b-4495e09f1182", "errors": null, "name": "Filter", "post_job_actions": {}, "label": null, "inputs": [], "position": {"top": 10, "left": 450}, "annotation": "", "content_id": "Filter1", "type": "tool"}, "3": {"tool_id": "Filter1", "tool_version": "1.1.0", "outputs": [{"type": "input", "name": "out_file1"}], "workflow_outputs": [], "input_connections": {"input": {"output_name": "out_file1", "id": 1}}, "tool_state": "{\"__page__\": null, \"__rerun_remap_job_id__\": null, \"cond\": \"\\\"c6=='-'\\\"\", \"input\": \"null\", \"header_lines\": \"\\\"0\\\"\", \"chromInfo\": \"\\\"/usr/local/galaxy/galaxy-dist/tool-data/shared/ucsc/chrom/hg38.len\\\"\"}", "id": 3, "uuid": "702c9f21-3817-4ca7-b21d-392c79a5821a", "errors": null, "name": "Filter", "post_job_actions": {}, "label": null, "inputs": [], "position": {"top": 130, "left": 450}, "annotation": "", "content_id": "Filter1", "type": "tool"}, "4": {"tool_id": "toolshed.g2.bx.psu.edu/repos/devteam/intersect/gops_intersect_1/1.0.0", "tool_version": "1.0.0", "outputs": [{"type": "input", "name": "output"}], "workflow_outputs": [], "input_connections": {"input2": {"output_name": "out_file1", "id": 3}, "input1": {"output_name": "out_file1", "id": 2}}, "tool_state": "{\"input2\": \"null\", \"__page__\": null, \"input1\": \"null\", \"min\": \"\\\"1\\\"\", \"__rerun_remap_job_id__\": null, \"returntype\": \"\\\"\\\"\", \"chromInfo\": \"\\\"/usr/local/galaxy/galaxy-dist/tool-data/shared/ucsc/chrom/hg38.len\\\"\"}", "id": 4, "tool_shed_repository": {"owner": "devteam", "changeset_revision": "33b3f3688db4", "name": "intersect", "tool_shed": "toolshed.g2.bx.psu.edu"}, "uuid": "b354dbb2-ff82-4cc7-8af6-87bdccac2da4", "errors": null, "name": "Intersect", "post_job_actions": {}, "label": null, "inputs": [], "position": {"top": 10, "left": 670}, "annotation": "", "content_id": "toolshed.g2.bx.psu.edu/repos/devteam/intersect/gops_intersect_1/1.0.0", "type": "tool"}, "5": {"tool_id": "toolshed.g2.bx.psu.edu/repos/devteam/intersect/gops_intersect_1/1.0.0", "tool_version": "1.0.0", "outputs": [{"type": "input", "name": "output"}], "workflow_outputs": [], "input_connections": {"input2": {"output_name": "out_file1", "id": 2}, "input1": {"output_name": "out_file1", "id": 3}}, "tool_state": "{\"input2\": \"null\", \"__page__\": null, \"input1\": \"null\", \"min\": \"\\\"1\\\"\", \"__rerun_remap_job_id__\": null, \"returntype\": \"\\\"\\\"\", \"chromInfo\": \"\\\"/usr/local/galaxy/galaxy-dist/tool-data/shared/ucsc/chrom/hg38.len\\\"\"}", "id": 5, "tool_shed_repository": {"owner": "devteam", "changeset_revision": "33b3f3688db4", "name": "intersect", "tool_shed": "toolshed.g2.bx.psu.edu"}, "uuid": "26cae419-33ee-4df3-a945-a26a8bdbd35b", "errors": null, "name": "Intersect", "post_job_actions": {}, "label": null, "inputs": [], "position": {"top": 130, "left": 670}, "annotation": "", "content_id": "toolshed.g2.bx.psu.edu/repos/devteam/intersect/gops_intersect_1/1.0.0", "type": "tool"}, "6": {"tool_id": "toolshed.g2.bx.psu.edu/repos/bgruening/text_processing/tp_cat/0.1.0", "tool_version": "0.1.0", "outputs": [{"type": "input", "name": "out_file1"}], "workflow_outputs": [], "input_connections": {"inputs": {"output_name": "output", "id": 5}, "queries_0|inputs2": {"output_name": "output", "id": 4}}, "tool_state": "{\"__page__\": null, \"inputs\": \"null\", \"__rerun_remap_job_id__\": null, \"chromInfo\": \"\\\"/usr/local/galaxy/galaxy-dist/tool-data/shared/ucsc/chrom/hg38.len\\\"\", \"queries\": \"[{\\\"inputs2\\\": null, \\\"__index__\\\": 0}]\"}", "id": 6, "tool_shed_repository": {"owner": "bgruening", "changeset_revision": "74a8bef53a00", "name": "text_processing", "tool_shed": "toolshed.g2.bx.psu.edu"}, "uuid": "58ad50c3-c00f-4211-85f3-16de5a2630a1", "errors": null, "name": "Concatenate datasets", "post_job_actions": {}, "label": null, "inputs": [], "position": {"top": 10, "left": 890}, "annotation": "", "content_id": "toolshed.g2.bx.psu.edu/repos/bgruening/text_processing/tp_cat/0.1.0", "type": "tool"}}, "annotation": "", "a_galaxy_workflow": "true"}
+{
+  "a_galaxy_workflow": "true",
+  "annotation": "",
+  "format-version": "0.1",
+  "name": "galaxy-intro-strands-2",
+  "steps": {
+    "0": {
+      "annotation": "",
+      "content_id": null,
+      "errors": null,
+      "id": 0,
+      "input_connections": {},
+      "inputs": [
+        {
+          "description": "",
+          "name": "Genes"
+        }
+      ],
+      "label": null,
+      "name": "Input dataset",
+      "outputs": [],
+      "position": {
+        "left": 10,
+        "top": 10
+      },
+      "tool_id": null,
+      "tool_state": "{\"name\": \"Genes\"}",
+      "tool_version": null,
+      "type": "data_input",
+      "uuid": "286c5925-431f-432d-a658-515befa7c6d3",
+      "workflow_outputs": []
+    },
+    "1": {
+      "annotation": "",
+      "content_id": "gene2exon1",
+      "errors": null,
+      "id": 1,
+      "input_connections": {
+        "input1": {
+          "id": 0,
+          "output_name": "output"
+        }
+      },
+      "inputs": [],
+      "label": null,
+      "name": "Gene BED To Exon/Intron/Codon BED",
+      "outputs": [
+        {
+          "name": "out_file1",
+          "type": "bed"
+        }
+      ],
+      "position": {
+        "left": 230,
+        "top": 10
+      },
+      "post_job_actions": {},
+      "tool_id": "gene2exon1",
+      "tool_state": "{\"__page__\": null, \"region\": \"\\\"coding\\\"\", \"input1\": \"null\", \"chromInfo\": \"\\\"/usr/local/galaxy/galaxy-dist/tool-data/shared/ucsc/chrom/hg38.len\\\"\", \"__rerun_remap_job_id__\": null}",
+      "tool_version": "1.0.0",
+      "type": "tool",
+      "uuid": "876165cb-ae9d-432b-ba84-adb4ce2fbf71",
+      "workflow_outputs": []
+    },
+    "2": {
+      "annotation": "",
+      "content_id": "Filter1",
+      "errors": null,
+      "id": 2,
+      "input_connections": {
+        "input": {
+          "id": 1,
+          "output_name": "out_file1"
+        }
+      },
+      "inputs": [],
+      "label": null,
+      "name": "Filter",
+      "outputs": [
+        {
+          "name": "out_file1",
+          "type": "input"
+        }
+      ],
+      "position": {
+        "left": 450,
+        "top": 10
+      },
+      "post_job_actions": {},
+      "tool_id": "Filter1",
+      "tool_state": "{\"__page__\": null, \"__rerun_remap_job_id__\": null, \"cond\": \"\\\"c6=='+'\\\"\", \"input\": \"null\", \"header_lines\": \"\\\"0\\\"\", \"chromInfo\": \"\\\"/usr/local/galaxy/galaxy-dist/tool-data/shared/ucsc/chrom/hg38.len\\\"\"}",
+      "tool_version": "1.1.0",
+      "type": "tool",
+      "uuid": "6f97b25d-fb6c-49bf-aa8b-4495e09f1182",
+      "workflow_outputs": []
+    },
+    "3": {
+      "annotation": "",
+      "content_id": "Filter1",
+      "errors": null,
+      "id": 3,
+      "input_connections": {
+        "input": {
+          "id": 1,
+          "output_name": "out_file1"
+        }
+      },
+      "inputs": [],
+      "label": null,
+      "name": "Filter",
+      "outputs": [
+        {
+          "name": "out_file1",
+          "type": "input"
+        }
+      ],
+      "position": {
+        "left": 450,
+        "top": 130
+      },
+      "post_job_actions": {},
+      "tool_id": "Filter1",
+      "tool_state": "{\"__page__\": null, \"__rerun_remap_job_id__\": null, \"cond\": \"\\\"c6=='-'\\\"\", \"input\": \"null\", \"header_lines\": \"\\\"0\\\"\", \"chromInfo\": \"\\\"/usr/local/galaxy/galaxy-dist/tool-data/shared/ucsc/chrom/hg38.len\\\"\"}",
+      "tool_version": "1.1.0",
+      "type": "tool",
+      "uuid": "702c9f21-3817-4ca7-b21d-392c79a5821a",
+      "workflow_outputs": []
+    },
+    "4": {
+      "annotation": "",
+      "content_id": "toolshed.g2.bx.psu.edu/repos/devteam/intersect/gops_intersect_1/1.0.0",
+      "errors": null,
+      "id": 4,
+      "input_connections": {
+        "input1": {
+          "id": 2,
+          "output_name": "out_file1"
+        },
+        "input2": {
+          "id": 3,
+          "output_name": "out_file1"
+        }
+      },
+      "inputs": [],
+      "label": null,
+      "name": "Intersect",
+      "outputs": [
+        {
+          "name": "output",
+          "type": "input"
+        }
+      ],
+      "position": {
+        "left": 670,
+        "top": 10
+      },
+      "post_job_actions": {},
+      "tool_id": "toolshed.g2.bx.psu.edu/repos/devteam/intersect/gops_intersect_1/1.0.0",
+      "tool_shed_repository": {
+        "changeset_revision": "33b3f3688db4",
+        "name": "intersect",
+        "owner": "devteam",
+        "tool_shed": "toolshed.g2.bx.psu.edu"
+      },
+      "tool_state": "{\"input2\": \"null\", \"__page__\": null, \"input1\": \"null\", \"min\": \"\\\"1\\\"\", \"__rerun_remap_job_id__\": null, \"returntype\": \"\\\"\\\"\", \"chromInfo\": \"\\\"/usr/local/galaxy/galaxy-dist/tool-data/shared/ucsc/chrom/hg38.len\\\"\"}",
+      "tool_version": "1.0.0",
+      "type": "tool",
+      "uuid": "b354dbb2-ff82-4cc7-8af6-87bdccac2da4",
+      "workflow_outputs": []
+    },
+    "5": {
+      "annotation": "",
+      "content_id": "toolshed.g2.bx.psu.edu/repos/devteam/intersect/gops_intersect_1/1.0.0",
+      "errors": null,
+      "id": 5,
+      "input_connections": {
+        "input1": {
+          "id": 3,
+          "output_name": "out_file1"
+        },
+        "input2": {
+          "id": 2,
+          "output_name": "out_file1"
+        }
+      },
+      "inputs": [],
+      "label": null,
+      "name": "Intersect",
+      "outputs": [
+        {
+          "name": "output",
+          "type": "input"
+        }
+      ],
+      "position": {
+        "left": 670,
+        "top": 130
+      },
+      "post_job_actions": {},
+      "tool_id": "toolshed.g2.bx.psu.edu/repos/devteam/intersect/gops_intersect_1/1.0.0",
+      "tool_shed_repository": {
+        "changeset_revision": "33b3f3688db4",
+        "name": "intersect",
+        "owner": "devteam",
+        "tool_shed": "toolshed.g2.bx.psu.edu"
+      },
+      "tool_state": "{\"input2\": \"null\", \"__page__\": null, \"input1\": \"null\", \"min\": \"\\\"1\\\"\", \"__rerun_remap_job_id__\": null, \"returntype\": \"\\\"\\\"\", \"chromInfo\": \"\\\"/usr/local/galaxy/galaxy-dist/tool-data/shared/ucsc/chrom/hg38.len\\\"\"}",
+      "tool_version": "1.0.0",
+      "type": "tool",
+      "uuid": "26cae419-33ee-4df3-a945-a26a8bdbd35b",
+      "workflow_outputs": []
+    },
+    "6": {
+      "annotation": "",
+      "content_id": "toolshed.g2.bx.psu.edu/repos/bgruening/text_processing/tp_cat/0.1.0",
+      "errors": null,
+      "id": 6,
+      "input_connections": {
+        "inputs": {
+          "id": 5,
+          "output_name": "output"
+        },
+        "queries_0|inputs2": {
+          "id": 4,
+          "output_name": "output"
+        }
+      },
+      "inputs": [],
+      "label": null,
+      "name": "Concatenate datasets",
+      "outputs": [
+        {
+          "name": "out_file1",
+          "type": "input"
+        }
+      ],
+      "position": {
+        "left": 890,
+        "top": 10
+      },
+      "post_job_actions": {},
+      "tool_id": "toolshed.g2.bx.psu.edu/repos/bgruening/text_processing/tp_cat/0.1.0",
+      "tool_shed_repository": {
+        "changeset_revision": "74a8bef53a00",
+        "name": "text_processing",
+        "owner": "bgruening",
+        "tool_shed": "toolshed.g2.bx.psu.edu"
+      },
+      "tool_state": "{\"__page__\": null, \"inputs\": \"null\", \"__rerun_remap_job_id__\": null, \"chromInfo\": \"\\\"/usr/local/galaxy/galaxy-dist/tool-data/shared/ucsc/chrom/hg38.len\\\"\", \"queries\": \"[{\\\"inputs2\\\": null, \\\"__index__\\\": 0}]\"}",
+      "tool_version": "0.1.0",
+      "type": "tool",
+      "uuid": "58ad50c3-c00f-4211-85f3-16de5a2630a1",
+      "workflow_outputs": []
+    }
+  },
+  "tags": [],
+  "uuid": "4211a2fa-833f-49f9-a0fb-151db5491730"
+}

--- a/topics/introduction/tutorials/galaxy-intro-strands/workflows/Galaxy-Workflow-galaxy-intro-strands.ga
+++ b/topics/introduction/tutorials/galaxy-intro-strands/workflows/Galaxy-Workflow-galaxy-intro-strands.ga
@@ -1,1 +1,258 @@
-{"uuid": "fc366e2f-2611-43f4-98cf-170c8acbee22", "tags": [], "format-version": "0.1", "name": "galaxy-intro-strands", "steps": {"0": {"tool_id": null, "tool_version": null, "outputs": [], "workflow_outputs": [], "input_connections": {}, "tool_state": "{\"name\": \"Genes\"}", "id": 0, "uuid": "d69a6248-140c-4b97-bc0f-ce88a4452c75", "errors": null, "name": "Input dataset", "label": null, "inputs": [{"name": "Genes", "description": ""}], "position": {"top": 10, "left": 10}, "annotation": "", "content_id": null, "type": "data_input"}, "1": {"tool_id": "Filter1", "tool_version": "1.1.0", "outputs": [{"type": "input", "name": "out_file1"}], "workflow_outputs": [], "input_connections": {"input": {"output_name": "output", "id": 0}}, "tool_state": "{\"__page__\": null, \"__rerun_remap_job_id__\": null, \"cond\": \"\\\"c1=='chr22'\\\"\", \"input\": \"null\", \"header_lines\": \"\\\"0\\\"\", \"chromInfo\": \"\\\"/usr/local/galaxy/galaxy-dist/tool-data/shared/ucsc/chrom/hg38.len\\\"\"}", "id": 1, "uuid": "66383e36-da73-42ec-87cc-00ef806cf8e8", "errors": null, "name": "Filter", "post_job_actions": {}, "label": null, "inputs": [], "position": {"top": 10, "left": 230}, "annotation": "", "content_id": "Filter1", "type": "tool"}, "2": {"tool_id": "Filter1", "tool_version": "1.1.0", "outputs": [{"type": "input", "name": "out_file1"}], "workflow_outputs": [], "input_connections": {"input": {"output_name": "output", "id": 0}}, "tool_state": "{\"__page__\": null, \"__rerun_remap_job_id__\": null, \"cond\": \"\\\"c6=='+'\\\"\", \"input\": \"null\", \"header_lines\": \"\\\"0\\\"\", \"chromInfo\": \"\\\"/usr/local/galaxy/galaxy-dist/tool-data/shared/ucsc/chrom/hg38.len\\\"\"}", "id": 2, "uuid": "42557e8d-325f-40bd-b895-a9252c510426", "errors": null, "name": "Filter", "post_job_actions": {}, "label": null, "inputs": [], "position": {"top": 130, "left": 230}, "annotation": "", "content_id": "Filter1", "type": "tool"}, "3": {"tool_id": "Filter1", "tool_version": "1.1.0", "outputs": [{"type": "input", "name": "out_file1"}], "workflow_outputs": [], "input_connections": {"input": {"output_name": "output", "id": 0}}, "tool_state": "{\"__page__\": null, \"__rerun_remap_job_id__\": null, \"cond\": \"\\\"c6=='-'\\\"\", \"input\": \"null\", \"header_lines\": \"\\\"0\\\"\", \"chromInfo\": \"\\\"/usr/local/galaxy/galaxy-dist/tool-data/shared/ucsc/chrom/hg38.len\\\"\"}", "id": 3, "uuid": "097c61df-65bf-42e6-b532-49607430a5aa", "errors": null, "name": "Filter", "post_job_actions": {}, "label": null, "inputs": [], "position": {"top": 250, "left": 230}, "annotation": "", "content_id": "Filter1", "type": "tool"}, "4": {"tool_id": "toolshed.g2.bx.psu.edu/repos/devteam/intersect/gops_intersect_1/1.0.0", "tool_version": "1.0.0", "outputs": [{"type": "input", "name": "output"}], "workflow_outputs": [], "input_connections": {"input2": {"output_name": "out_file1", "id": 3}, "input1": {"output_name": "out_file1", "id": 2}}, "tool_state": "{\"input2\": \"null\", \"__page__\": null, \"input1\": \"null\", \"min\": \"\\\"1\\\"\", \"__rerun_remap_job_id__\": null, \"returntype\": \"\\\"\\\"\", \"chromInfo\": \"\\\"/usr/local/galaxy/galaxy-dist/tool-data/shared/ucsc/chrom/hg38.len\\\"\"}", "id": 4, "tool_shed_repository": {"owner": "devteam", "changeset_revision": "33b3f3688db4", "name": "intersect", "tool_shed": "toolshed.g2.bx.psu.edu"}, "uuid": "cb0036ec-108a-4760-9c52-4ce15f1a4aca", "errors": null, "name": "Intersect", "post_job_actions": {}, "label": null, "inputs": [], "position": {"top": 10, "left": 450}, "annotation": "", "content_id": "toolshed.g2.bx.psu.edu/repos/devteam/intersect/gops_intersect_1/1.0.0", "type": "tool"}, "5": {"tool_id": "toolshed.g2.bx.psu.edu/repos/devteam/intersect/gops_intersect_1/1.0.0", "tool_version": "1.0.0", "outputs": [{"type": "input", "name": "output"}], "workflow_outputs": [], "input_connections": {"input2": {"output_name": "out_file1", "id": 2}, "input1": {"output_name": "out_file1", "id": 3}}, "tool_state": "{\"input2\": \"null\", \"__page__\": null, \"input1\": \"null\", \"min\": \"\\\"1\\\"\", \"__rerun_remap_job_id__\": null, \"returntype\": \"\\\"\\\"\", \"chromInfo\": \"\\\"/usr/local/galaxy/galaxy-dist/tool-data/shared/ucsc/chrom/hg38.len\\\"\"}", "id": 5, "tool_shed_repository": {"owner": "devteam", "changeset_revision": "33b3f3688db4", "name": "intersect", "tool_shed": "toolshed.g2.bx.psu.edu"}, "uuid": "7a6e8d44-1878-4c66-8744-a91a31036ee9", "errors": null, "name": "Intersect", "post_job_actions": {}, "label": null, "inputs": [], "position": {"top": 130, "left": 450}, "annotation": "", "content_id": "toolshed.g2.bx.psu.edu/repos/devteam/intersect/gops_intersect_1/1.0.0", "type": "tool"}, "6": {"tool_id": "toolshed.g2.bx.psu.edu/repos/bgruening/text_processing/tp_cat/0.1.0", "tool_version": "0.1.0", "outputs": [{"type": "input", "name": "out_file1"}], "workflow_outputs": [], "input_connections": {"inputs": {"output_name": "output", "id": 5}, "queries_0|inputs2": {"output_name": "output", "id": 4}}, "tool_state": "{\"__page__\": null, \"inputs\": \"null\", \"__rerun_remap_job_id__\": null, \"chromInfo\": \"\\\"/usr/local/galaxy/galaxy-dist/tool-data/shared/ucsc/chrom/hg38.len\\\"\", \"queries\": \"[{\\\"inputs2\\\": null, \\\"__index__\\\": 0}]\"}", "id": 6, "tool_shed_repository": {"owner": "bgruening", "changeset_revision": "74a8bef53a00", "name": "text_processing", "tool_shed": "toolshed.g2.bx.psu.edu"}, "uuid": "b62261d8-c260-42a6-bbb6-41ab90f12139", "errors": null, "name": "Concatenate datasets", "post_job_actions": {}, "label": null, "inputs": [], "position": {"top": 10, "left": 670}, "annotation": "", "content_id": "toolshed.g2.bx.psu.edu/repos/bgruening/text_processing/tp_cat/0.1.0", "type": "tool"}}, "annotation": "", "a_galaxy_workflow": "true"}
+{
+  "a_galaxy_workflow": "true",
+  "annotation": "",
+  "format-version": "0.1",
+  "name": "galaxy-intro-strands",
+  "steps": {
+    "0": {
+      "annotation": "",
+      "content_id": null,
+      "errors": null,
+      "id": 0,
+      "input_connections": {},
+      "inputs": [
+        {
+          "description": "",
+          "name": "Genes"
+        }
+      ],
+      "label": null,
+      "name": "Input dataset",
+      "outputs": [],
+      "position": {
+        "left": 10,
+        "top": 10
+      },
+      "tool_id": null,
+      "tool_state": "{\"name\": \"Genes\"}",
+      "tool_version": null,
+      "type": "data_input",
+      "uuid": "d69a6248-140c-4b97-bc0f-ce88a4452c75",
+      "workflow_outputs": []
+    },
+    "1": {
+      "annotation": "",
+      "content_id": "Filter1",
+      "errors": null,
+      "id": 1,
+      "input_connections": {
+        "input": {
+          "id": 0,
+          "output_name": "output"
+        }
+      },
+      "inputs": [],
+      "label": null,
+      "name": "Filter",
+      "outputs": [
+        {
+          "name": "out_file1",
+          "type": "input"
+        }
+      ],
+      "position": {
+        "left": 230,
+        "top": 10
+      },
+      "post_job_actions": {},
+      "tool_id": "Filter1",
+      "tool_state": "{\"__page__\": null, \"__rerun_remap_job_id__\": null, \"cond\": \"\\\"c1=='chr22'\\\"\", \"input\": \"null\", \"header_lines\": \"\\\"0\\\"\", \"chromInfo\": \"\\\"/usr/local/galaxy/galaxy-dist/tool-data/shared/ucsc/chrom/hg38.len\\\"\"}",
+      "tool_version": "1.1.0",
+      "type": "tool",
+      "uuid": "66383e36-da73-42ec-87cc-00ef806cf8e8",
+      "workflow_outputs": []
+    },
+    "2": {
+      "annotation": "",
+      "content_id": "Filter1",
+      "errors": null,
+      "id": 2,
+      "input_connections": {
+        "input": {
+          "id": 0,
+          "output_name": "output"
+        }
+      },
+      "inputs": [],
+      "label": null,
+      "name": "Filter",
+      "outputs": [
+        {
+          "name": "out_file1",
+          "type": "input"
+        }
+      ],
+      "position": {
+        "left": 230,
+        "top": 130
+      },
+      "post_job_actions": {},
+      "tool_id": "Filter1",
+      "tool_state": "{\"__page__\": null, \"__rerun_remap_job_id__\": null, \"cond\": \"\\\"c6=='+'\\\"\", \"input\": \"null\", \"header_lines\": \"\\\"0\\\"\", \"chromInfo\": \"\\\"/usr/local/galaxy/galaxy-dist/tool-data/shared/ucsc/chrom/hg38.len\\\"\"}",
+      "tool_version": "1.1.0",
+      "type": "tool",
+      "uuid": "42557e8d-325f-40bd-b895-a9252c510426",
+      "workflow_outputs": []
+    },
+    "3": {
+      "annotation": "",
+      "content_id": "Filter1",
+      "errors": null,
+      "id": 3,
+      "input_connections": {
+        "input": {
+          "id": 0,
+          "output_name": "output"
+        }
+      },
+      "inputs": [],
+      "label": null,
+      "name": "Filter",
+      "outputs": [
+        {
+          "name": "out_file1",
+          "type": "input"
+        }
+      ],
+      "position": {
+        "left": 230,
+        "top": 250
+      },
+      "post_job_actions": {},
+      "tool_id": "Filter1",
+      "tool_state": "{\"__page__\": null, \"__rerun_remap_job_id__\": null, \"cond\": \"\\\"c6=='-'\\\"\", \"input\": \"null\", \"header_lines\": \"\\\"0\\\"\", \"chromInfo\": \"\\\"/usr/local/galaxy/galaxy-dist/tool-data/shared/ucsc/chrom/hg38.len\\\"\"}",
+      "tool_version": "1.1.0",
+      "type": "tool",
+      "uuid": "097c61df-65bf-42e6-b532-49607430a5aa",
+      "workflow_outputs": []
+    },
+    "4": {
+      "annotation": "",
+      "content_id": "toolshed.g2.bx.psu.edu/repos/devteam/intersect/gops_intersect_1/1.0.0",
+      "errors": null,
+      "id": 4,
+      "input_connections": {
+        "input1": {
+          "id": 2,
+          "output_name": "out_file1"
+        },
+        "input2": {
+          "id": 3,
+          "output_name": "out_file1"
+        }
+      },
+      "inputs": [],
+      "label": null,
+      "name": "Intersect",
+      "outputs": [
+        {
+          "name": "output",
+          "type": "input"
+        }
+      ],
+      "position": {
+        "left": 450,
+        "top": 10
+      },
+      "post_job_actions": {},
+      "tool_id": "toolshed.g2.bx.psu.edu/repos/devteam/intersect/gops_intersect_1/1.0.0",
+      "tool_shed_repository": {
+        "changeset_revision": "33b3f3688db4",
+        "name": "intersect",
+        "owner": "devteam",
+        "tool_shed": "toolshed.g2.bx.psu.edu"
+      },
+      "tool_state": "{\"input2\": \"null\", \"__page__\": null, \"input1\": \"null\", \"min\": \"\\\"1\\\"\", \"__rerun_remap_job_id__\": null, \"returntype\": \"\\\"\\\"\", \"chromInfo\": \"\\\"/usr/local/galaxy/galaxy-dist/tool-data/shared/ucsc/chrom/hg38.len\\\"\"}",
+      "tool_version": "1.0.0",
+      "type": "tool",
+      "uuid": "cb0036ec-108a-4760-9c52-4ce15f1a4aca",
+      "workflow_outputs": []
+    },
+    "5": {
+      "annotation": "",
+      "content_id": "toolshed.g2.bx.psu.edu/repos/devteam/intersect/gops_intersect_1/1.0.0",
+      "errors": null,
+      "id": 5,
+      "input_connections": {
+        "input1": {
+          "id": 3,
+          "output_name": "out_file1"
+        },
+        "input2": {
+          "id": 2,
+          "output_name": "out_file1"
+        }
+      },
+      "inputs": [],
+      "label": null,
+      "name": "Intersect",
+      "outputs": [
+        {
+          "name": "output",
+          "type": "input"
+        }
+      ],
+      "position": {
+        "left": 450,
+        "top": 130
+      },
+      "post_job_actions": {},
+      "tool_id": "toolshed.g2.bx.psu.edu/repos/devteam/intersect/gops_intersect_1/1.0.0",
+      "tool_shed_repository": {
+        "changeset_revision": "33b3f3688db4",
+        "name": "intersect",
+        "owner": "devteam",
+        "tool_shed": "toolshed.g2.bx.psu.edu"
+      },
+      "tool_state": "{\"input2\": \"null\", \"__page__\": null, \"input1\": \"null\", \"min\": \"\\\"1\\\"\", \"__rerun_remap_job_id__\": null, \"returntype\": \"\\\"\\\"\", \"chromInfo\": \"\\\"/usr/local/galaxy/galaxy-dist/tool-data/shared/ucsc/chrom/hg38.len\\\"\"}",
+      "tool_version": "1.0.0",
+      "type": "tool",
+      "uuid": "7a6e8d44-1878-4c66-8744-a91a31036ee9",
+      "workflow_outputs": []
+    },
+    "6": {
+      "annotation": "",
+      "content_id": "toolshed.g2.bx.psu.edu/repos/bgruening/text_processing/tp_cat/0.1.0",
+      "errors": null,
+      "id": 6,
+      "input_connections": {
+        "inputs": {
+          "id": 5,
+          "output_name": "output"
+        },
+        "queries_0|inputs2": {
+          "id": 4,
+          "output_name": "output"
+        }
+      },
+      "inputs": [],
+      "label": null,
+      "name": "Concatenate datasets",
+      "outputs": [
+        {
+          "name": "out_file1",
+          "type": "input"
+        }
+      ],
+      "position": {
+        "left": 670,
+        "top": 10
+      },
+      "post_job_actions": {},
+      "tool_id": "toolshed.g2.bx.psu.edu/repos/bgruening/text_processing/tp_cat/0.1.0",
+      "tool_shed_repository": {
+        "changeset_revision": "74a8bef53a00",
+        "name": "text_processing",
+        "owner": "bgruening",
+        "tool_shed": "toolshed.g2.bx.psu.edu"
+      },
+      "tool_state": "{\"__page__\": null, \"inputs\": \"null\", \"__rerun_remap_job_id__\": null, \"chromInfo\": \"\\\"/usr/local/galaxy/galaxy-dist/tool-data/shared/ucsc/chrom/hg38.len\\\"\", \"queries\": \"[{\\\"inputs2\\\": null, \\\"__index__\\\": 0}]\"}",
+      "tool_version": "0.1.0",
+      "type": "tool",
+      "uuid": "b62261d8-c260-42a6-bbb6-41ab90f12139",
+      "workflow_outputs": []
+    }
+  },
+  "tags": [],
+  "uuid": "fc366e2f-2611-43f4-98cf-170c8acbee22"
+}

--- a/topics/metabolomics/tutorials/msi-analyte-distribution/workflows/main_workflow.ga
+++ b/topics/metabolomics/tutorials/msi-analyte-distribution/workflows/main_workflow.ga
@@ -1,1 +1,477 @@
-{"uuid": "2f45ce5c-e116-4a49-8387-1a1b77b7cb99", "tags": [], "format-version": "0.1", "name": "MSI workflow: Chilli training", "version": 1, "steps": {"0": {"tool_id": null, "tool_version": null, "outputs": [], "workflow_outputs": [], "input_connections": {}, "tool_state": "{\"name\": \"ltpmsi-chilli.i\"}", "id": 0, "uuid": "4cf14f96-333f-4fc8-a195-0c9744aa0069", "errors": null, "name": "Input dataset", "label": "ltpmsi-chilli.i", "inputs": [{"name": "ltpmsi-chilli.i", "description": ""}], "position": {"top": 200.0000114440918, "left": 257.9861259460449}, "annotation": "", "content_id": null, "type": "data_input"}, "1": {"tool_id": null, "tool_version": null, "outputs": [], "workflow_outputs": [], "input_connections": {}, "tool_state": "{}", "id": 1, "uuid": "330ce952-9e5e-48a4-8217-b6c52bdb40da", "errors": null, "name": "Input dataset", "label": "coordinates of interest", "inputs": [], "position": {"top": 320.00002670288086, "left": 257.9861259460449}, "annotation": "", "content_id": null, "type": "data_input"}, "2": {"tool_id": null, "tool_version": null, "outputs": [], "workflow_outputs": [], "input_connections": {}, "tool_state": "{}", "id": 2, "uuid": "61f3323f-bf54-457a-97f7-9f0a0caf9594", "errors": null, "name": "Input dataset", "label": "mz of interest", "inputs": [], "position": {"top": 562.986141204834, "left": 256.9791831970215}, "annotation": "", "content_id": null, "type": "data_input"}, "3": {"tool_id": "toolshed.g2.bx.psu.edu/repos/galaxyp/cardinal_quality_report/cardinal_quality_report/1.12.1.2", "tool_version": "1.12.1.2", "outputs": [{"type": "pdf", "name": "QC_report"}], "workflow_outputs": [], "input_connections": {"infile": {"output_name": "output", "id": 0}}, "tool_state": "{\"calibrant_header\": \"\\\"false\\\"\", \"infile\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\", \"calibrantratio\": \"[]\", \"__page__\": null, \"name_column\": \"null\", \"__rerun_remap_job_id__\": null, \"tabular_annotation\": \"{\\\"__current_case__\\\": 1, \\\"load_annotation\\\": \\\"no_annotation\\\"}\", \"centroids\": \"\\\"false\\\"\", \"calibrant_file\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\", \"processed_cond\": \"{\\\"__current_case__\\\": 1, \\\"accuracy\\\": \\\"0.1\\\", \\\"processed_file\\\": \\\"processed\\\", \\\"units\\\": \\\"mz\\\"}\", \"do_pca\": \"\\\"true\\\"\", \"filename\": \"\\\"\\\"\", \"chromInfo\": \"\\\"/opt/galaxy/tool-data/shared/ucsc/chrom/?.len\\\"\", \"plusminus_ppm\": \"\\\"200.0\\\"\", \"mz_column\": \"null\"}", "id": 3, "tool_shed_repository": {"owner": "galaxyp", "changeset_revision": "d4803c1e5e19", "name": "cardinal_quality_report", "tool_shed": "toolshed.g2.bx.psu.edu"}, "uuid": "9e2d50b1-a9ee-45c0-a75e-9af2af61855f", "errors": null, "name": "MSI Qualitycontrol", "post_job_actions": {}, "label": null, "inputs": [{"name": "calibrant_file", "description": "runtime parameter for tool MSI Qualitycontrol"}, {"name": "infile", "description": "runtime parameter for tool MSI Qualitycontrol"}], "position": {"top": 137.98611068725586, "left": 503.9757194519043}, "annotation": "", "content_id": "toolshed.g2.bx.psu.edu/repos/galaxyp/cardinal_quality_report/cardinal_quality_report/1.12.1.2", "type": "tool"}, "4": {"tool_id": "toolshed.g2.bx.psu.edu/repos/galaxyp/cardinal_spectra_plots/cardinal_spectra_plots/1.12.1.2", "tool_version": "1.12.1.2", "outputs": [{"type": "pdf", "name": "plots"}], "workflow_outputs": [], "input_connections": {"infile": {"output_name": "output", "id": 0}}, "tool_state": "{\"pixel_conditional\": \"{\\\"__current_case__\\\": 1, \\\"pixel_type\\\": \\\"sample_pixel\\\", \\\"tabular_annotation\\\": {\\\"__current_case__\\\": 1, \\\"load_annotation\\\": \\\"no_annotation\\\"}, \\\"zoomed_sample\\\": [{\\\"__index__\\\": 0, \\\"xlimmax\\\": \\\"200\\\", \\\"xlimmin\\\": \\\"10\\\"}, {\\\"__index__\\\": 1, \\\"xlimmax\\\": \\\"500\\\", \\\"xlimmin\\\": \\\"200\\\"}, {\\\"__index__\\\": 2, \\\"xlimmax\\\": \\\"1000\\\", \\\"xlimmin\\\": \\\"500\\\"}, {\\\"__index__\\\": 3, \\\"xlimmax\\\": \\\"1500\\\", \\\"xlimmin\\\": \\\"1000\\\"}, {\\\"__index__\\\": 4, \\\"xlimmax\\\": \\\"2000\\\", \\\"xlimmin\\\": \\\"1500\\\"}]}\", \"__page__\": null, \"__rerun_remap_job_id__\": null, \"centroids\": \"\\\"false\\\"\", \"filename\": \"\\\"\\\"\", \"processed_cond\": \"{\\\"__current_case__\\\": 1, \\\"accuracy\\\": \\\"0.1\\\", \\\"processed_file\\\": \\\"processed\\\", \\\"units\\\": \\\"mz\\\"}\", \"chromInfo\": \"\\\"/opt/galaxy/tool-data/shared/ucsc/chrom/?.len\\\"\", \"infile\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\"}", "id": 4, "tool_shed_repository": {"owner": "galaxyp", "changeset_revision": "3642ed221eb2", "name": "cardinal_spectra_plots", "tool_shed": "toolshed.g2.bx.psu.edu"}, "uuid": "ef42a98f-a337-452d-be22-9178c59727ae", "errors": null, "name": "MSI plot spectra", "post_job_actions": {}, "label": null, "inputs": [{"name": "infile", "description": "runtime parameter for tool MSI plot spectra"}], "position": {"top": 302.98611068725586, "left": 527.9861259460449}, "annotation": "", "content_id": "toolshed.g2.bx.psu.edu/repos/galaxyp/cardinal_spectra_plots/cardinal_spectra_plots/1.12.1.2", "type": "tool"}, "5": {"tool_id": "toolshed.g2.bx.psu.edu/repos/galaxyp/cardinal_filtering/cardinal_filtering/1.12.1.2", "tool_version": "1.12.1.2", "outputs": [{"type": "imzml", "name": "outfile_imzml"}, {"type": "rdata", "name": "outfile_rdata"}, {"type": "pdf", "name": "QC_overview"}], "workflow_outputs": [], "input_connections": {"infile": {"output_name": "output", "id": 0}}, "tool_state": "{\"__page__\": null, \"features_cond\": \"{\\\"__current_case__\\\": 2, \\\"features_filtering\\\": \\\"features_range\\\", \\\"max_mz\\\": \\\"1000.0\\\", \\\"min_mz\\\": \\\"15.0\\\"}\", \"__rerun_remap_job_id__\": null, \"centroids\": \"\\\"false\\\"\", \"imzml_output\": \"\\\"imzml_format\\\"\", \"processed_cond\": \"{\\\"__current_case__\\\": 1, \\\"accuracy\\\": \\\"0.1\\\", \\\"processed_file\\\": \\\"processed\\\", \\\"units\\\": \\\"mz\\\"}\", \"pixels_cond\": \"{\\\"__current_case__\\\": 0, \\\"pixel_filtering\\\": \\\"none\\\"}\", \"chromInfo\": \"\\\"/opt/galaxy/tool-data/shared/ucsc/chrom/?.len\\\"\", \"infile\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\"}", "id": 5, "tool_shed_repository": {"owner": "galaxyp", "changeset_revision": "0c4579390f73", "name": "cardinal_filtering", "tool_shed": "toolshed.g2.bx.psu.edu"}, "uuid": "843ebcef-8117-4534-b0dd-a813545b87dc", "errors": null, "name": "MSI filtering", "post_job_actions": {}, "label": null, "inputs": [{"name": "infile", "description": "runtime parameter for tool MSI filtering"}], "position": {"top": 432.986141204834, "left": 855.9722709655762}, "annotation": "", "content_id": "toolshed.g2.bx.psu.edu/repos/galaxyp/cardinal_filtering/cardinal_filtering/1.12.1.2", "type": "tool"}, "6": {"tool_id": "toolshed.g2.bx.psu.edu/repos/galaxyp/cardinal_spectra_plots/cardinal_spectra_plots/1.12.1.2", "tool_version": "1.12.1.2", "outputs": [{"type": "pdf", "name": "plots"}], "workflow_outputs": [], "input_connections": {"infile": {"output_name": "output", "id": 0}, "pixel_conditional|tabular_annotation|annotation_file": {"output_name": "output", "id": 1}}, "tool_state": "{\"pixel_conditional\": \"{\\\"__current_case__\\\": 1, \\\"pixel_type\\\": \\\"sample_pixel\\\", \\\"tabular_annotation\\\": {\\\"__current_case__\\\": 0, \\\"annotation_file\\\": {\\\"__class__\\\": \\\"RuntimeValue\\\"}, \\\"column_names\\\": \\\"3\\\", \\\"column_x\\\": \\\"1\\\", \\\"column_y\\\": \\\"2\\\", \\\"load_annotation\\\": \\\"yes_annotation\\\", \\\"tabular_header\\\": \\\"true\\\"}, \\\"zoomed_sample\\\": [{\\\"__index__\\\": 0, \\\"xlimmax\\\": \\\"200\\\", \\\"xlimmin\\\": \\\"10\\\"}, {\\\"__index__\\\": 1, \\\"xlimmax\\\": \\\"500\\\", \\\"xlimmin\\\": \\\"200\\\"}, {\\\"__index__\\\": 2, \\\"xlimmax\\\": \\\"1000\\\", \\\"xlimmin\\\": \\\"500\\\"}, {\\\"__index__\\\": 3, \\\"xlimmax\\\": \\\"1500\\\", \\\"xlimmin\\\": \\\"1000\\\"}, {\\\"__index__\\\": 4, \\\"xlimmax\\\": \\\"2000\\\", \\\"xlimmin\\\": \\\"1500\\\"}]}\", \"__page__\": null, \"__rerun_remap_job_id__\": null, \"centroids\": \"\\\"false\\\"\", \"filename\": \"\\\"\\\"\", \"processed_cond\": \"{\\\"__current_case__\\\": 1, \\\"accuracy\\\": \\\"0.1\\\", \\\"processed_file\\\": \\\"processed\\\", \\\"units\\\": \\\"mz\\\"}\", \"chromInfo\": \"\\\"/opt/galaxy/tool-data/shared/ucsc/chrom/?.len\\\"\", \"infile\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\"}", "id": 6, "tool_shed_repository": {"owner": "galaxyp", "changeset_revision": "3642ed221eb2", "name": "cardinal_spectra_plots", "tool_shed": "toolshed.g2.bx.psu.edu"}, "uuid": "ade8fad0-98eb-40ee-9c0c-a31555aa8581", "errors": null, "name": "MSI plot spectra", "post_job_actions": {}, "label": null, "inputs": [{"name": "infile", "description": "runtime parameter for tool MSI plot spectra"}], "position": {"top": 435.00002670288086, "left": 507.9687614440918}, "annotation": "", "content_id": "toolshed.g2.bx.psu.edu/repos/galaxyp/cardinal_spectra_plots/cardinal_spectra_plots/1.12.1.2", "type": "tool"}, "7": {"tool_id": "toolshed.g2.bx.psu.edu/repos/galaxyp/cardinal_data_exporter/cardinal_data_exporter/1.12.1.1", "tool_version": "1.12.1.1", "outputs": [{"type": "tabular", "name": "intensity_matrix"}, {"type": "tabular", "name": "pixel_output"}, {"type": "tabular", "name": "feature_output"}, {"type": "tabular", "name": "summarized_mean"}, {"type": "tabular", "name": "summarized_median"}, {"type": "tabular", "name": "summarized_sd"}], "workflow_outputs": [], "input_connections": {"infile": {"output_name": "outfile_imzml", "id": 5}}, "tool_state": "{\"__page__\": null, \"output_options\": \"[\\\"mz_tabular\\\"]\", \"tabular_annotation\": \"{\\\"__current_case__\\\": 0, \\\"load_annotation\\\": \\\"no_annotation\\\"}\", \"__rerun_remap_job_id__\": null, \"centroids\": \"\\\"false\\\"\", \"processed_cond\": \"{\\\"__current_case__\\\": 0, \\\"processed_file\\\": \\\"no_processed\\\"}\", \"counting_calibrants\": \"{\\\"__current_case__\\\": 0, \\\"pixel_with_calibrants\\\": \\\"no_calibrants\\\"}\", \"chromInfo\": \"\\\"/opt/galaxy/tool-data/shared/ucsc/chrom/?.len\\\"\", \"infile\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\"}", "id": 7, "tool_shed_repository": {"owner": "galaxyp", "changeset_revision": "e30d8b72415f", "name": "cardinal_data_exporter", "tool_shed": "toolshed.g2.bx.psu.edu"}, "uuid": "056b0817-7aba-4011-8a6b-2506f8509179", "errors": null, "name": "MSI data exporter", "post_job_actions": {}, "label": null, "inputs": [{"name": "infile", "description": "runtime parameter for tool MSI data exporter"}], "position": {"top": 187.98612594604492, "left": 1103.9757499694824}, "annotation": "", "content_id": "toolshed.g2.bx.psu.edu/repos/galaxyp/cardinal_data_exporter/cardinal_data_exporter/1.12.1.1", "type": "tool"}, "8": {"tool_id": "toolshed.g2.bx.psu.edu/repos/galaxyp/cardinal_mz_images/cardinal_mz_images/1.12.1.2", "tool_version": "1.12.1.2", "outputs": [{"type": "pdf", "name": "plots"}, {"type": "svg", "name": "svg_output"}], "workflow_outputs": [], "input_connections": {"infile": {"output_name": "outfile_imzml", "id": 5}, "calibrant_file": {"output_name": "output", "id": 2}}, "tool_state": "{\"calibrant_header\": \"\\\"false\\\"\", \"infile\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\", \"image_contrast\": \"\\\"suppression\\\"\", \"image_smoothing\": \"\\\"none\\\"\", \"image_type\": \"\\\"true\\\"\", \"name_column\": \"\\\"1\\\"\", \"__rerun_remap_job_id__\": null, \"svg_pixelimage\": \"\\\"false\\\"\", \"calibrant_file\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\", \"centroids\": \"\\\"false\\\"\", \"filename\": \"\\\"\\\"\", \"colorkey\": \"\\\"true\\\"\", \"processed_cond\": \"{\\\"__current_case__\\\": 0, \\\"processed_file\\\": \\\"no_processed\\\"}\", \"strip\": \"\\\"true\\\"\", \"__page__\": null, \"overlay_cond\": \"{\\\"__current_case__\\\": 1, \\\"colours\\\": [{\\\"__index__\\\": 0, \\\"feature_color\\\": \\\"#c00000\\\"}, {\\\"__index__\\\": 1, \\\"feature_color\\\": \\\"#0070c0\\\"}, {\\\"__index__\\\": 2, \\\"feature_color\\\": \\\"#00b050\\\"}], \\\"overlay_selection\\\": \\\"yes_overlay\\\"}\", \"chromInfo\": \"\\\"/opt/galaxy/tool-data/shared/ucsc/chrom/?.len\\\"\", \"plusminus_dalton\": \"\\\"0.4\\\"\", \"mz_column\": \"\\\"1\\\"\"}", "id": 8, "tool_shed_repository": {"owner": "galaxyp", "changeset_revision": "27a4c660bbca", "name": "cardinal_mz_images", "tool_shed": "toolshed.g2.bx.psu.edu"}, "uuid": "ade9852a-1f01-4ac1-b1a2-8cbff0c52ec6", "errors": null, "name": "MSI mz images", "post_job_actions": {}, "label": null, "inputs": [{"name": "calibrant_file", "description": "runtime parameter for tool MSI mz images"}, {"name": "infile", "description": "runtime parameter for tool MSI mz images"}], "position": {"top": 640.972225189209, "left": 1355.954875946045}, "annotation": "", "content_id": "toolshed.g2.bx.psu.edu/repos/galaxyp/cardinal_mz_images/cardinal_mz_images/1.12.1.2", "type": "tool"}, "9": {"tool_id": "Filter1", "tool_version": "1.1.0", "outputs": [{"type": "input", "name": "out_file1"}], "workflow_outputs": [], "input_connections": {"input": {"output_name": "feature_output", "id": 7}}, "tool_state": "{\"__page__\": null, \"__rerun_remap_job_id__\": null, \"cond\": \"\\\"c2>=55 and c2<=65 or c2>=75 and c2<=85\\\"\", \"input\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\", \"header_lines\": \"\\\"1\\\"\", \"chromInfo\": \"\\\"/opt/galaxy/tool-data/shared/ucsc/chrom/?.len\\\"\"}", "id": 9, "uuid": "cb99d16b-a131-47b8-9b32-bca89303da46", "errors": null, "name": "Filter", "post_job_actions": {}, "label": null, "inputs": [{"name": "input", "description": "runtime parameter for tool Filter"}], "position": {"top": 312.96877670288086, "left": 1479.948040008545}, "annotation": "", "content_id": "Filter1", "type": "tool"}, "10": {"tool_id": "toolshed.g2.bx.psu.edu/repos/galaxyp/cardinal_mz_images/cardinal_mz_images/1.12.1.2", "tool_version": "1.12.1.2", "outputs": [{"type": "pdf", "name": "plots"}, {"type": "svg", "name": "svg_output"}], "workflow_outputs": [], "input_connections": {"infile": {"output_name": "outfile_imzml", "id": 5}, "calibrant_file": {"output_name": "out_file1", "id": 9}}, "tool_state": "{\"calibrant_header\": \"\\\"true\\\"\", \"infile\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\", \"image_contrast\": \"\\\"suppression\\\"\", \"image_smoothing\": \"\\\"none\\\"\", \"image_type\": \"\\\"true\\\"\", \"name_column\": \"\\\"2\\\"\", \"__rerun_remap_job_id__\": null, \"svg_pixelimage\": \"\\\"false\\\"\", \"calibrant_file\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\", \"centroids\": \"\\\"false\\\"\", \"filename\": \"\\\"\\\"\", \"colorkey\": \"\\\"true\\\"\", \"processed_cond\": \"{\\\"__current_case__\\\": 0, \\\"processed_file\\\": \\\"no_processed\\\"}\", \"strip\": \"\\\"true\\\"\", \"__page__\": null, \"overlay_cond\": \"{\\\"__current_case__\\\": 0, \\\"overlay_selection\\\": \\\"no_overlay\\\"}\", \"chromInfo\": \"\\\"/opt/galaxy/tool-data/shared/ucsc/chrom/?.len\\\"\", \"plusminus_dalton\": \"\\\"0.4\\\"\", \"mz_column\": \"\\\"2\\\"\"}", "id": 10, "tool_shed_repository": {"owner": "galaxyp", "changeset_revision": "27a4c660bbca", "name": "cardinal_mz_images", "tool_shed": "toolshed.g2.bx.psu.edu"}, "uuid": "76b29ca8-bc40-44db-9545-10c315d8f512", "errors": null, "name": "MSI mz images", "post_job_actions": {}, "label": null, "inputs": [{"name": "calibrant_file", "description": "runtime parameter for tool MSI mz images"}, {"name": "infile", "description": "runtime parameter for tool MSI mz images"}], "position": {"top": 420.9722557067871, "left": 1870.93754196167}, "annotation": "", "content_id": "toolshed.g2.bx.psu.edu/repos/galaxyp/cardinal_mz_images/cardinal_mz_images/1.12.1.2", "type": "tool"}}, "annotation": "", "a_galaxy_workflow": "true"}
+{
+  "a_galaxy_workflow": "true",
+  "annotation": "",
+  "format-version": "0.1",
+  "name": "MSI workflow: Chilli training",
+  "steps": {
+    "0": {
+      "annotation": "",
+      "content_id": null,
+      "errors": null,
+      "id": 0,
+      "input_connections": {},
+      "inputs": [
+        {
+          "description": "",
+          "name": "ltpmsi-chilli.i"
+        }
+      ],
+      "label": "ltpmsi-chilli.i",
+      "name": "Input dataset",
+      "outputs": [],
+      "position": {
+        "left": 257.9861259460449,
+        "top": 200.0000114440918
+      },
+      "tool_id": null,
+      "tool_state": "{\"name\": \"ltpmsi-chilli.i\"}",
+      "tool_version": null,
+      "type": "data_input",
+      "uuid": "4cf14f96-333f-4fc8-a195-0c9744aa0069",
+      "workflow_outputs": []
+    },
+    "1": {
+      "annotation": "",
+      "content_id": null,
+      "errors": null,
+      "id": 1,
+      "input_connections": {},
+      "inputs": [],
+      "label": "coordinates of interest",
+      "name": "Input dataset",
+      "outputs": [],
+      "position": {
+        "left": 257.9861259460449,
+        "top": 320.00002670288086
+      },
+      "tool_id": null,
+      "tool_state": "{}",
+      "tool_version": null,
+      "type": "data_input",
+      "uuid": "330ce952-9e5e-48a4-8217-b6c52bdb40da",
+      "workflow_outputs": []
+    },
+    "10": {
+      "annotation": "",
+      "content_id": "toolshed.g2.bx.psu.edu/repos/galaxyp/cardinal_mz_images/cardinal_mz_images/1.12.1.2",
+      "errors": null,
+      "id": 10,
+      "input_connections": {
+        "calibrant_file": {
+          "id": 9,
+          "output_name": "out_file1"
+        },
+        "infile": {
+          "id": 5,
+          "output_name": "outfile_imzml"
+        }
+      },
+      "inputs": [
+        {
+          "description": "runtime parameter for tool MSI mz images",
+          "name": "calibrant_file"
+        },
+        {
+          "description": "runtime parameter for tool MSI mz images",
+          "name": "infile"
+        }
+      ],
+      "label": null,
+      "name": "MSI mz images",
+      "outputs": [
+        {
+          "name": "plots",
+          "type": "pdf"
+        },
+        {
+          "name": "svg_output",
+          "type": "svg"
+        }
+      ],
+      "position": {
+        "left": 1870.93754196167,
+        "top": 420.9722557067871
+      },
+      "post_job_actions": {},
+      "tool_id": "toolshed.g2.bx.psu.edu/repos/galaxyp/cardinal_mz_images/cardinal_mz_images/1.12.1.2",
+      "tool_shed_repository": {
+        "changeset_revision": "27a4c660bbca",
+        "name": "cardinal_mz_images",
+        "owner": "galaxyp",
+        "tool_shed": "toolshed.g2.bx.psu.edu"
+      },
+      "tool_state": "{\"calibrant_header\": \"\\\"true\\\"\", \"infile\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\", \"image_contrast\": \"\\\"suppression\\\"\", \"image_smoothing\": \"\\\"none\\\"\", \"image_type\": \"\\\"true\\\"\", \"name_column\": \"\\\"2\\\"\", \"__rerun_remap_job_id__\": null, \"svg_pixelimage\": \"\\\"false\\\"\", \"calibrant_file\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\", \"centroids\": \"\\\"false\\\"\", \"filename\": \"\\\"\\\"\", \"colorkey\": \"\\\"true\\\"\", \"processed_cond\": \"{\\\"__current_case__\\\": 0, \\\"processed_file\\\": \\\"no_processed\\\"}\", \"strip\": \"\\\"true\\\"\", \"__page__\": null, \"overlay_cond\": \"{\\\"__current_case__\\\": 0, \\\"overlay_selection\\\": \\\"no_overlay\\\"}\", \"chromInfo\": \"\\\"/opt/galaxy/tool-data/shared/ucsc/chrom/?.len\\\"\", \"plusminus_dalton\": \"\\\"0.4\\\"\", \"mz_column\": \"\\\"2\\\"\"}",
+      "tool_version": "1.12.1.2",
+      "type": "tool",
+      "uuid": "76b29ca8-bc40-44db-9545-10c315d8f512",
+      "workflow_outputs": []
+    },
+    "2": {
+      "annotation": "",
+      "content_id": null,
+      "errors": null,
+      "id": 2,
+      "input_connections": {},
+      "inputs": [],
+      "label": "mz of interest",
+      "name": "Input dataset",
+      "outputs": [],
+      "position": {
+        "left": 256.9791831970215,
+        "top": 562.986141204834
+      },
+      "tool_id": null,
+      "tool_state": "{}",
+      "tool_version": null,
+      "type": "data_input",
+      "uuid": "61f3323f-bf54-457a-97f7-9f0a0caf9594",
+      "workflow_outputs": []
+    },
+    "3": {
+      "annotation": "",
+      "content_id": "toolshed.g2.bx.psu.edu/repos/galaxyp/cardinal_quality_report/cardinal_quality_report/1.12.1.2",
+      "errors": null,
+      "id": 3,
+      "input_connections": {
+        "infile": {
+          "id": 0,
+          "output_name": "output"
+        }
+      },
+      "inputs": [
+        {
+          "description": "runtime parameter for tool MSI Qualitycontrol",
+          "name": "calibrant_file"
+        },
+        {
+          "description": "runtime parameter for tool MSI Qualitycontrol",
+          "name": "infile"
+        }
+      ],
+      "label": null,
+      "name": "MSI Qualitycontrol",
+      "outputs": [
+        {
+          "name": "QC_report",
+          "type": "pdf"
+        }
+      ],
+      "position": {
+        "left": 503.9757194519043,
+        "top": 137.98611068725586
+      },
+      "post_job_actions": {},
+      "tool_id": "toolshed.g2.bx.psu.edu/repos/galaxyp/cardinal_quality_report/cardinal_quality_report/1.12.1.2",
+      "tool_shed_repository": {
+        "changeset_revision": "d4803c1e5e19",
+        "name": "cardinal_quality_report",
+        "owner": "galaxyp",
+        "tool_shed": "toolshed.g2.bx.psu.edu"
+      },
+      "tool_state": "{\"calibrant_header\": \"\\\"false\\\"\", \"infile\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\", \"calibrantratio\": \"[]\", \"__page__\": null, \"name_column\": \"null\", \"__rerun_remap_job_id__\": null, \"tabular_annotation\": \"{\\\"__current_case__\\\": 1, \\\"load_annotation\\\": \\\"no_annotation\\\"}\", \"centroids\": \"\\\"false\\\"\", \"calibrant_file\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\", \"processed_cond\": \"{\\\"__current_case__\\\": 1, \\\"accuracy\\\": \\\"0.1\\\", \\\"processed_file\\\": \\\"processed\\\", \\\"units\\\": \\\"mz\\\"}\", \"do_pca\": \"\\\"true\\\"\", \"filename\": \"\\\"\\\"\", \"chromInfo\": \"\\\"/opt/galaxy/tool-data/shared/ucsc/chrom/?.len\\\"\", \"plusminus_ppm\": \"\\\"200.0\\\"\", \"mz_column\": \"null\"}",
+      "tool_version": "1.12.1.2",
+      "type": "tool",
+      "uuid": "9e2d50b1-a9ee-45c0-a75e-9af2af61855f",
+      "workflow_outputs": []
+    },
+    "4": {
+      "annotation": "",
+      "content_id": "toolshed.g2.bx.psu.edu/repos/galaxyp/cardinal_spectra_plots/cardinal_spectra_plots/1.12.1.2",
+      "errors": null,
+      "id": 4,
+      "input_connections": {
+        "infile": {
+          "id": 0,
+          "output_name": "output"
+        }
+      },
+      "inputs": [
+        {
+          "description": "runtime parameter for tool MSI plot spectra",
+          "name": "infile"
+        }
+      ],
+      "label": null,
+      "name": "MSI plot spectra",
+      "outputs": [
+        {
+          "name": "plots",
+          "type": "pdf"
+        }
+      ],
+      "position": {
+        "left": 527.9861259460449,
+        "top": 302.98611068725586
+      },
+      "post_job_actions": {},
+      "tool_id": "toolshed.g2.bx.psu.edu/repos/galaxyp/cardinal_spectra_plots/cardinal_spectra_plots/1.12.1.2",
+      "tool_shed_repository": {
+        "changeset_revision": "3642ed221eb2",
+        "name": "cardinal_spectra_plots",
+        "owner": "galaxyp",
+        "tool_shed": "toolshed.g2.bx.psu.edu"
+      },
+      "tool_state": "{\"pixel_conditional\": \"{\\\"__current_case__\\\": 1, \\\"pixel_type\\\": \\\"sample_pixel\\\", \\\"tabular_annotation\\\": {\\\"__current_case__\\\": 1, \\\"load_annotation\\\": \\\"no_annotation\\\"}, \\\"zoomed_sample\\\": [{\\\"__index__\\\": 0, \\\"xlimmax\\\": \\\"200\\\", \\\"xlimmin\\\": \\\"10\\\"}, {\\\"__index__\\\": 1, \\\"xlimmax\\\": \\\"500\\\", \\\"xlimmin\\\": \\\"200\\\"}, {\\\"__index__\\\": 2, \\\"xlimmax\\\": \\\"1000\\\", \\\"xlimmin\\\": \\\"500\\\"}, {\\\"__index__\\\": 3, \\\"xlimmax\\\": \\\"1500\\\", \\\"xlimmin\\\": \\\"1000\\\"}, {\\\"__index__\\\": 4, \\\"xlimmax\\\": \\\"2000\\\", \\\"xlimmin\\\": \\\"1500\\\"}]}\", \"__page__\": null, \"__rerun_remap_job_id__\": null, \"centroids\": \"\\\"false\\\"\", \"filename\": \"\\\"\\\"\", \"processed_cond\": \"{\\\"__current_case__\\\": 1, \\\"accuracy\\\": \\\"0.1\\\", \\\"processed_file\\\": \\\"processed\\\", \\\"units\\\": \\\"mz\\\"}\", \"chromInfo\": \"\\\"/opt/galaxy/tool-data/shared/ucsc/chrom/?.len\\\"\", \"infile\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\"}",
+      "tool_version": "1.12.1.2",
+      "type": "tool",
+      "uuid": "ef42a98f-a337-452d-be22-9178c59727ae",
+      "workflow_outputs": []
+    },
+    "5": {
+      "annotation": "",
+      "content_id": "toolshed.g2.bx.psu.edu/repos/galaxyp/cardinal_filtering/cardinal_filtering/1.12.1.2",
+      "errors": null,
+      "id": 5,
+      "input_connections": {
+        "infile": {
+          "id": 0,
+          "output_name": "output"
+        }
+      },
+      "inputs": [
+        {
+          "description": "runtime parameter for tool MSI filtering",
+          "name": "infile"
+        }
+      ],
+      "label": null,
+      "name": "MSI filtering",
+      "outputs": [
+        {
+          "name": "outfile_imzml",
+          "type": "imzml"
+        },
+        {
+          "name": "outfile_rdata",
+          "type": "rdata"
+        },
+        {
+          "name": "QC_overview",
+          "type": "pdf"
+        }
+      ],
+      "position": {
+        "left": 855.9722709655762,
+        "top": 432.986141204834
+      },
+      "post_job_actions": {},
+      "tool_id": "toolshed.g2.bx.psu.edu/repos/galaxyp/cardinal_filtering/cardinal_filtering/1.12.1.2",
+      "tool_shed_repository": {
+        "changeset_revision": "0c4579390f73",
+        "name": "cardinal_filtering",
+        "owner": "galaxyp",
+        "tool_shed": "toolshed.g2.bx.psu.edu"
+      },
+      "tool_state": "{\"__page__\": null, \"features_cond\": \"{\\\"__current_case__\\\": 2, \\\"features_filtering\\\": \\\"features_range\\\", \\\"max_mz\\\": \\\"1000.0\\\", \\\"min_mz\\\": \\\"15.0\\\"}\", \"__rerun_remap_job_id__\": null, \"centroids\": \"\\\"false\\\"\", \"imzml_output\": \"\\\"imzml_format\\\"\", \"processed_cond\": \"{\\\"__current_case__\\\": 1, \\\"accuracy\\\": \\\"0.1\\\", \\\"processed_file\\\": \\\"processed\\\", \\\"units\\\": \\\"mz\\\"}\", \"pixels_cond\": \"{\\\"__current_case__\\\": 0, \\\"pixel_filtering\\\": \\\"none\\\"}\", \"chromInfo\": \"\\\"/opt/galaxy/tool-data/shared/ucsc/chrom/?.len\\\"\", \"infile\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\"}",
+      "tool_version": "1.12.1.2",
+      "type": "tool",
+      "uuid": "843ebcef-8117-4534-b0dd-a813545b87dc",
+      "workflow_outputs": []
+    },
+    "6": {
+      "annotation": "",
+      "content_id": "toolshed.g2.bx.psu.edu/repos/galaxyp/cardinal_spectra_plots/cardinal_spectra_plots/1.12.1.2",
+      "errors": null,
+      "id": 6,
+      "input_connections": {
+        "infile": {
+          "id": 0,
+          "output_name": "output"
+        },
+        "pixel_conditional|tabular_annotation|annotation_file": {
+          "id": 1,
+          "output_name": "output"
+        }
+      },
+      "inputs": [
+        {
+          "description": "runtime parameter for tool MSI plot spectra",
+          "name": "infile"
+        }
+      ],
+      "label": null,
+      "name": "MSI plot spectra",
+      "outputs": [
+        {
+          "name": "plots",
+          "type": "pdf"
+        }
+      ],
+      "position": {
+        "left": 507.9687614440918,
+        "top": 435.00002670288086
+      },
+      "post_job_actions": {},
+      "tool_id": "toolshed.g2.bx.psu.edu/repos/galaxyp/cardinal_spectra_plots/cardinal_spectra_plots/1.12.1.2",
+      "tool_shed_repository": {
+        "changeset_revision": "3642ed221eb2",
+        "name": "cardinal_spectra_plots",
+        "owner": "galaxyp",
+        "tool_shed": "toolshed.g2.bx.psu.edu"
+      },
+      "tool_state": "{\"pixel_conditional\": \"{\\\"__current_case__\\\": 1, \\\"pixel_type\\\": \\\"sample_pixel\\\", \\\"tabular_annotation\\\": {\\\"__current_case__\\\": 0, \\\"annotation_file\\\": {\\\"__class__\\\": \\\"RuntimeValue\\\"}, \\\"column_names\\\": \\\"3\\\", \\\"column_x\\\": \\\"1\\\", \\\"column_y\\\": \\\"2\\\", \\\"load_annotation\\\": \\\"yes_annotation\\\", \\\"tabular_header\\\": \\\"true\\\"}, \\\"zoomed_sample\\\": [{\\\"__index__\\\": 0, \\\"xlimmax\\\": \\\"200\\\", \\\"xlimmin\\\": \\\"10\\\"}, {\\\"__index__\\\": 1, \\\"xlimmax\\\": \\\"500\\\", \\\"xlimmin\\\": \\\"200\\\"}, {\\\"__index__\\\": 2, \\\"xlimmax\\\": \\\"1000\\\", \\\"xlimmin\\\": \\\"500\\\"}, {\\\"__index__\\\": 3, \\\"xlimmax\\\": \\\"1500\\\", \\\"xlimmin\\\": \\\"1000\\\"}, {\\\"__index__\\\": 4, \\\"xlimmax\\\": \\\"2000\\\", \\\"xlimmin\\\": \\\"1500\\\"}]}\", \"__page__\": null, \"__rerun_remap_job_id__\": null, \"centroids\": \"\\\"false\\\"\", \"filename\": \"\\\"\\\"\", \"processed_cond\": \"{\\\"__current_case__\\\": 1, \\\"accuracy\\\": \\\"0.1\\\", \\\"processed_file\\\": \\\"processed\\\", \\\"units\\\": \\\"mz\\\"}\", \"chromInfo\": \"\\\"/opt/galaxy/tool-data/shared/ucsc/chrom/?.len\\\"\", \"infile\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\"}",
+      "tool_version": "1.12.1.2",
+      "type": "tool",
+      "uuid": "ade8fad0-98eb-40ee-9c0c-a31555aa8581",
+      "workflow_outputs": []
+    },
+    "7": {
+      "annotation": "",
+      "content_id": "toolshed.g2.bx.psu.edu/repos/galaxyp/cardinal_data_exporter/cardinal_data_exporter/1.12.1.1",
+      "errors": null,
+      "id": 7,
+      "input_connections": {
+        "infile": {
+          "id": 5,
+          "output_name": "outfile_imzml"
+        }
+      },
+      "inputs": [
+        {
+          "description": "runtime parameter for tool MSI data exporter",
+          "name": "infile"
+        }
+      ],
+      "label": null,
+      "name": "MSI data exporter",
+      "outputs": [
+        {
+          "name": "intensity_matrix",
+          "type": "tabular"
+        },
+        {
+          "name": "pixel_output",
+          "type": "tabular"
+        },
+        {
+          "name": "feature_output",
+          "type": "tabular"
+        },
+        {
+          "name": "summarized_mean",
+          "type": "tabular"
+        },
+        {
+          "name": "summarized_median",
+          "type": "tabular"
+        },
+        {
+          "name": "summarized_sd",
+          "type": "tabular"
+        }
+      ],
+      "position": {
+        "left": 1103.9757499694824,
+        "top": 187.98612594604492
+      },
+      "post_job_actions": {},
+      "tool_id": "toolshed.g2.bx.psu.edu/repos/galaxyp/cardinal_data_exporter/cardinal_data_exporter/1.12.1.1",
+      "tool_shed_repository": {
+        "changeset_revision": "e30d8b72415f",
+        "name": "cardinal_data_exporter",
+        "owner": "galaxyp",
+        "tool_shed": "toolshed.g2.bx.psu.edu"
+      },
+      "tool_state": "{\"__page__\": null, \"output_options\": \"[\\\"mz_tabular\\\"]\", \"tabular_annotation\": \"{\\\"__current_case__\\\": 0, \\\"load_annotation\\\": \\\"no_annotation\\\"}\", \"__rerun_remap_job_id__\": null, \"centroids\": \"\\\"false\\\"\", \"processed_cond\": \"{\\\"__current_case__\\\": 0, \\\"processed_file\\\": \\\"no_processed\\\"}\", \"counting_calibrants\": \"{\\\"__current_case__\\\": 0, \\\"pixel_with_calibrants\\\": \\\"no_calibrants\\\"}\", \"chromInfo\": \"\\\"/opt/galaxy/tool-data/shared/ucsc/chrom/?.len\\\"\", \"infile\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\"}",
+      "tool_version": "1.12.1.1",
+      "type": "tool",
+      "uuid": "056b0817-7aba-4011-8a6b-2506f8509179",
+      "workflow_outputs": []
+    },
+    "8": {
+      "annotation": "",
+      "content_id": "toolshed.g2.bx.psu.edu/repos/galaxyp/cardinal_mz_images/cardinal_mz_images/1.12.1.2",
+      "errors": null,
+      "id": 8,
+      "input_connections": {
+        "calibrant_file": {
+          "id": 2,
+          "output_name": "output"
+        },
+        "infile": {
+          "id": 5,
+          "output_name": "outfile_imzml"
+        }
+      },
+      "inputs": [
+        {
+          "description": "runtime parameter for tool MSI mz images",
+          "name": "calibrant_file"
+        },
+        {
+          "description": "runtime parameter for tool MSI mz images",
+          "name": "infile"
+        }
+      ],
+      "label": null,
+      "name": "MSI mz images",
+      "outputs": [
+        {
+          "name": "plots",
+          "type": "pdf"
+        },
+        {
+          "name": "svg_output",
+          "type": "svg"
+        }
+      ],
+      "position": {
+        "left": 1355.954875946045,
+        "top": 640.972225189209
+      },
+      "post_job_actions": {},
+      "tool_id": "toolshed.g2.bx.psu.edu/repos/galaxyp/cardinal_mz_images/cardinal_mz_images/1.12.1.2",
+      "tool_shed_repository": {
+        "changeset_revision": "27a4c660bbca",
+        "name": "cardinal_mz_images",
+        "owner": "galaxyp",
+        "tool_shed": "toolshed.g2.bx.psu.edu"
+      },
+      "tool_state": "{\"calibrant_header\": \"\\\"false\\\"\", \"infile\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\", \"image_contrast\": \"\\\"suppression\\\"\", \"image_smoothing\": \"\\\"none\\\"\", \"image_type\": \"\\\"true\\\"\", \"name_column\": \"\\\"1\\\"\", \"__rerun_remap_job_id__\": null, \"svg_pixelimage\": \"\\\"false\\\"\", \"calibrant_file\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\", \"centroids\": \"\\\"false\\\"\", \"filename\": \"\\\"\\\"\", \"colorkey\": \"\\\"true\\\"\", \"processed_cond\": \"{\\\"__current_case__\\\": 0, \\\"processed_file\\\": \\\"no_processed\\\"}\", \"strip\": \"\\\"true\\\"\", \"__page__\": null, \"overlay_cond\": \"{\\\"__current_case__\\\": 1, \\\"colours\\\": [{\\\"__index__\\\": 0, \\\"feature_color\\\": \\\"#c00000\\\"}, {\\\"__index__\\\": 1, \\\"feature_color\\\": \\\"#0070c0\\\"}, {\\\"__index__\\\": 2, \\\"feature_color\\\": \\\"#00b050\\\"}], \\\"overlay_selection\\\": \\\"yes_overlay\\\"}\", \"chromInfo\": \"\\\"/opt/galaxy/tool-data/shared/ucsc/chrom/?.len\\\"\", \"plusminus_dalton\": \"\\\"0.4\\\"\", \"mz_column\": \"\\\"1\\\"\"}",
+      "tool_version": "1.12.1.2",
+      "type": "tool",
+      "uuid": "ade9852a-1f01-4ac1-b1a2-8cbff0c52ec6",
+      "workflow_outputs": []
+    },
+    "9": {
+      "annotation": "",
+      "content_id": "Filter1",
+      "errors": null,
+      "id": 9,
+      "input_connections": {
+        "input": {
+          "id": 7,
+          "output_name": "feature_output"
+        }
+      },
+      "inputs": [
+        {
+          "description": "runtime parameter for tool Filter",
+          "name": "input"
+        }
+      ],
+      "label": null,
+      "name": "Filter",
+      "outputs": [
+        {
+          "name": "out_file1",
+          "type": "input"
+        }
+      ],
+      "position": {
+        "left": 1479.948040008545,
+        "top": 312.96877670288086
+      },
+      "post_job_actions": {},
+      "tool_id": "Filter1",
+      "tool_state": "{\"__page__\": null, \"__rerun_remap_job_id__\": null, \"cond\": \"\\\"c2>=55 and c2<=65 or c2>=75 and c2<=85\\\"\", \"input\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\", \"header_lines\": \"\\\"1\\\"\", \"chromInfo\": \"\\\"/opt/galaxy/tool-data/shared/ucsc/chrom/?.len\\\"\"}",
+      "tool_version": "1.1.0",
+      "type": "tool",
+      "uuid": "cb99d16b-a131-47b8-9b32-bca89303da46",
+      "workflow_outputs": []
+    }
+  },
+  "tags": [],
+  "uuid": "2f45ce5c-e116-4a49-8387-1a1b77b7cb99",
+  "version": 1
+}

--- a/topics/proteomics/tutorials/mass-spectrometry-imaging-loading-exploring-data/workflows/ms_imaging_loading_exploring_data.ga
+++ b/topics/proteomics/tutorials/mass-spectrometry-imaging-loading-exploring-data/workflows/ms_imaging_loading_exploring_data.ga
@@ -1,1 +1,257 @@
-{"uuid": "6a7f48e8-71af-4cf9-b917-a82a7cb3a601", "tags": [], "format-version": "0.1", "name": "MS_imaging_loading_exploring_data", "version": 1, "steps": {"0": {"tool_id": null, "tool_version": null, "outputs": [], "workflow_outputs": [], "input_connections": {}, "tool_state": "{\"name\": \"mouse_kidney_cut.i\"}", "id": 0, "uuid": "bd40d0ba-d5ce-496f-9988-c8be1f81a75d", "errors": null, "name": "Input dataset", "label": "mouse_kidney_cut.i", "inputs": [{"name": "mouse_kidney_cut.i", "description": ""}], "position": {"top": 239.99999237060547, "left": 208.9204559326172}, "annotation": "", "content_id": null, "type": "data_input"}, "1": {"tool_id": null, "tool_version": null, "outputs": [], "workflow_outputs": [], "input_connections": {}, "tool_state": "{\"name\": \"internal calibrants.tab\"}", "id": 1, "uuid": "15455ea4-e2cc-4872-a441-d40e979c7660", "errors": null, "name": "Input dataset", "label": "internal calibrants.tab", "inputs": [{"name": "internal calibrants.tab", "description": ""}], "position": {"top": 417.0028305053711, "left": 199.92897033691406}, "annotation": "", "content_id": null, "type": "data_input"}, "2": {"tool_id": "toolshed.g2.bx.psu.edu/repos/galaxyp/cardinal_data_exporter/cardinal_data_exporter/1.12.1.1", "tool_version": "1.12.1.1", "outputs": [{"type": "tabular", "name": "intensity_matrix"}, {"type": "tabular", "name": "pixel_output"}, {"type": "tabular", "name": "feature_output"}, {"type": "tabular", "name": "summarized_mean"}, {"type": "tabular", "name": "summarized_median"}, {"type": "tabular", "name": "summarized_sd"}], "workflow_outputs": [], "input_connections": {"infile": {"output_name": "output", "id": 0}}, "tool_state": "{\"__page__\": null, \"output_options\": \"[\\\"mz_tabular\\\", \\\"pixel_tabular\\\"]\", \"tabular_annotation\": \"{\\\"__current_case__\\\": 0, \\\"load_annotation\\\": \\\"no_annotation\\\"}\", \"__rerun_remap_job_id__\": null, \"centroids\": \"\\\"false\\\"\", \"processed_cond\": \"{\\\"__current_case__\\\": 0, \\\"processed_file\\\": \\\"no_processed\\\"}\", \"counting_calibrants\": \"{\\\"__current_case__\\\": 0, \\\"pixel_with_calibrants\\\": \\\"no_calibrants\\\"}\", \"chromInfo\": \"\\\"/opt/galaxy/tool-data/shared/ucsc/chrom/?.len\\\"\", \"infile\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\"}", "id": 2, "tool_shed_repository": {"owner": "galaxyp", "changeset_revision": "e30d8b72415f", "name": "cardinal_data_exporter", "tool_shed": "toolshed.g2.bx.psu.edu"}, "uuid": "2fb59dde-237c-443b-9ab4-f339fff48c64", "errors": null, "name": "MSI data exporter", "post_job_actions": {}, "label": null, "inputs": [{"name": "infile", "description": "runtime parameter for tool MSI data exporter"}], "position": {"top": 394.99999237060547, "left": 490.93748474121094}, "annotation": "", "content_id": "toolshed.g2.bx.psu.edu/repos/galaxyp/cardinal_data_exporter/cardinal_data_exporter/1.12.1.1", "type": "tool"}, "3": {"tool_id": "toolshed.g2.bx.psu.edu/repos/galaxyp/cardinal_quality_report/cardinal_quality_report/1.12.1.2", "tool_version": "1.12.1.2", "outputs": [{"type": "pdf", "name": "QC_report"}], "workflow_outputs": [], "input_connections": {"infile": {"output_name": "output", "id": 0}, "calibrant_file": {"output_name": "output", "id": 1}}, "tool_state": "{\"calibrant_header\": \"\\\"true\\\"\", \"infile\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\", \"calibrantratio\": \"[{\\\"__index__\\\": 0, \\\"distance\\\": \\\"200.0\\\", \\\"filenameratioplot\\\": \\\"\\\", \\\"mass1\\\": \\\"1224.63\\\", \\\"mass2\\\": \\\"1619.89\\\"}]\", \"__page__\": null, \"name_column\": \"\\\"2\\\"\", \"__rerun_remap_job_id__\": null, \"tabular_annotation\": \"{\\\"__current_case__\\\": 1, \\\"load_annotation\\\": \\\"no_annotation\\\"}\", \"centroids\": \"\\\"false\\\"\", \"calibrant_file\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\", \"processed_cond\": \"{\\\"__current_case__\\\": 0, \\\"processed_file\\\": \\\"no_processed\\\"}\", \"do_pca\": \"\\\"false\\\"\", \"filename\": \"\\\"Mouse kidney introduction tutorial\\\"\", \"chromInfo\": \"\\\"/opt/galaxy/tool-data/shared/ucsc/chrom/?.len\\\"\", \"plusminus_ppm\": \"\\\"200.0\\\"\", \"mz_column\": \"\\\"1\\\"\"}", "id": 3, "tool_shed_repository": {"owner": "galaxyp", "changeset_revision": "d4803c1e5e19", "name": "cardinal_quality_report", "tool_shed": "toolshed.g2.bx.psu.edu"}, "uuid": "23f62e03-66cc-442a-926b-962d9a1f4c0f", "errors": null, "name": "MSI Qualitycontrol", "post_job_actions": {}, "label": null, "inputs": [{"name": "calibrant_file", "description": "runtime parameter for tool MSI Qualitycontrol"}, {"name": "infile", "description": "runtime parameter for tool MSI Qualitycontrol"}], "position": {"top": 199.99999237060547, "left": 489.9857635498047}, "annotation": "", "content_id": "toolshed.g2.bx.psu.edu/repos/galaxyp/cardinal_quality_report/cardinal_quality_report/1.12.1.2", "type": "tool"}, "4": {"tool_id": "toolshed.g2.bx.psu.edu/repos/bgruening/text_processing/tp_sort_header_tool/1.1.1", "tool_version": "1.1.1", "outputs": [{"type": "input", "name": "outfile"}], "workflow_outputs": [], "input_connections": {"infile": {"output_name": "feature_output", "id": 2}}, "tool_state": "{\"sortkeys\": \"[{\\\"__index__\\\": 0, \\\"column\\\": \\\"3\\\", \\\"order\\\": \\\"r\\\", \\\"style\\\": \\\"g\\\"}]\", \"__page__\": null, \"ignore_case\": \"\\\"false\\\"\", \"__rerun_remap_job_id__\": null, \"header\": \"\\\"1\\\"\", \"unique\": \"\\\"false\\\"\", \"chromInfo\": \"\\\"/opt/galaxy/tool-data/shared/ucsc/chrom/?.len\\\"\", \"infile\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\"}", "id": 4, "tool_shed_repository": {"owner": "bgruening", "changeset_revision": "a6f147a050a2", "name": "text_processing", "tool_shed": "toolshed.g2.bx.psu.edu"}, "uuid": "8fec4a92-c607-4f34-934b-c3b8769f938c", "errors": null, "name": "Sort", "post_job_actions": {}, "label": null, "inputs": [{"name": "infile", "description": "runtime parameter for tool Sort"}], "position": {"top": 319.99999237060547, "left": 814.9573822021484}, "annotation": "", "content_id": "toolshed.g2.bx.psu.edu/repos/bgruening/text_processing/tp_sort_header_tool/1.1.1", "type": "tool"}, "5": {"tool_id": "Grep1", "tool_version": "1.0.1", "outputs": [{"type": "input", "name": "out_file1"}], "workflow_outputs": [], "input_connections": {"input": {"output_name": "pixel_output", "id": 2}}, "tool_state": "{\"__page__\": null, \"pattern\": \"\\\"(xy_40_40)|(xy_23_70)|(xy_20_73)\\\"\", \"invert\": \"\\\"false\\\"\", \"input\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\", \"chromInfo\": \"\\\"/opt/galaxy/tool-data/shared/ucsc/chrom/?.len\\\"\", \"__rerun_remap_job_id__\": null}", "id": 5, "uuid": "9b86165d-4754-4015-a487-4341fcd00d0b", "errors": null, "name": "Select", "post_job_actions": {}, "label": null, "inputs": [{"name": "input", "description": "runtime parameter for tool Select"}], "position": {"top": 495.0141830444336, "left": 808.9914398193359}, "annotation": "", "content_id": "Grep1", "type": "tool"}}, "annotation": "", "a_galaxy_workflow": "true"}
+{
+  "a_galaxy_workflow": "true",
+  "annotation": "",
+  "format-version": "0.1",
+  "name": "MS_imaging_loading_exploring_data",
+  "steps": {
+    "0": {
+      "annotation": "",
+      "content_id": null,
+      "errors": null,
+      "id": 0,
+      "input_connections": {},
+      "inputs": [
+        {
+          "description": "",
+          "name": "mouse_kidney_cut.i"
+        }
+      ],
+      "label": "mouse_kidney_cut.i",
+      "name": "Input dataset",
+      "outputs": [],
+      "position": {
+        "left": 208.9204559326172,
+        "top": 239.99999237060547
+      },
+      "tool_id": null,
+      "tool_state": "{\"name\": \"mouse_kidney_cut.i\"}",
+      "tool_version": null,
+      "type": "data_input",
+      "uuid": "bd40d0ba-d5ce-496f-9988-c8be1f81a75d",
+      "workflow_outputs": []
+    },
+    "1": {
+      "annotation": "",
+      "content_id": null,
+      "errors": null,
+      "id": 1,
+      "input_connections": {},
+      "inputs": [
+        {
+          "description": "",
+          "name": "internal calibrants.tab"
+        }
+      ],
+      "label": "internal calibrants.tab",
+      "name": "Input dataset",
+      "outputs": [],
+      "position": {
+        "left": 199.92897033691406,
+        "top": 417.0028305053711
+      },
+      "tool_id": null,
+      "tool_state": "{\"name\": \"internal calibrants.tab\"}",
+      "tool_version": null,
+      "type": "data_input",
+      "uuid": "15455ea4-e2cc-4872-a441-d40e979c7660",
+      "workflow_outputs": []
+    },
+    "2": {
+      "annotation": "",
+      "content_id": "toolshed.g2.bx.psu.edu/repos/galaxyp/cardinal_data_exporter/cardinal_data_exporter/1.12.1.1",
+      "errors": null,
+      "id": 2,
+      "input_connections": {
+        "infile": {
+          "id": 0,
+          "output_name": "output"
+        }
+      },
+      "inputs": [
+        {
+          "description": "runtime parameter for tool MSI data exporter",
+          "name": "infile"
+        }
+      ],
+      "label": null,
+      "name": "MSI data exporter",
+      "outputs": [
+        {
+          "name": "intensity_matrix",
+          "type": "tabular"
+        },
+        {
+          "name": "pixel_output",
+          "type": "tabular"
+        },
+        {
+          "name": "feature_output",
+          "type": "tabular"
+        },
+        {
+          "name": "summarized_mean",
+          "type": "tabular"
+        },
+        {
+          "name": "summarized_median",
+          "type": "tabular"
+        },
+        {
+          "name": "summarized_sd",
+          "type": "tabular"
+        }
+      ],
+      "position": {
+        "left": 490.93748474121094,
+        "top": 394.99999237060547
+      },
+      "post_job_actions": {},
+      "tool_id": "toolshed.g2.bx.psu.edu/repos/galaxyp/cardinal_data_exporter/cardinal_data_exporter/1.12.1.1",
+      "tool_shed_repository": {
+        "changeset_revision": "e30d8b72415f",
+        "name": "cardinal_data_exporter",
+        "owner": "galaxyp",
+        "tool_shed": "toolshed.g2.bx.psu.edu"
+      },
+      "tool_state": "{\"__page__\": null, \"output_options\": \"[\\\"mz_tabular\\\", \\\"pixel_tabular\\\"]\", \"tabular_annotation\": \"{\\\"__current_case__\\\": 0, \\\"load_annotation\\\": \\\"no_annotation\\\"}\", \"__rerun_remap_job_id__\": null, \"centroids\": \"\\\"false\\\"\", \"processed_cond\": \"{\\\"__current_case__\\\": 0, \\\"processed_file\\\": \\\"no_processed\\\"}\", \"counting_calibrants\": \"{\\\"__current_case__\\\": 0, \\\"pixel_with_calibrants\\\": \\\"no_calibrants\\\"}\", \"chromInfo\": \"\\\"/opt/galaxy/tool-data/shared/ucsc/chrom/?.len\\\"\", \"infile\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\"}",
+      "tool_version": "1.12.1.1",
+      "type": "tool",
+      "uuid": "2fb59dde-237c-443b-9ab4-f339fff48c64",
+      "workflow_outputs": []
+    },
+    "3": {
+      "annotation": "",
+      "content_id": "toolshed.g2.bx.psu.edu/repos/galaxyp/cardinal_quality_report/cardinal_quality_report/1.12.1.2",
+      "errors": null,
+      "id": 3,
+      "input_connections": {
+        "calibrant_file": {
+          "id": 1,
+          "output_name": "output"
+        },
+        "infile": {
+          "id": 0,
+          "output_name": "output"
+        }
+      },
+      "inputs": [
+        {
+          "description": "runtime parameter for tool MSI Qualitycontrol",
+          "name": "calibrant_file"
+        },
+        {
+          "description": "runtime parameter for tool MSI Qualitycontrol",
+          "name": "infile"
+        }
+      ],
+      "label": null,
+      "name": "MSI Qualitycontrol",
+      "outputs": [
+        {
+          "name": "QC_report",
+          "type": "pdf"
+        }
+      ],
+      "position": {
+        "left": 489.9857635498047,
+        "top": 199.99999237060547
+      },
+      "post_job_actions": {},
+      "tool_id": "toolshed.g2.bx.psu.edu/repos/galaxyp/cardinal_quality_report/cardinal_quality_report/1.12.1.2",
+      "tool_shed_repository": {
+        "changeset_revision": "d4803c1e5e19",
+        "name": "cardinal_quality_report",
+        "owner": "galaxyp",
+        "tool_shed": "toolshed.g2.bx.psu.edu"
+      },
+      "tool_state": "{\"calibrant_header\": \"\\\"true\\\"\", \"infile\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\", \"calibrantratio\": \"[{\\\"__index__\\\": 0, \\\"distance\\\": \\\"200.0\\\", \\\"filenameratioplot\\\": \\\"\\\", \\\"mass1\\\": \\\"1224.63\\\", \\\"mass2\\\": \\\"1619.89\\\"}]\", \"__page__\": null, \"name_column\": \"\\\"2\\\"\", \"__rerun_remap_job_id__\": null, \"tabular_annotation\": \"{\\\"__current_case__\\\": 1, \\\"load_annotation\\\": \\\"no_annotation\\\"}\", \"centroids\": \"\\\"false\\\"\", \"calibrant_file\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\", \"processed_cond\": \"{\\\"__current_case__\\\": 0, \\\"processed_file\\\": \\\"no_processed\\\"}\", \"do_pca\": \"\\\"false\\\"\", \"filename\": \"\\\"Mouse kidney introduction tutorial\\\"\", \"chromInfo\": \"\\\"/opt/galaxy/tool-data/shared/ucsc/chrom/?.len\\\"\", \"plusminus_ppm\": \"\\\"200.0\\\"\", \"mz_column\": \"\\\"1\\\"\"}",
+      "tool_version": "1.12.1.2",
+      "type": "tool",
+      "uuid": "23f62e03-66cc-442a-926b-962d9a1f4c0f",
+      "workflow_outputs": []
+    },
+    "4": {
+      "annotation": "",
+      "content_id": "toolshed.g2.bx.psu.edu/repos/bgruening/text_processing/tp_sort_header_tool/1.1.1",
+      "errors": null,
+      "id": 4,
+      "input_connections": {
+        "infile": {
+          "id": 2,
+          "output_name": "feature_output"
+        }
+      },
+      "inputs": [
+        {
+          "description": "runtime parameter for tool Sort",
+          "name": "infile"
+        }
+      ],
+      "label": null,
+      "name": "Sort",
+      "outputs": [
+        {
+          "name": "outfile",
+          "type": "input"
+        }
+      ],
+      "position": {
+        "left": 814.9573822021484,
+        "top": 319.99999237060547
+      },
+      "post_job_actions": {},
+      "tool_id": "toolshed.g2.bx.psu.edu/repos/bgruening/text_processing/tp_sort_header_tool/1.1.1",
+      "tool_shed_repository": {
+        "changeset_revision": "a6f147a050a2",
+        "name": "text_processing",
+        "owner": "bgruening",
+        "tool_shed": "toolshed.g2.bx.psu.edu"
+      },
+      "tool_state": "{\"sortkeys\": \"[{\\\"__index__\\\": 0, \\\"column\\\": \\\"3\\\", \\\"order\\\": \\\"r\\\", \\\"style\\\": \\\"g\\\"}]\", \"__page__\": null, \"ignore_case\": \"\\\"false\\\"\", \"__rerun_remap_job_id__\": null, \"header\": \"\\\"1\\\"\", \"unique\": \"\\\"false\\\"\", \"chromInfo\": \"\\\"/opt/galaxy/tool-data/shared/ucsc/chrom/?.len\\\"\", \"infile\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\"}",
+      "tool_version": "1.1.1",
+      "type": "tool",
+      "uuid": "8fec4a92-c607-4f34-934b-c3b8769f938c",
+      "workflow_outputs": []
+    },
+    "5": {
+      "annotation": "",
+      "content_id": "Grep1",
+      "errors": null,
+      "id": 5,
+      "input_connections": {
+        "input": {
+          "id": 2,
+          "output_name": "pixel_output"
+        }
+      },
+      "inputs": [
+        {
+          "description": "runtime parameter for tool Select",
+          "name": "input"
+        }
+      ],
+      "label": null,
+      "name": "Select",
+      "outputs": [
+        {
+          "name": "out_file1",
+          "type": "input"
+        }
+      ],
+      "position": {
+        "left": 808.9914398193359,
+        "top": 495.0141830444336
+      },
+      "post_job_actions": {},
+      "tool_id": "Grep1",
+      "tool_state": "{\"__page__\": null, \"pattern\": \"\\\"(xy_40_40)|(xy_23_70)|(xy_20_73)\\\"\", \"invert\": \"\\\"false\\\"\", \"input\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\", \"chromInfo\": \"\\\"/opt/galaxy/tool-data/shared/ucsc/chrom/?.len\\\"\", \"__rerun_remap_job_id__\": null}",
+      "tool_version": "1.0.1",
+      "type": "tool",
+      "uuid": "9b86165d-4754-4015-a487-4341fcd00d0b",
+      "workflow_outputs": []
+    }
+  },
+  "tags": [],
+  "uuid": "6a7f48e8-71af-4cf9-b917-a82a7cb3a601",
+  "version": 1
+}

--- a/topics/proteomics/tutorials/proteogenomics-dbcreation/workflows/galaxy-workflow-mouse_rnaseq_dbcreation.ga
+++ b/topics/proteomics/tutorials/proteogenomics-dbcreation/workflows/galaxy-workflow-mouse_rnaseq_dbcreation.ga
@@ -1,1 +1,1448 @@
-{"uuid": "7ef9be1f-2e05-4309-a1ff-f2f6da1400d7", "tags": [], "format-version": "0.1", "name": "ABRF_Workflow1_RNAseq_DBcreation", "steps": {"0": {"tool_id": null, "tool_version": null, "outputs": [], "workflow_outputs": [{"output_name": "output", "uuid": "a49bbc5e-b817-4309-938f-046d94e28072", "label": null}], "input_connections": {}, "tool_state": "{}", "id": 0, "uuid": "1c77a4cc-70d3-4465-8cbd-d794c93d998e", "errors": null, "name": "Input dataset", "label": "ProB.fastq", "inputs": [], "position": {"top": 276, "left": 303.984375}, "annotation": "", "content_id": null, "type": "data_input"}, "1": {"tool_id": null, "tool_version": null, "outputs": [], "workflow_outputs": [{"output_name": "output", "uuid": "5e070017-21a6-41cb-995a-cd091b898fe1", "label": null}], "input_connections": {}, "tool_state": "{\"name\": \"Mus_musculus.GRCm38.86.gtf\"}", "id": 1, "uuid": "42d28c1e-a173-404c-8e34-bd7fd02f71e5", "errors": null, "name": "Input dataset", "label": "Mus_musculus.GRCm38.86.gtf", "inputs": [{"name": "Mus_musculus.GRCm38.86.gtf", "description": ""}], "position": {"top": 531.03125, "left": 299.984375}, "annotation": "", "content_id": null, "type": "data_input"}, "2": {"tool_id": null, "tool_version": null, "outputs": [], "workflow_outputs": [{"output_name": "output", "uuid": "6378f914-6d5d-4564-90bc-eac023ced219", "label": null}], "input_connections": {}, "tool_state": "{}", "id": 2, "uuid": "f61674c7-2b2c-4bdc-bf4e-30d30c477483", "errors": null, "name": "Input dataset", "label": "Reference_5000UNIPROT_cRAP", "inputs": [], "position": {"top": 290.421875, "left": 2670.015625}, "annotation": "", "content_id": null, "type": "data_input"}, "3": {"tool_id": "toolshed.g2.bx.psu.edu/repos/galaxyp/regex_find_replace/regexColumn1/1.0.0", "tool_version": "1.0.0", "outputs": [{"type": "input", "name": "out_file1"}], "workflow_outputs": [], "input_connections": {"input": {"output_name": "output", "id": 1}}, "tool_state": "{\"__page__\": null, \"field\": \"\\\"1\\\"\", \"__rerun_remap_job_id__\": null, \"checks\": \"[{\\\"__index__\\\": 0, \\\"replacement\\\": \\\"chr\\\\\\\\1\\\", \\\"pattern\\\": \\\"^(\\\\\\\\d+)$\\\"}, {\\\"__index__\\\": 1, \\\"replacement\\\": \\\"chr\\\\\\\\1\\\", \\\"pattern\\\": \\\"^([XY])$\\\"}, {\\\"__index__\\\": 2, \\\"replacement\\\": \\\"chrM\\\", \\\"pattern\\\": \\\"^MT$\\\"}]\", \"input\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\"}", "id": 3, "tool_shed_repository": {"owner": "galaxyp", "changeset_revision": "209b7c5ee9d7", "name": "regex_find_replace", "tool_shed": "toolshed.g2.bx.psu.edu"}, "uuid": "73bb496c-9238-4347-a6b7-39f29ece5ee0", "errors": null, "name": "Column Regex Find And Replace", "post_job_actions": {"RenameDatasetActionout_file1": {"output_name": "out_file1", "action_type": "RenameDatasetAction", "action_arguments": {"newname": "Chr_adding2GTF"}}, "HideDatasetActionout_file1": {"output_name": "out_file1", "action_type": "HideDatasetAction", "action_arguments": {}}}, "label": "Chr_name_change", "inputs": [{"name": "input", "description": "runtime parameter for tool Column Regex Find And Replace"}], "position": {"top": 787.46875, "left": 200}, "annotation": "", "content_id": "toolshed.g2.bx.psu.edu/repos/galaxyp/regex_find_replace/regexColumn1/1.0.0", "type": "tool"}, "4": {"tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/hisat2/hisat2/2.1.0", "tool_version": "2.1.0", "outputs": [{"type": "bam", "name": "output_alignments"}, {"type": "fastqsanger", "name": "output_unaligned_reads_l"}, {"type": "fastqsanger", "name": "output_aligned_reads_l"}, {"type": "fastqsanger", "name": "output_unaligned_reads_r"}, {"type": "fastqsanger", "name": "output_aligned_reads_r"}, {"type": "txt", "name": "summary_file"}], "workflow_outputs": [{"output_name": "output_alignments", "uuid": "00fe9e69-d41e-4332-b553-49983716dd1e", "label": null}, {"output_name": "summary_file", "uuid": "6554a1ed-09c4-41da-b6a9-886e37ff904a", "label": null}], "input_connections": {"library|input_1": {"output_name": "output", "id": 0}, "adv|spliced_options|known_splice_gtf": {"output_name": "out_file1", "id": 3}}, "tool_state": "{\"adv\": \"{\\\"alignment_options\\\": {\\\"__current_case__\\\": 0, \\\"alignment_options_selector\\\": \\\"defaults\\\"}, \\\"output_options\\\": {\\\"output_options_selector\\\": \\\"defaults\\\", \\\"__current_case__\\\": 0}, \\\"other_options\\\": {\\\"other_options_selector\\\": \\\"defaults\\\", \\\"__current_case__\\\": 0}, \\\"scoring_options\\\": {\\\"scoring_options_selector\\\": \\\"defaults\\\", \\\"__current_case__\\\": 0}, \\\"spliced_options\\\": {\\\"coefficient\\\": \\\"1.0\\\", \\\"canonical_penalty\\\": \\\"0\\\", \\\"no_spliced_alignment_options\\\": {\\\"no_spliced_alignment\\\": \\\"\\\", \\\"__current_case__\\\": 1}, \\\"nc_function_type\\\": \\\"G\\\", \\\"constant_term\\\": \\\"-8.0\\\", \\\"nc_coefficient\\\": \\\"1.0\\\", \\\"noncanonical_penalty\\\": \\\"12\\\", \\\"known_splice_gtf\\\": {\\\"__class__\\\": \\\"RuntimeValue\\\"}, \\\"nc_constant_term\\\": \\\"-8.0\\\", \\\"min_intron\\\": \\\"20\\\", \\\"function_type\\\": \\\"G\\\", \\\"__current_case__\\\": 1, \\\"notmplen\\\": \\\"false\\\", \\\"tma\\\": \\\"--dta\\\", \\\"max_intron\\\": \\\"500000\\\", \\\"spliced_options_selector\\\": \\\"advanced\\\"}, \\\"reporting_options\\\": {\\\"reporting_options_selector\\\": \\\"defaults\\\", \\\"__current_case__\\\": 0}, \\\"input_options\\\": {\\\"input_options_selector\\\": \\\"defaults\\\", \\\"__current_case__\\\": 0}}\", \"__page__\": null, \"sum\": \"{\\\"new_summary\\\": \\\"false\\\", \\\"summary_file\\\": \\\"false\\\"}\", \"library\": \"{\\\"rna_strandness\\\": \\\"\\\", \\\"type\\\": \\\"single\\\", \\\"__current_case__\\\": 0, \\\"input_1\\\": {\\\"__class__\\\": \\\"RuntimeValue\\\"}}\", \"reference_genome\": \"{\\\"source\\\": \\\"indexed\\\", \\\"__current_case__\\\": 0, \\\"index\\\": \\\"mm10\\\"}\", \"__rerun_remap_job_id__\": null}", "id": 4, "tool_shed_repository": {"owner": "iuc", "changeset_revision": "fbf98f24097b", "name": "hisat2", "tool_shed": "toolshed.g2.bx.psu.edu"}, "uuid": "6927800f-5f0f-43a1-bcc7-223abd25555a", "errors": null, "name": "HISAT2", "post_job_actions": {"HideDatasetActionoutput_unaligned_reads_r": {"output_name": "output_unaligned_reads_r", "action_type": "HideDatasetAction", "action_arguments": {}}, "HideDatasetActionoutput_aligned_reads_l": {"output_name": "output_aligned_reads_l", "action_type": "HideDatasetAction", "action_arguments": {}}, "HideDatasetActionoutput_aligned_reads_r": {"output_name": "output_aligned_reads_r", "action_type": "HideDatasetAction", "action_arguments": {}}, "RenameDatasetActionoutput_alignments": {"output_name": "output_alignments", "action_type": "RenameDatasetAction", "action_arguments": {"newname": "#{input_1|basename}.bam"}}, "HideDatasetActionoutput_unaligned_reads_l": {"output_name": "output_unaligned_reads_l", "action_type": "HideDatasetAction", "action_arguments": {}}, "ChangeDatatypeActionoutput_alignments": {"output_name": "output_alignments", "action_type": "ChangeDatatypeAction", "action_arguments": {"newtype": "bam"}}}, "label": null, "inputs": [{"name": "library", "description": "runtime parameter for tool HISAT2"}], "position": {"top": 301.015625, "left": 647.984375}, "annotation": "", "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/hisat2/hisat2/2.1.0", "type": "tool"}, "5": {"tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/stringtie/stringtie/1.3.3.1", "tool_version": "1.3.3.1", "outputs": [{"type": "gtf", "name": "output_gtf"}, {"type": "gtf", "name": "gene_abundance_estimation"}, {"type": "gtf", "name": "coverage"}, {"type": "tabular", "name": "exon_expression"}, {"type": "tabular", "name": "intron_expression"}, {"type": "tabular", "name": "transcript_expression"}, {"type": "tabular", "name": "exon_transcript_mapping"}, {"type": "tabular", "name": "intron_transcript_mapping"}, {"type": "tabular", "name": "gene_counts"}, {"type": "tabular", "name": "transcript_counts"}, {"type": "tabular", "name": "legend"}], "workflow_outputs": [{"output_name": "output_gtf", "uuid": "fc79dd16-0110-4b33-b2ca-7631bd92a2c7", "label": null}], "input_connections": {"guide|guide_source|ref_hist": {"output_name": "out_file1", "id": 3}, "input_bam": {"output_name": "output_alignments", "id": 4}}, "tool_state": "{\"adv\": \"{\\\"min_bundle_cov\\\": \\\"2\\\", \\\"min_tlen\\\": \\\"200\\\", \\\"bdist\\\": \\\"50\\\", \\\"multi_mapping\\\": \\\"false\\\", \\\"abundance_estimation\\\": \\\"false\\\", \\\"fraction\\\": \\\"0.15\\\", \\\"disable_trimming\\\": \\\"false\\\", \\\"omit_sequences\\\": \\\"\\\", \\\"name_prefix\\\": \\\"\\\", \\\"min_anchor_len\\\": \\\"10\\\", \\\"bundle_fraction\\\": \\\"0.95\\\", \\\"min_anchor_cov\\\": \\\"1\\\"}\", \"__page__\": null, \"__rerun_remap_job_id__\": null, \"rna_strandness\": \"\\\"\\\"\", \"input_bam\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\", \"guide\": \"{\\\"guide_source\\\": {\\\"ref_hist\\\": {\\\"__class__\\\": \\\"RuntimeValue\\\"}, \\\"guide_gff_select\\\": \\\"history\\\", \\\"__current_case__\\\": 1}, \\\"use_guide\\\": \\\"yes\\\", \\\"coverage_file\\\": \\\"false\\\", \\\"__current_case__\\\": 1, \\\"special_outputs\\\": {\\\"__current_case__\\\": 2, \\\"special_outputs_select\\\": \\\"no\\\"}, \\\"input_estimation\\\": \\\"false\\\"}\"}", "id": 5, "tool_shed_repository": {"owner": "iuc", "changeset_revision": "76d290331481", "name": "stringtie", "tool_shed": "toolshed.g2.bx.psu.edu"}, "uuid": "52a055e7-e8aa-4224-a1f9-01c68a5e714a", "errors": null, "name": "StringTie", "post_job_actions": {"HideDatasetActiongene_counts": {"output_name": "gene_counts", "action_type": "HideDatasetAction", "action_arguments": {}}, "HideDatasetActionintron_transcript_mapping": {"output_name": "intron_transcript_mapping", "action_type": "HideDatasetAction", "action_arguments": {}}, "HideDatasetActioncoverage": {"output_name": "coverage", "action_type": "HideDatasetAction", "action_arguments": {}}, "HideDatasetActiontranscript_counts": {"output_name": "transcript_counts", "action_type": "HideDatasetAction", "action_arguments": {}}, "HideDatasetActionlegend": {"output_name": "legend", "action_type": "HideDatasetAction", "action_arguments": {}}, "HideDatasetActiongene_abundance_estimation": {"output_name": "gene_abundance_estimation", "action_type": "HideDatasetAction", "action_arguments": {}}, "HideDatasetActionexon_expression": {"output_name": "exon_expression", "action_type": "HideDatasetAction", "action_arguments": {}}, "RenameDatasetActionoutput_gtf": {"output_name": "output_gtf", "action_type": "RenameDatasetAction", "action_arguments": {"newname": "StringTie_ProB.gtf"}}, "HideDatasetActiontranscript_expression": {"output_name": "transcript_expression", "action_type": "HideDatasetAction", "action_arguments": {}}, "HideDatasetActionexon_transcript_mapping": {"output_name": "exon_transcript_mapping", "action_type": "HideDatasetAction", "action_arguments": {}}, "HideDatasetActionintron_expression": {"output_name": "intron_expression", "action_type": "HideDatasetAction", "action_arguments": {}}}, "label": null, "inputs": [{"name": "input_bam", "description": "runtime parameter for tool StringTie"}], "position": {"top": 631, "left": 652.984375}, "annotation": "", "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/stringtie/stringtie/1.3.3.1", "type": "tool"}, "6": {"tool_id": "toolshed.g2.bx.psu.edu/repos/devteam/freebayes/freebayes/1.1.0.46-0", "tool_version": "1.1.0.46-0", "outputs": [{"type": "vcf", "name": "output_vcf"}, {"type": "bed", "name": "output_failed_alleles_bed"}, {"type": "txt", "name": "output_trace"}], "workflow_outputs": [{"output_name": "output_vcf", "uuid": "fc40b553-834c-4c4f-a2e5-e276cee02ddd", "label": null}], "input_connections": {"reference_source|batchmode|input_bams": {"output_name": "output_alignments", "id": 4}}, "tool_state": "{\"__page__\": null, \"reference_source\": \"{\\\"batchmode\\\": {\\\"input_bams\\\": {\\\"__class__\\\": \\\"RuntimeValue\\\"}, \\\"processmode\\\": \\\"individual\\\", \\\"__current_case__\\\": 0}, \\\"ref_file\\\": \\\"mm10\\\", \\\"reference_source_selector\\\": \\\"cached\\\", \\\"__current_case__\\\": 0}\", \"__rerun_remap_job_id__\": null, \"options_type\": \"{\\\"__current_case__\\\": 1, \\\"options_type_selector\\\": \\\"simple\\\"}\", \"target_limit_type\": \"{\\\"target_limit_type_selector\\\": \\\"do_not_limit\\\", \\\"__current_case__\\\": 0}\"}", "id": 6, "tool_shed_repository": {"owner": "devteam", "changeset_revision": "156b60c1530f", "name": "freebayes", "tool_shed": "toolshed.g2.bx.psu.edu"}, "uuid": "32c1e654-2f61-4c1c-a366-5a62a6c1efe2", "errors": null, "name": "FreeBayes", "post_job_actions": {"HideDatasetActionoutput_trace": {"output_name": "output_trace", "action_type": "HideDatasetAction", "action_arguments": {}}, "HideDatasetActionoutput_failed_alleles_bed": {"output_name": "output_failed_alleles_bed", "action_type": "HideDatasetAction", "action_arguments": {}}, "RenameDatasetActionoutput_vcf": {"output_name": "output_vcf", "action_type": "RenameDatasetAction", "action_arguments": {"newname": "ProB.vcf"}}, "ChangeDatatypeActionoutput_vcf": {"output_name": "output_vcf", "action_type": "ChangeDatatypeAction", "action_arguments": {"newtype": "vcf"}}}, "label": null, "inputs": [], "position": {"top": 431, "left": 969.984375}, "annotation": "", "content_id": "toolshed.g2.bx.psu.edu/repos/devteam/freebayes/freebayes/1.1.0.46-0", "type": "tool"}, "7": {"tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/gffcompare/gffcompare/0.9.8", "tool_version": "0.9.8", "outputs": [{"type": "txt", "name": "transcripts_stats"}, {"type": "tabular", "name": "transcripts_loci"}, {"type": "tabular", "name": "transcripts_tracking"}, {"type": "gtf", "name": "transcripts_combined"}, {"type": "gtf", "name": "transcripts_annotated"}], "workflow_outputs": [{"output_name": "transcripts_annotated", "uuid": "b126a129-5550-4b2a-818f-26d16193589e", "label": null}], "input_connections": {"inputs": {"output_name": "output_gtf", "id": 5}, "annotation|reference_annotation": {"output_name": "out_file1", "id": 3}}, "tool_state": "{\"seq_data\": \"{\\\"use_seq_data\\\": \\\"No\\\", \\\"__current_case__\\\": 0}\", \"inputs\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\", \"max_dist_group\": \"\\\"100\\\"\", \"__page__\": null, \"max_dist_exon\": \"\\\"100\\\"\", \"__rerun_remap_job_id__\": null, \"discard_single_exon\": \"\\\"\\\"\", \"discard_intron_redundant_transfrags\": \"\\\"false\\\"\", \"annotation\": \"{\\\"reference_annotation\\\": {\\\"__class__\\\": \\\"RuntimeValue\\\"}, \\\"use_ref_annotation\\\": \\\"Yes\\\", \\\"ignore_nonoverlapping_reference\\\": \\\"false\\\", \\\"__current_case__\\\": 0, \\\"ignore_nonoverlapping_transfrags\\\": \\\"false\\\"}\"}", "id": 7, "tool_shed_repository": {"owner": "iuc", "changeset_revision": "3c97c841a443", "name": "gffcompare", "tool_shed": "toolshed.g2.bx.psu.edu"}, "uuid": "a3282081-fa2c-45f2-a0d9-8657ca4ce01e", "errors": null, "name": "GffCompare", "post_job_actions": {"HideDatasetActiontranscripts_tracking": {"output_name": "transcripts_tracking", "action_type": "HideDatasetAction", "action_arguments": {}}, "HideDatasetActiontranscripts_stats": {"output_name": "transcripts_stats", "action_type": "HideDatasetAction", "action_arguments": {}}, "HideDatasetActiontranscripts_loci": {"output_name": "transcripts_loci", "action_type": "HideDatasetAction", "action_arguments": {}}, "HideDatasetActiontranscripts_combined": {"output_name": "transcripts_combined", "action_type": "HideDatasetAction", "action_arguments": {}}, "RenameDatasetActiontranscripts_annotated": {"output_name": "transcripts_annotated", "action_type": "RenameDatasetAction", "action_arguments": {"newname": "GFFcompare_results"}}}, "label": null, "inputs": [{"name": "inputs", "description": "runtime parameter for tool GffCompare"}, {"name": "annotation", "description": "runtime parameter for tool GffCompare"}], "position": {"top": 740.046875, "left": 1139}, "annotation": "", "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/gffcompare/gffcompare/0.9.8", "type": "tool"}, "8": {"tool_id": "toolshed.g2.bx.psu.edu/repos/galaxyp/custom_pro_db/custom_pro_db/1.22.0", "tool_version": "1.16.1.0", "outputs": [{"type": "fasta", "name": "output_rpkm"}, {"type": "fasta", "name": "output_snv"}, {"type": "fasta", "name": "output_indel"}, {"type": "rdata", "name": "output_variant_annotation_rdata"}, {"type": "sqlite", "name": "output_genomic_mapping_sqlite"}, {"type": "sqlite", "name": "output_variant_annotation_sqlite"}], "workflow_outputs": [], "input_connections": {"genome_annotation|bamInput": {"output_name": "output_alignments", "id": 4}, "genome_annotation|vcfInput": {"output_name": "output_vcf", "id": 6}}, "tool_state": "{\"outputIndels\": \"\\\"true\\\"\", \"__page__\": null, \"outputSQLite\": \"\\\"true\\\"\", \"outputRData\": \"\\\"true\\\"\", \"genome_annotation\": \"{\\\"cosmic\\\": \\\"false\\\", \\\"bamInput\\\": {\\\"__class__\\\": \\\"RuntimeValue\\\"}, \\\"source\\\": \\\"builtin\\\", \\\"builtin\\\": \\\"mmusculus_gene_ensembl_89_dbsnp142\\\", \\\"__current_case__\\\": 0, \\\"vcfInput\\\": {\\\"__class__\\\": \\\"RuntimeValue\\\"}, \\\"dbsnpInCoding\\\": \\\"true\\\"}\", \"__rerun_remap_job_id__\": null, \"rpkmCutoff\": \"\\\"1.0\\\"\"}", "id": 8, "tool_shed_repository": {"owner": "galaxyp", "changeset_revision": "2c7df0077d28", "name": "custom_pro_db", "tool_shed": "toolshed.g2.bx.psu.edu"}, "uuid": "8a61b496-8961-4b74-a65a-8758939aa410", "errors": null, "name": "CustomProDB", "post_job_actions": {"HideDatasetActionoutput_genomic_mapping_sqlite": {"output_name": "output_genomic_mapping_sqlite", "action_type": "HideDatasetAction", "action_arguments": {}}, "HideDatasetActionoutput_rpkm": {"output_name": "output_rpkm", "action_type": "HideDatasetAction", "action_arguments": {}}, "HideDatasetActionoutput_snv": {"output_name": "output_snv", "action_type": "HideDatasetAction", "action_arguments": {}}, "HideDatasetActionoutput_variant_annotation_rdata": {"output_name": "output_variant_annotation_rdata", "action_type": "HideDatasetAction", "action_arguments": {}}, "HideDatasetActionoutput_variant_annotation_sqlite": {"output_name": "output_variant_annotation_sqlite", "action_type": "HideDatasetAction", "action_arguments": {}}, "HideDatasetActionoutput_indel": {"output_name": "output_indel", "action_type": "HideDatasetAction", "action_arguments": {}}}, "label": null, "inputs": [{"name": "genome_annotation", "description": "runtime parameter for tool CustomProDB"}, {"name": "genome_annotation", "description": "runtime parameter for tool CustomProDB"}], "position": {"top": 329.015625, "left": 1317.96875}, "annotation": "", "content_id": "toolshed.g2.bx.psu.edu/repos/galaxyp/custom_pro_db/custom_pro_db/1.22.0", "type": "tool"}, "9": {"tool_id": "toolshed.g2.bx.psu.edu/repos/galaxyp/gffcompare_to_bed/gffcompare_to_bed/0.1.0", "tool_version": "0.1.0", "outputs": [{"type": "bed", "name": "output"}], "workflow_outputs": [], "input_connections": {"input": {"output_name": "transcripts_annotated", "id": 7}}, "tool_state": "{\"input\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\", \"__rerun_remap_job_id__\": null, \"class_codes\": \"[\\\"j\\\", \\\"e\\\", \\\"i\\\", \\\"p\\\", \\\"u\\\"]\", \"__page__\": null}", "id": 9, "tool_shed_repository": {"owner": "galaxyp", "changeset_revision": "7e572e148175", "name": "gffcompare_to_bed", "tool_shed": "toolshed.g2.bx.psu.edu"}, "uuid": "356cf12c-a3ae-4bd6-bc0d-330983084c93", "errors": null, "name": "Convert gffCompare annotated GTF to BED", "post_job_actions": {"HideDatasetActionoutput": {"output_name": "output", "action_type": "HideDatasetAction", "action_arguments": {}}, "RenameDatasetActionoutput": {"output_name": "output", "action_type": "RenameDatasetAction", "action_arguments": {"newname": "GTF2BED"}}}, "label": "GTF2BED", "inputs": [{"name": "input", "description": "runtime parameter for tool Convert gffCompare annotated GTF to BED"}], "position": {"top": 849.046875, "left": 1472.921875}, "annotation": "", "content_id": "toolshed.g2.bx.psu.edu/repos/galaxyp/gffcompare_to_bed/gffcompare_to_bed/0.1.0", "type": "tool"}, "10": {"tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/sqlite_to_tabular/sqlite_to_tabular/2.0.0", "tool_version": "2.0.0", "outputs": [{"type": "tabular", "name": "query_results"}], "workflow_outputs": [], "input_connections": {"sqlitedb": {"output_name": "output_genomic_mapping_sqlite", "id": 8}}, "tool_state": "{\"sqlquery\": \"\\\"SELECT pro_name, chr_name, cds_chr_start - 1, cds_chr_end,strand,cds_start - 1, cds_end\\\\nFROM genomic_mapping\\\\nORDER BY pro_name, cds_start, cds_end\\\"\", \"__page__\": null, \"sqlitedb\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\", \"query_result\": \"{\\\"header\\\": \\\"no\\\", \\\"__current_case__\\\": 1}\", \"__rerun_remap_job_id__\": null}", "id": 10, "tool_shed_repository": {"owner": "iuc", "changeset_revision": "6e72fd26a9d3", "name": "sqlite_to_tabular", "tool_shed": "toolshed.g2.bx.psu.edu"}, "uuid": "8568d385-239c-4503-8266-56281615a696", "errors": null, "name": "SQLite to tabular", "post_job_actions": {"HideDatasetActionquery_results": {"output_name": "query_results", "action_type": "HideDatasetAction", "action_arguments": {}}}, "label": null, "inputs": [{"name": "sqlitedb", "description": "runtime parameter for tool SQLite to tabular"}], "position": {"top": 545.953125, "left": 1611}, "annotation": "", "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/sqlite_to_tabular/sqlite_to_tabular/2.0.0", "type": "tool"}, "11": {"tool_id": "toolshed.g2.bx.psu.edu/repos/galaxyp/fasta_merge_files_and_filter_unique_sequences/fasta_merge_files_and_filter_unique_sequences/1.2.0", "tool_version": "1.2.0", "outputs": [{"type": "fasta", "name": "output"}], "workflow_outputs": [{"output_name": "output", "uuid": "cd9c2d08-2c3b-47fe-ac8e-15797b2a8ece", "label": null}], "input_connections": {"batchmode|input_fastas_0|input_fasta": {"output_name": "output_rpkm", "id": 8}, "batchmode|input_fastas_1|input_fasta": {"output_name": "output_snv", "id": 8}, "batchmode|input_fastas_2|input_fasta": {"output_name": "output_indel", "id": 8}}, "tool_state": "{\"batchmode\": \"{\\\"input_fastas\\\": [{\\\"__index__\\\": 0, \\\"input_fasta\\\": {\\\"__class__\\\": \\\"RuntimeValue\\\"}}, {\\\"__index__\\\": 1, \\\"input_fasta\\\": {\\\"__class__\\\": \\\"RuntimeValue\\\"}}, {\\\"__index__\\\": 2, \\\"input_fasta\\\": {\\\"__class__\\\": \\\"RuntimeValue\\\"}}], \\\"processmode\\\": \\\"individual\\\", \\\"__current_case__\\\": 0}\", \"__page__\": null, \"accession_parser\": \"\\\"^>([^ |]+).*$\\\"\", \"uniqueness_criterion\": \"\\\"sequence\\\"\", \"__rerun_remap_job_id__\": null}", "id": 11, "tool_shed_repository": {"owner": "galaxyp", "changeset_revision": "650d553c1fda", "name": "fasta_merge_files_and_filter_unique_sequences", "tool_shed": "toolshed.g2.bx.psu.edu"}, "uuid": "3793e19f-8780-485c-94dc-92939eacbe2f", "errors": null, "name": "FASTA Merge Files and Filter Unique Sequences", "post_job_actions": {"RenameDatasetActionoutput": {"output_name": "output", "action_type": "RenameDatasetAction", "action_arguments": {"newname": "CustomProDb_SAV_INDEL"}}}, "label": "SAMPLE__SAP_INDEL_FASTA", "inputs": [], "position": {"top": 341, "left": 1912}, "annotation": "", "content_id": "toolshed.g2.bx.psu.edu/repos/galaxyp/fasta_merge_files_and_filter_unique_sequences/fasta_merge_files_and_filter_unique_sequences/1.2.0", "type": "tool"}, "12": {"tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/sqlite_to_tabular/sqlite_to_tabular/2.0.0", "tool_version": "2.0.0", "outputs": [{"type": "tabular", "name": "query_results"}], "workflow_outputs": [], "input_connections": {"sqlitedb": {"output_name": "output_variant_annotation_sqlite", "id": 8}}, "tool_state": "{\"__page__\": null, \"query_result\": \"{\\\"header\\\": \\\"no\\\", \\\"__current_case__\\\": 1}\", \"__rerun_remap_job_id__\": null, \"__workflow_invocation_uuid__\": \"\\\"b731d99c082711e8825dfa163e14a73a\\\"\", \"sqlquery\": \"\\\"SELECT var_pro_name,pro_name,cigar,annotation\\\\nFROM variant_annotation\\\"\", \"sqlitedb\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\", \"chromInfo\": \"\\\"/panfs/roc/website/galaxyp.msi.umn.edu/GALAXYP/tool-data/shared/ucsc/chrom/GRCm38_canon.len\\\"\"}", "id": 12, "tool_shed_repository": {"owner": "iuc", "changeset_revision": "6e72fd26a9d3", "name": "sqlite_to_tabular", "tool_shed": "toolshed.g2.bx.psu.edu"}, "uuid": "3b64131c-d15b-41f3-a0fa-fc0215235ce5", "errors": null, "name": "SQLite to tabular", "post_job_actions": {"HideDatasetActionquery_results": {"output_name": "query_results", "action_type": "HideDatasetAction", "action_arguments": {}}}, "label": null, "inputs": [{"name": "sqlitedb", "description": "runtime parameter for tool SQLite to tabular"}], "position": {"top": 658.03125, "left": 1836.96875}, "annotation": "", "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/sqlite_to_tabular/sqlite_to_tabular/2.0.0", "type": "tool"}, "13": {"tool_id": "toolshed.g2.bx.psu.edu/repos/galaxyp/translate_bed/translate_bed/0.1.0", "tool_version": "0.1.0", "outputs": [{"type": "bed", "name": "translation_bed"}, {"type": "fasta", "name": "translation_fasta"}], "workflow_outputs": [{"output_name": "translation_fasta", "uuid": "8bfa12da-f932-40d5-af75-71c54766fe54", "label": null}, {"output_name": "translation_bed", "uuid": "19e33033-f1c5-44a7-be6d-3bc14e5edbe0", "label": null}], "input_connections": {"input": {"output_name": "output", "id": 9}}, "tool_state": "{\"__page__\": null, \"__rerun_remap_job_id__\": null, \"translations\": \"{\\\"min_length\\\": \\\"10\\\", \\\"enzyme\\\": null, \\\"translate\\\": \\\"cDNA_minus_CDS\\\", \\\"start_codon\\\": \\\"false\\\"}\", \"fa_id\": \"{\\\"fa_sep\\\": \\\"\\\", \\\"fa_db\\\": \\\"generic\\\", \\\"reference\\\": \\\"mm10\\\", \\\"id_prefix\\\": \\\"\\\"}\", \"bed_filters\": \"{\\\"regions\\\": \\\"\\\", \\\"biotypes\\\": \\\"\\\"}\", \"input\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\", \"ref\": \"{\\\"ref_source\\\": \\\"cached\\\", \\\"__current_case__\\\": 0, \\\"ref_loc\\\": \\\"mm10\\\"}\"}", "id": 13, "tool_shed_repository": {"owner": "galaxyp", "changeset_revision": "038ecf54cbec", "name": "translate_bed", "tool_shed": "toolshed.g2.bx.psu.edu"}, "uuid": "812b3f58-6de6-4515-99ef-65afa2624e62", "errors": null, "name": "Translate BED transcripts", "post_job_actions": {"RenameDatasetActiontranslation_bed": {"output_name": "translation_bed", "action_type": "RenameDatasetAction", "action_arguments": {"newname": "TranslatedcDNA_bed"}}, "RenameDatasetActiontranslation_fasta": {"output_name": "translation_fasta", "action_type": "RenameDatasetAction", "action_arguments": {"newname": "TranslatedcDNA_fasta"}}}, "label": null, "inputs": [{"name": "input", "description": "runtime parameter for tool Translate BED transcripts"}], "position": {"top": 821.046875, "left": 1741}, "annotation": "", "content_id": "toolshed.g2.bx.psu.edu/repos/galaxyp/translate_bed/translate_bed/0.1.0", "type": "tool"}, "14": {"tool_id": "toolshed.g2.bx.psu.edu/repos/galaxyp/regex_find_replace/regexColumn1/1.0.0", "tool_version": "1.0.0", "outputs": [{"type": "input", "name": "out_file1"}], "workflow_outputs": [], "input_connections": {"input": {"output_name": "query_results", "id": 10}}, "tool_state": "{\"__page__\": null, \"field\": \"\\\"1\\\"\", \"__rerun_remap_job_id__\": null, \"checks\": \"[{\\\"__index__\\\": 0, \\\"replacement\\\": \\\"\\\\\\\\1\\\\\\\\2_\\\\\\\\3\\\", \\\"pattern\\\": \\\"^(ENS[^_]+_\\\\\\\\d+:)([ACGTacgt]+)>([ACGTacgt]+)\\\\\\\\s*\\\"}, {\\\"__index__\\\": 1, \\\"replacement\\\": \\\".\\\\\\\\1\\\", \\\"pattern\\\": \\\",([A-Z]\\\\\\\\d+[A-Z])\\\\\\\\s*\\\"}, {\\\"__index__\\\": 2, \\\"replacement\\\": \\\"\\\\\\\\1\\\", \\\"pattern\\\": \\\"^(ENS[^ |]*)\\\\\\\\s*\\\"}]\", \"input\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\"}", "id": 14, "tool_shed_repository": {"owner": "galaxyp", "changeset_revision": "209b7c5ee9d7", "name": "regex_find_replace", "tool_shed": "toolshed.g2.bx.psu.edu"}, "uuid": "cd883af9-e0a8-49e0-9b44-993d16cb26d8", "errors": null, "name": "Column Regex Find And Replace", "post_job_actions": {"HideDatasetActionout_file1": {"output_name": "out_file1", "action_type": "HideDatasetAction", "action_arguments": {}}}, "label": "SearchGUI compatible Protein Names Genomic Mapping", "inputs": [{"name": "input", "description": "runtime parameter for tool Column Regex Find And Replace"}], "position": {"top": 505.015625, "left": 1869.484375}, "annotation": "", "content_id": "toolshed.g2.bx.psu.edu/repos/galaxyp/regex_find_replace/regexColumn1/1.0.0", "type": "tool"}, "15": {"tool_id": "toolshed.g2.bx.psu.edu/repos/galaxyp/regex_find_replace/regex1/1.0.0", "tool_version": "1.0.0", "outputs": [{"type": "input", "name": "out_file1"}], "workflow_outputs": [], "input_connections": {"input": {"output_name": "output", "id": 11}}, "tool_state": "{\"input\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\", \"__rerun_remap_job_id__\": null, \"checks\": \"[{\\\"__index__\\\": 0, \\\"replacement\\\": \\\"\\\\\\\\1\\\\\\\\2_\\\\\\\\3\\\", \\\"pattern\\\": \\\"^(>ENS[^_]+_\\\\\\\\d+:)([ACGTacgt]+)>([ACGTacgt]+)\\\\\\\\s*\\\"}, {\\\"__index__\\\": 1, \\\"replacement\\\": \\\".\\\\\\\\1\\\", \\\"pattern\\\": \\\",([A-Z]\\\\\\\\d+[A-Z])\\\\\\\\s*\\\"}, {\\\"__index__\\\": 2, \\\"replacement\\\": \\\"\\\\\\\\1\\\\\\\\2\\\", \\\"pattern\\\": \\\"^(>)(ENS[^ |]*)\\\\\\\\s*\\\"}, {\\\"__index__\\\": 3, \\\"replacement\\\": \\\">generic|\\\", \\\"pattern\\\": \\\"^>\\\"}]\", \"__page__\": null}", "id": 15, "tool_shed_repository": {"owner": "galaxyp", "changeset_revision": "209b7c5ee9d7", "name": "regex_find_replace", "tool_shed": "toolshed.g2.bx.psu.edu"}, "uuid": "853dcafc-f150-4cca-9b4d-73f09fe9d5fe", "errors": null, "name": "Regex Find And Replace", "post_job_actions": {"RenameDatasetActionout_file1": {"output_name": "out_file1", "action_type": "RenameDatasetAction", "action_arguments": {"newname": "CustomProdb_SAP_indel"}}, "HideDatasetActionout_file1": {"output_name": "out_file1", "action_type": "HideDatasetAction", "action_arguments": {}}}, "label": "SearchGUI compatible Protein Names Fasta", "inputs": [{"name": "input", "description": "runtime parameter for tool Regex Find And Replace"}], "position": {"top": 373.015625, "left": 2270}, "annotation": "", "content_id": "toolshed.g2.bx.psu.edu/repos/galaxyp/regex_find_replace/regex1/1.0.0", "type": "tool"}, "16": {"tool_id": "toolshed.g2.bx.psu.edu/repos/galaxyp/regex_find_replace/regexColumn1/1.0.0", "tool_version": "1.0.0", "outputs": [{"type": "input", "name": "out_file1"}], "workflow_outputs": [], "input_connections": {"input": {"output_name": "query_results", "id": 12}}, "tool_state": "{\"__page__\": null, \"field\": \"\\\"1\\\"\", \"__rerun_remap_job_id__\": null, \"checks\": \"[{\\\"__index__\\\": 0, \\\"replacement\\\": \\\"\\\\\\\\1\\\\\\\\2_\\\\\\\\3\\\", \\\"pattern\\\": \\\"^(ENS[^_]+_\\\\\\\\d+:)([ACGTacgt]+)>([ACGTacgt]+)\\\\\\\\s*\\\"}, {\\\"__index__\\\": 1, \\\"replacement\\\": \\\".\\\\\\\\1\\\", \\\"pattern\\\": \\\",([A-Z]\\\\\\\\d+[A-Z])\\\\\\\\s*\\\"}, {\\\"__index__\\\": 2, \\\"replacement\\\": \\\"\\\\\\\\1\\\", \\\"pattern\\\": \\\"^(ENS[^ |]*)\\\\\\\\s*\\\"}]\", \"input\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\"}", "id": 16, "tool_shed_repository": {"owner": "galaxyp", "changeset_revision": "209b7c5ee9d7", "name": "regex_find_replace", "tool_shed": "toolshed.g2.bx.psu.edu"}, "uuid": "50f13eee-ff5a-4648-b8e3-1ea989d7451d", "errors": null, "name": "Column Regex Find And Replace", "post_job_actions": {"HideDatasetActionout_file1": {"output_name": "out_file1", "action_type": "HideDatasetAction", "action_arguments": {}}}, "label": "SearchGUI compatible Protein Names Variant Annotation", "inputs": [{"name": "input", "description": "runtime parameter for tool Column Regex Find And Replace"}], "position": {"top": 645.015625, "left": 2106.5}, "annotation": "", "content_id": "toolshed.g2.bx.psu.edu/repos/galaxyp/regex_find_replace/regexColumn1/1.0.0", "type": "tool"}, "17": {"tool_id": "toolshed.g2.bx.psu.edu/repos/galaxyp/bed_to_protein_map/bed_to_protein_map/0.1.0", "tool_version": "0.1.0", "outputs": [{"type": "tabular", "name": "output"}], "workflow_outputs": [{"output_name": "output", "uuid": "4a3603af-22dd-426d-bf8d-4168adc28027", "label": null}], "input_connections": {"input": {"output_name": "translation_bed", "id": 13}}, "tool_state": "{\"input\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\", \"__rerun_remap_job_id__\": null, \"__page__\": null}", "id": 17, "tool_shed_repository": {"owner": "galaxyp", "changeset_revision": "024ed7b0ad93", "name": "bed_to_protein_map", "tool_shed": "toolshed.g2.bx.psu.edu"}, "uuid": "37541c1d-fe35-45c4-9cc5-32640f063c7c", "errors": null, "name": "bed to protein map", "post_job_actions": {"RenameDatasetActionoutput": {"output_name": "output", "action_type": "RenameDatasetAction", "action_arguments": {"newname": "Bed2protein_SJ_SAV_INDEL"}}}, "label": null, "inputs": [{"name": "input", "description": "runtime parameter for tool bed to protein map"}], "position": {"top": 1000.96875, "left": 1901.96875}, "annotation": "", "content_id": "toolshed.g2.bx.psu.edu/repos/galaxyp/bed_to_protein_map/bed_to_protein_map/0.1.0", "type": "tool"}, "18": {"tool_id": "toolshed.g2.bx.psu.edu/repos/galaxyp/fasta_merge_files_and_filter_unique_sequences/fasta_merge_files_and_filter_unique_sequences/1.2.0", "tool_version": "1.2.0", "outputs": [{"type": "fasta", "name": "output"}], "workflow_outputs": [{"output_name": "output", "uuid": "72cc0e9a-963e-4b72-9cad-595421f3e035", "label": null}], "input_connections": {"batchmode|input_fastas_0|input_fasta": {"output_name": "output", "id": 2}, "batchmode|input_fastas_1|input_fasta": {"output_name": "translation_fasta", "id": 13}, "batchmode|input_fastas_2|input_fasta": {"output_name": "out_file1", "id": 15}}, "tool_state": "{\"batchmode\": \"{\\\"input_fastas\\\": [{\\\"__index__\\\": 0, \\\"input_fasta\\\": {\\\"__class__\\\": \\\"RuntimeValue\\\"}}, {\\\"__index__\\\": 1, \\\"input_fasta\\\": {\\\"__class__\\\": \\\"RuntimeValue\\\"}}, {\\\"__index__\\\": 2, \\\"input_fasta\\\": {\\\"__class__\\\": \\\"RuntimeValue\\\"}}], \\\"processmode\\\": \\\"individual\\\", \\\"__current_case__\\\": 0}\", \"__page__\": null, \"accession_parser\": \"\\\"^>[^ |]*[ |]([^ |]+).*$\\\"\", \"uniqueness_criterion\": \"\\\"sequence\\\"\", \"__rerun_remap_job_id__\": null}", "id": 18, "tool_shed_repository": {"owner": "galaxyp", "changeset_revision": "650d553c1fda", "name": "fasta_merge_files_and_filter_unique_sequences", "tool_shed": "toolshed.g2.bx.psu.edu"}, "uuid": "63bc2925-96db-424c-8621-c9bf3ec4d1a1", "errors": null, "name": "FASTA Merge Files and Filter Unique Sequences", "post_job_actions": {"RenameDatasetActionoutput": {"output_name": "output", "action_type": "RenameDatasetAction", "action_arguments": {"newname": "Uniprot_cRAP_SAV_indel_translatedbed.fasta"}}}, "label": "Uniprot+cRAP+Translate_cDNA+CustomProDb", "inputs": [], "position": {"top": 620.984375, "left": 2959.96875}, "annotation": "", "content_id": "toolshed.g2.bx.psu.edu/repos/galaxyp/fasta_merge_files_and_filter_unique_sequences/fasta_merge_files_and_filter_unique_sequences/1.2.0", "type": "tool"}, "19": {"tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/query_tabular/query_tabular/2.0.0", "tool_version": "2.0.0", "outputs": [{"type": "sqlite", "name": "sqlitedb"}, {"type": "tabular", "name": "output"}], "workflow_outputs": [{"output_name": "sqlitedb", "uuid": "a84d0ca8-ae25-4092-ba26-95d95990df9c", "label": null}], "input_connections": {"tables_0|table": {"output_name": "out_file1", "id": 16}}, "tool_state": "{\"tables\": \"[{\\\"tbl_opts\\\": {\\\"pkey_autoincr\\\": \\\"\\\", \\\"load_named_columns\\\": \\\"false\\\", \\\"indexes\\\": [{\\\"__index__\\\": 0, \\\"unique\\\": \\\"false\\\", \\\"index_columns\\\": \\\"name,cigar\\\"}], \\\"table_name\\\": \\\"variant_annotation\\\", \\\"col_names\\\": \\\"name,reference,cigar,annotation\\\", \\\"column_names_from_first_line\\\": \\\"false\\\"}, \\\"__index__\\\": 0, \\\"input_opts\\\": {\\\"linefilters\\\": []}, \\\"table\\\": {\\\"__class__\\\": \\\"RuntimeValue\\\"}}]\", \"save_db\": \"\\\"true\\\"\", \"__page__\": null, \"__rerun_remap_job_id__\": null, \"sqlquery\": \"\\\"\\\"\", \"add_to_database\": \"{\\\"withdb\\\": {\\\"__class__\\\": \\\"RuntimeValue\\\"}}\", \"query_result\": \"{\\\"header\\\": \\\"no\\\", \\\"__current_case__\\\": 1}\", \"workdb\": \"\\\"workdb.sqlite\\\"\"}", "id": 19, "tool_shed_repository": {"owner": "iuc", "changeset_revision": "1ea4e668bf73", "name": "query_tabular", "tool_shed": "toolshed.g2.bx.psu.edu"}, "uuid": "1bc44829-8f41-4437-a100-e4783fce0d9a", "errors": null, "name": "Query Tabular", "post_job_actions": {"RenameDatasetActionsqlitedb": {"output_name": "sqlitedb", "action_type": "RenameDatasetAction", "action_arguments": {"newname": "Variant_annotation_sqlitedb"}}, "HideDatasetActionoutput": {"output_name": "output", "action_type": "HideDatasetAction", "action_arguments": {}}}, "label": "Variant_Annotations", "inputs": [{"name": "add_to_database", "description": "runtime parameter for tool Query Tabular"}], "position": {"top": 506.03125, "left": 2403.484375}, "annotation": "", "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/query_tabular/query_tabular/2.0.0", "type": "tool"}, "20": {"tool_id": "toolshed.g2.bx.psu.edu/repos/mvdbeek/concatenate_multiple_datasets/cat_multiple/0.2", "tool_version": "0.2", "outputs": [{"type": "input", "name": "out_file1"}], "workflow_outputs": [], "input_connections": {"input": [{"output_name": "output", "id": 17}, {"output_name": "out_file1", "id": 14}]}, "tool_state": "{\"input\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\", \"__rerun_remap_job_id__\": null, \"__page__\": null}", "id": 20, "tool_shed_repository": {"owner": "mvdbeek", "changeset_revision": "201c568972c3", "name": "concatenate_multiple_datasets", "tool_shed": "toolshed.g2.bx.psu.edu"}, "uuid": "07cb2802-2c24-4f62-936b-1f4d52b9a0f1", "errors": null, "name": "Concatenate multiple datasets", "post_job_actions": {"RenameDatasetActionout_file1": {"output_name": "out_file1", "action_type": "RenameDatasetAction", "action_arguments": {"newname": "Genomic_Protein_map"}}, "HideDatasetActionout_file1": {"output_name": "out_file1", "action_type": "HideDatasetAction", "action_arguments": {}}}, "label": null, "inputs": [{"name": "input", "description": "runtime parameter for tool Concatenate multiple datasets"}], "position": {"top": 878, "left": 2152.484375}, "annotation": "", "content_id": "toolshed.g2.bx.psu.edu/repos/mvdbeek/concatenate_multiple_datasets/cat_multiple/0.2", "type": "tool"}, "21": {"tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/query_tabular/query_tabular/2.0.0", "tool_version": "2.0.0", "outputs": [{"type": "sqlite", "name": "sqlitedb"}, {"type": "tabular", "name": "output"}], "workflow_outputs": [{"output_name": "sqlitedb", "uuid": "0df8a509-3fb6-4154-8112-eb1bb21c03e5", "label": null}], "input_connections": {"tables_0|table": {"output_name": "out_file1", "id": 20}}, "tool_state": "{\"tables\": \"[{\\\"tbl_opts\\\": {\\\"pkey_autoincr\\\": \\\"\\\", \\\"load_named_columns\\\": \\\"false\\\", \\\"indexes\\\": [{\\\"__index__\\\": 0, \\\"unique\\\": \\\"false\\\", \\\"index_columns\\\": \\\"name,cds_start,cds_end\\\"}], \\\"table_name\\\": \\\"feature_cds_map\\\", \\\"col_names\\\": \\\"name,chrom,start,end,strand,cds_start,cds_end\\\", \\\"column_names_from_first_line\\\": \\\"false\\\"}, \\\"__index__\\\": 0, \\\"input_opts\\\": {\\\"linefilters\\\": []}, \\\"table\\\": {\\\"__class__\\\": \\\"RuntimeValue\\\"}}]\", \"save_db\": \"\\\"true\\\"\", \"__page__\": null, \"__rerun_remap_job_id__\": null, \"sqlquery\": \"\\\"\\\"\", \"add_to_database\": \"{\\\"withdb\\\": {\\\"__class__\\\": \\\"RuntimeValue\\\"}}\", \"query_result\": \"{\\\"header\\\": \\\"no\\\", \\\"__current_case__\\\": 1}\", \"workdb\": \"\\\"workdb.sqlite\\\"\"}", "id": 21, "tool_shed_repository": {"owner": "iuc", "changeset_revision": "1ea4e668bf73", "name": "query_tabular", "tool_shed": "toolshed.g2.bx.psu.edu"}, "uuid": "888eb7db-0773-453d-968b-d6df10b6a73b", "errors": null, "name": "Query Tabular", "post_job_actions": {"RenameDatasetActionsqlitedb": {"output_name": "sqlitedb", "action_type": "RenameDatasetAction", "action_arguments": {"newname": "genomic_mapping_sqlite"}}, "HideDatasetActionoutput": {"output_name": "output", "action_type": "HideDatasetAction", "action_arguments": {}}}, "label": "genomic_mapping_sqlite", "inputs": [{"name": "add_to_database", "description": "runtime parameter for tool Query Tabular"}], "position": {"top": 776.046875, "left": 2451.46875}, "annotation": "", "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/query_tabular/query_tabular/2.0.0", "type": "tool"}}, "annotation": "", "a_galaxy_workflow": "true"}
+{
+  "a_galaxy_workflow": "true",
+  "annotation": "",
+  "format-version": "0.1",
+  "name": "ABRF_Workflow1_RNAseq_DBcreation",
+  "steps": {
+    "0": {
+      "annotation": "",
+      "content_id": null,
+      "errors": null,
+      "id": 0,
+      "input_connections": {},
+      "inputs": [],
+      "label": "ProB.fastq",
+      "name": "Input dataset",
+      "outputs": [],
+      "position": {
+        "left": 303.984375,
+        "top": 276
+      },
+      "tool_id": null,
+      "tool_state": "{}",
+      "tool_version": null,
+      "type": "data_input",
+      "uuid": "1c77a4cc-70d3-4465-8cbd-d794c93d998e",
+      "workflow_outputs": [
+        {
+          "label": null,
+          "output_name": "output",
+          "uuid": "a49bbc5e-b817-4309-938f-046d94e28072"
+        }
+      ]
+    },
+    "1": {
+      "annotation": "",
+      "content_id": null,
+      "errors": null,
+      "id": 1,
+      "input_connections": {},
+      "inputs": [
+        {
+          "description": "",
+          "name": "Mus_musculus.GRCm38.86.gtf"
+        }
+      ],
+      "label": "Mus_musculus.GRCm38.86.gtf",
+      "name": "Input dataset",
+      "outputs": [],
+      "position": {
+        "left": 299.984375,
+        "top": 531.03125
+      },
+      "tool_id": null,
+      "tool_state": "{\"name\": \"Mus_musculus.GRCm38.86.gtf\"}",
+      "tool_version": null,
+      "type": "data_input",
+      "uuid": "42d28c1e-a173-404c-8e34-bd7fd02f71e5",
+      "workflow_outputs": [
+        {
+          "label": null,
+          "output_name": "output",
+          "uuid": "5e070017-21a6-41cb-995a-cd091b898fe1"
+        }
+      ]
+    },
+    "10": {
+      "annotation": "",
+      "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/sqlite_to_tabular/sqlite_to_tabular/2.0.0",
+      "errors": null,
+      "id": 10,
+      "input_connections": {
+        "sqlitedb": {
+          "id": 8,
+          "output_name": "output_genomic_mapping_sqlite"
+        }
+      },
+      "inputs": [
+        {
+          "description": "runtime parameter for tool SQLite to tabular",
+          "name": "sqlitedb"
+        }
+      ],
+      "label": null,
+      "name": "SQLite to tabular",
+      "outputs": [
+        {
+          "name": "query_results",
+          "type": "tabular"
+        }
+      ],
+      "position": {
+        "left": 1611,
+        "top": 545.953125
+      },
+      "post_job_actions": {
+        "HideDatasetActionquery_results": {
+          "action_arguments": {},
+          "action_type": "HideDatasetAction",
+          "output_name": "query_results"
+        }
+      },
+      "tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/sqlite_to_tabular/sqlite_to_tabular/2.0.0",
+      "tool_shed_repository": {
+        "changeset_revision": "6e72fd26a9d3",
+        "name": "sqlite_to_tabular",
+        "owner": "iuc",
+        "tool_shed": "toolshed.g2.bx.psu.edu"
+      },
+      "tool_state": "{\"sqlquery\": \"\\\"SELECT pro_name, chr_name, cds_chr_start - 1, cds_chr_end,strand,cds_start - 1, cds_end\\\\nFROM genomic_mapping\\\\nORDER BY pro_name, cds_start, cds_end\\\"\", \"__page__\": null, \"sqlitedb\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\", \"query_result\": \"{\\\"header\\\": \\\"no\\\", \\\"__current_case__\\\": 1}\", \"__rerun_remap_job_id__\": null}",
+      "tool_version": "2.0.0",
+      "type": "tool",
+      "uuid": "8568d385-239c-4503-8266-56281615a696",
+      "workflow_outputs": []
+    },
+    "11": {
+      "annotation": "",
+      "content_id": "toolshed.g2.bx.psu.edu/repos/galaxyp/fasta_merge_files_and_filter_unique_sequences/fasta_merge_files_and_filter_unique_sequences/1.2.0",
+      "errors": null,
+      "id": 11,
+      "input_connections": {
+        "batchmode|input_fastas_0|input_fasta": {
+          "id": 8,
+          "output_name": "output_rpkm"
+        },
+        "batchmode|input_fastas_1|input_fasta": {
+          "id": 8,
+          "output_name": "output_snv"
+        },
+        "batchmode|input_fastas_2|input_fasta": {
+          "id": 8,
+          "output_name": "output_indel"
+        }
+      },
+      "inputs": [],
+      "label": "SAMPLE__SAP_INDEL_FASTA",
+      "name": "FASTA Merge Files and Filter Unique Sequences",
+      "outputs": [
+        {
+          "name": "output",
+          "type": "fasta"
+        }
+      ],
+      "position": {
+        "left": 1912,
+        "top": 341
+      },
+      "post_job_actions": {
+        "RenameDatasetActionoutput": {
+          "action_arguments": {
+            "newname": "CustomProDb_SAV_INDEL"
+          },
+          "action_type": "RenameDatasetAction",
+          "output_name": "output"
+        }
+      },
+      "tool_id": "toolshed.g2.bx.psu.edu/repos/galaxyp/fasta_merge_files_and_filter_unique_sequences/fasta_merge_files_and_filter_unique_sequences/1.2.0",
+      "tool_shed_repository": {
+        "changeset_revision": "650d553c1fda",
+        "name": "fasta_merge_files_and_filter_unique_sequences",
+        "owner": "galaxyp",
+        "tool_shed": "toolshed.g2.bx.psu.edu"
+      },
+      "tool_state": "{\"batchmode\": \"{\\\"input_fastas\\\": [{\\\"__index__\\\": 0, \\\"input_fasta\\\": {\\\"__class__\\\": \\\"RuntimeValue\\\"}}, {\\\"__index__\\\": 1, \\\"input_fasta\\\": {\\\"__class__\\\": \\\"RuntimeValue\\\"}}, {\\\"__index__\\\": 2, \\\"input_fasta\\\": {\\\"__class__\\\": \\\"RuntimeValue\\\"}}], \\\"processmode\\\": \\\"individual\\\", \\\"__current_case__\\\": 0}\", \"__page__\": null, \"accession_parser\": \"\\\"^>([^ |]+).*$\\\"\", \"uniqueness_criterion\": \"\\\"sequence\\\"\", \"__rerun_remap_job_id__\": null}",
+      "tool_version": "1.2.0",
+      "type": "tool",
+      "uuid": "3793e19f-8780-485c-94dc-92939eacbe2f",
+      "workflow_outputs": [
+        {
+          "label": null,
+          "output_name": "output",
+          "uuid": "cd9c2d08-2c3b-47fe-ac8e-15797b2a8ece"
+        }
+      ]
+    },
+    "12": {
+      "annotation": "",
+      "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/sqlite_to_tabular/sqlite_to_tabular/2.0.0",
+      "errors": null,
+      "id": 12,
+      "input_connections": {
+        "sqlitedb": {
+          "id": 8,
+          "output_name": "output_variant_annotation_sqlite"
+        }
+      },
+      "inputs": [
+        {
+          "description": "runtime parameter for tool SQLite to tabular",
+          "name": "sqlitedb"
+        }
+      ],
+      "label": null,
+      "name": "SQLite to tabular",
+      "outputs": [
+        {
+          "name": "query_results",
+          "type": "tabular"
+        }
+      ],
+      "position": {
+        "left": 1836.96875,
+        "top": 658.03125
+      },
+      "post_job_actions": {
+        "HideDatasetActionquery_results": {
+          "action_arguments": {},
+          "action_type": "HideDatasetAction",
+          "output_name": "query_results"
+        }
+      },
+      "tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/sqlite_to_tabular/sqlite_to_tabular/2.0.0",
+      "tool_shed_repository": {
+        "changeset_revision": "6e72fd26a9d3",
+        "name": "sqlite_to_tabular",
+        "owner": "iuc",
+        "tool_shed": "toolshed.g2.bx.psu.edu"
+      },
+      "tool_state": "{\"__page__\": null, \"query_result\": \"{\\\"header\\\": \\\"no\\\", \\\"__current_case__\\\": 1}\", \"__rerun_remap_job_id__\": null, \"__workflow_invocation_uuid__\": \"\\\"b731d99c082711e8825dfa163e14a73a\\\"\", \"sqlquery\": \"\\\"SELECT var_pro_name,pro_name,cigar,annotation\\\\nFROM variant_annotation\\\"\", \"sqlitedb\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\", \"chromInfo\": \"\\\"/panfs/roc/website/galaxyp.msi.umn.edu/GALAXYP/tool-data/shared/ucsc/chrom/GRCm38_canon.len\\\"\"}",
+      "tool_version": "2.0.0",
+      "type": "tool",
+      "uuid": "3b64131c-d15b-41f3-a0fa-fc0215235ce5",
+      "workflow_outputs": []
+    },
+    "13": {
+      "annotation": "",
+      "content_id": "toolshed.g2.bx.psu.edu/repos/galaxyp/translate_bed/translate_bed/0.1.0",
+      "errors": null,
+      "id": 13,
+      "input_connections": {
+        "input": {
+          "id": 9,
+          "output_name": "output"
+        }
+      },
+      "inputs": [
+        {
+          "description": "runtime parameter for tool Translate BED transcripts",
+          "name": "input"
+        }
+      ],
+      "label": null,
+      "name": "Translate BED transcripts",
+      "outputs": [
+        {
+          "name": "translation_bed",
+          "type": "bed"
+        },
+        {
+          "name": "translation_fasta",
+          "type": "fasta"
+        }
+      ],
+      "position": {
+        "left": 1741,
+        "top": 821.046875
+      },
+      "post_job_actions": {
+        "RenameDatasetActiontranslation_bed": {
+          "action_arguments": {
+            "newname": "TranslatedcDNA_bed"
+          },
+          "action_type": "RenameDatasetAction",
+          "output_name": "translation_bed"
+        },
+        "RenameDatasetActiontranslation_fasta": {
+          "action_arguments": {
+            "newname": "TranslatedcDNA_fasta"
+          },
+          "action_type": "RenameDatasetAction",
+          "output_name": "translation_fasta"
+        }
+      },
+      "tool_id": "toolshed.g2.bx.psu.edu/repos/galaxyp/translate_bed/translate_bed/0.1.0",
+      "tool_shed_repository": {
+        "changeset_revision": "038ecf54cbec",
+        "name": "translate_bed",
+        "owner": "galaxyp",
+        "tool_shed": "toolshed.g2.bx.psu.edu"
+      },
+      "tool_state": "{\"__page__\": null, \"__rerun_remap_job_id__\": null, \"translations\": \"{\\\"min_length\\\": \\\"10\\\", \\\"enzyme\\\": null, \\\"translate\\\": \\\"cDNA_minus_CDS\\\", \\\"start_codon\\\": \\\"false\\\"}\", \"fa_id\": \"{\\\"fa_sep\\\": \\\"\\\", \\\"fa_db\\\": \\\"generic\\\", \\\"reference\\\": \\\"mm10\\\", \\\"id_prefix\\\": \\\"\\\"}\", \"bed_filters\": \"{\\\"regions\\\": \\\"\\\", \\\"biotypes\\\": \\\"\\\"}\", \"input\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\", \"ref\": \"{\\\"ref_source\\\": \\\"cached\\\", \\\"__current_case__\\\": 0, \\\"ref_loc\\\": \\\"mm10\\\"}\"}",
+      "tool_version": "0.1.0",
+      "type": "tool",
+      "uuid": "812b3f58-6de6-4515-99ef-65afa2624e62",
+      "workflow_outputs": [
+        {
+          "label": null,
+          "output_name": "translation_fasta",
+          "uuid": "8bfa12da-f932-40d5-af75-71c54766fe54"
+        },
+        {
+          "label": null,
+          "output_name": "translation_bed",
+          "uuid": "19e33033-f1c5-44a7-be6d-3bc14e5edbe0"
+        }
+      ]
+    },
+    "14": {
+      "annotation": "",
+      "content_id": "toolshed.g2.bx.psu.edu/repos/galaxyp/regex_find_replace/regexColumn1/1.0.0",
+      "errors": null,
+      "id": 14,
+      "input_connections": {
+        "input": {
+          "id": 10,
+          "output_name": "query_results"
+        }
+      },
+      "inputs": [
+        {
+          "description": "runtime parameter for tool Column Regex Find And Replace",
+          "name": "input"
+        }
+      ],
+      "label": "SearchGUI compatible Protein Names Genomic Mapping",
+      "name": "Column Regex Find And Replace",
+      "outputs": [
+        {
+          "name": "out_file1",
+          "type": "input"
+        }
+      ],
+      "position": {
+        "left": 1869.484375,
+        "top": 505.015625
+      },
+      "post_job_actions": {
+        "HideDatasetActionout_file1": {
+          "action_arguments": {},
+          "action_type": "HideDatasetAction",
+          "output_name": "out_file1"
+        }
+      },
+      "tool_id": "toolshed.g2.bx.psu.edu/repos/galaxyp/regex_find_replace/regexColumn1/1.0.0",
+      "tool_shed_repository": {
+        "changeset_revision": "209b7c5ee9d7",
+        "name": "regex_find_replace",
+        "owner": "galaxyp",
+        "tool_shed": "toolshed.g2.bx.psu.edu"
+      },
+      "tool_state": "{\"__page__\": null, \"field\": \"\\\"1\\\"\", \"__rerun_remap_job_id__\": null, \"checks\": \"[{\\\"__index__\\\": 0, \\\"replacement\\\": \\\"\\\\\\\\1\\\\\\\\2_\\\\\\\\3\\\", \\\"pattern\\\": \\\"^(ENS[^_]+_\\\\\\\\d+:)([ACGTacgt]+)>([ACGTacgt]+)\\\\\\\\s*\\\"}, {\\\"__index__\\\": 1, \\\"replacement\\\": \\\".\\\\\\\\1\\\", \\\"pattern\\\": \\\",([A-Z]\\\\\\\\d+[A-Z])\\\\\\\\s*\\\"}, {\\\"__index__\\\": 2, \\\"replacement\\\": \\\"\\\\\\\\1\\\", \\\"pattern\\\": \\\"^(ENS[^ |]*)\\\\\\\\s*\\\"}]\", \"input\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\"}",
+      "tool_version": "1.0.0",
+      "type": "tool",
+      "uuid": "cd883af9-e0a8-49e0-9b44-993d16cb26d8",
+      "workflow_outputs": []
+    },
+    "15": {
+      "annotation": "",
+      "content_id": "toolshed.g2.bx.psu.edu/repos/galaxyp/regex_find_replace/regex1/1.0.0",
+      "errors": null,
+      "id": 15,
+      "input_connections": {
+        "input": {
+          "id": 11,
+          "output_name": "output"
+        }
+      },
+      "inputs": [
+        {
+          "description": "runtime parameter for tool Regex Find And Replace",
+          "name": "input"
+        }
+      ],
+      "label": "SearchGUI compatible Protein Names Fasta",
+      "name": "Regex Find And Replace",
+      "outputs": [
+        {
+          "name": "out_file1",
+          "type": "input"
+        }
+      ],
+      "position": {
+        "left": 2270,
+        "top": 373.015625
+      },
+      "post_job_actions": {
+        "HideDatasetActionout_file1": {
+          "action_arguments": {},
+          "action_type": "HideDatasetAction",
+          "output_name": "out_file1"
+        },
+        "RenameDatasetActionout_file1": {
+          "action_arguments": {
+            "newname": "CustomProdb_SAP_indel"
+          },
+          "action_type": "RenameDatasetAction",
+          "output_name": "out_file1"
+        }
+      },
+      "tool_id": "toolshed.g2.bx.psu.edu/repos/galaxyp/regex_find_replace/regex1/1.0.0",
+      "tool_shed_repository": {
+        "changeset_revision": "209b7c5ee9d7",
+        "name": "regex_find_replace",
+        "owner": "galaxyp",
+        "tool_shed": "toolshed.g2.bx.psu.edu"
+      },
+      "tool_state": "{\"input\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\", \"__rerun_remap_job_id__\": null, \"checks\": \"[{\\\"__index__\\\": 0, \\\"replacement\\\": \\\"\\\\\\\\1\\\\\\\\2_\\\\\\\\3\\\", \\\"pattern\\\": \\\"^(>ENS[^_]+_\\\\\\\\d+:)([ACGTacgt]+)>([ACGTacgt]+)\\\\\\\\s*\\\"}, {\\\"__index__\\\": 1, \\\"replacement\\\": \\\".\\\\\\\\1\\\", \\\"pattern\\\": \\\",([A-Z]\\\\\\\\d+[A-Z])\\\\\\\\s*\\\"}, {\\\"__index__\\\": 2, \\\"replacement\\\": \\\"\\\\\\\\1\\\\\\\\2\\\", \\\"pattern\\\": \\\"^(>)(ENS[^ |]*)\\\\\\\\s*\\\"}, {\\\"__index__\\\": 3, \\\"replacement\\\": \\\">generic|\\\", \\\"pattern\\\": \\\"^>\\\"}]\", \"__page__\": null}",
+      "tool_version": "1.0.0",
+      "type": "tool",
+      "uuid": "853dcafc-f150-4cca-9b4d-73f09fe9d5fe",
+      "workflow_outputs": []
+    },
+    "16": {
+      "annotation": "",
+      "content_id": "toolshed.g2.bx.psu.edu/repos/galaxyp/regex_find_replace/regexColumn1/1.0.0",
+      "errors": null,
+      "id": 16,
+      "input_connections": {
+        "input": {
+          "id": 12,
+          "output_name": "query_results"
+        }
+      },
+      "inputs": [
+        {
+          "description": "runtime parameter for tool Column Regex Find And Replace",
+          "name": "input"
+        }
+      ],
+      "label": "SearchGUI compatible Protein Names Variant Annotation",
+      "name": "Column Regex Find And Replace",
+      "outputs": [
+        {
+          "name": "out_file1",
+          "type": "input"
+        }
+      ],
+      "position": {
+        "left": 2106.5,
+        "top": 645.015625
+      },
+      "post_job_actions": {
+        "HideDatasetActionout_file1": {
+          "action_arguments": {},
+          "action_type": "HideDatasetAction",
+          "output_name": "out_file1"
+        }
+      },
+      "tool_id": "toolshed.g2.bx.psu.edu/repos/galaxyp/regex_find_replace/regexColumn1/1.0.0",
+      "tool_shed_repository": {
+        "changeset_revision": "209b7c5ee9d7",
+        "name": "regex_find_replace",
+        "owner": "galaxyp",
+        "tool_shed": "toolshed.g2.bx.psu.edu"
+      },
+      "tool_state": "{\"__page__\": null, \"field\": \"\\\"1\\\"\", \"__rerun_remap_job_id__\": null, \"checks\": \"[{\\\"__index__\\\": 0, \\\"replacement\\\": \\\"\\\\\\\\1\\\\\\\\2_\\\\\\\\3\\\", \\\"pattern\\\": \\\"^(ENS[^_]+_\\\\\\\\d+:)([ACGTacgt]+)>([ACGTacgt]+)\\\\\\\\s*\\\"}, {\\\"__index__\\\": 1, \\\"replacement\\\": \\\".\\\\\\\\1\\\", \\\"pattern\\\": \\\",([A-Z]\\\\\\\\d+[A-Z])\\\\\\\\s*\\\"}, {\\\"__index__\\\": 2, \\\"replacement\\\": \\\"\\\\\\\\1\\\", \\\"pattern\\\": \\\"^(ENS[^ |]*)\\\\\\\\s*\\\"}]\", \"input\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\"}",
+      "tool_version": "1.0.0",
+      "type": "tool",
+      "uuid": "50f13eee-ff5a-4648-b8e3-1ea989d7451d",
+      "workflow_outputs": []
+    },
+    "17": {
+      "annotation": "",
+      "content_id": "toolshed.g2.bx.psu.edu/repos/galaxyp/bed_to_protein_map/bed_to_protein_map/0.1.0",
+      "errors": null,
+      "id": 17,
+      "input_connections": {
+        "input": {
+          "id": 13,
+          "output_name": "translation_bed"
+        }
+      },
+      "inputs": [
+        {
+          "description": "runtime parameter for tool bed to protein map",
+          "name": "input"
+        }
+      ],
+      "label": null,
+      "name": "bed to protein map",
+      "outputs": [
+        {
+          "name": "output",
+          "type": "tabular"
+        }
+      ],
+      "position": {
+        "left": 1901.96875,
+        "top": 1000.96875
+      },
+      "post_job_actions": {
+        "RenameDatasetActionoutput": {
+          "action_arguments": {
+            "newname": "Bed2protein_SJ_SAV_INDEL"
+          },
+          "action_type": "RenameDatasetAction",
+          "output_name": "output"
+        }
+      },
+      "tool_id": "toolshed.g2.bx.psu.edu/repos/galaxyp/bed_to_protein_map/bed_to_protein_map/0.1.0",
+      "tool_shed_repository": {
+        "changeset_revision": "024ed7b0ad93",
+        "name": "bed_to_protein_map",
+        "owner": "galaxyp",
+        "tool_shed": "toolshed.g2.bx.psu.edu"
+      },
+      "tool_state": "{\"input\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\", \"__rerun_remap_job_id__\": null, \"__page__\": null}",
+      "tool_version": "0.1.0",
+      "type": "tool",
+      "uuid": "37541c1d-fe35-45c4-9cc5-32640f063c7c",
+      "workflow_outputs": [
+        {
+          "label": null,
+          "output_name": "output",
+          "uuid": "4a3603af-22dd-426d-bf8d-4168adc28027"
+        }
+      ]
+    },
+    "18": {
+      "annotation": "",
+      "content_id": "toolshed.g2.bx.psu.edu/repos/galaxyp/fasta_merge_files_and_filter_unique_sequences/fasta_merge_files_and_filter_unique_sequences/1.2.0",
+      "errors": null,
+      "id": 18,
+      "input_connections": {
+        "batchmode|input_fastas_0|input_fasta": {
+          "id": 2,
+          "output_name": "output"
+        },
+        "batchmode|input_fastas_1|input_fasta": {
+          "id": 13,
+          "output_name": "translation_fasta"
+        },
+        "batchmode|input_fastas_2|input_fasta": {
+          "id": 15,
+          "output_name": "out_file1"
+        }
+      },
+      "inputs": [],
+      "label": "Uniprot+cRAP+Translate_cDNA+CustomProDb",
+      "name": "FASTA Merge Files and Filter Unique Sequences",
+      "outputs": [
+        {
+          "name": "output",
+          "type": "fasta"
+        }
+      ],
+      "position": {
+        "left": 2959.96875,
+        "top": 620.984375
+      },
+      "post_job_actions": {
+        "RenameDatasetActionoutput": {
+          "action_arguments": {
+            "newname": "Uniprot_cRAP_SAV_indel_translatedbed.fasta"
+          },
+          "action_type": "RenameDatasetAction",
+          "output_name": "output"
+        }
+      },
+      "tool_id": "toolshed.g2.bx.psu.edu/repos/galaxyp/fasta_merge_files_and_filter_unique_sequences/fasta_merge_files_and_filter_unique_sequences/1.2.0",
+      "tool_shed_repository": {
+        "changeset_revision": "650d553c1fda",
+        "name": "fasta_merge_files_and_filter_unique_sequences",
+        "owner": "galaxyp",
+        "tool_shed": "toolshed.g2.bx.psu.edu"
+      },
+      "tool_state": "{\"batchmode\": \"{\\\"input_fastas\\\": [{\\\"__index__\\\": 0, \\\"input_fasta\\\": {\\\"__class__\\\": \\\"RuntimeValue\\\"}}, {\\\"__index__\\\": 1, \\\"input_fasta\\\": {\\\"__class__\\\": \\\"RuntimeValue\\\"}}, {\\\"__index__\\\": 2, \\\"input_fasta\\\": {\\\"__class__\\\": \\\"RuntimeValue\\\"}}], \\\"processmode\\\": \\\"individual\\\", \\\"__current_case__\\\": 0}\", \"__page__\": null, \"accession_parser\": \"\\\"^>[^ |]*[ |]([^ |]+).*$\\\"\", \"uniqueness_criterion\": \"\\\"sequence\\\"\", \"__rerun_remap_job_id__\": null}",
+      "tool_version": "1.2.0",
+      "type": "tool",
+      "uuid": "63bc2925-96db-424c-8621-c9bf3ec4d1a1",
+      "workflow_outputs": [
+        {
+          "label": null,
+          "output_name": "output",
+          "uuid": "72cc0e9a-963e-4b72-9cad-595421f3e035"
+        }
+      ]
+    },
+    "19": {
+      "annotation": "",
+      "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/query_tabular/query_tabular/2.0.0",
+      "errors": null,
+      "id": 19,
+      "input_connections": {
+        "tables_0|table": {
+          "id": 16,
+          "output_name": "out_file1"
+        }
+      },
+      "inputs": [
+        {
+          "description": "runtime parameter for tool Query Tabular",
+          "name": "add_to_database"
+        }
+      ],
+      "label": "Variant_Annotations",
+      "name": "Query Tabular",
+      "outputs": [
+        {
+          "name": "sqlitedb",
+          "type": "sqlite"
+        },
+        {
+          "name": "output",
+          "type": "tabular"
+        }
+      ],
+      "position": {
+        "left": 2403.484375,
+        "top": 506.03125
+      },
+      "post_job_actions": {
+        "HideDatasetActionoutput": {
+          "action_arguments": {},
+          "action_type": "HideDatasetAction",
+          "output_name": "output"
+        },
+        "RenameDatasetActionsqlitedb": {
+          "action_arguments": {
+            "newname": "Variant_annotation_sqlitedb"
+          },
+          "action_type": "RenameDatasetAction",
+          "output_name": "sqlitedb"
+        }
+      },
+      "tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/query_tabular/query_tabular/2.0.0",
+      "tool_shed_repository": {
+        "changeset_revision": "1ea4e668bf73",
+        "name": "query_tabular",
+        "owner": "iuc",
+        "tool_shed": "toolshed.g2.bx.psu.edu"
+      },
+      "tool_state": "{\"tables\": \"[{\\\"tbl_opts\\\": {\\\"pkey_autoincr\\\": \\\"\\\", \\\"load_named_columns\\\": \\\"false\\\", \\\"indexes\\\": [{\\\"__index__\\\": 0, \\\"unique\\\": \\\"false\\\", \\\"index_columns\\\": \\\"name,cigar\\\"}], \\\"table_name\\\": \\\"variant_annotation\\\", \\\"col_names\\\": \\\"name,reference,cigar,annotation\\\", \\\"column_names_from_first_line\\\": \\\"false\\\"}, \\\"__index__\\\": 0, \\\"input_opts\\\": {\\\"linefilters\\\": []}, \\\"table\\\": {\\\"__class__\\\": \\\"RuntimeValue\\\"}}]\", \"save_db\": \"\\\"true\\\"\", \"__page__\": null, \"__rerun_remap_job_id__\": null, \"sqlquery\": \"\\\"\\\"\", \"add_to_database\": \"{\\\"withdb\\\": {\\\"__class__\\\": \\\"RuntimeValue\\\"}}\", \"query_result\": \"{\\\"header\\\": \\\"no\\\", \\\"__current_case__\\\": 1}\", \"workdb\": \"\\\"workdb.sqlite\\\"\"}",
+      "tool_version": "2.0.0",
+      "type": "tool",
+      "uuid": "1bc44829-8f41-4437-a100-e4783fce0d9a",
+      "workflow_outputs": [
+        {
+          "label": null,
+          "output_name": "sqlitedb",
+          "uuid": "a84d0ca8-ae25-4092-ba26-95d95990df9c"
+        }
+      ]
+    },
+    "2": {
+      "annotation": "",
+      "content_id": null,
+      "errors": null,
+      "id": 2,
+      "input_connections": {},
+      "inputs": [],
+      "label": "Reference_5000UNIPROT_cRAP",
+      "name": "Input dataset",
+      "outputs": [],
+      "position": {
+        "left": 2670.015625,
+        "top": 290.421875
+      },
+      "tool_id": null,
+      "tool_state": "{}",
+      "tool_version": null,
+      "type": "data_input",
+      "uuid": "f61674c7-2b2c-4bdc-bf4e-30d30c477483",
+      "workflow_outputs": [
+        {
+          "label": null,
+          "output_name": "output",
+          "uuid": "6378f914-6d5d-4564-90bc-eac023ced219"
+        }
+      ]
+    },
+    "20": {
+      "annotation": "",
+      "content_id": "toolshed.g2.bx.psu.edu/repos/mvdbeek/concatenate_multiple_datasets/cat_multiple/0.2",
+      "errors": null,
+      "id": 20,
+      "input_connections": {
+        "input": [
+          {
+            "id": 17,
+            "output_name": "output"
+          },
+          {
+            "id": 14,
+            "output_name": "out_file1"
+          }
+        ]
+      },
+      "inputs": [
+        {
+          "description": "runtime parameter for tool Concatenate multiple datasets",
+          "name": "input"
+        }
+      ],
+      "label": null,
+      "name": "Concatenate multiple datasets",
+      "outputs": [
+        {
+          "name": "out_file1",
+          "type": "input"
+        }
+      ],
+      "position": {
+        "left": 2152.484375,
+        "top": 878
+      },
+      "post_job_actions": {
+        "HideDatasetActionout_file1": {
+          "action_arguments": {},
+          "action_type": "HideDatasetAction",
+          "output_name": "out_file1"
+        },
+        "RenameDatasetActionout_file1": {
+          "action_arguments": {
+            "newname": "Genomic_Protein_map"
+          },
+          "action_type": "RenameDatasetAction",
+          "output_name": "out_file1"
+        }
+      },
+      "tool_id": "toolshed.g2.bx.psu.edu/repos/mvdbeek/concatenate_multiple_datasets/cat_multiple/0.2",
+      "tool_shed_repository": {
+        "changeset_revision": "201c568972c3",
+        "name": "concatenate_multiple_datasets",
+        "owner": "mvdbeek",
+        "tool_shed": "toolshed.g2.bx.psu.edu"
+      },
+      "tool_state": "{\"input\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\", \"__rerun_remap_job_id__\": null, \"__page__\": null}",
+      "tool_version": "0.2",
+      "type": "tool",
+      "uuid": "07cb2802-2c24-4f62-936b-1f4d52b9a0f1",
+      "workflow_outputs": []
+    },
+    "21": {
+      "annotation": "",
+      "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/query_tabular/query_tabular/2.0.0",
+      "errors": null,
+      "id": 21,
+      "input_connections": {
+        "tables_0|table": {
+          "id": 20,
+          "output_name": "out_file1"
+        }
+      },
+      "inputs": [
+        {
+          "description": "runtime parameter for tool Query Tabular",
+          "name": "add_to_database"
+        }
+      ],
+      "label": "genomic_mapping_sqlite",
+      "name": "Query Tabular",
+      "outputs": [
+        {
+          "name": "sqlitedb",
+          "type": "sqlite"
+        },
+        {
+          "name": "output",
+          "type": "tabular"
+        }
+      ],
+      "position": {
+        "left": 2451.46875,
+        "top": 776.046875
+      },
+      "post_job_actions": {
+        "HideDatasetActionoutput": {
+          "action_arguments": {},
+          "action_type": "HideDatasetAction",
+          "output_name": "output"
+        },
+        "RenameDatasetActionsqlitedb": {
+          "action_arguments": {
+            "newname": "genomic_mapping_sqlite"
+          },
+          "action_type": "RenameDatasetAction",
+          "output_name": "sqlitedb"
+        }
+      },
+      "tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/query_tabular/query_tabular/2.0.0",
+      "tool_shed_repository": {
+        "changeset_revision": "1ea4e668bf73",
+        "name": "query_tabular",
+        "owner": "iuc",
+        "tool_shed": "toolshed.g2.bx.psu.edu"
+      },
+      "tool_state": "{\"tables\": \"[{\\\"tbl_opts\\\": {\\\"pkey_autoincr\\\": \\\"\\\", \\\"load_named_columns\\\": \\\"false\\\", \\\"indexes\\\": [{\\\"__index__\\\": 0, \\\"unique\\\": \\\"false\\\", \\\"index_columns\\\": \\\"name,cds_start,cds_end\\\"}], \\\"table_name\\\": \\\"feature_cds_map\\\", \\\"col_names\\\": \\\"name,chrom,start,end,strand,cds_start,cds_end\\\", \\\"column_names_from_first_line\\\": \\\"false\\\"}, \\\"__index__\\\": 0, \\\"input_opts\\\": {\\\"linefilters\\\": []}, \\\"table\\\": {\\\"__class__\\\": \\\"RuntimeValue\\\"}}]\", \"save_db\": \"\\\"true\\\"\", \"__page__\": null, \"__rerun_remap_job_id__\": null, \"sqlquery\": \"\\\"\\\"\", \"add_to_database\": \"{\\\"withdb\\\": {\\\"__class__\\\": \\\"RuntimeValue\\\"}}\", \"query_result\": \"{\\\"header\\\": \\\"no\\\", \\\"__current_case__\\\": 1}\", \"workdb\": \"\\\"workdb.sqlite\\\"\"}",
+      "tool_version": "2.0.0",
+      "type": "tool",
+      "uuid": "888eb7db-0773-453d-968b-d6df10b6a73b",
+      "workflow_outputs": [
+        {
+          "label": null,
+          "output_name": "sqlitedb",
+          "uuid": "0df8a509-3fb6-4154-8112-eb1bb21c03e5"
+        }
+      ]
+    },
+    "3": {
+      "annotation": "",
+      "content_id": "toolshed.g2.bx.psu.edu/repos/galaxyp/regex_find_replace/regexColumn1/1.0.0",
+      "errors": null,
+      "id": 3,
+      "input_connections": {
+        "input": {
+          "id": 1,
+          "output_name": "output"
+        }
+      },
+      "inputs": [
+        {
+          "description": "runtime parameter for tool Column Regex Find And Replace",
+          "name": "input"
+        }
+      ],
+      "label": "Chr_name_change",
+      "name": "Column Regex Find And Replace",
+      "outputs": [
+        {
+          "name": "out_file1",
+          "type": "input"
+        }
+      ],
+      "position": {
+        "left": 200,
+        "top": 787.46875
+      },
+      "post_job_actions": {
+        "HideDatasetActionout_file1": {
+          "action_arguments": {},
+          "action_type": "HideDatasetAction",
+          "output_name": "out_file1"
+        },
+        "RenameDatasetActionout_file1": {
+          "action_arguments": {
+            "newname": "Chr_adding2GTF"
+          },
+          "action_type": "RenameDatasetAction",
+          "output_name": "out_file1"
+        }
+      },
+      "tool_id": "toolshed.g2.bx.psu.edu/repos/galaxyp/regex_find_replace/regexColumn1/1.0.0",
+      "tool_shed_repository": {
+        "changeset_revision": "209b7c5ee9d7",
+        "name": "regex_find_replace",
+        "owner": "galaxyp",
+        "tool_shed": "toolshed.g2.bx.psu.edu"
+      },
+      "tool_state": "{\"__page__\": null, \"field\": \"\\\"1\\\"\", \"__rerun_remap_job_id__\": null, \"checks\": \"[{\\\"__index__\\\": 0, \\\"replacement\\\": \\\"chr\\\\\\\\1\\\", \\\"pattern\\\": \\\"^(\\\\\\\\d+)$\\\"}, {\\\"__index__\\\": 1, \\\"replacement\\\": \\\"chr\\\\\\\\1\\\", \\\"pattern\\\": \\\"^([XY])$\\\"}, {\\\"__index__\\\": 2, \\\"replacement\\\": \\\"chrM\\\", \\\"pattern\\\": \\\"^MT$\\\"}]\", \"input\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\"}",
+      "tool_version": "1.0.0",
+      "type": "tool",
+      "uuid": "73bb496c-9238-4347-a6b7-39f29ece5ee0",
+      "workflow_outputs": []
+    },
+    "4": {
+      "annotation": "",
+      "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/hisat2/hisat2/2.1.0",
+      "errors": null,
+      "id": 4,
+      "input_connections": {
+        "adv|spliced_options|known_splice_gtf": {
+          "id": 3,
+          "output_name": "out_file1"
+        },
+        "library|input_1": {
+          "id": 0,
+          "output_name": "output"
+        }
+      },
+      "inputs": [
+        {
+          "description": "runtime parameter for tool HISAT2",
+          "name": "library"
+        }
+      ],
+      "label": null,
+      "name": "HISAT2",
+      "outputs": [
+        {
+          "name": "output_alignments",
+          "type": "bam"
+        },
+        {
+          "name": "output_unaligned_reads_l",
+          "type": "fastqsanger"
+        },
+        {
+          "name": "output_aligned_reads_l",
+          "type": "fastqsanger"
+        },
+        {
+          "name": "output_unaligned_reads_r",
+          "type": "fastqsanger"
+        },
+        {
+          "name": "output_aligned_reads_r",
+          "type": "fastqsanger"
+        },
+        {
+          "name": "summary_file",
+          "type": "txt"
+        }
+      ],
+      "position": {
+        "left": 647.984375,
+        "top": 301.015625
+      },
+      "post_job_actions": {
+        "ChangeDatatypeActionoutput_alignments": {
+          "action_arguments": {
+            "newtype": "bam"
+          },
+          "action_type": "ChangeDatatypeAction",
+          "output_name": "output_alignments"
+        },
+        "HideDatasetActionoutput_aligned_reads_l": {
+          "action_arguments": {},
+          "action_type": "HideDatasetAction",
+          "output_name": "output_aligned_reads_l"
+        },
+        "HideDatasetActionoutput_aligned_reads_r": {
+          "action_arguments": {},
+          "action_type": "HideDatasetAction",
+          "output_name": "output_aligned_reads_r"
+        },
+        "HideDatasetActionoutput_unaligned_reads_l": {
+          "action_arguments": {},
+          "action_type": "HideDatasetAction",
+          "output_name": "output_unaligned_reads_l"
+        },
+        "HideDatasetActionoutput_unaligned_reads_r": {
+          "action_arguments": {},
+          "action_type": "HideDatasetAction",
+          "output_name": "output_unaligned_reads_r"
+        },
+        "RenameDatasetActionoutput_alignments": {
+          "action_arguments": {
+            "newname": "#{input_1|basename}.bam"
+          },
+          "action_type": "RenameDatasetAction",
+          "output_name": "output_alignments"
+        }
+      },
+      "tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/hisat2/hisat2/2.1.0",
+      "tool_shed_repository": {
+        "changeset_revision": "fbf98f24097b",
+        "name": "hisat2",
+        "owner": "iuc",
+        "tool_shed": "toolshed.g2.bx.psu.edu"
+      },
+      "tool_state": "{\"adv\": \"{\\\"alignment_options\\\": {\\\"__current_case__\\\": 0, \\\"alignment_options_selector\\\": \\\"defaults\\\"}, \\\"output_options\\\": {\\\"output_options_selector\\\": \\\"defaults\\\", \\\"__current_case__\\\": 0}, \\\"other_options\\\": {\\\"other_options_selector\\\": \\\"defaults\\\", \\\"__current_case__\\\": 0}, \\\"scoring_options\\\": {\\\"scoring_options_selector\\\": \\\"defaults\\\", \\\"__current_case__\\\": 0}, \\\"spliced_options\\\": {\\\"coefficient\\\": \\\"1.0\\\", \\\"canonical_penalty\\\": \\\"0\\\", \\\"no_spliced_alignment_options\\\": {\\\"no_spliced_alignment\\\": \\\"\\\", \\\"__current_case__\\\": 1}, \\\"nc_function_type\\\": \\\"G\\\", \\\"constant_term\\\": \\\"-8.0\\\", \\\"nc_coefficient\\\": \\\"1.0\\\", \\\"noncanonical_penalty\\\": \\\"12\\\", \\\"known_splice_gtf\\\": {\\\"__class__\\\": \\\"RuntimeValue\\\"}, \\\"nc_constant_term\\\": \\\"-8.0\\\", \\\"min_intron\\\": \\\"20\\\", \\\"function_type\\\": \\\"G\\\", \\\"__current_case__\\\": 1, \\\"notmplen\\\": \\\"false\\\", \\\"tma\\\": \\\"--dta\\\", \\\"max_intron\\\": \\\"500000\\\", \\\"spliced_options_selector\\\": \\\"advanced\\\"}, \\\"reporting_options\\\": {\\\"reporting_options_selector\\\": \\\"defaults\\\", \\\"__current_case__\\\": 0}, \\\"input_options\\\": {\\\"input_options_selector\\\": \\\"defaults\\\", \\\"__current_case__\\\": 0}}\", \"__page__\": null, \"sum\": \"{\\\"new_summary\\\": \\\"false\\\", \\\"summary_file\\\": \\\"false\\\"}\", \"library\": \"{\\\"rna_strandness\\\": \\\"\\\", \\\"type\\\": \\\"single\\\", \\\"__current_case__\\\": 0, \\\"input_1\\\": {\\\"__class__\\\": \\\"RuntimeValue\\\"}}\", \"reference_genome\": \"{\\\"source\\\": \\\"indexed\\\", \\\"__current_case__\\\": 0, \\\"index\\\": \\\"mm10\\\"}\", \"__rerun_remap_job_id__\": null}",
+      "tool_version": "2.1.0",
+      "type": "tool",
+      "uuid": "6927800f-5f0f-43a1-bcc7-223abd25555a",
+      "workflow_outputs": [
+        {
+          "label": null,
+          "output_name": "output_alignments",
+          "uuid": "00fe9e69-d41e-4332-b553-49983716dd1e"
+        },
+        {
+          "label": null,
+          "output_name": "summary_file",
+          "uuid": "6554a1ed-09c4-41da-b6a9-886e37ff904a"
+        }
+      ]
+    },
+    "5": {
+      "annotation": "",
+      "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/stringtie/stringtie/1.3.3.1",
+      "errors": null,
+      "id": 5,
+      "input_connections": {
+        "guide|guide_source|ref_hist": {
+          "id": 3,
+          "output_name": "out_file1"
+        },
+        "input_bam": {
+          "id": 4,
+          "output_name": "output_alignments"
+        }
+      },
+      "inputs": [
+        {
+          "description": "runtime parameter for tool StringTie",
+          "name": "input_bam"
+        }
+      ],
+      "label": null,
+      "name": "StringTie",
+      "outputs": [
+        {
+          "name": "output_gtf",
+          "type": "gtf"
+        },
+        {
+          "name": "gene_abundance_estimation",
+          "type": "gtf"
+        },
+        {
+          "name": "coverage",
+          "type": "gtf"
+        },
+        {
+          "name": "exon_expression",
+          "type": "tabular"
+        },
+        {
+          "name": "intron_expression",
+          "type": "tabular"
+        },
+        {
+          "name": "transcript_expression",
+          "type": "tabular"
+        },
+        {
+          "name": "exon_transcript_mapping",
+          "type": "tabular"
+        },
+        {
+          "name": "intron_transcript_mapping",
+          "type": "tabular"
+        },
+        {
+          "name": "gene_counts",
+          "type": "tabular"
+        },
+        {
+          "name": "transcript_counts",
+          "type": "tabular"
+        },
+        {
+          "name": "legend",
+          "type": "tabular"
+        }
+      ],
+      "position": {
+        "left": 652.984375,
+        "top": 631
+      },
+      "post_job_actions": {
+        "HideDatasetActioncoverage": {
+          "action_arguments": {},
+          "action_type": "HideDatasetAction",
+          "output_name": "coverage"
+        },
+        "HideDatasetActionexon_expression": {
+          "action_arguments": {},
+          "action_type": "HideDatasetAction",
+          "output_name": "exon_expression"
+        },
+        "HideDatasetActionexon_transcript_mapping": {
+          "action_arguments": {},
+          "action_type": "HideDatasetAction",
+          "output_name": "exon_transcript_mapping"
+        },
+        "HideDatasetActiongene_abundance_estimation": {
+          "action_arguments": {},
+          "action_type": "HideDatasetAction",
+          "output_name": "gene_abundance_estimation"
+        },
+        "HideDatasetActiongene_counts": {
+          "action_arguments": {},
+          "action_type": "HideDatasetAction",
+          "output_name": "gene_counts"
+        },
+        "HideDatasetActionintron_expression": {
+          "action_arguments": {},
+          "action_type": "HideDatasetAction",
+          "output_name": "intron_expression"
+        },
+        "HideDatasetActionintron_transcript_mapping": {
+          "action_arguments": {},
+          "action_type": "HideDatasetAction",
+          "output_name": "intron_transcript_mapping"
+        },
+        "HideDatasetActionlegend": {
+          "action_arguments": {},
+          "action_type": "HideDatasetAction",
+          "output_name": "legend"
+        },
+        "HideDatasetActiontranscript_counts": {
+          "action_arguments": {},
+          "action_type": "HideDatasetAction",
+          "output_name": "transcript_counts"
+        },
+        "HideDatasetActiontranscript_expression": {
+          "action_arguments": {},
+          "action_type": "HideDatasetAction",
+          "output_name": "transcript_expression"
+        },
+        "RenameDatasetActionoutput_gtf": {
+          "action_arguments": {
+            "newname": "StringTie_ProB.gtf"
+          },
+          "action_type": "RenameDatasetAction",
+          "output_name": "output_gtf"
+        }
+      },
+      "tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/stringtie/stringtie/1.3.3.1",
+      "tool_shed_repository": {
+        "changeset_revision": "76d290331481",
+        "name": "stringtie",
+        "owner": "iuc",
+        "tool_shed": "toolshed.g2.bx.psu.edu"
+      },
+      "tool_state": "{\"adv\": \"{\\\"min_bundle_cov\\\": \\\"2\\\", \\\"min_tlen\\\": \\\"200\\\", \\\"bdist\\\": \\\"50\\\", \\\"multi_mapping\\\": \\\"false\\\", \\\"abundance_estimation\\\": \\\"false\\\", \\\"fraction\\\": \\\"0.15\\\", \\\"disable_trimming\\\": \\\"false\\\", \\\"omit_sequences\\\": \\\"\\\", \\\"name_prefix\\\": \\\"\\\", \\\"min_anchor_len\\\": \\\"10\\\", \\\"bundle_fraction\\\": \\\"0.95\\\", \\\"min_anchor_cov\\\": \\\"1\\\"}\", \"__page__\": null, \"__rerun_remap_job_id__\": null, \"rna_strandness\": \"\\\"\\\"\", \"input_bam\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\", \"guide\": \"{\\\"guide_source\\\": {\\\"ref_hist\\\": {\\\"__class__\\\": \\\"RuntimeValue\\\"}, \\\"guide_gff_select\\\": \\\"history\\\", \\\"__current_case__\\\": 1}, \\\"use_guide\\\": \\\"yes\\\", \\\"coverage_file\\\": \\\"false\\\", \\\"__current_case__\\\": 1, \\\"special_outputs\\\": {\\\"__current_case__\\\": 2, \\\"special_outputs_select\\\": \\\"no\\\"}, \\\"input_estimation\\\": \\\"false\\\"}\"}",
+      "tool_version": "1.3.3.1",
+      "type": "tool",
+      "uuid": "52a055e7-e8aa-4224-a1f9-01c68a5e714a",
+      "workflow_outputs": [
+        {
+          "label": null,
+          "output_name": "output_gtf",
+          "uuid": "fc79dd16-0110-4b33-b2ca-7631bd92a2c7"
+        }
+      ]
+    },
+    "6": {
+      "annotation": "",
+      "content_id": "toolshed.g2.bx.psu.edu/repos/devteam/freebayes/freebayes/1.1.0.46-0",
+      "errors": null,
+      "id": 6,
+      "input_connections": {
+        "reference_source|batchmode|input_bams": {
+          "id": 4,
+          "output_name": "output_alignments"
+        }
+      },
+      "inputs": [],
+      "label": null,
+      "name": "FreeBayes",
+      "outputs": [
+        {
+          "name": "output_vcf",
+          "type": "vcf"
+        },
+        {
+          "name": "output_failed_alleles_bed",
+          "type": "bed"
+        },
+        {
+          "name": "output_trace",
+          "type": "txt"
+        }
+      ],
+      "position": {
+        "left": 969.984375,
+        "top": 431
+      },
+      "post_job_actions": {
+        "ChangeDatatypeActionoutput_vcf": {
+          "action_arguments": {
+            "newtype": "vcf"
+          },
+          "action_type": "ChangeDatatypeAction",
+          "output_name": "output_vcf"
+        },
+        "HideDatasetActionoutput_failed_alleles_bed": {
+          "action_arguments": {},
+          "action_type": "HideDatasetAction",
+          "output_name": "output_failed_alleles_bed"
+        },
+        "HideDatasetActionoutput_trace": {
+          "action_arguments": {},
+          "action_type": "HideDatasetAction",
+          "output_name": "output_trace"
+        },
+        "RenameDatasetActionoutput_vcf": {
+          "action_arguments": {
+            "newname": "ProB.vcf"
+          },
+          "action_type": "RenameDatasetAction",
+          "output_name": "output_vcf"
+        }
+      },
+      "tool_id": "toolshed.g2.bx.psu.edu/repos/devteam/freebayes/freebayes/1.1.0.46-0",
+      "tool_shed_repository": {
+        "changeset_revision": "156b60c1530f",
+        "name": "freebayes",
+        "owner": "devteam",
+        "tool_shed": "toolshed.g2.bx.psu.edu"
+      },
+      "tool_state": "{\"__page__\": null, \"reference_source\": \"{\\\"batchmode\\\": {\\\"input_bams\\\": {\\\"__class__\\\": \\\"RuntimeValue\\\"}, \\\"processmode\\\": \\\"individual\\\", \\\"__current_case__\\\": 0}, \\\"ref_file\\\": \\\"mm10\\\", \\\"reference_source_selector\\\": \\\"cached\\\", \\\"__current_case__\\\": 0}\", \"__rerun_remap_job_id__\": null, \"options_type\": \"{\\\"__current_case__\\\": 1, \\\"options_type_selector\\\": \\\"simple\\\"}\", \"target_limit_type\": \"{\\\"target_limit_type_selector\\\": \\\"do_not_limit\\\", \\\"__current_case__\\\": 0}\"}",
+      "tool_version": "1.1.0.46-0",
+      "type": "tool",
+      "uuid": "32c1e654-2f61-4c1c-a366-5a62a6c1efe2",
+      "workflow_outputs": [
+        {
+          "label": null,
+          "output_name": "output_vcf",
+          "uuid": "fc40b553-834c-4c4f-a2e5-e276cee02ddd"
+        }
+      ]
+    },
+    "7": {
+      "annotation": "",
+      "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/gffcompare/gffcompare/0.9.8",
+      "errors": null,
+      "id": 7,
+      "input_connections": {
+        "annotation|reference_annotation": {
+          "id": 3,
+          "output_name": "out_file1"
+        },
+        "inputs": {
+          "id": 5,
+          "output_name": "output_gtf"
+        }
+      },
+      "inputs": [
+        {
+          "description": "runtime parameter for tool GffCompare",
+          "name": "inputs"
+        },
+        {
+          "description": "runtime parameter for tool GffCompare",
+          "name": "annotation"
+        }
+      ],
+      "label": null,
+      "name": "GffCompare",
+      "outputs": [
+        {
+          "name": "transcripts_stats",
+          "type": "txt"
+        },
+        {
+          "name": "transcripts_loci",
+          "type": "tabular"
+        },
+        {
+          "name": "transcripts_tracking",
+          "type": "tabular"
+        },
+        {
+          "name": "transcripts_combined",
+          "type": "gtf"
+        },
+        {
+          "name": "transcripts_annotated",
+          "type": "gtf"
+        }
+      ],
+      "position": {
+        "left": 1139,
+        "top": 740.046875
+      },
+      "post_job_actions": {
+        "HideDatasetActiontranscripts_combined": {
+          "action_arguments": {},
+          "action_type": "HideDatasetAction",
+          "output_name": "transcripts_combined"
+        },
+        "HideDatasetActiontranscripts_loci": {
+          "action_arguments": {},
+          "action_type": "HideDatasetAction",
+          "output_name": "transcripts_loci"
+        },
+        "HideDatasetActiontranscripts_stats": {
+          "action_arguments": {},
+          "action_type": "HideDatasetAction",
+          "output_name": "transcripts_stats"
+        },
+        "HideDatasetActiontranscripts_tracking": {
+          "action_arguments": {},
+          "action_type": "HideDatasetAction",
+          "output_name": "transcripts_tracking"
+        },
+        "RenameDatasetActiontranscripts_annotated": {
+          "action_arguments": {
+            "newname": "GFFcompare_results"
+          },
+          "action_type": "RenameDatasetAction",
+          "output_name": "transcripts_annotated"
+        }
+      },
+      "tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/gffcompare/gffcompare/0.9.8",
+      "tool_shed_repository": {
+        "changeset_revision": "3c97c841a443",
+        "name": "gffcompare",
+        "owner": "iuc",
+        "tool_shed": "toolshed.g2.bx.psu.edu"
+      },
+      "tool_state": "{\"seq_data\": \"{\\\"use_seq_data\\\": \\\"No\\\", \\\"__current_case__\\\": 0}\", \"inputs\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\", \"max_dist_group\": \"\\\"100\\\"\", \"__page__\": null, \"max_dist_exon\": \"\\\"100\\\"\", \"__rerun_remap_job_id__\": null, \"discard_single_exon\": \"\\\"\\\"\", \"discard_intron_redundant_transfrags\": \"\\\"false\\\"\", \"annotation\": \"{\\\"reference_annotation\\\": {\\\"__class__\\\": \\\"RuntimeValue\\\"}, \\\"use_ref_annotation\\\": \\\"Yes\\\", \\\"ignore_nonoverlapping_reference\\\": \\\"false\\\", \\\"__current_case__\\\": 0, \\\"ignore_nonoverlapping_transfrags\\\": \\\"false\\\"}\"}",
+      "tool_version": "0.9.8",
+      "type": "tool",
+      "uuid": "a3282081-fa2c-45f2-a0d9-8657ca4ce01e",
+      "workflow_outputs": [
+        {
+          "label": null,
+          "output_name": "transcripts_annotated",
+          "uuid": "b126a129-5550-4b2a-818f-26d16193589e"
+        }
+      ]
+    },
+    "8": {
+      "annotation": "",
+      "content_id": "toolshed.g2.bx.psu.edu/repos/galaxyp/custom_pro_db/custom_pro_db/1.22.0",
+      "errors": null,
+      "id": 8,
+      "input_connections": {
+        "genome_annotation|bamInput": {
+          "id": 4,
+          "output_name": "output_alignments"
+        },
+        "genome_annotation|vcfInput": {
+          "id": 6,
+          "output_name": "output_vcf"
+        }
+      },
+      "inputs": [
+        {
+          "description": "runtime parameter for tool CustomProDB",
+          "name": "genome_annotation"
+        },
+        {
+          "description": "runtime parameter for tool CustomProDB",
+          "name": "genome_annotation"
+        }
+      ],
+      "label": null,
+      "name": "CustomProDB",
+      "outputs": [
+        {
+          "name": "output_rpkm",
+          "type": "fasta"
+        },
+        {
+          "name": "output_snv",
+          "type": "fasta"
+        },
+        {
+          "name": "output_indel",
+          "type": "fasta"
+        },
+        {
+          "name": "output_variant_annotation_rdata",
+          "type": "rdata"
+        },
+        {
+          "name": "output_genomic_mapping_sqlite",
+          "type": "sqlite"
+        },
+        {
+          "name": "output_variant_annotation_sqlite",
+          "type": "sqlite"
+        }
+      ],
+      "position": {
+        "left": 1317.96875,
+        "top": 329.015625
+      },
+      "post_job_actions": {
+        "HideDatasetActionoutput_genomic_mapping_sqlite": {
+          "action_arguments": {},
+          "action_type": "HideDatasetAction",
+          "output_name": "output_genomic_mapping_sqlite"
+        },
+        "HideDatasetActionoutput_indel": {
+          "action_arguments": {},
+          "action_type": "HideDatasetAction",
+          "output_name": "output_indel"
+        },
+        "HideDatasetActionoutput_rpkm": {
+          "action_arguments": {},
+          "action_type": "HideDatasetAction",
+          "output_name": "output_rpkm"
+        },
+        "HideDatasetActionoutput_snv": {
+          "action_arguments": {},
+          "action_type": "HideDatasetAction",
+          "output_name": "output_snv"
+        },
+        "HideDatasetActionoutput_variant_annotation_rdata": {
+          "action_arguments": {},
+          "action_type": "HideDatasetAction",
+          "output_name": "output_variant_annotation_rdata"
+        },
+        "HideDatasetActionoutput_variant_annotation_sqlite": {
+          "action_arguments": {},
+          "action_type": "HideDatasetAction",
+          "output_name": "output_variant_annotation_sqlite"
+        }
+      },
+      "tool_id": "toolshed.g2.bx.psu.edu/repos/galaxyp/custom_pro_db/custom_pro_db/1.22.0",
+      "tool_shed_repository": {
+        "changeset_revision": "2c7df0077d28",
+        "name": "custom_pro_db",
+        "owner": "galaxyp",
+        "tool_shed": "toolshed.g2.bx.psu.edu"
+      },
+      "tool_state": "{\"outputIndels\": \"\\\"true\\\"\", \"__page__\": null, \"outputSQLite\": \"\\\"true\\\"\", \"outputRData\": \"\\\"true\\\"\", \"genome_annotation\": \"{\\\"cosmic\\\": \\\"false\\\", \\\"bamInput\\\": {\\\"__class__\\\": \\\"RuntimeValue\\\"}, \\\"source\\\": \\\"builtin\\\", \\\"builtin\\\": \\\"mmusculus_gene_ensembl_89_dbsnp142\\\", \\\"__current_case__\\\": 0, \\\"vcfInput\\\": {\\\"__class__\\\": \\\"RuntimeValue\\\"}, \\\"dbsnpInCoding\\\": \\\"true\\\"}\", \"__rerun_remap_job_id__\": null, \"rpkmCutoff\": \"\\\"1.0\\\"\"}",
+      "tool_version": "1.16.1.0",
+      "type": "tool",
+      "uuid": "8a61b496-8961-4b74-a65a-8758939aa410",
+      "workflow_outputs": []
+    },
+    "9": {
+      "annotation": "",
+      "content_id": "toolshed.g2.bx.psu.edu/repos/galaxyp/gffcompare_to_bed/gffcompare_to_bed/0.1.0",
+      "errors": null,
+      "id": 9,
+      "input_connections": {
+        "input": {
+          "id": 7,
+          "output_name": "transcripts_annotated"
+        }
+      },
+      "inputs": [
+        {
+          "description": "runtime parameter for tool Convert gffCompare annotated GTF to BED",
+          "name": "input"
+        }
+      ],
+      "label": "GTF2BED",
+      "name": "Convert gffCompare annotated GTF to BED",
+      "outputs": [
+        {
+          "name": "output",
+          "type": "bed"
+        }
+      ],
+      "position": {
+        "left": 1472.921875,
+        "top": 849.046875
+      },
+      "post_job_actions": {
+        "HideDatasetActionoutput": {
+          "action_arguments": {},
+          "action_type": "HideDatasetAction",
+          "output_name": "output"
+        },
+        "RenameDatasetActionoutput": {
+          "action_arguments": {
+            "newname": "GTF2BED"
+          },
+          "action_type": "RenameDatasetAction",
+          "output_name": "output"
+        }
+      },
+      "tool_id": "toolshed.g2.bx.psu.edu/repos/galaxyp/gffcompare_to_bed/gffcompare_to_bed/0.1.0",
+      "tool_shed_repository": {
+        "changeset_revision": "7e572e148175",
+        "name": "gffcompare_to_bed",
+        "owner": "galaxyp",
+        "tool_shed": "toolshed.g2.bx.psu.edu"
+      },
+      "tool_state": "{\"input\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\", \"__rerun_remap_job_id__\": null, \"class_codes\": \"[\\\"j\\\", \\\"e\\\", \\\"i\\\", \\\"p\\\", \\\"u\\\"]\", \"__page__\": null}",
+      "tool_version": "0.1.0",
+      "type": "tool",
+      "uuid": "356cf12c-a3ae-4bd6-bc0d-330983084c93",
+      "workflow_outputs": []
+    }
+  },
+  "tags": [],
+  "uuid": "7ef9be1f-2e05-4309-a1ff-f2f6da1400d7"
+}

--- a/topics/proteomics/tutorials/proteogenomics-dbsearch/workflows/galaxy-workflow-mouse_rnaseq_dbsearch.ga
+++ b/topics/proteomics/tutorials/proteogenomics-dbsearch/workflows/galaxy-workflow-mouse_rnaseq_dbsearch.ga
@@ -1,1 +1,918 @@
-{"uuid": "62f3e5f9-d98b-415f-96b0-531085ff6476", "tags": [], "format-version": "0.1", "name": "Mouse_RNAseq_DBsearch", "steps": {"0": {"tool_id": null, "tool_version": null, "outputs": [], "workflow_outputs": [{"output_name": "output", "uuid": "d370dad2-e701-4976-850c-61d8e5427bb0", "label": null}], "input_connections": {}, "tool_state": "{}", "id": 0, "uuid": "1da7ddd9-7b32-4db0-ad96-84e8f51277de", "errors": null, "name": "Input dataset", "label": "RNA_seq_DB (Uniprot_cRAP_SAV_indel_translatedbed)", "inputs": [], "position": {"top": 457.078125, "left": 155.46875}, "annotation": "", "content_id": null, "type": "data_input"}, "1": {"tool_id": null, "tool_version": null, "outputs": [], "workflow_outputs": [{"output_name": "output", "uuid": "37f7ef68-3573-42a2-bf3a-f0c078a584c9", "label": null}], "input_connections": {}, "tool_state": "{\"collection_type\": \"list\"}", "id": 1, "uuid": "96b55c30-bae3-4c6a-8a8f-a118a64ec4ff", "errors": null, "name": "Input dataset collection", "label": "MGF", "inputs": [], "position": {"top": 580.5, "left": 115}, "annotation": "", "content_id": null, "type": "data_collection_input"}, "2": {"tool_id": null, "tool_version": null, "outputs": [], "workflow_outputs": [{"output_name": "output", "uuid": "bcda7abb-912b-4084-a9f4-a0172ee3af59", "label": null}], "input_connections": {}, "tool_state": "{}", "id": 2, "uuid": "c7f1f1b8-18eb-4ad1-9dce-e95f51df744d", "errors": null, "name": "Input dataset", "label": "Reference_5000UNIPROT_cRAP", "inputs": [], "position": {"top": 204.5, "left": 819.5}, "annotation": "", "content_id": null, "type": "data_input"}, "3": {"tool_id": "toolshed.g2.bx.psu.edu/repos/galaxyp/peptideshaker/search_gui/3.2.13.4", "tool_version": "3.2.13.4", "outputs": [{"type": "searchgui_archive", "name": "searchgui_results"}], "workflow_outputs": [{"output_name": "searchgui_results", "uuid": "a5c8ec25-0f78-407e-8302-ad876087b003", "label": null}], "input_connections": {"input_database": {"output_name": "output", "id": 0}, "peak_lists": {"output_name": "output", "id": 1}}, "tool_state": "{\"__page__\": null, \"peak_lists\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\", \"protein_database_options\": \"{\\\"update_gene_mapping\\\": \\\"false\\\", \\\"use_gene_mapping\\\": \\\"false\\\", \\\"create_decoy\\\": \\\"true\\\"}\", \"protein_digest_options\": \"{\\\"digestion\\\": {\\\"cleavage\\\": \\\"default\\\", \\\"missed_cleavages\\\": \\\"2\\\", \\\"__current_case__\\\": 0}}\", \"__rerun_remap_job_id__\": null, \"search_engines_options\": \"{\\\"engines\\\": [\\\"X!Tandem\\\"]}\", \"precursor_options\": \"{\\\"forward_ion\\\": \\\"b\\\", \\\"max_charge\\\": \\\"6\\\", \\\"fragment_tol_units\\\": \\\"0\\\", \\\"max_isotope\\\": \\\"1\\\", \\\"precursor_ion_tol_units\\\": \\\"1\\\", \\\"min_isotope\\\": \\\"0\\\", \\\"fragment_tol\\\": \\\"0.05\\\", \\\"min_charge\\\": \\\"2\\\", \\\"reverse_ion\\\": \\\"y\\\", \\\"precursor_ion_tol\\\": \\\"10.0\\\"}\", \"advanced_options\": \"{\\\"ms_amanda\\\": {\\\"ms_amanda_advanced\\\": \\\"no\\\", \\\"__current_case__\\\": 0}, \\\"searchgui_advanced\\\": {\\\"searchgui_advanced_selector\\\": \\\"basic\\\", \\\"__current_case__\\\": 0}, \\\"xtandem\\\": {\\\"xtandem_quick_acetyl\\\": \\\"false\\\", \\\"xtandem_min_peaks\\\": \\\"15\\\", \\\"xtandem_quick_pyro\\\": \\\"false\\\", \\\"xtandem_stp_bias\\\": \\\"false\\\", \\\"xtandem_advanced\\\": \\\"yes\\\", \\\"xtandem_dynamic_range\\\": \\\"100\\\", \\\"xtandem_min_prec_mass\\\": \\\"200\\\", \\\"xtandem_output_sequences\\\": \\\"false\\\", \\\"__current_case__\\\": 1, \\\"xtandem_output_proteins\\\": \\\"false\\\", \\\"xtandem_output_spectra\\\": \\\"true\\\", \\\"xtandem_npeaks\\\": \\\"50\\\", \\\"xtandem_noise_suppr\\\": \\\"true\\\", \\\"xtandem_min_frag_mz\\\": \\\"200\\\", \\\"xtandem_evalue\\\": \\\"100.0\\\", \\\"xtandem_refine\\\": {\\\"xtandem_refine_selector\\\": \\\"no\\\", \\\"__current_case__\\\": 0}}, \\\"tide\\\": {\\\"tide_advanced\\\": \\\"no\\\", \\\"__current_case__\\\": 0}, \\\"msgf\\\": {\\\"msgf_advanced\\\": \\\"no\\\", \\\"__current_case__\\\": 0}, \\\"directtag\\\": {\\\"directtag_advanced\\\": \\\"no\\\", \\\"__current_case__\\\": 0}, \\\"comet\\\": {\\\"comet_advanced\\\": \\\"no\\\", \\\"__current_case__\\\": 0}, \\\"omssa\\\": {\\\"omssa_advanced\\\": \\\"no\\\", \\\"__current_case__\\\": 0}, \\\"novor\\\": {\\\"novor_advanced\\\": \\\"no\\\", \\\"__current_case__\\\": 0}}\", \"input_database\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\", \"protein_modification_options\": \"{\\\"variable_modifications\\\": [\\\"Oxidation of M\\\", \\\"iTRAQ 4-plex of Y\\\"], \\\"fixed_modifications\\\": [\\\"Carbamidomethylation of C\\\", \\\"iTRAQ 4-plex of K\\\", \\\"iTRAQ 4-plex of peptide N-term\\\"]}\"}", "id": 3, "tool_shed_repository": {"owner": "galaxyp", "changeset_revision": "f35bb9d0c93e", "name": "peptideshaker", "tool_shed": "toolshed.g2.bx.psu.edu"}, "uuid": "2f25422b-bbf0-4e43-9a3d-23a67de432fd", "errors": null, "name": "Search GUI", "post_job_actions": {"RenameDatasetActionsearchgui_results": {"output_name": "searchgui_results", "action_type": "RenameDatasetAction", "action_arguments": {"newname": "SearchGUI_Output"}}}, "label": null, "inputs": [{"name": "peak_lists", "description": "runtime parameter for tool Search GUI"}, {"name": "input_database", "description": "runtime parameter for tool Search GUI"}], "position": {"top": 248.5, "left": 497.5}, "annotation": "", "content_id": "toolshed.g2.bx.psu.edu/repos/galaxyp/peptideshaker/search_gui/3.2.13.4", "type": "tool"}, "4": {"tool_id": "toolshed.g2.bx.psu.edu/repos/devteam/fasta_to_tabular/fasta2tab/1.1.0", "tool_version": "1.1.0", "outputs": [{"type": "tabular", "name": "output"}], "workflow_outputs": [], "input_connections": {"input": {"output_name": "output", "id": 2}}, "tool_state": "{\"input\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\", \"keep_first\": \"\\\"0\\\"\", \"__rerun_remap_job_id__\": null, \"descr_columns\": \"\\\"2\\\"\", \"__page__\": null}", "id": 4, "tool_shed_repository": {"owner": "devteam", "changeset_revision": "7e801ab2b70e", "name": "fasta_to_tabular", "tool_shed": "toolshed.g2.bx.psu.edu"}, "uuid": "8ab50b77-fd6a-4b85-bd05-d4d45efc627a", "errors": null, "name": "FASTA-to-Tabular", "post_job_actions": {"HideDatasetActionoutput": {"output_name": "output", "action_type": "HideDatasetAction", "action_arguments": {}}}, "label": null, "inputs": [{"name": "input", "description": "runtime parameter for tool FASTA-to-Tabular"}], "position": {"top": 329, "left": 836.5}, "annotation": "", "content_id": "toolshed.g2.bx.psu.edu/repos/devteam/fasta_to_tabular/fasta2tab/1.1.0", "type": "tool"}, "5": {"tool_id": "toolshed.g2.bx.psu.edu/repos/galaxyp/peptideshaker/peptide_shaker/1.16.17", "tool_version": "1.16.17", "outputs": [{"type": "mzid", "name": "mzidentML"}, {"type": "peptideshaker_archive", "name": "output_cps"}, {"type": "zip", "name": "output_zip"}, {"type": "txt", "name": "output_certificate"}, {"type": "tabular", "name": "output_hierarchical"}, {"type": "tabular", "name": "output_psm_phosphorylation"}, {"type": "tabular", "name": "output_psm"}, {"type": "tabular", "name": "output_extended_psm"}, {"type": "tabular", "name": "output_peptides_phosphorylation"}, {"type": "tabular", "name": "output_peptides"}, {"type": "tabular", "name": "output_proteins_phosphorylation"}, {"type": "tabular", "name": "output_proteins"}], "workflow_outputs": [{"output_name": "mzidentML", "uuid": "5868e504-5ea5-46b8-bb2e-a00c161e35f8", "label": null}, {"output_name": "output_psm", "uuid": "f3b5bede-649d-45ef-b8b4-95b43dbe7973", "label": null}], "input_connections": {"searchgui_input": {"output_name": "searchgui_results", "id": 3}}, "tool_state": "{\"__page__\": null, \"outputs\": \"[\\\"mzidentML\\\", \\\"3\\\", \\\"5\\\", \\\"7\\\", \\\"0\\\"]\", \"__rerun_remap_job_id__\": null, \"filtering_options\": \"{\\\"max_precursor_error_type\\\": \\\"1\\\", \\\"filtering_options_selector\\\": \\\"yes\\\", \\\"__current_case__\\\": 1, \\\"max_precursor_error\\\": \\\"10.0\\\", \\\"exclude_unknown_ptms\\\": \\\"true\\\", \\\"max_peptide_length\\\": \\\"30\\\", \\\"min_peptide_length\\\": \\\"6\\\"}\", \"searchgui_input\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\", \"contact_options\": \"{\\\"contact_options_selector\\\": \\\"no\\\", \\\"__current_case__\\\": 0}\", \"processing_options\": \"{\\\"processing_options_selector\\\": \\\"no\\\", \\\"__current_case__\\\": 0}\", \"include_sequences\": \"\\\"false\\\"\"}", "id": 5, "tool_shed_repository": {"owner": "galaxyp", "changeset_revision": "f35bb9d0c93e", "name": "peptideshaker", "tool_shed": "toolshed.g2.bx.psu.edu"}, "uuid": "59cb75cb-3de7-4407-ba38-82f9c8e49deb", "errors": null, "name": "Peptide Shaker", "post_job_actions": {"HideDatasetActionoutput_proteins": {"output_name": "output_proteins", "action_type": "HideDatasetAction", "action_arguments": {}}, "HideDatasetActionoutput_psm_phosphorylation": {"output_name": "output_psm_phosphorylation", "action_type": "HideDatasetAction", "action_arguments": {}}, "RenameDatasetActionoutput_peptides": {"output_name": "output_peptides", "action_type": "RenameDatasetAction", "action_arguments": {"newname": "PeptideShaker_peptides"}}, "RenameDatasetActionoutput_proteins": {"output_name": "output_proteins", "action_type": "RenameDatasetAction", "action_arguments": {"newname": "PeptideShaker_proteins"}}, "HideDatasetActionoutput_peptides": {"output_name": "output_peptides", "action_type": "HideDatasetAction", "action_arguments": {}}, "HideDatasetActionoutput_cps": {"output_name": "output_cps", "action_type": "HideDatasetAction", "action_arguments": {}}, "HideDatasetActionoutput_proteins_phosphorylation": {"output_name": "output_proteins_phosphorylation", "action_type": "HideDatasetAction", "action_arguments": {}}, "HideDatasetActionoutput_extended_psm": {"output_name": "output_extended_psm", "action_type": "HideDatasetAction", "action_arguments": {}}, "HideDatasetActionoutput_peptides_phosphorylation": {"output_name": "output_peptides_phosphorylation", "action_type": "HideDatasetAction", "action_arguments": {}}, "HideDatasetActionoutput_hierarchical": {"output_name": "output_hierarchical", "action_type": "HideDatasetAction", "action_arguments": {}}, "HideDatasetActionoutput_zip": {"output_name": "output_zip", "action_type": "HideDatasetAction", "action_arguments": {}}, "RenameDatasetActionoutput_psm": {"output_name": "output_psm", "action_type": "RenameDatasetAction", "action_arguments": {"newname": "PeptideShaker_PSM"}}, "RenameDatasetActionoutput_certificate": {"output_name": "output_certificate", "action_type": "RenameDatasetAction", "action_arguments": {"newname": "PeptideShaker_logfile"}}, "HideDatasetActionoutput_certificate": {"output_name": "output_certificate", "action_type": "HideDatasetAction", "action_arguments": {}}, "RenameDatasetActionoutput_zip": {"output_name": "output_zip", "action_type": "RenameDatasetAction", "action_arguments": {"newname": "PeptideShaker_zip"}}, "RenameDatasetActionmzidentML": {"output_name": "mzidentML", "action_type": "RenameDatasetAction", "action_arguments": {"newname": "PeptideShaker_mzidentml"}}}, "label": null, "inputs": [{"name": "searchgui_input", "description": "runtime parameter for tool Peptide Shaker"}], "position": {"top": 403.5, "left": 468.5}, "annotation": "", "content_id": "toolshed.g2.bx.psu.edu/repos/galaxyp/peptideshaker/peptide_shaker/1.16.17", "type": "tool"}, "6": {"tool_id": "Cut1", "tool_version": "1.0.2", "outputs": [{"type": "tabular", "name": "out_file1"}], "workflow_outputs": [], "input_connections": {"input": {"output_name": "output", "id": 4}}, "tool_state": "{\"columnList\": \"\\\"c1\\\"\", \"input\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\", \"delimiter\": \"\\\"T\\\"\", \"__rerun_remap_job_id__\": null, \"__page__\": null}", "id": 6, "uuid": "6a75b6ec-b6ab-4e3e-8785-a365e81f21ea", "errors": null, "name": "Cut", "post_job_actions": {"HideDatasetActionout_file1": {"output_name": "out_file1", "action_type": "HideDatasetAction", "action_arguments": {}}}, "label": null, "inputs": [{"name": "input", "description": "runtime parameter for tool Cut"}], "position": {"top": 435, "left": 820.5}, "annotation": "", "content_id": "Cut1", "type": "tool"}, "7": {"tool_id": "toolshed.g2.bx.psu.edu/repos/galaxyp/mz_to_sqlite/mz_to_sqlite/2.0.0", "tool_version": "2.0.0", "outputs": [{"type": "mz.sqlite", "name": "sqlite_db"}], "workflow_outputs": [{"output_name": "mzsqlite", "uuid": "2c84fce6-1a3c-478a-8874-e9bdc1e29ac4", "label": null}, {"output_name": "sqlite_db", "uuid": "31596320-24c8-4170-ab9e-91ba5ec5fe37", "label": null}], "input_connections": {"mzinput": {"output_name": "mzidentML", "id": 5}, "searchdbs": {"output_name": "output", "id": 0}, "scanfiles": {"output_name": "output", "id": 1}}, "tool_state": "{\"mzinput\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\", \"__page__\": null, \"__rerun_remap_job_id__\": null, \"mzinputs\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\", \"searchdbs\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\", \"scanfiles\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\"}", "id": 7, "tool_shed_repository": {"owner": "galaxyp", "changeset_revision": "e34bdac5b157", "name": "mz_to_sqlite", "tool_shed": "toolshed.g2.bx.psu.edu"}, "uuid": "fc64ff6f-2335-48f2-b2a4-ede525ed0475", "errors": null, "name": "mz to sqlite", "post_job_actions": {}, "label": null, "inputs": [{"name": "mzinput", "description": "runtime parameter for tool mz to sqlite"}, {"name": "searchdbs", "description": "runtime parameter for tool mz to sqlite"}, {"name": "scanfiles", "description": "runtime parameter for tool mz to sqlite"}], "position": {"top": 856, "left": 490.5}, "annotation": "", "content_id": "toolshed.g2.bx.psu.edu/repos/galaxyp/mz_to_sqlite/mz_to_sqlite/2.0.0", "type": "tool"}, "8": {"tool_id": "Convert characters1", "tool_version": "1.0.0", "outputs": [{"type": "tabular", "name": "out_file1"}], "workflow_outputs": [], "input_connections": {"input": {"output_name": "out_file1", "id": 6}}, "tool_state": "{\"__page__\": null, \"__rerun_remap_job_id__\": null, \"condense\": \"\\\"true\\\"\", \"strip\": \"\\\"true\\\"\", \"input\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\", \"convert_from\": \"\\\"s\\\"\"}", "id": 8, "uuid": "f6503170-53cd-4c4c-b1e3-082e94a5c281", "errors": null, "name": "Convert", "post_job_actions": {"HideDatasetActionout_file1": {"output_name": "out_file1", "action_type": "HideDatasetAction", "action_arguments": {}}}, "label": null, "inputs": [{"name": "input", "description": "runtime parameter for tool Convert"}], "position": {"top": 540, "left": 817.5}, "annotation": "", "content_id": "Convert characters1", "type": "tool"}, "9": {"tool_id": "Cut1", "tool_version": "1.0.2", "outputs": [{"type": "tabular", "name": "out_file1"}], "workflow_outputs": [], "input_connections": {"input": {"output_name": "out_file1", "id": 8}}, "tool_state": "{\"columnList\": \"\\\"c2\\\"\", \"input\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\", \"delimiter\": \"\\\"P\\\"\", \"__rerun_remap_job_id__\": null, \"__page__\": null}", "id": 9, "uuid": "0333ed3f-0027-487c-9f98-debad7b861ba", "errors": null, "name": "Cut", "post_job_actions": {"HideDatasetActionout_file1": {"output_name": "out_file1", "action_type": "HideDatasetAction", "action_arguments": {}}}, "label": null, "inputs": [{"name": "input", "description": "runtime parameter for tool Cut"}], "position": {"top": 657, "left": 819.5}, "annotation": "", "content_id": "Cut1", "type": "tool"}, "10": {"tool_id": "Convert characters1", "tool_version": "1.0.0", "outputs": [{"type": "tabular", "name": "out_file1"}], "workflow_outputs": [], "input_connections": {"input": {"output_name": "out_file1", "id": 9}}, "tool_state": "{\"__page__\": null, \"__rerun_remap_job_id__\": null, \"condense\": \"\\\"true\\\"\", \"strip\": \"\\\"true\\\"\", \"input\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\", \"convert_from\": \"\\\"Dt\\\"\"}", "id": 10, "uuid": "46f3b28d-c5d3-44f4-847c-5a2a9b9d51b6", "errors": null, "name": "Convert", "post_job_actions": {"HideDatasetActionout_file1": {"output_name": "out_file1", "action_type": "HideDatasetAction", "action_arguments": {}}}, "label": null, "inputs": [{"name": "input", "description": "runtime parameter for tool Convert"}], "position": {"top": 775, "left": 820.5}, "annotation": "", "content_id": "Convert characters1", "type": "tool"}, "11": {"tool_id": "Grouping1", "tool_version": "2.1.1", "outputs": [{"type": "tabular", "name": "out_file1"}], "workflow_outputs": [], "input_connections": {"input1": {"output_name": "out_file1", "id": 10}}, "tool_state": "{\"operations\": \"[]\", \"__page__\": null, \"input1\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\", \"ignorelines\": \"null\", \"groupcol\": \"\\\"1\\\"\", \"__rerun_remap_job_id__\": null, \"ignorecase\": \"\\\"false\\\"\"}", "id": 11, "uuid": "ff2b6af2-ea72-41bd-b37e-005c05510ee5", "errors": null, "name": "Group", "post_job_actions": {"HideDatasetActionout_file1": {"output_name": "out_file1", "action_type": "HideDatasetAction", "action_arguments": {}}}, "label": null, "inputs": [{"name": "input1", "description": "runtime parameter for tool Group"}], "position": {"top": 894, "left": 829.5}, "annotation": "", "content_id": "Grouping1", "type": "tool"}, "12": {"tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/query_tabular/query_tabular/2.0.0", "tool_version": "2.0.0", "outputs": [{"type": "sqlite", "name": "sqlitedb"}, {"type": "tabular", "name": "output"}], "workflow_outputs": [], "input_connections": {"tables_1|table": {"output_name": "output_psm", "id": 5}, "tables_2|table": {"output_name": "output_psm", "id": 5}, "tables_0|table": {"output_name": "out_file1", "id": 11}}, "tool_state": "{\"tables\": \"[{\\\"tbl_opts\\\": {\\\"pkey_autoincr\\\": \\\"\\\", \\\"load_named_columns\\\": \\\"true\\\", \\\"indexes\\\": [{\\\"__index__\\\": 0, \\\"unique\\\": \\\"false\\\", \\\"index_columns\\\": \\\"prot\\\"}], \\\"table_name\\\": \\\"uniprot\\\", \\\"col_names\\\": \\\"prot\\\", \\\"column_names_from_first_line\\\": \\\"false\\\"}, \\\"__index__\\\": 0, \\\"input_opts\\\": {\\\"linefilters\\\": []}, \\\"table\\\": {\\\"__class__\\\": \\\"RuntimeValue\\\"}}, {\\\"tbl_opts\\\": {\\\"pkey_autoincr\\\": \\\"\\\", \\\"load_named_columns\\\": \\\"true\\\", \\\"indexes\\\": [{\\\"__index__\\\": 0, \\\"unique\\\": \\\"false\\\", \\\"index_columns\\\": \\\"id\\\"}], \\\"table_name\\\": \\\"psms\\\", \\\"col_names\\\": \\\"id,Proteins,Sequence\\\", \\\"column_names_from_first_line\\\": \\\"false\\\"}, \\\"__index__\\\": 1, \\\"input_opts\\\": {\\\"linefilters\\\": [{\\\"filter\\\": {\\\"skip_lines\\\": \\\"1\\\", \\\"__current_case__\\\": 0, \\\"filter_type\\\": \\\"skip\\\"}, \\\"__index__\\\": 0}]}, \\\"table\\\": {\\\"__class__\\\": \\\"RuntimeValue\\\"}}, {\\\"tbl_opts\\\": {\\\"pkey_autoincr\\\": \\\"\\\", \\\"load_named_columns\\\": \\\"true\\\", \\\"indexes\\\": [{\\\"__index__\\\": 0, \\\"unique\\\": \\\"false\\\", \\\"index_columns\\\": \\\"id,prot\\\"}, {\\\"__index__\\\": 1, \\\"unique\\\": \\\"false\\\", \\\"index_columns\\\": \\\"prot,id\\\"}], \\\"table_name\\\": \\\"prots\\\", \\\"col_names\\\": \\\"id,prot\\\", \\\"column_names_from_first_line\\\": \\\"false\\\"}, \\\"__index__\\\": 2, \\\"input_opts\\\": {\\\"linefilters\\\": [{\\\"filter\\\": {\\\"skip_lines\\\": \\\"1\\\", \\\"__current_case__\\\": 0, \\\"filter_type\\\": \\\"skip\\\"}, \\\"__index__\\\": 0}, {\\\"filter\\\": {\\\"columns\\\": \\\"1,2\\\", \\\"__current_case__\\\": 7, \\\"filter_type\\\": \\\"select_columns\\\"}, \\\"__index__\\\": 1}, {\\\"filter\\\": {\\\"columns\\\": \\\"2\\\", \\\"separator\\\": \\\",\\\", \\\"__current_case__\\\": 9, \\\"filter_type\\\": \\\"normalize\\\"}, \\\"__index__\\\": 2}]}, \\\"table\\\": {\\\"__class__\\\": \\\"RuntimeValue\\\"}}]\", \"save_db\": \"\\\"false\\\"\", \"__page__\": null, \"__rerun_remap_job_id__\": null, \"sqlquery\": \"\\\"SELECT psms.* \\\\nFROM psms \\\\nWHERE psms.id NOT IN \\\\n  (SELECT distinct prots.id \\\\n   FROM prots JOIN uniprot ON prots.prot = uniprot.prot) \\\\nORDER BY psms.id\\\"\", \"add_to_database\": \"{\\\"withdb\\\": {\\\"__class__\\\": \\\"RuntimeValue\\\"}}\", \"query_result\": \"{\\\"header\\\": \\\"yes\\\", \\\"header_prefix\\\": \\\"35\\\", \\\"__current_case__\\\": 0}\", \"workdb\": \"\\\"workdb.sqlite\\\"\"}", "id": 12, "tool_shed_repository": {"owner": "iuc", "changeset_revision": "1ea4e668bf73", "name": "query_tabular", "tool_shed": "toolshed.g2.bx.psu.edu"}, "uuid": "7de635ab-4196-43d4-aa98-bacb4dc560c5", "errors": null, "name": "Query Tabular", "post_job_actions": {"HideDatasetActionsqlitedb": {"output_name": "sqlitedb", "action_type": "HideDatasetAction", "action_arguments": {}}, "HideDatasetActionoutput": {"output_name": "output", "action_type": "HideDatasetAction", "action_arguments": {}}, "RenameDatasetActionoutput": {"output_name": "output", "action_type": "RenameDatasetAction", "action_arguments": {"newname": "Removing_Reference_Proteins"}}}, "label": "Removing_Reference_Proteins", "inputs": [{"name": "add_to_database", "description": "runtime parameter for tool Query Tabular"}], "position": {"top": 200, "left": 1140.5}, "annotation": "", "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/query_tabular/query_tabular/2.0.0", "type": "tool"}, "13": {"tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/query_tabular/query_tabular/2.0.0", "tool_version": "2.0.0", "outputs": [{"type": "sqlite", "name": "sqlitedb"}, {"type": "tabular", "name": "output"}], "workflow_outputs": [{"output_name": "output", "uuid": "e3ba96d5-99e4-4f9b-8ca7-be82ab65120f", "label": null}], "input_connections": {"tables_0|table": {"output_name": "output", "id": 12}}, "tool_state": "{\"tables\": \"[{\\\"tbl_opts\\\": {\\\"pkey_autoincr\\\": \\\"\\\", \\\"load_named_columns\\\": \\\"true\\\", \\\"indexes\\\": [], \\\"table_name\\\": \\\"psm\\\", \\\"col_names\\\": \\\"id,Proteins,Sequence\\\", \\\"column_names_from_first_line\\\": \\\"false\\\"}, \\\"__index__\\\": 0, \\\"input_opts\\\": {\\\"linefilters\\\": [{\\\"filter\\\": {\\\"skip_lines\\\": \\\"1\\\", \\\"__current_case__\\\": 0, \\\"filter_type\\\": \\\"skip\\\"}, \\\"__index__\\\": 0}]}, \\\"table\\\": {\\\"__class__\\\": \\\"RuntimeValue\\\"}}]\", \"save_db\": \"\\\"false\\\"\", \"__page__\": null, \"__rerun_remap_job_id__\": null, \"sqlquery\": \"\\\"SELECT Sequence || ' PSM=' || group_concat(id,',') || ' length=' || length(Sequence) as \\\\\\\"ID\\\\\\\",Sequence\\\\nFROM  psm\\\\nWHERE length(Sequence) >6  \\\\nAND length(Sequence) <= 30\\\\nGROUP BY Sequence \\\\nORDER BY length(Sequence),Sequence\\\"\", \"add_to_database\": \"{\\\"withdb\\\": {\\\"__class__\\\": \\\"RuntimeValue\\\"}}\", \"query_result\": \"{\\\"header\\\": \\\"yes\\\", \\\"header_prefix\\\": \\\"35\\\", \\\"__current_case__\\\": 0}\", \"workdb\": \"\\\"workdb.sqlite\\\"\"}", "id": 13, "tool_shed_repository": {"owner": "iuc", "changeset_revision": "1ea4e668bf73", "name": "query_tabular", "tool_shed": "toolshed.g2.bx.psu.edu"}, "uuid": "ab358467-99b2-43b9-b3fc-b5bea2129b5e", "errors": null, "name": "Query Tabular", "post_job_actions": {"HideDatasetActionsqlitedb": {"output_name": "sqlitedb", "action_type": "HideDatasetAction", "action_arguments": {}}, "RenameDatasetActionoutput": {"output_name": "output", "action_type": "RenameDatasetAction", "action_arguments": {"newname": "Peptides_for_Blast-P_analysis"}}}, "label": "Peptides_for_Blast-P", "inputs": [{"name": "add_to_database", "description": "runtime parameter for tool Query Tabular"}], "position": {"top": 571, "left": 1213.5}, "annotation": "", "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/query_tabular/query_tabular/2.0.0", "type": "tool"}, "14": {"tool_id": "toolshed.g2.bx.psu.edu/repos/devteam/tabular_to_fasta/tab2fasta/1.1.0", "tool_version": "1.1.0", "outputs": [{"type": "fasta", "name": "output"}], "workflow_outputs": [{"output_name": "output", "uuid": "d2ddc11a-2d23-4eb4-987d-c6c720d2b7bd", "label": null}], "input_connections": {"input": {"output_name": "output", "id": 13}}, "tool_state": "{\"title_col\": \"null\", \"seq_col\": \"\\\"1\\\"\", \"__page__\": null, \"__rerun_remap_job_id__\": null, \"input\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\"}", "id": 14, "tool_shed_repository": {"owner": "devteam", "changeset_revision": "0b4e36026794", "name": "tabular_to_fasta", "tool_shed": "toolshed.g2.bx.psu.edu"}, "uuid": "6691769b-2c8f-4cb1-bd62-3dbad0c8e805", "errors": null, "name": "Tabular-to-FASTA", "post_job_actions": {}, "label": null, "inputs": [{"name": "input", "description": "runtime parameter for tool Tabular-to-FASTA"}], "position": {"top": 578, "left": 1529}, "annotation": "", "content_id": "toolshed.g2.bx.psu.edu/repos/devteam/tabular_to_fasta/tab2fasta/1.1.0", "type": "tool"}, "15": {"tool_id": "toolshed.g2.bx.psu.edu/repos/devteam/ncbi_blast_plus/ncbi_blastp_wrapper/0.3.1", "tool_version": "0.3.1", "outputs": [{"type": "tabular", "name": "output1"}], "workflow_outputs": [], "input_connections": {"query": {"output_name": "output", "id": 14}}, "tool_state": "{\"evalue_cutoff\": \"\\\"200000.0\\\"\", \"__page__\": null, \"adv_opts\": \"{\\\"adv_optional_id_files_opts\\\": {\\\"__current_case__\\\": 0, \\\"adv_optional_id_files_opts_selector\\\": \\\"none\\\"}, \\\"use_sw_tback\\\": \\\"false\\\", \\\"matrix_gapcosts\\\": {\\\"gap_costs\\\": \\\"-gapopen 9 -gapextend 1\\\", \\\"matrix\\\": \\\"PAM30\\\", \\\"__current_case__\\\": 8}, \\\"parse_deflines\\\": \\\"false\\\", \\\"max_hsps\\\": \\\"1\\\", \\\"adv_opts_selector\\\": \\\"advanced\\\", \\\"comp_based_stats\\\": \\\"0\\\", \\\"window_size\\\": \\\"40\\\", \\\"filter_query\\\": \\\"false\\\", \\\"word_size\\\": \\\"2\\\", \\\"__current_case__\\\": 1, \\\"threshold\\\": \\\"11\\\", \\\"qcov_hsp_perc\\\": \\\"0.0\\\", \\\"max_hits\\\": \\\"1\\\"}\", \"__rerun_remap_job_id__\": null, \"db_opts\": \"{\\\"db_opts_selector\\\": \\\"db\\\", \\\"subject\\\": \\\"\\\", \\\"histdb\\\": \\\"\\\", \\\"__current_case__\\\": 0, \\\"database\\\": [\\\"nr_mouse_current\\\"]}\", \"query\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\", \"blast_type\": \"\\\"blastp-short\\\"\", \"output\": \"{\\\"out_format\\\": \\\"ext\\\", \\\"__current_case__\\\": 1}\"}", "id": 15, "tool_shed_repository": {"owner": "devteam", "changeset_revision": "e25d3acf6e68", "name": "ncbi_blast_plus", "tool_shed": "toolshed.g2.bx.psu.edu"}, "uuid": "d1468b56-2613-4a3a-8a5d-e28a60a7bb18", "errors": null, "name": "NCBI BLAST+ blastp", "post_job_actions": {"HideDatasetActionoutput1": {"output_name": "output1", "action_type": "HideDatasetAction", "action_arguments": {}}}, "label": null, "inputs": [{"name": "query", "description": "runtime parameter for tool NCBI BLAST+ blastp"}], "position": {"top": 571, "left": 1756.5}, "annotation": "", "content_id": "toolshed.g2.bx.psu.edu/repos/devteam/ncbi_blast_plus/ncbi_blastp_wrapper/0.3.1", "type": "tool"}}, "annotation": "", "a_galaxy_workflow": "true"}
+{
+  "a_galaxy_workflow": "true",
+  "annotation": "",
+  "format-version": "0.1",
+  "name": "Mouse_RNAseq_DBsearch",
+  "steps": {
+    "0": {
+      "annotation": "",
+      "content_id": null,
+      "errors": null,
+      "id": 0,
+      "input_connections": {},
+      "inputs": [],
+      "label": "RNA_seq_DB (Uniprot_cRAP_SAV_indel_translatedbed)",
+      "name": "Input dataset",
+      "outputs": [],
+      "position": {
+        "left": 155.46875,
+        "top": 457.078125
+      },
+      "tool_id": null,
+      "tool_state": "{}",
+      "tool_version": null,
+      "type": "data_input",
+      "uuid": "1da7ddd9-7b32-4db0-ad96-84e8f51277de",
+      "workflow_outputs": [
+        {
+          "label": null,
+          "output_name": "output",
+          "uuid": "d370dad2-e701-4976-850c-61d8e5427bb0"
+        }
+      ]
+    },
+    "1": {
+      "annotation": "",
+      "content_id": null,
+      "errors": null,
+      "id": 1,
+      "input_connections": {},
+      "inputs": [],
+      "label": "MGF",
+      "name": "Input dataset collection",
+      "outputs": [],
+      "position": {
+        "left": 115,
+        "top": 580.5
+      },
+      "tool_id": null,
+      "tool_state": "{\"collection_type\": \"list\"}",
+      "tool_version": null,
+      "type": "data_collection_input",
+      "uuid": "96b55c30-bae3-4c6a-8a8f-a118a64ec4ff",
+      "workflow_outputs": [
+        {
+          "label": null,
+          "output_name": "output",
+          "uuid": "37f7ef68-3573-42a2-bf3a-f0c078a584c9"
+        }
+      ]
+    },
+    "10": {
+      "annotation": "",
+      "content_id": "Convert characters1",
+      "errors": null,
+      "id": 10,
+      "input_connections": {
+        "input": {
+          "id": 9,
+          "output_name": "out_file1"
+        }
+      },
+      "inputs": [
+        {
+          "description": "runtime parameter for tool Convert",
+          "name": "input"
+        }
+      ],
+      "label": null,
+      "name": "Convert",
+      "outputs": [
+        {
+          "name": "out_file1",
+          "type": "tabular"
+        }
+      ],
+      "position": {
+        "left": 820.5,
+        "top": 775
+      },
+      "post_job_actions": {
+        "HideDatasetActionout_file1": {
+          "action_arguments": {},
+          "action_type": "HideDatasetAction",
+          "output_name": "out_file1"
+        }
+      },
+      "tool_id": "Convert characters1",
+      "tool_state": "{\"__page__\": null, \"__rerun_remap_job_id__\": null, \"condense\": \"\\\"true\\\"\", \"strip\": \"\\\"true\\\"\", \"input\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\", \"convert_from\": \"\\\"Dt\\\"\"}",
+      "tool_version": "1.0.0",
+      "type": "tool",
+      "uuid": "46f3b28d-c5d3-44f4-847c-5a2a9b9d51b6",
+      "workflow_outputs": []
+    },
+    "11": {
+      "annotation": "",
+      "content_id": "Grouping1",
+      "errors": null,
+      "id": 11,
+      "input_connections": {
+        "input1": {
+          "id": 10,
+          "output_name": "out_file1"
+        }
+      },
+      "inputs": [
+        {
+          "description": "runtime parameter for tool Group",
+          "name": "input1"
+        }
+      ],
+      "label": null,
+      "name": "Group",
+      "outputs": [
+        {
+          "name": "out_file1",
+          "type": "tabular"
+        }
+      ],
+      "position": {
+        "left": 829.5,
+        "top": 894
+      },
+      "post_job_actions": {
+        "HideDatasetActionout_file1": {
+          "action_arguments": {},
+          "action_type": "HideDatasetAction",
+          "output_name": "out_file1"
+        }
+      },
+      "tool_id": "Grouping1",
+      "tool_state": "{\"operations\": \"[]\", \"__page__\": null, \"input1\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\", \"ignorelines\": \"null\", \"groupcol\": \"\\\"1\\\"\", \"__rerun_remap_job_id__\": null, \"ignorecase\": \"\\\"false\\\"\"}",
+      "tool_version": "2.1.1",
+      "type": "tool",
+      "uuid": "ff2b6af2-ea72-41bd-b37e-005c05510ee5",
+      "workflow_outputs": []
+    },
+    "12": {
+      "annotation": "",
+      "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/query_tabular/query_tabular/2.0.0",
+      "errors": null,
+      "id": 12,
+      "input_connections": {
+        "tables_0|table": {
+          "id": 11,
+          "output_name": "out_file1"
+        },
+        "tables_1|table": {
+          "id": 5,
+          "output_name": "output_psm"
+        },
+        "tables_2|table": {
+          "id": 5,
+          "output_name": "output_psm"
+        }
+      },
+      "inputs": [
+        {
+          "description": "runtime parameter for tool Query Tabular",
+          "name": "add_to_database"
+        }
+      ],
+      "label": "Removing_Reference_Proteins",
+      "name": "Query Tabular",
+      "outputs": [
+        {
+          "name": "sqlitedb",
+          "type": "sqlite"
+        },
+        {
+          "name": "output",
+          "type": "tabular"
+        }
+      ],
+      "position": {
+        "left": 1140.5,
+        "top": 200
+      },
+      "post_job_actions": {
+        "HideDatasetActionoutput": {
+          "action_arguments": {},
+          "action_type": "HideDatasetAction",
+          "output_name": "output"
+        },
+        "HideDatasetActionsqlitedb": {
+          "action_arguments": {},
+          "action_type": "HideDatasetAction",
+          "output_name": "sqlitedb"
+        },
+        "RenameDatasetActionoutput": {
+          "action_arguments": {
+            "newname": "Removing_Reference_Proteins"
+          },
+          "action_type": "RenameDatasetAction",
+          "output_name": "output"
+        }
+      },
+      "tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/query_tabular/query_tabular/2.0.0",
+      "tool_shed_repository": {
+        "changeset_revision": "1ea4e668bf73",
+        "name": "query_tabular",
+        "owner": "iuc",
+        "tool_shed": "toolshed.g2.bx.psu.edu"
+      },
+      "tool_state": "{\"tables\": \"[{\\\"tbl_opts\\\": {\\\"pkey_autoincr\\\": \\\"\\\", \\\"load_named_columns\\\": \\\"true\\\", \\\"indexes\\\": [{\\\"__index__\\\": 0, \\\"unique\\\": \\\"false\\\", \\\"index_columns\\\": \\\"prot\\\"}], \\\"table_name\\\": \\\"uniprot\\\", \\\"col_names\\\": \\\"prot\\\", \\\"column_names_from_first_line\\\": \\\"false\\\"}, \\\"__index__\\\": 0, \\\"input_opts\\\": {\\\"linefilters\\\": []}, \\\"table\\\": {\\\"__class__\\\": \\\"RuntimeValue\\\"}}, {\\\"tbl_opts\\\": {\\\"pkey_autoincr\\\": \\\"\\\", \\\"load_named_columns\\\": \\\"true\\\", \\\"indexes\\\": [{\\\"__index__\\\": 0, \\\"unique\\\": \\\"false\\\", \\\"index_columns\\\": \\\"id\\\"}], \\\"table_name\\\": \\\"psms\\\", \\\"col_names\\\": \\\"id,Proteins,Sequence\\\", \\\"column_names_from_first_line\\\": \\\"false\\\"}, \\\"__index__\\\": 1, \\\"input_opts\\\": {\\\"linefilters\\\": [{\\\"filter\\\": {\\\"skip_lines\\\": \\\"1\\\", \\\"__current_case__\\\": 0, \\\"filter_type\\\": \\\"skip\\\"}, \\\"__index__\\\": 0}]}, \\\"table\\\": {\\\"__class__\\\": \\\"RuntimeValue\\\"}}, {\\\"tbl_opts\\\": {\\\"pkey_autoincr\\\": \\\"\\\", \\\"load_named_columns\\\": \\\"true\\\", \\\"indexes\\\": [{\\\"__index__\\\": 0, \\\"unique\\\": \\\"false\\\", \\\"index_columns\\\": \\\"id,prot\\\"}, {\\\"__index__\\\": 1, \\\"unique\\\": \\\"false\\\", \\\"index_columns\\\": \\\"prot,id\\\"}], \\\"table_name\\\": \\\"prots\\\", \\\"col_names\\\": \\\"id,prot\\\", \\\"column_names_from_first_line\\\": \\\"false\\\"}, \\\"__index__\\\": 2, \\\"input_opts\\\": {\\\"linefilters\\\": [{\\\"filter\\\": {\\\"skip_lines\\\": \\\"1\\\", \\\"__current_case__\\\": 0, \\\"filter_type\\\": \\\"skip\\\"}, \\\"__index__\\\": 0}, {\\\"filter\\\": {\\\"columns\\\": \\\"1,2\\\", \\\"__current_case__\\\": 7, \\\"filter_type\\\": \\\"select_columns\\\"}, \\\"__index__\\\": 1}, {\\\"filter\\\": {\\\"columns\\\": \\\"2\\\", \\\"separator\\\": \\\",\\\", \\\"__current_case__\\\": 9, \\\"filter_type\\\": \\\"normalize\\\"}, \\\"__index__\\\": 2}]}, \\\"table\\\": {\\\"__class__\\\": \\\"RuntimeValue\\\"}}]\", \"save_db\": \"\\\"false\\\"\", \"__page__\": null, \"__rerun_remap_job_id__\": null, \"sqlquery\": \"\\\"SELECT psms.* \\\\nFROM psms \\\\nWHERE psms.id NOT IN \\\\n  (SELECT distinct prots.id \\\\n   FROM prots JOIN uniprot ON prots.prot = uniprot.prot) \\\\nORDER BY psms.id\\\"\", \"add_to_database\": \"{\\\"withdb\\\": {\\\"__class__\\\": \\\"RuntimeValue\\\"}}\", \"query_result\": \"{\\\"header\\\": \\\"yes\\\", \\\"header_prefix\\\": \\\"35\\\", \\\"__current_case__\\\": 0}\", \"workdb\": \"\\\"workdb.sqlite\\\"\"}",
+      "tool_version": "2.0.0",
+      "type": "tool",
+      "uuid": "7de635ab-4196-43d4-aa98-bacb4dc560c5",
+      "workflow_outputs": []
+    },
+    "13": {
+      "annotation": "",
+      "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/query_tabular/query_tabular/2.0.0",
+      "errors": null,
+      "id": 13,
+      "input_connections": {
+        "tables_0|table": {
+          "id": 12,
+          "output_name": "output"
+        }
+      },
+      "inputs": [
+        {
+          "description": "runtime parameter for tool Query Tabular",
+          "name": "add_to_database"
+        }
+      ],
+      "label": "Peptides_for_Blast-P",
+      "name": "Query Tabular",
+      "outputs": [
+        {
+          "name": "sqlitedb",
+          "type": "sqlite"
+        },
+        {
+          "name": "output",
+          "type": "tabular"
+        }
+      ],
+      "position": {
+        "left": 1213.5,
+        "top": 571
+      },
+      "post_job_actions": {
+        "HideDatasetActionsqlitedb": {
+          "action_arguments": {},
+          "action_type": "HideDatasetAction",
+          "output_name": "sqlitedb"
+        },
+        "RenameDatasetActionoutput": {
+          "action_arguments": {
+            "newname": "Peptides_for_Blast-P_analysis"
+          },
+          "action_type": "RenameDatasetAction",
+          "output_name": "output"
+        }
+      },
+      "tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/query_tabular/query_tabular/2.0.0",
+      "tool_shed_repository": {
+        "changeset_revision": "1ea4e668bf73",
+        "name": "query_tabular",
+        "owner": "iuc",
+        "tool_shed": "toolshed.g2.bx.psu.edu"
+      },
+      "tool_state": "{\"tables\": \"[{\\\"tbl_opts\\\": {\\\"pkey_autoincr\\\": \\\"\\\", \\\"load_named_columns\\\": \\\"true\\\", \\\"indexes\\\": [], \\\"table_name\\\": \\\"psm\\\", \\\"col_names\\\": \\\"id,Proteins,Sequence\\\", \\\"column_names_from_first_line\\\": \\\"false\\\"}, \\\"__index__\\\": 0, \\\"input_opts\\\": {\\\"linefilters\\\": [{\\\"filter\\\": {\\\"skip_lines\\\": \\\"1\\\", \\\"__current_case__\\\": 0, \\\"filter_type\\\": \\\"skip\\\"}, \\\"__index__\\\": 0}]}, \\\"table\\\": {\\\"__class__\\\": \\\"RuntimeValue\\\"}}]\", \"save_db\": \"\\\"false\\\"\", \"__page__\": null, \"__rerun_remap_job_id__\": null, \"sqlquery\": \"\\\"SELECT Sequence || ' PSM=' || group_concat(id,',') || ' length=' || length(Sequence) as \\\\\\\"ID\\\\\\\",Sequence\\\\nFROM  psm\\\\nWHERE length(Sequence) >6  \\\\nAND length(Sequence) <= 30\\\\nGROUP BY Sequence \\\\nORDER BY length(Sequence),Sequence\\\"\", \"add_to_database\": \"{\\\"withdb\\\": {\\\"__class__\\\": \\\"RuntimeValue\\\"}}\", \"query_result\": \"{\\\"header\\\": \\\"yes\\\", \\\"header_prefix\\\": \\\"35\\\", \\\"__current_case__\\\": 0}\", \"workdb\": \"\\\"workdb.sqlite\\\"\"}",
+      "tool_version": "2.0.0",
+      "type": "tool",
+      "uuid": "ab358467-99b2-43b9-b3fc-b5bea2129b5e",
+      "workflow_outputs": [
+        {
+          "label": null,
+          "output_name": "output",
+          "uuid": "e3ba96d5-99e4-4f9b-8ca7-be82ab65120f"
+        }
+      ]
+    },
+    "14": {
+      "annotation": "",
+      "content_id": "toolshed.g2.bx.psu.edu/repos/devteam/tabular_to_fasta/tab2fasta/1.1.0",
+      "errors": null,
+      "id": 14,
+      "input_connections": {
+        "input": {
+          "id": 13,
+          "output_name": "output"
+        }
+      },
+      "inputs": [
+        {
+          "description": "runtime parameter for tool Tabular-to-FASTA",
+          "name": "input"
+        }
+      ],
+      "label": null,
+      "name": "Tabular-to-FASTA",
+      "outputs": [
+        {
+          "name": "output",
+          "type": "fasta"
+        }
+      ],
+      "position": {
+        "left": 1529,
+        "top": 578
+      },
+      "post_job_actions": {},
+      "tool_id": "toolshed.g2.bx.psu.edu/repos/devteam/tabular_to_fasta/tab2fasta/1.1.0",
+      "tool_shed_repository": {
+        "changeset_revision": "0b4e36026794",
+        "name": "tabular_to_fasta",
+        "owner": "devteam",
+        "tool_shed": "toolshed.g2.bx.psu.edu"
+      },
+      "tool_state": "{\"title_col\": \"null\", \"seq_col\": \"\\\"1\\\"\", \"__page__\": null, \"__rerun_remap_job_id__\": null, \"input\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\"}",
+      "tool_version": "1.1.0",
+      "type": "tool",
+      "uuid": "6691769b-2c8f-4cb1-bd62-3dbad0c8e805",
+      "workflow_outputs": [
+        {
+          "label": null,
+          "output_name": "output",
+          "uuid": "d2ddc11a-2d23-4eb4-987d-c6c720d2b7bd"
+        }
+      ]
+    },
+    "15": {
+      "annotation": "",
+      "content_id": "toolshed.g2.bx.psu.edu/repos/devteam/ncbi_blast_plus/ncbi_blastp_wrapper/0.3.1",
+      "errors": null,
+      "id": 15,
+      "input_connections": {
+        "query": {
+          "id": 14,
+          "output_name": "output"
+        }
+      },
+      "inputs": [
+        {
+          "description": "runtime parameter for tool NCBI BLAST+ blastp",
+          "name": "query"
+        }
+      ],
+      "label": null,
+      "name": "NCBI BLAST+ blastp",
+      "outputs": [
+        {
+          "name": "output1",
+          "type": "tabular"
+        }
+      ],
+      "position": {
+        "left": 1756.5,
+        "top": 571
+      },
+      "post_job_actions": {
+        "HideDatasetActionoutput1": {
+          "action_arguments": {},
+          "action_type": "HideDatasetAction",
+          "output_name": "output1"
+        }
+      },
+      "tool_id": "toolshed.g2.bx.psu.edu/repos/devteam/ncbi_blast_plus/ncbi_blastp_wrapper/0.3.1",
+      "tool_shed_repository": {
+        "changeset_revision": "e25d3acf6e68",
+        "name": "ncbi_blast_plus",
+        "owner": "devteam",
+        "tool_shed": "toolshed.g2.bx.psu.edu"
+      },
+      "tool_state": "{\"evalue_cutoff\": \"\\\"200000.0\\\"\", \"__page__\": null, \"adv_opts\": \"{\\\"adv_optional_id_files_opts\\\": {\\\"__current_case__\\\": 0, \\\"adv_optional_id_files_opts_selector\\\": \\\"none\\\"}, \\\"use_sw_tback\\\": \\\"false\\\", \\\"matrix_gapcosts\\\": {\\\"gap_costs\\\": \\\"-gapopen 9 -gapextend 1\\\", \\\"matrix\\\": \\\"PAM30\\\", \\\"__current_case__\\\": 8}, \\\"parse_deflines\\\": \\\"false\\\", \\\"max_hsps\\\": \\\"1\\\", \\\"adv_opts_selector\\\": \\\"advanced\\\", \\\"comp_based_stats\\\": \\\"0\\\", \\\"window_size\\\": \\\"40\\\", \\\"filter_query\\\": \\\"false\\\", \\\"word_size\\\": \\\"2\\\", \\\"__current_case__\\\": 1, \\\"threshold\\\": \\\"11\\\", \\\"qcov_hsp_perc\\\": \\\"0.0\\\", \\\"max_hits\\\": \\\"1\\\"}\", \"__rerun_remap_job_id__\": null, \"db_opts\": \"{\\\"db_opts_selector\\\": \\\"db\\\", \\\"subject\\\": \\\"\\\", \\\"histdb\\\": \\\"\\\", \\\"__current_case__\\\": 0, \\\"database\\\": [\\\"nr_mouse_current\\\"]}\", \"query\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\", \"blast_type\": \"\\\"blastp-short\\\"\", \"output\": \"{\\\"out_format\\\": \\\"ext\\\", \\\"__current_case__\\\": 1}\"}",
+      "tool_version": "0.3.1",
+      "type": "tool",
+      "uuid": "d1468b56-2613-4a3a-8a5d-e28a60a7bb18",
+      "workflow_outputs": []
+    },
+    "2": {
+      "annotation": "",
+      "content_id": null,
+      "errors": null,
+      "id": 2,
+      "input_connections": {},
+      "inputs": [],
+      "label": "Reference_5000UNIPROT_cRAP",
+      "name": "Input dataset",
+      "outputs": [],
+      "position": {
+        "left": 819.5,
+        "top": 204.5
+      },
+      "tool_id": null,
+      "tool_state": "{}",
+      "tool_version": null,
+      "type": "data_input",
+      "uuid": "c7f1f1b8-18eb-4ad1-9dce-e95f51df744d",
+      "workflow_outputs": [
+        {
+          "label": null,
+          "output_name": "output",
+          "uuid": "bcda7abb-912b-4084-a9f4-a0172ee3af59"
+        }
+      ]
+    },
+    "3": {
+      "annotation": "",
+      "content_id": "toolshed.g2.bx.psu.edu/repos/galaxyp/peptideshaker/search_gui/3.2.13.4",
+      "errors": null,
+      "id": 3,
+      "input_connections": {
+        "input_database": {
+          "id": 0,
+          "output_name": "output"
+        },
+        "peak_lists": {
+          "id": 1,
+          "output_name": "output"
+        }
+      },
+      "inputs": [
+        {
+          "description": "runtime parameter for tool Search GUI",
+          "name": "peak_lists"
+        },
+        {
+          "description": "runtime parameter for tool Search GUI",
+          "name": "input_database"
+        }
+      ],
+      "label": null,
+      "name": "Search GUI",
+      "outputs": [
+        {
+          "name": "searchgui_results",
+          "type": "searchgui_archive"
+        }
+      ],
+      "position": {
+        "left": 497.5,
+        "top": 248.5
+      },
+      "post_job_actions": {
+        "RenameDatasetActionsearchgui_results": {
+          "action_arguments": {
+            "newname": "SearchGUI_Output"
+          },
+          "action_type": "RenameDatasetAction",
+          "output_name": "searchgui_results"
+        }
+      },
+      "tool_id": "toolshed.g2.bx.psu.edu/repos/galaxyp/peptideshaker/search_gui/3.2.13.4",
+      "tool_shed_repository": {
+        "changeset_revision": "f35bb9d0c93e",
+        "name": "peptideshaker",
+        "owner": "galaxyp",
+        "tool_shed": "toolshed.g2.bx.psu.edu"
+      },
+      "tool_state": "{\"__page__\": null, \"peak_lists\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\", \"protein_database_options\": \"{\\\"update_gene_mapping\\\": \\\"false\\\", \\\"use_gene_mapping\\\": \\\"false\\\", \\\"create_decoy\\\": \\\"true\\\"}\", \"protein_digest_options\": \"{\\\"digestion\\\": {\\\"cleavage\\\": \\\"default\\\", \\\"missed_cleavages\\\": \\\"2\\\", \\\"__current_case__\\\": 0}}\", \"__rerun_remap_job_id__\": null, \"search_engines_options\": \"{\\\"engines\\\": [\\\"X!Tandem\\\"]}\", \"precursor_options\": \"{\\\"forward_ion\\\": \\\"b\\\", \\\"max_charge\\\": \\\"6\\\", \\\"fragment_tol_units\\\": \\\"0\\\", \\\"max_isotope\\\": \\\"1\\\", \\\"precursor_ion_tol_units\\\": \\\"1\\\", \\\"min_isotope\\\": \\\"0\\\", \\\"fragment_tol\\\": \\\"0.05\\\", \\\"min_charge\\\": \\\"2\\\", \\\"reverse_ion\\\": \\\"y\\\", \\\"precursor_ion_tol\\\": \\\"10.0\\\"}\", \"advanced_options\": \"{\\\"ms_amanda\\\": {\\\"ms_amanda_advanced\\\": \\\"no\\\", \\\"__current_case__\\\": 0}, \\\"searchgui_advanced\\\": {\\\"searchgui_advanced_selector\\\": \\\"basic\\\", \\\"__current_case__\\\": 0}, \\\"xtandem\\\": {\\\"xtandem_quick_acetyl\\\": \\\"false\\\", \\\"xtandem_min_peaks\\\": \\\"15\\\", \\\"xtandem_quick_pyro\\\": \\\"false\\\", \\\"xtandem_stp_bias\\\": \\\"false\\\", \\\"xtandem_advanced\\\": \\\"yes\\\", \\\"xtandem_dynamic_range\\\": \\\"100\\\", \\\"xtandem_min_prec_mass\\\": \\\"200\\\", \\\"xtandem_output_sequences\\\": \\\"false\\\", \\\"__current_case__\\\": 1, \\\"xtandem_output_proteins\\\": \\\"false\\\", \\\"xtandem_output_spectra\\\": \\\"true\\\", \\\"xtandem_npeaks\\\": \\\"50\\\", \\\"xtandem_noise_suppr\\\": \\\"true\\\", \\\"xtandem_min_frag_mz\\\": \\\"200\\\", \\\"xtandem_evalue\\\": \\\"100.0\\\", \\\"xtandem_refine\\\": {\\\"xtandem_refine_selector\\\": \\\"no\\\", \\\"__current_case__\\\": 0}}, \\\"tide\\\": {\\\"tide_advanced\\\": \\\"no\\\", \\\"__current_case__\\\": 0}, \\\"msgf\\\": {\\\"msgf_advanced\\\": \\\"no\\\", \\\"__current_case__\\\": 0}, \\\"directtag\\\": {\\\"directtag_advanced\\\": \\\"no\\\", \\\"__current_case__\\\": 0}, \\\"comet\\\": {\\\"comet_advanced\\\": \\\"no\\\", \\\"__current_case__\\\": 0}, \\\"omssa\\\": {\\\"omssa_advanced\\\": \\\"no\\\", \\\"__current_case__\\\": 0}, \\\"novor\\\": {\\\"novor_advanced\\\": \\\"no\\\", \\\"__current_case__\\\": 0}}\", \"input_database\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\", \"protein_modification_options\": \"{\\\"variable_modifications\\\": [\\\"Oxidation of M\\\", \\\"iTRAQ 4-plex of Y\\\"], \\\"fixed_modifications\\\": [\\\"Carbamidomethylation of C\\\", \\\"iTRAQ 4-plex of K\\\", \\\"iTRAQ 4-plex of peptide N-term\\\"]}\"}",
+      "tool_version": "3.2.13.4",
+      "type": "tool",
+      "uuid": "2f25422b-bbf0-4e43-9a3d-23a67de432fd",
+      "workflow_outputs": [
+        {
+          "label": null,
+          "output_name": "searchgui_results",
+          "uuid": "a5c8ec25-0f78-407e-8302-ad876087b003"
+        }
+      ]
+    },
+    "4": {
+      "annotation": "",
+      "content_id": "toolshed.g2.bx.psu.edu/repos/devteam/fasta_to_tabular/fasta2tab/1.1.0",
+      "errors": null,
+      "id": 4,
+      "input_connections": {
+        "input": {
+          "id": 2,
+          "output_name": "output"
+        }
+      },
+      "inputs": [
+        {
+          "description": "runtime parameter for tool FASTA-to-Tabular",
+          "name": "input"
+        }
+      ],
+      "label": null,
+      "name": "FASTA-to-Tabular",
+      "outputs": [
+        {
+          "name": "output",
+          "type": "tabular"
+        }
+      ],
+      "position": {
+        "left": 836.5,
+        "top": 329
+      },
+      "post_job_actions": {
+        "HideDatasetActionoutput": {
+          "action_arguments": {},
+          "action_type": "HideDatasetAction",
+          "output_name": "output"
+        }
+      },
+      "tool_id": "toolshed.g2.bx.psu.edu/repos/devteam/fasta_to_tabular/fasta2tab/1.1.0",
+      "tool_shed_repository": {
+        "changeset_revision": "7e801ab2b70e",
+        "name": "fasta_to_tabular",
+        "owner": "devteam",
+        "tool_shed": "toolshed.g2.bx.psu.edu"
+      },
+      "tool_state": "{\"input\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\", \"keep_first\": \"\\\"0\\\"\", \"__rerun_remap_job_id__\": null, \"descr_columns\": \"\\\"2\\\"\", \"__page__\": null}",
+      "tool_version": "1.1.0",
+      "type": "tool",
+      "uuid": "8ab50b77-fd6a-4b85-bd05-d4d45efc627a",
+      "workflow_outputs": []
+    },
+    "5": {
+      "annotation": "",
+      "content_id": "toolshed.g2.bx.psu.edu/repos/galaxyp/peptideshaker/peptide_shaker/1.16.17",
+      "errors": null,
+      "id": 5,
+      "input_connections": {
+        "searchgui_input": {
+          "id": 3,
+          "output_name": "searchgui_results"
+        }
+      },
+      "inputs": [
+        {
+          "description": "runtime parameter for tool Peptide Shaker",
+          "name": "searchgui_input"
+        }
+      ],
+      "label": null,
+      "name": "Peptide Shaker",
+      "outputs": [
+        {
+          "name": "mzidentML",
+          "type": "mzid"
+        },
+        {
+          "name": "output_cps",
+          "type": "peptideshaker_archive"
+        },
+        {
+          "name": "output_zip",
+          "type": "zip"
+        },
+        {
+          "name": "output_certificate",
+          "type": "txt"
+        },
+        {
+          "name": "output_hierarchical",
+          "type": "tabular"
+        },
+        {
+          "name": "output_psm_phosphorylation",
+          "type": "tabular"
+        },
+        {
+          "name": "output_psm",
+          "type": "tabular"
+        },
+        {
+          "name": "output_extended_psm",
+          "type": "tabular"
+        },
+        {
+          "name": "output_peptides_phosphorylation",
+          "type": "tabular"
+        },
+        {
+          "name": "output_peptides",
+          "type": "tabular"
+        },
+        {
+          "name": "output_proteins_phosphorylation",
+          "type": "tabular"
+        },
+        {
+          "name": "output_proteins",
+          "type": "tabular"
+        }
+      ],
+      "position": {
+        "left": 468.5,
+        "top": 403.5
+      },
+      "post_job_actions": {
+        "HideDatasetActionoutput_certificate": {
+          "action_arguments": {},
+          "action_type": "HideDatasetAction",
+          "output_name": "output_certificate"
+        },
+        "HideDatasetActionoutput_cps": {
+          "action_arguments": {},
+          "action_type": "HideDatasetAction",
+          "output_name": "output_cps"
+        },
+        "HideDatasetActionoutput_extended_psm": {
+          "action_arguments": {},
+          "action_type": "HideDatasetAction",
+          "output_name": "output_extended_psm"
+        },
+        "HideDatasetActionoutput_hierarchical": {
+          "action_arguments": {},
+          "action_type": "HideDatasetAction",
+          "output_name": "output_hierarchical"
+        },
+        "HideDatasetActionoutput_peptides": {
+          "action_arguments": {},
+          "action_type": "HideDatasetAction",
+          "output_name": "output_peptides"
+        },
+        "HideDatasetActionoutput_peptides_phosphorylation": {
+          "action_arguments": {},
+          "action_type": "HideDatasetAction",
+          "output_name": "output_peptides_phosphorylation"
+        },
+        "HideDatasetActionoutput_proteins": {
+          "action_arguments": {},
+          "action_type": "HideDatasetAction",
+          "output_name": "output_proteins"
+        },
+        "HideDatasetActionoutput_proteins_phosphorylation": {
+          "action_arguments": {},
+          "action_type": "HideDatasetAction",
+          "output_name": "output_proteins_phosphorylation"
+        },
+        "HideDatasetActionoutput_psm_phosphorylation": {
+          "action_arguments": {},
+          "action_type": "HideDatasetAction",
+          "output_name": "output_psm_phosphorylation"
+        },
+        "HideDatasetActionoutput_zip": {
+          "action_arguments": {},
+          "action_type": "HideDatasetAction",
+          "output_name": "output_zip"
+        },
+        "RenameDatasetActionmzidentML": {
+          "action_arguments": {
+            "newname": "PeptideShaker_mzidentml"
+          },
+          "action_type": "RenameDatasetAction",
+          "output_name": "mzidentML"
+        },
+        "RenameDatasetActionoutput_certificate": {
+          "action_arguments": {
+            "newname": "PeptideShaker_logfile"
+          },
+          "action_type": "RenameDatasetAction",
+          "output_name": "output_certificate"
+        },
+        "RenameDatasetActionoutput_peptides": {
+          "action_arguments": {
+            "newname": "PeptideShaker_peptides"
+          },
+          "action_type": "RenameDatasetAction",
+          "output_name": "output_peptides"
+        },
+        "RenameDatasetActionoutput_proteins": {
+          "action_arguments": {
+            "newname": "PeptideShaker_proteins"
+          },
+          "action_type": "RenameDatasetAction",
+          "output_name": "output_proteins"
+        },
+        "RenameDatasetActionoutput_psm": {
+          "action_arguments": {
+            "newname": "PeptideShaker_PSM"
+          },
+          "action_type": "RenameDatasetAction",
+          "output_name": "output_psm"
+        },
+        "RenameDatasetActionoutput_zip": {
+          "action_arguments": {
+            "newname": "PeptideShaker_zip"
+          },
+          "action_type": "RenameDatasetAction",
+          "output_name": "output_zip"
+        }
+      },
+      "tool_id": "toolshed.g2.bx.psu.edu/repos/galaxyp/peptideshaker/peptide_shaker/1.16.17",
+      "tool_shed_repository": {
+        "changeset_revision": "f35bb9d0c93e",
+        "name": "peptideshaker",
+        "owner": "galaxyp",
+        "tool_shed": "toolshed.g2.bx.psu.edu"
+      },
+      "tool_state": "{\"__page__\": null, \"outputs\": \"[\\\"mzidentML\\\", \\\"3\\\", \\\"5\\\", \\\"7\\\", \\\"0\\\"]\", \"__rerun_remap_job_id__\": null, \"filtering_options\": \"{\\\"max_precursor_error_type\\\": \\\"1\\\", \\\"filtering_options_selector\\\": \\\"yes\\\", \\\"__current_case__\\\": 1, \\\"max_precursor_error\\\": \\\"10.0\\\", \\\"exclude_unknown_ptms\\\": \\\"true\\\", \\\"max_peptide_length\\\": \\\"30\\\", \\\"min_peptide_length\\\": \\\"6\\\"}\", \"searchgui_input\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\", \"contact_options\": \"{\\\"contact_options_selector\\\": \\\"no\\\", \\\"__current_case__\\\": 0}\", \"processing_options\": \"{\\\"processing_options_selector\\\": \\\"no\\\", \\\"__current_case__\\\": 0}\", \"include_sequences\": \"\\\"false\\\"\"}",
+      "tool_version": "1.16.17",
+      "type": "tool",
+      "uuid": "59cb75cb-3de7-4407-ba38-82f9c8e49deb",
+      "workflow_outputs": [
+        {
+          "label": null,
+          "output_name": "mzidentML",
+          "uuid": "5868e504-5ea5-46b8-bb2e-a00c161e35f8"
+        },
+        {
+          "label": null,
+          "output_name": "output_psm",
+          "uuid": "f3b5bede-649d-45ef-b8b4-95b43dbe7973"
+        }
+      ]
+    },
+    "6": {
+      "annotation": "",
+      "content_id": "Cut1",
+      "errors": null,
+      "id": 6,
+      "input_connections": {
+        "input": {
+          "id": 4,
+          "output_name": "output"
+        }
+      },
+      "inputs": [
+        {
+          "description": "runtime parameter for tool Cut",
+          "name": "input"
+        }
+      ],
+      "label": null,
+      "name": "Cut",
+      "outputs": [
+        {
+          "name": "out_file1",
+          "type": "tabular"
+        }
+      ],
+      "position": {
+        "left": 820.5,
+        "top": 435
+      },
+      "post_job_actions": {
+        "HideDatasetActionout_file1": {
+          "action_arguments": {},
+          "action_type": "HideDatasetAction",
+          "output_name": "out_file1"
+        }
+      },
+      "tool_id": "Cut1",
+      "tool_state": "{\"columnList\": \"\\\"c1\\\"\", \"input\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\", \"delimiter\": \"\\\"T\\\"\", \"__rerun_remap_job_id__\": null, \"__page__\": null}",
+      "tool_version": "1.0.2",
+      "type": "tool",
+      "uuid": "6a75b6ec-b6ab-4e3e-8785-a365e81f21ea",
+      "workflow_outputs": []
+    },
+    "7": {
+      "annotation": "",
+      "content_id": "toolshed.g2.bx.psu.edu/repos/galaxyp/mz_to_sqlite/mz_to_sqlite/2.0.0",
+      "errors": null,
+      "id": 7,
+      "input_connections": {
+        "mzinput": {
+          "id": 5,
+          "output_name": "mzidentML"
+        },
+        "scanfiles": {
+          "id": 1,
+          "output_name": "output"
+        },
+        "searchdbs": {
+          "id": 0,
+          "output_name": "output"
+        }
+      },
+      "inputs": [
+        {
+          "description": "runtime parameter for tool mz to sqlite",
+          "name": "mzinput"
+        },
+        {
+          "description": "runtime parameter for tool mz to sqlite",
+          "name": "searchdbs"
+        },
+        {
+          "description": "runtime parameter for tool mz to sqlite",
+          "name": "scanfiles"
+        }
+      ],
+      "label": null,
+      "name": "mz to sqlite",
+      "outputs": [
+        {
+          "name": "sqlite_db",
+          "type": "mz.sqlite"
+        }
+      ],
+      "position": {
+        "left": 490.5,
+        "top": 856
+      },
+      "post_job_actions": {},
+      "tool_id": "toolshed.g2.bx.psu.edu/repos/galaxyp/mz_to_sqlite/mz_to_sqlite/2.0.0",
+      "tool_shed_repository": {
+        "changeset_revision": "e34bdac5b157",
+        "name": "mz_to_sqlite",
+        "owner": "galaxyp",
+        "tool_shed": "toolshed.g2.bx.psu.edu"
+      },
+      "tool_state": "{\"mzinput\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\", \"__page__\": null, \"__rerun_remap_job_id__\": null, \"mzinputs\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\", \"searchdbs\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\", \"scanfiles\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\"}",
+      "tool_version": "2.0.0",
+      "type": "tool",
+      "uuid": "fc64ff6f-2335-48f2-b2a4-ede525ed0475",
+      "workflow_outputs": [
+        {
+          "label": null,
+          "output_name": "mzsqlite",
+          "uuid": "2c84fce6-1a3c-478a-8874-e9bdc1e29ac4"
+        },
+        {
+          "label": null,
+          "output_name": "sqlite_db",
+          "uuid": "31596320-24c8-4170-ab9e-91ba5ec5fe37"
+        }
+      ]
+    },
+    "8": {
+      "annotation": "",
+      "content_id": "Convert characters1",
+      "errors": null,
+      "id": 8,
+      "input_connections": {
+        "input": {
+          "id": 6,
+          "output_name": "out_file1"
+        }
+      },
+      "inputs": [
+        {
+          "description": "runtime parameter for tool Convert",
+          "name": "input"
+        }
+      ],
+      "label": null,
+      "name": "Convert",
+      "outputs": [
+        {
+          "name": "out_file1",
+          "type": "tabular"
+        }
+      ],
+      "position": {
+        "left": 817.5,
+        "top": 540
+      },
+      "post_job_actions": {
+        "HideDatasetActionout_file1": {
+          "action_arguments": {},
+          "action_type": "HideDatasetAction",
+          "output_name": "out_file1"
+        }
+      },
+      "tool_id": "Convert characters1",
+      "tool_state": "{\"__page__\": null, \"__rerun_remap_job_id__\": null, \"condense\": \"\\\"true\\\"\", \"strip\": \"\\\"true\\\"\", \"input\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\", \"convert_from\": \"\\\"s\\\"\"}",
+      "tool_version": "1.0.0",
+      "type": "tool",
+      "uuid": "f6503170-53cd-4c4c-b1e3-082e94a5c281",
+      "workflow_outputs": []
+    },
+    "9": {
+      "annotation": "",
+      "content_id": "Cut1",
+      "errors": null,
+      "id": 9,
+      "input_connections": {
+        "input": {
+          "id": 8,
+          "output_name": "out_file1"
+        }
+      },
+      "inputs": [
+        {
+          "description": "runtime parameter for tool Cut",
+          "name": "input"
+        }
+      ],
+      "label": null,
+      "name": "Cut",
+      "outputs": [
+        {
+          "name": "out_file1",
+          "type": "tabular"
+        }
+      ],
+      "position": {
+        "left": 819.5,
+        "top": 657
+      },
+      "post_job_actions": {
+        "HideDatasetActionout_file1": {
+          "action_arguments": {},
+          "action_type": "HideDatasetAction",
+          "output_name": "out_file1"
+        }
+      },
+      "tool_id": "Cut1",
+      "tool_state": "{\"columnList\": \"\\\"c2\\\"\", \"input\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\", \"delimiter\": \"\\\"P\\\"\", \"__rerun_remap_job_id__\": null, \"__page__\": null}",
+      "tool_version": "1.0.2",
+      "type": "tool",
+      "uuid": "0333ed3f-0027-487c-9f98-debad7b861ba",
+      "workflow_outputs": []
+    }
+  },
+  "tags": [],
+  "uuid": "62f3e5f9-d98b-415f-96b0-531085ff6476"
+}

--- a/topics/proteomics/tutorials/proteogenomics-novel-peptide-analysis/workflows/galaxy-workflow-mouse_novel_peptide_analysis.ga
+++ b/topics/proteomics/tutorials/proteogenomics-novel-peptide-analysis/workflows/galaxy-workflow-mouse_novel_peptide_analysis.ga
@@ -1,1 +1,462 @@
-{"uuid": "92196cd4-283a-4f0e-af12-c6a17ddf9295", "tags": [], "format-version": "0.1", "name": "Copy of ABRF_Workflow3_Novel_peptide_analysis", "steps": {"0": {"tool_id": null, "tool_version": null, "outputs": [], "workflow_outputs": [], "input_connections": {}, "tool_state": "{}", "id": 0, "uuid": "5dfd4419-dc5f-4eb3-abfc-63a2d67b10d2", "errors": null, "name": "Input dataset", "label": "After_BlastP_Peptides", "inputs": [], "position": {"top": 301.5, "left": 291}, "annotation": "", "content_id": null, "type": "data_input"}, "1": {"tool_id": null, "tool_version": null, "outputs": [], "workflow_outputs": [{"output_name": "output", "uuid": "0e94e5da-13a2-4b9e-96db-05aca8dc5778", "label": null}], "input_connections": {}, "tool_state": "{}", "id": 1, "uuid": "b0ed88a7-2260-4ef6-a96d-3ce746c62829", "errors": null, "name": "Input dataset", "label": "PeptideShaker_PSM", "inputs": [], "position": {"top": 707, "left": 284}, "annotation": "", "content_id": null, "type": "data_input"}, "2": {"tool_id": null, "tool_version": null, "outputs": [], "workflow_outputs": [{"output_name": "output", "uuid": "6ad88525-7840-4777-bd3b-dbe5564b9528", "label": null}], "input_connections": {}, "tool_state": "{}", "id": 2, "uuid": "cdf8da96-3078-45f6-b756-ca609b87af2d", "errors": null, "name": "Input dataset", "label": "mz_to_sqlite", "inputs": [], "position": {"top": 791, "left": 274.5}, "annotation": "", "content_id": null, "type": "data_input"}, "3": {"tool_id": null, "tool_version": null, "outputs": [], "workflow_outputs": [{"output_name": "output", "uuid": "c6793f2d-2855-4bc5-bf66-3cd16107057e", "label": null}], "input_connections": {}, "tool_state": "{}", "id": 3, "uuid": "651e708c-8739-40b5-9723-ed2a25bed62e", "errors": null, "name": "Input dataset", "label": "Genomic_mapping_sqlite", "inputs": [], "position": {"top": 886, "left": 282.5}, "annotation": "", "content_id": null, "type": "data_input"}, "4": {"tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/query_tabular/query_tabular/2.0.0", "tool_version": "2.0.0", "outputs": [{"type": "sqlite", "name": "sqlitedb"}, {"type": "tabular", "name": "output"}], "workflow_outputs": [{"output_name": "output", "uuid": "cc67207d-a83f-4f0a-98e9-a9d55845395e", "label": null}], "input_connections": {"tables_1|table": {"output_name": "output", "id": 1}, "tables_0|table": {"output_name": "output", "id": 0}}, "tool_state": "{\"tables\": \"[{\\\"tbl_opts\\\": {\\\"pkey_autoincr\\\": \\\"\\\", \\\"load_named_columns\\\": \\\"false\\\", \\\"indexes\\\": [], \\\"table_name\\\": \\\"blast\\\", \\\"col_names\\\": \\\"qseqid,sseqid,pident,length,mismatch,gapopen,qstart,qend,sstart,send,evalue,bitscore,sallseqid,score,nident,positive,gaps,ppos,qframe,sframe,qseq,sseq,qlen,slen,salltitles\\\", \\\"column_names_from_first_line\\\": \\\"false\\\"}, \\\"__index__\\\": 0, \\\"input_opts\\\": {\\\"linefilters\\\": []}, \\\"table\\\": {\\\"__class__\\\": \\\"RuntimeValue\\\"}}, {\\\"tbl_opts\\\": {\\\"pkey_autoincr\\\": \\\"\\\", \\\"load_named_columns\\\": \\\"false\\\", \\\"indexes\\\": [], \\\"table_name\\\": \\\"psm\\\", \\\"col_names\\\": \\\"ID,Proteins,Sequence,AAs_Before,AAs_After,Position,Modified_Sequence,Variable_Modifications,Fixed_Modifications,Spectrum_File,Spectrum_Title,Spectrum_Scan_Number,RT,mz,Measured_Charge,Identification_Charge,Theoretical_Mass,Isotope_Number,Precursor_mz_Error_ppm,Localization_Confidence,Probabilistic_PTM_score,Dscore,Confidence,Validation\\\", \\\"column_names_from_first_line\\\": \\\"false\\\"}, \\\"__index__\\\": 1, \\\"input_opts\\\": {\\\"linefilters\\\": [{\\\"filter\\\": {\\\"skip_lines\\\": \\\"1\\\", \\\"__current_case__\\\": 0, \\\"filter_type\\\": \\\"skip\\\"}, \\\"__index__\\\": 0}]}, \\\"table\\\": {\\\"__class__\\\": \\\"RuntimeValue\\\"}}]\", \"save_db\": \"\\\"false\\\"\", \"__page__\": null, \"__rerun_remap_job_id__\": null, \"sqlquery\": \"\\\"SELECT distinct psm.*\\\\nFROM psm join blast on psm.Sequence = blast.qseqid\\\\nWHERE blast.pident < 100 OR blast.gapopen >= 1 OR blast.length < blast.qlen\\\\nORDER BY psm.Sequence, psm.ID\\\"\", \"add_to_database\": \"{\\\"withdb\\\": {\\\"__class__\\\": \\\"RuntimeValue\\\"}}\", \"query_result\": \"{\\\"header\\\": \\\"yes\\\", \\\"header_prefix\\\": \\\"35\\\", \\\"__current_case__\\\": 0}\", \"workdb\": \"\\\"workdb.sqlite\\\"\"}", "id": 4, "tool_shed_repository": {"owner": "iuc", "changeset_revision": "1ea4e668bf73", "name": "query_tabular", "tool_shed": "toolshed.g2.bx.psu.edu"}, "uuid": "992204de-3d7f-4f6a-b123-7114287bc5ae", "errors": null, "name": "Query Tabular", "post_job_actions": {"HideDatasetActionsqlitedb": {"output_name": "sqlitedb", "action_type": "HideDatasetAction", "action_arguments": {}}, "RenameDatasetActionoutput": {"output_name": "output", "action_type": "RenameDatasetAction", "action_arguments": {"newname": "Identifying_Novel_Peptides"}}}, "label": "PSM_Novel_Peptides", "inputs": [{"name": "add_to_database", "description": "runtime parameter for tool Query Tabular"}], "position": {"top": 240.5, "left": 614.5}, "annotation": "", "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/query_tabular/query_tabular/2.0.0", "type": "tool"}, "5": {"tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/query_tabular/query_tabular/2.0.0", "tool_version": "2.0.0", "outputs": [{"type": "sqlite", "name": "sqlitedb"}, {"type": "tabular", "name": "output"}], "workflow_outputs": [{"output_name": "output", "uuid": "36e2f71c-0bbf-4f27-b1fa-4b95baf785a1", "label": null}], "input_connections": {"tables_0|table": {"output_name": "output", "id": 4}}, "tool_state": "{\"tables\": \"[{\\\"tbl_opts\\\": {\\\"pkey_autoincr\\\": \\\"\\\", \\\"load_named_columns\\\": \\\"false\\\", \\\"indexes\\\": [], \\\"table_name\\\": \\\"psm\\\", \\\"col_names\\\": \\\"ID,Proteins,Sequence\\\", \\\"column_names_from_first_line\\\": \\\"false\\\"}, \\\"__index__\\\": 0, \\\"input_opts\\\": {\\\"linefilters\\\": [{\\\"filter\\\": {\\\"skip_lines\\\": \\\"1\\\", \\\"__current_case__\\\": 0, \\\"filter_type\\\": \\\"skip\\\"}, \\\"__index__\\\": 0}]}, \\\"table\\\": {\\\"__class__\\\": \\\"RuntimeValue\\\"}}]\", \"save_db\": \"\\\"false\\\"\", \"__page__\": null, \"__rerun_remap_job_id__\": null, \"sqlquery\": \"\\\"select distinct Sequence from psm\\\"\", \"add_to_database\": \"{\\\"withdb\\\": {\\\"__class__\\\": \\\"RuntimeValue\\\"}}\", \"query_result\": \"{\\\"header\\\": \\\"no\\\", \\\"__current_case__\\\": 1}\", \"workdb\": \"\\\"workdb.sqlite\\\"\"}", "id": 5, "tool_shed_repository": {"owner": "iuc", "changeset_revision": "1ea4e668bf73", "name": "query_tabular", "tool_shed": "toolshed.g2.bx.psu.edu"}, "uuid": "4e91e65f-2c04-4213-b161-b105db718a0b", "errors": null, "name": "Query Tabular", "post_job_actions": {"HideDatasetActionsqlitedb": {"output_name": "sqlitedb", "action_type": "HideDatasetAction", "action_arguments": {}}, "RenameDatasetActionoutput": {"output_name": "output", "action_type": "RenameDatasetAction", "action_arguments": {"newname": "Novel_Peptides"}}}, "label": "Novel_Peptides", "inputs": [{"name": "add_to_database", "description": "runtime parameter for tool Query Tabular"}], "position": {"top": 488, "left": 608.5}, "annotation": "", "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/query_tabular/query_tabular/2.0.0", "type": "tool"}, "6": {"tool_id": "toolshed.g2.bx.psu.edu/repos/pravs/peptidegenomiccoordinate/peptidegenomiccoordinate/0.1.1", "tool_version": "0.1.1", "outputs": [{"type": "bed", "name": "peptide_bed"}], "workflow_outputs": [{"output_name": "peptide_bed", "uuid": "52cb0533-4f0e-4dcf-8fa8-1deed1bfc26d", "label": null}], "input_connections": {"peptideinput": {"output_name": "output", "id": 5}, "mapping": {"output_name": "output", "id": 3}, "mzsqlite": {"output_name": "output", "id": 2}}, "tool_state": "{\"__page__\": null, \"peptideinput\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\", \"__rerun_remap_job_id__\": null, \"mapping\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\", \"mzsqlite\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\"}", "id": 6, "tool_shed_repository": {"owner": "pravs", "changeset_revision": "561b62936e2c", "name": "peptidegenomiccoordinate", "tool_shed": "toolshed.g2.bx.psu.edu"}, "uuid": "e5823e0c-1de6-41bd-9470-d786c29f2674", "errors": null, "name": "Peptide Genomic Coordinate", "post_job_actions": {"ChangeDatatypeActionpeptide_bed": {"output_name": "peptide_bed", "action_type": "ChangeDatatypeAction", "action_arguments": {"newtype": "bed"}}, "RenameDatasetActionpeptide_bed": {"output_name": "peptide_bed", "action_type": "RenameDatasetAction", "action_arguments": {"newname": "Pep_gen_coordinate.bed"}}}, "label": null, "inputs": [{"name": "peptideinput", "description": "runtime parameter for tool Peptide Genomic Coordinate"}, {"name": "mapping", "description": "runtime parameter for tool Peptide Genomic Coordinate"}, {"name": "mzsqlite", "description": "runtime parameter for tool Peptide Genomic Coordinate"}], "position": {"top": 286, "left": 982.5}, "annotation": "", "content_id": "toolshed.g2.bx.psu.edu/repos/pravs/peptidegenomiccoordinate/peptidegenomiccoordinate/0.1.1", "type": "tool"}, "7": {"tool_id": "toolshed.g2.bx.psu.edu/repos/galaxyp/pep_pointer/pep_pointer/0.1.3", "tool_version": "0.1.3", "outputs": [{"type": "tabular", "name": "classified"}], "workflow_outputs": [{"output_name": "classified", "uuid": "9c96c105-4284-4db9-b0ef-941262062ea1", "label": null}], "input_connections": {"bed": {"output_name": "peptide_bed", "id": 6}}, "tool_state": "{\"__page__\": null, \"__rerun_remap_job_id__\": null, \"gtf_input\": \"{\\\"gtf\\\": \\\"Mus_Musculus_GRCm38.90_Ensembl_GTF\\\", \\\"gtf_source\\\": \\\"cached\\\", \\\"__current_case__\\\": 0}\", \"bed\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\"}", "id": 7, "tool_shed_repository": {"owner": "galaxyp", "changeset_revision": "073a2965e3b2", "name": "pep_pointer", "tool_shed": "toolshed.g2.bx.psu.edu"}, "uuid": "8c1dd3b7-ba0b-4899-9551-776fb0499469", "errors": null, "name": "PepPointer", "post_job_actions": {"ChangeDatatypeActionclassified": {"output_name": "classified", "action_type": "ChangeDatatypeAction", "action_arguments": {"newtype": "bed"}}, "RenameDatasetActionclassified": {"output_name": "classified", "action_type": "RenameDatasetAction", "action_arguments": {"newname": "PepPointer"}}}, "label": null, "inputs": [{"name": "bed", "description": "runtime parameter for tool PepPointer"}], "position": {"top": 551.5, "left": 939.5}, "annotation": "", "content_id": "toolshed.g2.bx.psu.edu/repos/galaxyp/pep_pointer/pep_pointer/0.1.3", "type": "tool"}, "8": {"tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/query_tabular/query_tabular/2.0.0", "tool_version": "2.0.0", "outputs": [{"type": "sqlite", "name": "sqlitedb"}, {"type": "tabular", "name": "output"}], "workflow_outputs": [{"output_name": "output", "uuid": "f042204b-816b-477f-b594-afea57c34f44", "label": null}], "input_connections": {"tables_1|table": {"output_name": "output", "id": 4}, "tables_0|table": {"output_name": "classified", "id": 7}}, "tool_state": "{\"tables\": \"[{\\\"tbl_opts\\\": {\\\"pkey_autoincr\\\": \\\"\\\", \\\"load_named_columns\\\": \\\"false\\\", \\\"indexes\\\": [], \\\"table_name\\\": \\\"bed_pep_pointer\\\", \\\"col_names\\\": \\\"chrom,start,end,peptide,score,strand,annot\\\", \\\"column_names_from_first_line\\\": \\\"false\\\"}, \\\"__index__\\\": 0, \\\"input_opts\\\": {\\\"linefilters\\\": []}, \\\"table\\\": {\\\"__class__\\\": \\\"RuntimeValue\\\"}}, {\\\"tbl_opts\\\": {\\\"pkey_autoincr\\\": \\\"\\\", \\\"load_named_columns\\\": \\\"false\\\", \\\"indexes\\\": [], \\\"table_name\\\": \\\"psm\\\", \\\"col_names\\\": \\\"ID,Proteins,Sequence,AAs_Before,AAs_After,Position,Modified_Sequence,Variable_Modifications,Fixed_Modifications,Spectrum_File,Spectrum_Title,Spectrum_Scan_Number,RT,mz,Measured_Charge,Identification_Charge,Theoretical_Mass,Isotope_Number,Precursor_mz_Error_ppm,Localization_Confidence,Probabilistic_PTM_score,Dscore,Confidence,Validation\\\", \\\"column_names_from_first_line\\\": \\\"false\\\"}, \\\"__index__\\\": 1, \\\"input_opts\\\": {\\\"linefilters\\\": [{\\\"filter\\\": {\\\"skip_lines\\\": \\\"1\\\", \\\"__current_case__\\\": 0, \\\"filter_type\\\": \\\"skip\\\"}, \\\"__index__\\\": 0}]}, \\\"table\\\": {\\\"__class__\\\": \\\"RuntimeValue\\\"}}]\", \"save_db\": \"\\\"false\\\"\", \"__page__\": null, \"__rerun_remap_job_id__\": null, \"sqlquery\": \"\\\"SELECT psm.Sequence as PeptideSequence, count(psm.Sequence) as SpectralCount, psm.Proteins as Proteins, bed_pep_pointer.chrom as Chromosome, bed_pep_pointer.start as Start, bed_pep_pointer.end as End, bed_pep_pointer.strand as Strand, bed_pep_pointer.annot as Annotation, bed_pep_pointer.chrom||':'||bed_pep_pointer.start||'-'||bed_pep_pointer.end as GenomeCoordinate,'https://genome.ucsc.edu/cgi-bin/hgTracks?db=mm10&position='||bed_pep_pointer.chrom||'%3A'||bed_pep_pointer.start||'-'||bed_pep_pointer.end as UCSC_Genome_Browser \\\\nFROM psm \\\\nINNER JOIN bed_pep_pointer on bed_pep_pointer.peptide = psm.Sequence \\\\nGROUP BY psm.Sequence\\\"\", \"add_to_database\": \"{\\\"withdb\\\": {\\\"__class__\\\": \\\"RuntimeValue\\\"}}\", \"query_result\": \"{\\\"header\\\": \\\"yes\\\", \\\"header_prefix\\\": \\\"35\\\", \\\"__current_case__\\\": 0}\", \"workdb\": \"\\\"workdb.sqlite\\\"\"}", "id": 8, "tool_shed_repository": {"owner": "iuc", "changeset_revision": "1ea4e668bf73", "name": "query_tabular", "tool_shed": "toolshed.g2.bx.psu.edu"}, "uuid": "624e04e1-828e-46f6-85cb-91f4f2bd8562", "errors": null, "name": "Query Tabular", "post_job_actions": {"HideDatasetActionsqlitedb": {"output_name": "sqlitedb", "action_type": "HideDatasetAction", "action_arguments": {}}, "RenameDatasetActionoutput": {"output_name": "output", "action_type": "RenameDatasetAction", "action_arguments": {"newname": "Final_Summary_Novel_Peptides_Output"}}}, "label": "Final_Summary_Novel_Peptides_Output", "inputs": [{"name": "add_to_database", "description": "runtime parameter for tool Query Tabular"}], "position": {"top": 720.5, "left": 889.5}, "annotation": "", "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/query_tabular/query_tabular/2.0.0", "type": "tool"}}, "annotation": "", "a_galaxy_workflow": "true"}
+{
+  "a_galaxy_workflow": "true",
+  "annotation": "",
+  "format-version": "0.1",
+  "name": "Copy of ABRF_Workflow3_Novel_peptide_analysis",
+  "steps": {
+    "0": {
+      "annotation": "",
+      "content_id": null,
+      "errors": null,
+      "id": 0,
+      "input_connections": {},
+      "inputs": [],
+      "label": "After_BlastP_Peptides",
+      "name": "Input dataset",
+      "outputs": [],
+      "position": {
+        "left": 291,
+        "top": 301.5
+      },
+      "tool_id": null,
+      "tool_state": "{}",
+      "tool_version": null,
+      "type": "data_input",
+      "uuid": "5dfd4419-dc5f-4eb3-abfc-63a2d67b10d2",
+      "workflow_outputs": []
+    },
+    "1": {
+      "annotation": "",
+      "content_id": null,
+      "errors": null,
+      "id": 1,
+      "input_connections": {},
+      "inputs": [],
+      "label": "PeptideShaker_PSM",
+      "name": "Input dataset",
+      "outputs": [],
+      "position": {
+        "left": 284,
+        "top": 707
+      },
+      "tool_id": null,
+      "tool_state": "{}",
+      "tool_version": null,
+      "type": "data_input",
+      "uuid": "b0ed88a7-2260-4ef6-a96d-3ce746c62829",
+      "workflow_outputs": [
+        {
+          "label": null,
+          "output_name": "output",
+          "uuid": "0e94e5da-13a2-4b9e-96db-05aca8dc5778"
+        }
+      ]
+    },
+    "2": {
+      "annotation": "",
+      "content_id": null,
+      "errors": null,
+      "id": 2,
+      "input_connections": {},
+      "inputs": [],
+      "label": "mz_to_sqlite",
+      "name": "Input dataset",
+      "outputs": [],
+      "position": {
+        "left": 274.5,
+        "top": 791
+      },
+      "tool_id": null,
+      "tool_state": "{}",
+      "tool_version": null,
+      "type": "data_input",
+      "uuid": "cdf8da96-3078-45f6-b756-ca609b87af2d",
+      "workflow_outputs": [
+        {
+          "label": null,
+          "output_name": "output",
+          "uuid": "6ad88525-7840-4777-bd3b-dbe5564b9528"
+        }
+      ]
+    },
+    "3": {
+      "annotation": "",
+      "content_id": null,
+      "errors": null,
+      "id": 3,
+      "input_connections": {},
+      "inputs": [],
+      "label": "Genomic_mapping_sqlite",
+      "name": "Input dataset",
+      "outputs": [],
+      "position": {
+        "left": 282.5,
+        "top": 886
+      },
+      "tool_id": null,
+      "tool_state": "{}",
+      "tool_version": null,
+      "type": "data_input",
+      "uuid": "651e708c-8739-40b5-9723-ed2a25bed62e",
+      "workflow_outputs": [
+        {
+          "label": null,
+          "output_name": "output",
+          "uuid": "c6793f2d-2855-4bc5-bf66-3cd16107057e"
+        }
+      ]
+    },
+    "4": {
+      "annotation": "",
+      "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/query_tabular/query_tabular/2.0.0",
+      "errors": null,
+      "id": 4,
+      "input_connections": {
+        "tables_0|table": {
+          "id": 0,
+          "output_name": "output"
+        },
+        "tables_1|table": {
+          "id": 1,
+          "output_name": "output"
+        }
+      },
+      "inputs": [
+        {
+          "description": "runtime parameter for tool Query Tabular",
+          "name": "add_to_database"
+        }
+      ],
+      "label": "PSM_Novel_Peptides",
+      "name": "Query Tabular",
+      "outputs": [
+        {
+          "name": "sqlitedb",
+          "type": "sqlite"
+        },
+        {
+          "name": "output",
+          "type": "tabular"
+        }
+      ],
+      "position": {
+        "left": 614.5,
+        "top": 240.5
+      },
+      "post_job_actions": {
+        "HideDatasetActionsqlitedb": {
+          "action_arguments": {},
+          "action_type": "HideDatasetAction",
+          "output_name": "sqlitedb"
+        },
+        "RenameDatasetActionoutput": {
+          "action_arguments": {
+            "newname": "Identifying_Novel_Peptides"
+          },
+          "action_type": "RenameDatasetAction",
+          "output_name": "output"
+        }
+      },
+      "tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/query_tabular/query_tabular/2.0.0",
+      "tool_shed_repository": {
+        "changeset_revision": "1ea4e668bf73",
+        "name": "query_tabular",
+        "owner": "iuc",
+        "tool_shed": "toolshed.g2.bx.psu.edu"
+      },
+      "tool_state": "{\"tables\": \"[{\\\"tbl_opts\\\": {\\\"pkey_autoincr\\\": \\\"\\\", \\\"load_named_columns\\\": \\\"false\\\", \\\"indexes\\\": [], \\\"table_name\\\": \\\"blast\\\", \\\"col_names\\\": \\\"qseqid,sseqid,pident,length,mismatch,gapopen,qstart,qend,sstart,send,evalue,bitscore,sallseqid,score,nident,positive,gaps,ppos,qframe,sframe,qseq,sseq,qlen,slen,salltitles\\\", \\\"column_names_from_first_line\\\": \\\"false\\\"}, \\\"__index__\\\": 0, \\\"input_opts\\\": {\\\"linefilters\\\": []}, \\\"table\\\": {\\\"__class__\\\": \\\"RuntimeValue\\\"}}, {\\\"tbl_opts\\\": {\\\"pkey_autoincr\\\": \\\"\\\", \\\"load_named_columns\\\": \\\"false\\\", \\\"indexes\\\": [], \\\"table_name\\\": \\\"psm\\\", \\\"col_names\\\": \\\"ID,Proteins,Sequence,AAs_Before,AAs_After,Position,Modified_Sequence,Variable_Modifications,Fixed_Modifications,Spectrum_File,Spectrum_Title,Spectrum_Scan_Number,RT,mz,Measured_Charge,Identification_Charge,Theoretical_Mass,Isotope_Number,Precursor_mz_Error_ppm,Localization_Confidence,Probabilistic_PTM_score,Dscore,Confidence,Validation\\\", \\\"column_names_from_first_line\\\": \\\"false\\\"}, \\\"__index__\\\": 1, \\\"input_opts\\\": {\\\"linefilters\\\": [{\\\"filter\\\": {\\\"skip_lines\\\": \\\"1\\\", \\\"__current_case__\\\": 0, \\\"filter_type\\\": \\\"skip\\\"}, \\\"__index__\\\": 0}]}, \\\"table\\\": {\\\"__class__\\\": \\\"RuntimeValue\\\"}}]\", \"save_db\": \"\\\"false\\\"\", \"__page__\": null, \"__rerun_remap_job_id__\": null, \"sqlquery\": \"\\\"SELECT distinct psm.*\\\\nFROM psm join blast on psm.Sequence = blast.qseqid\\\\nWHERE blast.pident < 100 OR blast.gapopen >= 1 OR blast.length < blast.qlen\\\\nORDER BY psm.Sequence, psm.ID\\\"\", \"add_to_database\": \"{\\\"withdb\\\": {\\\"__class__\\\": \\\"RuntimeValue\\\"}}\", \"query_result\": \"{\\\"header\\\": \\\"yes\\\", \\\"header_prefix\\\": \\\"35\\\", \\\"__current_case__\\\": 0}\", \"workdb\": \"\\\"workdb.sqlite\\\"\"}",
+      "tool_version": "2.0.0",
+      "type": "tool",
+      "uuid": "992204de-3d7f-4f6a-b123-7114287bc5ae",
+      "workflow_outputs": [
+        {
+          "label": null,
+          "output_name": "output",
+          "uuid": "cc67207d-a83f-4f0a-98e9-a9d55845395e"
+        }
+      ]
+    },
+    "5": {
+      "annotation": "",
+      "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/query_tabular/query_tabular/2.0.0",
+      "errors": null,
+      "id": 5,
+      "input_connections": {
+        "tables_0|table": {
+          "id": 4,
+          "output_name": "output"
+        }
+      },
+      "inputs": [
+        {
+          "description": "runtime parameter for tool Query Tabular",
+          "name": "add_to_database"
+        }
+      ],
+      "label": "Novel_Peptides",
+      "name": "Query Tabular",
+      "outputs": [
+        {
+          "name": "sqlitedb",
+          "type": "sqlite"
+        },
+        {
+          "name": "output",
+          "type": "tabular"
+        }
+      ],
+      "position": {
+        "left": 608.5,
+        "top": 488
+      },
+      "post_job_actions": {
+        "HideDatasetActionsqlitedb": {
+          "action_arguments": {},
+          "action_type": "HideDatasetAction",
+          "output_name": "sqlitedb"
+        },
+        "RenameDatasetActionoutput": {
+          "action_arguments": {
+            "newname": "Novel_Peptides"
+          },
+          "action_type": "RenameDatasetAction",
+          "output_name": "output"
+        }
+      },
+      "tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/query_tabular/query_tabular/2.0.0",
+      "tool_shed_repository": {
+        "changeset_revision": "1ea4e668bf73",
+        "name": "query_tabular",
+        "owner": "iuc",
+        "tool_shed": "toolshed.g2.bx.psu.edu"
+      },
+      "tool_state": "{\"tables\": \"[{\\\"tbl_opts\\\": {\\\"pkey_autoincr\\\": \\\"\\\", \\\"load_named_columns\\\": \\\"false\\\", \\\"indexes\\\": [], \\\"table_name\\\": \\\"psm\\\", \\\"col_names\\\": \\\"ID,Proteins,Sequence\\\", \\\"column_names_from_first_line\\\": \\\"false\\\"}, \\\"__index__\\\": 0, \\\"input_opts\\\": {\\\"linefilters\\\": [{\\\"filter\\\": {\\\"skip_lines\\\": \\\"1\\\", \\\"__current_case__\\\": 0, \\\"filter_type\\\": \\\"skip\\\"}, \\\"__index__\\\": 0}]}, \\\"table\\\": {\\\"__class__\\\": \\\"RuntimeValue\\\"}}]\", \"save_db\": \"\\\"false\\\"\", \"__page__\": null, \"__rerun_remap_job_id__\": null, \"sqlquery\": \"\\\"select distinct Sequence from psm\\\"\", \"add_to_database\": \"{\\\"withdb\\\": {\\\"__class__\\\": \\\"RuntimeValue\\\"}}\", \"query_result\": \"{\\\"header\\\": \\\"no\\\", \\\"__current_case__\\\": 1}\", \"workdb\": \"\\\"workdb.sqlite\\\"\"}",
+      "tool_version": "2.0.0",
+      "type": "tool",
+      "uuid": "4e91e65f-2c04-4213-b161-b105db718a0b",
+      "workflow_outputs": [
+        {
+          "label": null,
+          "output_name": "output",
+          "uuid": "36e2f71c-0bbf-4f27-b1fa-4b95baf785a1"
+        }
+      ]
+    },
+    "6": {
+      "annotation": "",
+      "content_id": "toolshed.g2.bx.psu.edu/repos/pravs/peptidegenomiccoordinate/peptidegenomiccoordinate/0.1.1",
+      "errors": null,
+      "id": 6,
+      "input_connections": {
+        "mapping": {
+          "id": 3,
+          "output_name": "output"
+        },
+        "mzsqlite": {
+          "id": 2,
+          "output_name": "output"
+        },
+        "peptideinput": {
+          "id": 5,
+          "output_name": "output"
+        }
+      },
+      "inputs": [
+        {
+          "description": "runtime parameter for tool Peptide Genomic Coordinate",
+          "name": "peptideinput"
+        },
+        {
+          "description": "runtime parameter for tool Peptide Genomic Coordinate",
+          "name": "mapping"
+        },
+        {
+          "description": "runtime parameter for tool Peptide Genomic Coordinate",
+          "name": "mzsqlite"
+        }
+      ],
+      "label": null,
+      "name": "Peptide Genomic Coordinate",
+      "outputs": [
+        {
+          "name": "peptide_bed",
+          "type": "bed"
+        }
+      ],
+      "position": {
+        "left": 982.5,
+        "top": 286
+      },
+      "post_job_actions": {
+        "ChangeDatatypeActionpeptide_bed": {
+          "action_arguments": {
+            "newtype": "bed"
+          },
+          "action_type": "ChangeDatatypeAction",
+          "output_name": "peptide_bed"
+        },
+        "RenameDatasetActionpeptide_bed": {
+          "action_arguments": {
+            "newname": "Pep_gen_coordinate.bed"
+          },
+          "action_type": "RenameDatasetAction",
+          "output_name": "peptide_bed"
+        }
+      },
+      "tool_id": "toolshed.g2.bx.psu.edu/repos/pravs/peptidegenomiccoordinate/peptidegenomiccoordinate/0.1.1",
+      "tool_shed_repository": {
+        "changeset_revision": "561b62936e2c",
+        "name": "peptidegenomiccoordinate",
+        "owner": "pravs",
+        "tool_shed": "toolshed.g2.bx.psu.edu"
+      },
+      "tool_state": "{\"__page__\": null, \"peptideinput\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\", \"__rerun_remap_job_id__\": null, \"mapping\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\", \"mzsqlite\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\"}",
+      "tool_version": "0.1.1",
+      "type": "tool",
+      "uuid": "e5823e0c-1de6-41bd-9470-d786c29f2674",
+      "workflow_outputs": [
+        {
+          "label": null,
+          "output_name": "peptide_bed",
+          "uuid": "52cb0533-4f0e-4dcf-8fa8-1deed1bfc26d"
+        }
+      ]
+    },
+    "7": {
+      "annotation": "",
+      "content_id": "toolshed.g2.bx.psu.edu/repos/galaxyp/pep_pointer/pep_pointer/0.1.3",
+      "errors": null,
+      "id": 7,
+      "input_connections": {
+        "bed": {
+          "id": 6,
+          "output_name": "peptide_bed"
+        }
+      },
+      "inputs": [
+        {
+          "description": "runtime parameter for tool PepPointer",
+          "name": "bed"
+        }
+      ],
+      "label": null,
+      "name": "PepPointer",
+      "outputs": [
+        {
+          "name": "classified",
+          "type": "tabular"
+        }
+      ],
+      "position": {
+        "left": 939.5,
+        "top": 551.5
+      },
+      "post_job_actions": {
+        "ChangeDatatypeActionclassified": {
+          "action_arguments": {
+            "newtype": "bed"
+          },
+          "action_type": "ChangeDatatypeAction",
+          "output_name": "classified"
+        },
+        "RenameDatasetActionclassified": {
+          "action_arguments": {
+            "newname": "PepPointer"
+          },
+          "action_type": "RenameDatasetAction",
+          "output_name": "classified"
+        }
+      },
+      "tool_id": "toolshed.g2.bx.psu.edu/repos/galaxyp/pep_pointer/pep_pointer/0.1.3",
+      "tool_shed_repository": {
+        "changeset_revision": "073a2965e3b2",
+        "name": "pep_pointer",
+        "owner": "galaxyp",
+        "tool_shed": "toolshed.g2.bx.psu.edu"
+      },
+      "tool_state": "{\"__page__\": null, \"__rerun_remap_job_id__\": null, \"gtf_input\": \"{\\\"gtf\\\": \\\"Mus_Musculus_GRCm38.90_Ensembl_GTF\\\", \\\"gtf_source\\\": \\\"cached\\\", \\\"__current_case__\\\": 0}\", \"bed\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\"}",
+      "tool_version": "0.1.3",
+      "type": "tool",
+      "uuid": "8c1dd3b7-ba0b-4899-9551-776fb0499469",
+      "workflow_outputs": [
+        {
+          "label": null,
+          "output_name": "classified",
+          "uuid": "9c96c105-4284-4db9-b0ef-941262062ea1"
+        }
+      ]
+    },
+    "8": {
+      "annotation": "",
+      "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/query_tabular/query_tabular/2.0.0",
+      "errors": null,
+      "id": 8,
+      "input_connections": {
+        "tables_0|table": {
+          "id": 7,
+          "output_name": "classified"
+        },
+        "tables_1|table": {
+          "id": 4,
+          "output_name": "output"
+        }
+      },
+      "inputs": [
+        {
+          "description": "runtime parameter for tool Query Tabular",
+          "name": "add_to_database"
+        }
+      ],
+      "label": "Final_Summary_Novel_Peptides_Output",
+      "name": "Query Tabular",
+      "outputs": [
+        {
+          "name": "sqlitedb",
+          "type": "sqlite"
+        },
+        {
+          "name": "output",
+          "type": "tabular"
+        }
+      ],
+      "position": {
+        "left": 889.5,
+        "top": 720.5
+      },
+      "post_job_actions": {
+        "HideDatasetActionsqlitedb": {
+          "action_arguments": {},
+          "action_type": "HideDatasetAction",
+          "output_name": "sqlitedb"
+        },
+        "RenameDatasetActionoutput": {
+          "action_arguments": {
+            "newname": "Final_Summary_Novel_Peptides_Output"
+          },
+          "action_type": "RenameDatasetAction",
+          "output_name": "output"
+        }
+      },
+      "tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/query_tabular/query_tabular/2.0.0",
+      "tool_shed_repository": {
+        "changeset_revision": "1ea4e668bf73",
+        "name": "query_tabular",
+        "owner": "iuc",
+        "tool_shed": "toolshed.g2.bx.psu.edu"
+      },
+      "tool_state": "{\"tables\": \"[{\\\"tbl_opts\\\": {\\\"pkey_autoincr\\\": \\\"\\\", \\\"load_named_columns\\\": \\\"false\\\", \\\"indexes\\\": [], \\\"table_name\\\": \\\"bed_pep_pointer\\\", \\\"col_names\\\": \\\"chrom,start,end,peptide,score,strand,annot\\\", \\\"column_names_from_first_line\\\": \\\"false\\\"}, \\\"__index__\\\": 0, \\\"input_opts\\\": {\\\"linefilters\\\": []}, \\\"table\\\": {\\\"__class__\\\": \\\"RuntimeValue\\\"}}, {\\\"tbl_opts\\\": {\\\"pkey_autoincr\\\": \\\"\\\", \\\"load_named_columns\\\": \\\"false\\\", \\\"indexes\\\": [], \\\"table_name\\\": \\\"psm\\\", \\\"col_names\\\": \\\"ID,Proteins,Sequence,AAs_Before,AAs_After,Position,Modified_Sequence,Variable_Modifications,Fixed_Modifications,Spectrum_File,Spectrum_Title,Spectrum_Scan_Number,RT,mz,Measured_Charge,Identification_Charge,Theoretical_Mass,Isotope_Number,Precursor_mz_Error_ppm,Localization_Confidence,Probabilistic_PTM_score,Dscore,Confidence,Validation\\\", \\\"column_names_from_first_line\\\": \\\"false\\\"}, \\\"__index__\\\": 1, \\\"input_opts\\\": {\\\"linefilters\\\": [{\\\"filter\\\": {\\\"skip_lines\\\": \\\"1\\\", \\\"__current_case__\\\": 0, \\\"filter_type\\\": \\\"skip\\\"}, \\\"__index__\\\": 0}]}, \\\"table\\\": {\\\"__class__\\\": \\\"RuntimeValue\\\"}}]\", \"save_db\": \"\\\"false\\\"\", \"__page__\": null, \"__rerun_remap_job_id__\": null, \"sqlquery\": \"\\\"SELECT psm.Sequence as PeptideSequence, count(psm.Sequence) as SpectralCount, psm.Proteins as Proteins, bed_pep_pointer.chrom as Chromosome, bed_pep_pointer.start as Start, bed_pep_pointer.end as End, bed_pep_pointer.strand as Strand, bed_pep_pointer.annot as Annotation, bed_pep_pointer.chrom||':'||bed_pep_pointer.start||'-'||bed_pep_pointer.end as GenomeCoordinate,'https://genome.ucsc.edu/cgi-bin/hgTracks?db=mm10&position='||bed_pep_pointer.chrom||'%3A'||bed_pep_pointer.start||'-'||bed_pep_pointer.end as UCSC_Genome_Browser \\\\nFROM psm \\\\nINNER JOIN bed_pep_pointer on bed_pep_pointer.peptide = psm.Sequence \\\\nGROUP BY psm.Sequence\\\"\", \"add_to_database\": \"{\\\"withdb\\\": {\\\"__class__\\\": \\\"RuntimeValue\\\"}}\", \"query_result\": \"{\\\"header\\\": \\\"yes\\\", \\\"header_prefix\\\": \\\"35\\\", \\\"__current_case__\\\": 0}\", \"workdb\": \"\\\"workdb.sqlite\\\"\"}",
+      "tool_version": "2.0.0",
+      "type": "tool",
+      "uuid": "624e04e1-828e-46f6-85cb-91f4f2bd8562",
+      "workflow_outputs": [
+        {
+          "label": null,
+          "output_name": "output",
+          "uuid": "f042204b-816b-477f-b594-afea57c34f44"
+        }
+      ]
+    }
+  },
+  "tags": [],
+  "uuid": "92196cd4-283a-4f0e-af12-c6a17ddf9295"
+}

--- a/topics/sequence-analysis/tutorials/de-novo-rad-seq/workflows/Galaxy-Workflow-de-novo-rad-seq.ga
+++ b/topics/sequence-analysis/tutorials/de-novo-rad-seq/workflows/Galaxy-Workflow-de-novo-rad-seq.ga
@@ -1,1 +1,672 @@
-{"uuid": "61fe11e8-8a9f-47b4-8d08-5936a818f364", "tags": [], "format-version": "0.1", "name": "de-novo-rad-seq (imported from uploaded file)", "steps": {"0": {"tool_id": null, "tool_version": null, "outputs": [], "workflow_outputs": [], "input_connections": {}, "tool_state": "{\"name\": \"Population_map.txt\"}", "id": 0, "uuid": "c070e872-bf5b-4690-85f8-20435bce6495", "errors": null, "name": "Input dataset", "label": "Population_map.txt", "inputs": [{"name": "Population_map.txt", "description": ""}], "position": {"top": 200, "left": 200}, "annotation": "", "content_id": null, "type": "data_input"}, "1": {"tool_id": null, "tool_version": null, "outputs": [], "workflow_outputs": [], "input_connections": {}, "tool_state": "{\"name\": \"Barcodes_SRR034310.tabular\"}", "id": 1, "uuid": "27073ffe-9a96-4cee-a9c5-a95b9ab1e7c7", "errors": null, "name": "Input dataset", "label": "Barcodes_SRR034310.tabular", "inputs": [{"name": "Barcodes_SRR034310.tabular", "description": ""}], "position": {"top": 320, "left": 200}, "annotation": "", "content_id": null, "type": "data_input"}, "2": {"tool_id": null, "tool_version": null, "outputs": [], "workflow_outputs": [], "input_connections": {}, "tool_state": "{\"name\": \"SRR034310.fastq\"}", "id": 2, "uuid": "16c3fb88-cdf5-418a-8e32-154bf142cca6", "errors": null, "name": "Input dataset", "label": "SRR034310.fastq", "inputs": [{"name": "SRR034310.fastq", "description": ""}], "position": {"top": 560, "left": 200}, "annotation": "", "content_id": null, "type": "data_input"}, "3": {"tool_id": null, "tool_version": null, "outputs": [], "workflow_outputs": [], "input_connections": {}, "tool_state": "{\"name\": \"ref_genome_chromFa.tar\"}", "id": 3, "uuid": "50b66134-d154-425e-a66f-51e05f5edb58", "errors": null, "name": "Input dataset", "label": "ref_genome_chromFa.tar", "inputs": [{"name": "ref_genome_chromFa.tar", "description": ""}], "position": {"top": 440, "left": 200}, "annotation": "", "content_id": null, "type": "data_input"}, "4": {"tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/stacks_procrad/stacks_procrad/1.46.0", "tool_version": "1.46.0", "outputs": [{"type": "input", "name": "demultiplexed"}, {"type": "input", "name": "remaining"}, {"type": "input", "name": "discarded"}, {"type": "txt", "name": "output_log"}], "workflow_outputs": [], "input_connections": {"barcode": {"output_name": "output", "id": 1}, "input_type|input_single": {"output_name": "output", "id": 2}}, "tool_state": "{\"capture\": \"\\\"true\\\"\", \"outype\": \"\\\"fastq\\\"\", \"options_enzyme\": \"{\\\"enzyme\\\": \\\"sbfI\\\", \\\"options_enzyme_selector\\\": \\\"1\\\", \\\"__current_case__\\\": 0}\", \"__page__\": null, \"input_type\": \"{\\\"input_single\\\": {\\\"__class__\\\": \\\"RuntimeValue\\\"}, \\\"barcode_encoding\\\": \\\"--inline_null\\\", \\\"__current_case__\\\": 0, \\\"options_type_selector\\\": \\\"single\\\"}\", \"__rerun_remap_job_id__\": null, \"barcode\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\", \"options_advanced\": \"{\\\"rescue\\\": \\\"false\\\", \\\"truncate\\\": \\\"\\\", \\\"remove\\\": \\\"false\\\", \\\"retain_header\\\": \\\"false\\\", \\\"score\\\": \\\"10\\\", \\\"discard\\\": \\\"false\\\", \\\"sliding\\\": \\\"0.15\\\"}\", \"chromInfo\": \"\\\"/usr/local/galaxy/galaxy-dist/tool-data/shared/ucsc/chrom/gasAcu1.len\\\"\"}", "id": 4, "tool_shed_repository": {"owner": "iuc", "changeset_revision": "57910d476be9", "name": "stacks_procrad", "tool_shed": "toolshed.g2.bx.psu.edu"}, "uuid": "4c9febcf-c953-44bd-a138-306a4a9efa4e", "errors": null, "name": "Stacks: process radtags", "post_job_actions": {}, "label": null, "inputs": [{"name": "input_type", "description": "runtime parameter for tool Stacks: process radtags"}, {"name": "barcode", "description": "runtime parameter for tool Stacks: process radtags"}], "position": {"top": 200, "left": 420}, "annotation": "", "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/stacks_procrad/stacks_procrad/1.46.0", "type": "tool"}, "5": {"tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/stacks_procrad/stacks_procrad/1.46.0", "tool_version": "1.46.0", "outputs": [{"type": "input", "name": "demultiplexed"}, {"type": "input", "name": "remaining"}, {"type": "input", "name": "discarded"}, {"type": "txt", "name": "output_log"}], "workflow_outputs": [], "input_connections": {"barcode": {"output_name": "output", "id": 1}, "input_type|input_single": {"output_name": "output", "id": 2}}, "tool_state": "{\"capture\": \"\\\"true\\\"\", \"outype\": \"\\\"fastq\\\"\", \"options_enzyme\": \"{\\\"enzyme\\\": \\\"sbfI\\\", \\\"options_enzyme_selector\\\": \\\"1\\\", \\\"__current_case__\\\": 0}\", \"__page__\": null, \"input_type\": \"{\\\"input_single\\\": {\\\"__class__\\\": \\\"RuntimeValue\\\"}, \\\"barcode_encoding\\\": \\\"--inline_null\\\", \\\"__current_case__\\\": 0, \\\"options_type_selector\\\": \\\"single\\\"}\", \"__rerun_remap_job_id__\": null, \"barcode\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\", \"options_advanced\": \"{\\\"rescue\\\": \\\"false\\\", \\\"truncate\\\": \\\"\\\", \\\"remove\\\": \\\"false\\\", \\\"retain_header\\\": \\\"false\\\", \\\"score\\\": \\\"10\\\", \\\"discard\\\": \\\"true\\\", \\\"sliding\\\": \\\"0.15\\\"}\", \"chromInfo\": \"\\\"/usr/local/galaxy/galaxy-dist/tool-data/shared/ucsc/chrom/gasAcu1.len\\\"\"}", "id": 5, "tool_shed_repository": {"owner": "iuc", "changeset_revision": "57910d476be9", "name": "stacks_procrad", "tool_shed": "toolshed.g2.bx.psu.edu"}, "uuid": "e67a2e03-f702-4d22-9776-0f758a79e9bf", "errors": null, "name": "Stacks: process radtags", "post_job_actions": {}, "label": null, "inputs": [{"name": "input_type", "description": "runtime parameter for tool Stacks: process radtags"}, {"name": "barcode", "description": "runtime parameter for tool Stacks: process radtags"}], "position": {"top": 320, "left": 420}, "annotation": "", "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/stacks_procrad/stacks_procrad/1.46.0", "type": "tool"}, "6": {"tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/stacks_procrad/stacks_procrad/1.46.0", "tool_version": "1.46.0", "outputs": [{"type": "input", "name": "demultiplexed"}, {"type": "input", "name": "remaining"}, {"type": "input", "name": "discarded"}, {"type": "txt", "name": "output_log"}], "workflow_outputs": [], "input_connections": {"barcode": {"output_name": "output", "id": 1}, "input_type|input_single": {"output_name": "output", "id": 2}}, "tool_state": "{\"capture\": \"\\\"true\\\"\", \"outype\": \"\\\"fastq\\\"\", \"options_enzyme\": \"{\\\"enzyme\\\": \\\"sbfI\\\", \\\"options_enzyme_selector\\\": \\\"1\\\", \\\"__current_case__\\\": 0}\", \"__page__\": null, \"input_type\": \"{\\\"input_single\\\": {\\\"__class__\\\": \\\"RuntimeValue\\\"}, \\\"barcode_encoding\\\": \\\"--inline_null\\\", \\\"__current_case__\\\": 0, \\\"options_type_selector\\\": \\\"single\\\"}\", \"__rerun_remap_job_id__\": null, \"barcode\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\", \"options_advanced\": \"{\\\"rescue\\\": \\\"false\\\", \\\"truncate\\\": \\\"\\\", \\\"remove\\\": \\\"false\\\", \\\"retain_header\\\": \\\"false\\\", \\\"score\\\": \\\"20\\\", \\\"discard\\\": \\\"true\\\", \\\"sliding\\\": \\\"0.15\\\"}\", \"chromInfo\": \"\\\"/usr/local/galaxy/galaxy-dist/tool-data/shared/ucsc/chrom/gasAcu1.len\\\"\"}", "id": 6, "tool_shed_repository": {"owner": "iuc", "changeset_revision": "57910d476be9", "name": "stacks_procrad", "tool_shed": "toolshed.g2.bx.psu.edu"}, "uuid": "a8ba2aa7-b806-40c7-be17-63afa1038db3", "errors": null, "name": "Stacks: process radtags", "post_job_actions": {}, "label": null, "inputs": [{"name": "input_type", "description": "runtime parameter for tool Stacks: process radtags"}, {"name": "barcode", "description": "runtime parameter for tool Stacks: process radtags"}], "position": {"top": 440, "left": 420}, "annotation": "", "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/stacks_procrad/stacks_procrad/1.46.0", "type": "tool"}, "7": {"tool_id": "toolshed.g2.bx.psu.edu/repos/devteam/fastqc/fastqc/0.69", "tool_version": "0.69", "outputs": [{"type": "html", "name": "html_file"}, {"type": "txt", "name": "text_file"}], "workflow_outputs": [], "input_connections": {"input_file": {"output_name": "output", "id": 2}}, "tool_state": "{\"__page__\": null, \"limits\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\", \"input_file\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\", \"__rerun_remap_job_id__\": null, \"contaminants\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\", \"chromInfo\": \"\\\"/usr/local/galaxy/galaxy-dist/tool-data/shared/ucsc/chrom/gasAcu1.len\\\"\"}", "id": 7, "tool_shed_repository": {"owner": "devteam", "changeset_revision": "f2e8552cf1d0", "name": "fastqc", "tool_shed": "toolshed.g2.bx.psu.edu"}, "uuid": "c6718efd-52b1-4870-a20d-a50b4462de19", "errors": null, "name": "FastQC", "post_job_actions": {}, "label": null, "inputs": [{"name": "contaminants", "description": "runtime parameter for tool FastQC"}, {"name": "limits", "description": "runtime parameter for tool FastQC"}, {"name": "input_file", "description": "runtime parameter for tool FastQC"}], "position": {"top": 680, "left": 420}, "annotation": "", "content_id": "toolshed.g2.bx.psu.edu/repos/devteam/fastqc/fastqc/0.69", "type": "tool"}, "8": {"tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/stacks_denovomap/stacks_denovomap/1.46.0", "tool_version": "1.46.0", "outputs": [{"type": "input", "name": "tags"}, {"type": "input", "name": "snps"}, {"type": "input", "name": "alleles"}, {"type": "input", "name": "matches"}, {"type": "input", "name": "all_output"}, {"type": "txt", "name": "output_log"}, {"type": "html", "name": "output_summary"}, {"type": "tabular", "name": "catalogtags"}, {"type": "tabular", "name": "catalogsnps"}, {"type": "tabular", "name": "catalogalleles"}, {"type": "txt", "name": "out_joinmap"}, {"type": "tabular", "name": "out_generic_haplo"}, {"type": "tabular", "name": "out_generic_geno"}, {"type": "tabular", "name": "out_sql_markers"}, {"type": "tabular", "name": "out_sql_genotypes"}, {"type": "tabular", "name": "out_haplotypes"}, {"type": "tabular", "name": "out_hapstats"}, {"type": "tabular", "name": "out_populations_log"}, {"type": "tabular", "name": "out_sumstats_sum"}, {"type": "tabular", "name": "out_sumstats"}, {"type": "tabular", "name": "out_sql"}], "workflow_outputs": [], "input_connections": {"options_usage|individual_sample": {"output_name": "demultiplexed", "id": 4}, "options_usage|popmap": {"output_name": "output", "id": 0}}, "tool_state": "{\"__page__\": null, \"__rerun_remap_job_id__\": null, \"options_usage\": \"{\\\"rad_analysis_type\\\": \\\"population\\\", \\\"individual_sample\\\": {\\\"__class__\\\": \\\"RuntimeValue\\\"}, \\\"__current_case__\\\": 1, \\\"popmap\\\": {\\\"__class__\\\": \\\"RuntimeValue\\\"}}\", \"snp_options\": \"{\\\"select_model\\\": {\\\"model_type\\\": \\\"snp\\\", \\\"alpha\\\": \\\"0.05\\\", \\\"__current_case__\\\": 0}}\", \"assembly_options\": \"{\\\"m\\\": \\\"3\\\", \\\"M\\\": \\\"2\\\", \\\"n\\\": \\\"3\\\", \\\"P\\\": \\\"\\\", \\\"t\\\": \\\"true\\\", \\\"H\\\": \\\"false\\\", \\\"N\\\": \\\"\\\"}\", \"chromInfo\": \"\\\"/usr/local/galaxy/galaxy-dist/tool-data/shared/ucsc/chrom/gasAcu1.len\\\"\"}", "id": 8, "tool_shed_repository": {"owner": "iuc", "changeset_revision": "2b1dd7ab69f7", "name": "stacks_denovomap", "tool_shed": "toolshed.g2.bx.psu.edu"}, "uuid": "4571d8b0-36ce-403f-b193-c0293faae81f", "errors": null, "name": "Stacks: de novo map", "post_job_actions": {}, "label": null, "inputs": [{"name": "options_usage", "description": "runtime parameter for tool Stacks: de novo map"}, {"name": "options_usage", "description": "runtime parameter for tool Stacks: de novo map"}], "position": {"top": 200, "left": 640}, "annotation": "", "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/stacks_denovomap/stacks_denovomap/1.46.0", "type": "tool"}, "9": {"tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/stacks_populations/stacks_populations/1.46.0", "tool_version": "1.46.0", "outputs": [{"type": "tabular", "name": "out_haplotypes"}, {"type": "tabular", "name": "out_hapstats"}, {"type": "tabular", "name": "out_populations_log"}, {"type": "tabular", "name": "out_sumstats_sum"}, {"type": "tabular", "name": "out_sumstats"}, {"type": "tabular", "name": "out_sql"}, {"type": "tabular", "name": "out_fstats"}, {"type": "tabular", "name": "out_fasta"}, {"type": "tabular", "name": "out_phylip_all_partitions"}, {"type": "tabular", "name": "out_phylip_all_pop"}, {"type": "tabular", "name": "out_phylip_all_loci"}, {"type": "tabular", "name": "out_genepop"}, {"type": "tabular", "name": "out_vcf_haplotypes"}, {"type": "tabular", "name": "out_hzar"}, {"type": "tabular", "name": "out_beagle_phased_haplotypes"}, {"type": "tabular", "name": "out_beagle_phased_markers"}, {"type": "tabular", "name": "out_beagle_haplotypes"}, {"type": "tabular", "name": "out_beagle_markers"}, {"type": "tabular", "name": "out_phylip_pop"}, {"type": "tabular", "name": "out_phylip_loci"}, {"type": "tabular", "name": "out_plink_markers"}, {"type": "tabular", "name": "out_plink_genotypes"}, {"type": "tabular", "name": "out_fasta_strict"}, {"type": "tabular", "name": "out_structure"}, {"type": "tabular", "name": "out_treemix_pop"}, {"type": "tabular", "name": "out_treemix_loci"}, {"type": "tabular", "name": "out_fastp\u0125ase"}, {"type": "tabular", "name": "out_phase"}, {"type": "tabular", "name": "out_vcf"}, {"type": "tabular", "name": "out_genomic"}, {"type": "html", "name": "output_summary"}], "workflow_outputs": [], "input_connections": {"options_usage|popmap": {"output_name": "output", "id": 0}, "options_usage|input_col": {"output_name": "all_output", "id": 8}}, "tool_state": "{\"options_kernel\": \"{\\\"kernel\\\": \\\"false\\\", \\\"__current_case__\\\": 1}\", \"__page__\": null, \"populations_output\": \"{\\\"phylip_var_all\\\": \\\"false\\\", \\\"fasta_strict\\\": \\\"false\\\", \\\"hzar\\\": \\\"false\\\", \\\"phylip_var\\\": \\\"false\\\", \\\"plink\\\": \\\"false\\\", \\\"vcf\\\": \\\"true\\\", \\\"phylip\\\": \\\"false\\\", \\\"beagle_phased\\\": \\\"false\\\", \\\"vcf_haplotypes\\\": \\\"false\\\", \\\"options_genomic\\\": {\\\"genomic\\\": \\\"false\\\", \\\"__current_case__\\\": 1}, \\\"genepop\\\": \\\"false\\\", \\\"beagle\\\": \\\"false\\\", \\\"fastphase\\\": \\\"false\\\", \\\"ordered_export\\\": \\\"false\\\", \\\"phase\\\": \\\"false\\\", \\\"fasta\\\": \\\"false\\\", \\\"treemix\\\": \\\"false\\\", \\\"structure\\\": \\\"true\\\"}\", \"options_usage\": \"{\\\"input_type\\\": \\\"stacks\\\", \\\"popmap\\\": {\\\"__class__\\\": \\\"RuntimeValue\\\"}, \\\"input_col\\\": {\\\"__class__\\\": \\\"RuntimeValue\\\"}, \\\"__current_case__\\\": 0}\", \"bootstrap_resampling\": \"{\\\"bootstrap_wl\\\": {\\\"__class__\\\": \\\"RuntimeValue\\\"}, \\\"bootstrap_reps\\\": \\\"100\\\", \\\"bootstrap_resampling_mode\\\": {\\\"bootstrap_phist\\\": \\\"false\\\", \\\"bootstrap_fst\\\": \\\"false\\\", \\\"bootstrap_all\\\": \\\"false\\\", \\\"bootstrap_pifis\\\": \\\"false\\\", \\\"__current_case__\\\": 1, \\\"bootstrap_div\\\": \\\"false\\\"}}\", \"options_filtering\": \"{\\\"write_single_snp\\\": \\\"false\\\", \\\"mindepth\\\": \\\"1\\\", \\\"minpop\\\": \\\"2\\\", \\\"minminor\\\": \\\"0.25\\\", \\\"max_obs_het\\\": \\\"\\\", \\\"lnl\\\": \\\"\\\", \\\"correction_select\\\": {\\\"correction\\\": \\\"no_corr\\\", \\\"__current_case__\\\": 0}, \\\"minperc\\\": \\\"0.75\\\", \\\"write_random_snp\\\": \\\"false\\\"}\", \"advanced_options\": \"{\\\"blacklist\\\": {\\\"__class__\\\": \\\"RuntimeValue\\\"}, \\\"batchid\\\": \\\"1\\\", \\\"whitelist\\\": {\\\"__class__\\\": \\\"RuntimeValue\\\"}}\", \"__rerun_remap_job_id__\": null, \"chromInfo\": \"\\\"/usr/local/galaxy/galaxy-dist/tool-data/shared/ucsc/chrom/gasAcu1.len\\\"\", \"fstats\": \"\\\"true\\\"\"}", "id": 9, "tool_shed_repository": {"owner": "iuc", "changeset_revision": "45db1ba16163", "name": "stacks_populations", "tool_shed": "toolshed.g2.bx.psu.edu"}, "uuid": "34fb1b8e-9ca5-4b8a-9671-18877598a77a", "errors": null, "name": "Stacks: populations", "post_job_actions": {}, "label": null, "inputs": [{"name": "options_usage", "description": "runtime parameter for tool Stacks: populations"}, {"name": "options_usage", "description": "runtime parameter for tool Stacks: populations"}, {"name": "bootstrap_resampling", "description": "runtime parameter for tool Stacks: populations"}, {"name": "advanced_options", "description": "runtime parameter for tool Stacks: populations"}, {"name": "advanced_options", "description": "runtime parameter for tool Stacks: populations"}], "position": {"top": 200, "left": 860}, "annotation": "", "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/stacks_populations/stacks_populations/1.46.0", "type": "tool"}}, "annotation": "", "a_galaxy_workflow": "true"}
+{
+  "a_galaxy_workflow": "true",
+  "annotation": "",
+  "format-version": "0.1",
+  "name": "de-novo-rad-seq (imported from uploaded file)",
+  "steps": {
+    "0": {
+      "annotation": "",
+      "content_id": null,
+      "errors": null,
+      "id": 0,
+      "input_connections": {},
+      "inputs": [
+        {
+          "description": "",
+          "name": "Population_map.txt"
+        }
+      ],
+      "label": "Population_map.txt",
+      "name": "Input dataset",
+      "outputs": [],
+      "position": {
+        "left": 200,
+        "top": 200
+      },
+      "tool_id": null,
+      "tool_state": "{\"name\": \"Population_map.txt\"}",
+      "tool_version": null,
+      "type": "data_input",
+      "uuid": "c070e872-bf5b-4690-85f8-20435bce6495",
+      "workflow_outputs": []
+    },
+    "1": {
+      "annotation": "",
+      "content_id": null,
+      "errors": null,
+      "id": 1,
+      "input_connections": {},
+      "inputs": [
+        {
+          "description": "",
+          "name": "Barcodes_SRR034310.tabular"
+        }
+      ],
+      "label": "Barcodes_SRR034310.tabular",
+      "name": "Input dataset",
+      "outputs": [],
+      "position": {
+        "left": 200,
+        "top": 320
+      },
+      "tool_id": null,
+      "tool_state": "{\"name\": \"Barcodes_SRR034310.tabular\"}",
+      "tool_version": null,
+      "type": "data_input",
+      "uuid": "27073ffe-9a96-4cee-a9c5-a95b9ab1e7c7",
+      "workflow_outputs": []
+    },
+    "2": {
+      "annotation": "",
+      "content_id": null,
+      "errors": null,
+      "id": 2,
+      "input_connections": {},
+      "inputs": [
+        {
+          "description": "",
+          "name": "SRR034310.fastq"
+        }
+      ],
+      "label": "SRR034310.fastq",
+      "name": "Input dataset",
+      "outputs": [],
+      "position": {
+        "left": 200,
+        "top": 560
+      },
+      "tool_id": null,
+      "tool_state": "{\"name\": \"SRR034310.fastq\"}",
+      "tool_version": null,
+      "type": "data_input",
+      "uuid": "16c3fb88-cdf5-418a-8e32-154bf142cca6",
+      "workflow_outputs": []
+    },
+    "3": {
+      "annotation": "",
+      "content_id": null,
+      "errors": null,
+      "id": 3,
+      "input_connections": {},
+      "inputs": [
+        {
+          "description": "",
+          "name": "ref_genome_chromFa.tar"
+        }
+      ],
+      "label": "ref_genome_chromFa.tar",
+      "name": "Input dataset",
+      "outputs": [],
+      "position": {
+        "left": 200,
+        "top": 440
+      },
+      "tool_id": null,
+      "tool_state": "{\"name\": \"ref_genome_chromFa.tar\"}",
+      "tool_version": null,
+      "type": "data_input",
+      "uuid": "50b66134-d154-425e-a66f-51e05f5edb58",
+      "workflow_outputs": []
+    },
+    "4": {
+      "annotation": "",
+      "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/stacks_procrad/stacks_procrad/1.46.0",
+      "errors": null,
+      "id": 4,
+      "input_connections": {
+        "barcode": {
+          "id": 1,
+          "output_name": "output"
+        },
+        "input_type|input_single": {
+          "id": 2,
+          "output_name": "output"
+        }
+      },
+      "inputs": [
+        {
+          "description": "runtime parameter for tool Stacks: process radtags",
+          "name": "input_type"
+        },
+        {
+          "description": "runtime parameter for tool Stacks: process radtags",
+          "name": "barcode"
+        }
+      ],
+      "label": null,
+      "name": "Stacks: process radtags",
+      "outputs": [
+        {
+          "name": "demultiplexed",
+          "type": "input"
+        },
+        {
+          "name": "remaining",
+          "type": "input"
+        },
+        {
+          "name": "discarded",
+          "type": "input"
+        },
+        {
+          "name": "output_log",
+          "type": "txt"
+        }
+      ],
+      "position": {
+        "left": 420,
+        "top": 200
+      },
+      "post_job_actions": {},
+      "tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/stacks_procrad/stacks_procrad/1.46.0",
+      "tool_shed_repository": {
+        "changeset_revision": "57910d476be9",
+        "name": "stacks_procrad",
+        "owner": "iuc",
+        "tool_shed": "toolshed.g2.bx.psu.edu"
+      },
+      "tool_state": "{\"capture\": \"\\\"true\\\"\", \"outype\": \"\\\"fastq\\\"\", \"options_enzyme\": \"{\\\"enzyme\\\": \\\"sbfI\\\", \\\"options_enzyme_selector\\\": \\\"1\\\", \\\"__current_case__\\\": 0}\", \"__page__\": null, \"input_type\": \"{\\\"input_single\\\": {\\\"__class__\\\": \\\"RuntimeValue\\\"}, \\\"barcode_encoding\\\": \\\"--inline_null\\\", \\\"__current_case__\\\": 0, \\\"options_type_selector\\\": \\\"single\\\"}\", \"__rerun_remap_job_id__\": null, \"barcode\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\", \"options_advanced\": \"{\\\"rescue\\\": \\\"false\\\", \\\"truncate\\\": \\\"\\\", \\\"remove\\\": \\\"false\\\", \\\"retain_header\\\": \\\"false\\\", \\\"score\\\": \\\"10\\\", \\\"discard\\\": \\\"false\\\", \\\"sliding\\\": \\\"0.15\\\"}\", \"chromInfo\": \"\\\"/usr/local/galaxy/galaxy-dist/tool-data/shared/ucsc/chrom/gasAcu1.len\\\"\"}",
+      "tool_version": "1.46.0",
+      "type": "tool",
+      "uuid": "4c9febcf-c953-44bd-a138-306a4a9efa4e",
+      "workflow_outputs": []
+    },
+    "5": {
+      "annotation": "",
+      "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/stacks_procrad/stacks_procrad/1.46.0",
+      "errors": null,
+      "id": 5,
+      "input_connections": {
+        "barcode": {
+          "id": 1,
+          "output_name": "output"
+        },
+        "input_type|input_single": {
+          "id": 2,
+          "output_name": "output"
+        }
+      },
+      "inputs": [
+        {
+          "description": "runtime parameter for tool Stacks: process radtags",
+          "name": "input_type"
+        },
+        {
+          "description": "runtime parameter for tool Stacks: process radtags",
+          "name": "barcode"
+        }
+      ],
+      "label": null,
+      "name": "Stacks: process radtags",
+      "outputs": [
+        {
+          "name": "demultiplexed",
+          "type": "input"
+        },
+        {
+          "name": "remaining",
+          "type": "input"
+        },
+        {
+          "name": "discarded",
+          "type": "input"
+        },
+        {
+          "name": "output_log",
+          "type": "txt"
+        }
+      ],
+      "position": {
+        "left": 420,
+        "top": 320
+      },
+      "post_job_actions": {},
+      "tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/stacks_procrad/stacks_procrad/1.46.0",
+      "tool_shed_repository": {
+        "changeset_revision": "57910d476be9",
+        "name": "stacks_procrad",
+        "owner": "iuc",
+        "tool_shed": "toolshed.g2.bx.psu.edu"
+      },
+      "tool_state": "{\"capture\": \"\\\"true\\\"\", \"outype\": \"\\\"fastq\\\"\", \"options_enzyme\": \"{\\\"enzyme\\\": \\\"sbfI\\\", \\\"options_enzyme_selector\\\": \\\"1\\\", \\\"__current_case__\\\": 0}\", \"__page__\": null, \"input_type\": \"{\\\"input_single\\\": {\\\"__class__\\\": \\\"RuntimeValue\\\"}, \\\"barcode_encoding\\\": \\\"--inline_null\\\", \\\"__current_case__\\\": 0, \\\"options_type_selector\\\": \\\"single\\\"}\", \"__rerun_remap_job_id__\": null, \"barcode\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\", \"options_advanced\": \"{\\\"rescue\\\": \\\"false\\\", \\\"truncate\\\": \\\"\\\", \\\"remove\\\": \\\"false\\\", \\\"retain_header\\\": \\\"false\\\", \\\"score\\\": \\\"10\\\", \\\"discard\\\": \\\"true\\\", \\\"sliding\\\": \\\"0.15\\\"}\", \"chromInfo\": \"\\\"/usr/local/galaxy/galaxy-dist/tool-data/shared/ucsc/chrom/gasAcu1.len\\\"\"}",
+      "tool_version": "1.46.0",
+      "type": "tool",
+      "uuid": "e67a2e03-f702-4d22-9776-0f758a79e9bf",
+      "workflow_outputs": []
+    },
+    "6": {
+      "annotation": "",
+      "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/stacks_procrad/stacks_procrad/1.46.0",
+      "errors": null,
+      "id": 6,
+      "input_connections": {
+        "barcode": {
+          "id": 1,
+          "output_name": "output"
+        },
+        "input_type|input_single": {
+          "id": 2,
+          "output_name": "output"
+        }
+      },
+      "inputs": [
+        {
+          "description": "runtime parameter for tool Stacks: process radtags",
+          "name": "input_type"
+        },
+        {
+          "description": "runtime parameter for tool Stacks: process radtags",
+          "name": "barcode"
+        }
+      ],
+      "label": null,
+      "name": "Stacks: process radtags",
+      "outputs": [
+        {
+          "name": "demultiplexed",
+          "type": "input"
+        },
+        {
+          "name": "remaining",
+          "type": "input"
+        },
+        {
+          "name": "discarded",
+          "type": "input"
+        },
+        {
+          "name": "output_log",
+          "type": "txt"
+        }
+      ],
+      "position": {
+        "left": 420,
+        "top": 440
+      },
+      "post_job_actions": {},
+      "tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/stacks_procrad/stacks_procrad/1.46.0",
+      "tool_shed_repository": {
+        "changeset_revision": "57910d476be9",
+        "name": "stacks_procrad",
+        "owner": "iuc",
+        "tool_shed": "toolshed.g2.bx.psu.edu"
+      },
+      "tool_state": "{\"capture\": \"\\\"true\\\"\", \"outype\": \"\\\"fastq\\\"\", \"options_enzyme\": \"{\\\"enzyme\\\": \\\"sbfI\\\", \\\"options_enzyme_selector\\\": \\\"1\\\", \\\"__current_case__\\\": 0}\", \"__page__\": null, \"input_type\": \"{\\\"input_single\\\": {\\\"__class__\\\": \\\"RuntimeValue\\\"}, \\\"barcode_encoding\\\": \\\"--inline_null\\\", \\\"__current_case__\\\": 0, \\\"options_type_selector\\\": \\\"single\\\"}\", \"__rerun_remap_job_id__\": null, \"barcode\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\", \"options_advanced\": \"{\\\"rescue\\\": \\\"false\\\", \\\"truncate\\\": \\\"\\\", \\\"remove\\\": \\\"false\\\", \\\"retain_header\\\": \\\"false\\\", \\\"score\\\": \\\"20\\\", \\\"discard\\\": \\\"true\\\", \\\"sliding\\\": \\\"0.15\\\"}\", \"chromInfo\": \"\\\"/usr/local/galaxy/galaxy-dist/tool-data/shared/ucsc/chrom/gasAcu1.len\\\"\"}",
+      "tool_version": "1.46.0",
+      "type": "tool",
+      "uuid": "a8ba2aa7-b806-40c7-be17-63afa1038db3",
+      "workflow_outputs": []
+    },
+    "7": {
+      "annotation": "",
+      "content_id": "toolshed.g2.bx.psu.edu/repos/devteam/fastqc/fastqc/0.69",
+      "errors": null,
+      "id": 7,
+      "input_connections": {
+        "input_file": {
+          "id": 2,
+          "output_name": "output"
+        }
+      },
+      "inputs": [
+        {
+          "description": "runtime parameter for tool FastQC",
+          "name": "contaminants"
+        },
+        {
+          "description": "runtime parameter for tool FastQC",
+          "name": "limits"
+        },
+        {
+          "description": "runtime parameter for tool FastQC",
+          "name": "input_file"
+        }
+      ],
+      "label": null,
+      "name": "FastQC",
+      "outputs": [
+        {
+          "name": "html_file",
+          "type": "html"
+        },
+        {
+          "name": "text_file",
+          "type": "txt"
+        }
+      ],
+      "position": {
+        "left": 420,
+        "top": 680
+      },
+      "post_job_actions": {},
+      "tool_id": "toolshed.g2.bx.psu.edu/repos/devteam/fastqc/fastqc/0.69",
+      "tool_shed_repository": {
+        "changeset_revision": "f2e8552cf1d0",
+        "name": "fastqc",
+        "owner": "devteam",
+        "tool_shed": "toolshed.g2.bx.psu.edu"
+      },
+      "tool_state": "{\"__page__\": null, \"limits\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\", \"input_file\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\", \"__rerun_remap_job_id__\": null, \"contaminants\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\", \"chromInfo\": \"\\\"/usr/local/galaxy/galaxy-dist/tool-data/shared/ucsc/chrom/gasAcu1.len\\\"\"}",
+      "tool_version": "0.69",
+      "type": "tool",
+      "uuid": "c6718efd-52b1-4870-a20d-a50b4462de19",
+      "workflow_outputs": []
+    },
+    "8": {
+      "annotation": "",
+      "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/stacks_denovomap/stacks_denovomap/1.46.0",
+      "errors": null,
+      "id": 8,
+      "input_connections": {
+        "options_usage|individual_sample": {
+          "id": 4,
+          "output_name": "demultiplexed"
+        },
+        "options_usage|popmap": {
+          "id": 0,
+          "output_name": "output"
+        }
+      },
+      "inputs": [
+        {
+          "description": "runtime parameter for tool Stacks: de novo map",
+          "name": "options_usage"
+        },
+        {
+          "description": "runtime parameter for tool Stacks: de novo map",
+          "name": "options_usage"
+        }
+      ],
+      "label": null,
+      "name": "Stacks: de novo map",
+      "outputs": [
+        {
+          "name": "tags",
+          "type": "input"
+        },
+        {
+          "name": "snps",
+          "type": "input"
+        },
+        {
+          "name": "alleles",
+          "type": "input"
+        },
+        {
+          "name": "matches",
+          "type": "input"
+        },
+        {
+          "name": "all_output",
+          "type": "input"
+        },
+        {
+          "name": "output_log",
+          "type": "txt"
+        },
+        {
+          "name": "output_summary",
+          "type": "html"
+        },
+        {
+          "name": "catalogtags",
+          "type": "tabular"
+        },
+        {
+          "name": "catalogsnps",
+          "type": "tabular"
+        },
+        {
+          "name": "catalogalleles",
+          "type": "tabular"
+        },
+        {
+          "name": "out_joinmap",
+          "type": "txt"
+        },
+        {
+          "name": "out_generic_haplo",
+          "type": "tabular"
+        },
+        {
+          "name": "out_generic_geno",
+          "type": "tabular"
+        },
+        {
+          "name": "out_sql_markers",
+          "type": "tabular"
+        },
+        {
+          "name": "out_sql_genotypes",
+          "type": "tabular"
+        },
+        {
+          "name": "out_haplotypes",
+          "type": "tabular"
+        },
+        {
+          "name": "out_hapstats",
+          "type": "tabular"
+        },
+        {
+          "name": "out_populations_log",
+          "type": "tabular"
+        },
+        {
+          "name": "out_sumstats_sum",
+          "type": "tabular"
+        },
+        {
+          "name": "out_sumstats",
+          "type": "tabular"
+        },
+        {
+          "name": "out_sql",
+          "type": "tabular"
+        }
+      ],
+      "position": {
+        "left": 640,
+        "top": 200
+      },
+      "post_job_actions": {},
+      "tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/stacks_denovomap/stacks_denovomap/1.46.0",
+      "tool_shed_repository": {
+        "changeset_revision": "2b1dd7ab69f7",
+        "name": "stacks_denovomap",
+        "owner": "iuc",
+        "tool_shed": "toolshed.g2.bx.psu.edu"
+      },
+      "tool_state": "{\"__page__\": null, \"__rerun_remap_job_id__\": null, \"options_usage\": \"{\\\"rad_analysis_type\\\": \\\"population\\\", \\\"individual_sample\\\": {\\\"__class__\\\": \\\"RuntimeValue\\\"}, \\\"__current_case__\\\": 1, \\\"popmap\\\": {\\\"__class__\\\": \\\"RuntimeValue\\\"}}\", \"snp_options\": \"{\\\"select_model\\\": {\\\"model_type\\\": \\\"snp\\\", \\\"alpha\\\": \\\"0.05\\\", \\\"__current_case__\\\": 0}}\", \"assembly_options\": \"{\\\"m\\\": \\\"3\\\", \\\"M\\\": \\\"2\\\", \\\"n\\\": \\\"3\\\", \\\"P\\\": \\\"\\\", \\\"t\\\": \\\"true\\\", \\\"H\\\": \\\"false\\\", \\\"N\\\": \\\"\\\"}\", \"chromInfo\": \"\\\"/usr/local/galaxy/galaxy-dist/tool-data/shared/ucsc/chrom/gasAcu1.len\\\"\"}",
+      "tool_version": "1.46.0",
+      "type": "tool",
+      "uuid": "4571d8b0-36ce-403f-b193-c0293faae81f",
+      "workflow_outputs": []
+    },
+    "9": {
+      "annotation": "",
+      "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/stacks_populations/stacks_populations/1.46.0",
+      "errors": null,
+      "id": 9,
+      "input_connections": {
+        "options_usage|input_col": {
+          "id": 8,
+          "output_name": "all_output"
+        },
+        "options_usage|popmap": {
+          "id": 0,
+          "output_name": "output"
+        }
+      },
+      "inputs": [
+        {
+          "description": "runtime parameter for tool Stacks: populations",
+          "name": "options_usage"
+        },
+        {
+          "description": "runtime parameter for tool Stacks: populations",
+          "name": "options_usage"
+        },
+        {
+          "description": "runtime parameter for tool Stacks: populations",
+          "name": "bootstrap_resampling"
+        },
+        {
+          "description": "runtime parameter for tool Stacks: populations",
+          "name": "advanced_options"
+        },
+        {
+          "description": "runtime parameter for tool Stacks: populations",
+          "name": "advanced_options"
+        }
+      ],
+      "label": null,
+      "name": "Stacks: populations",
+      "outputs": [
+        {
+          "name": "out_haplotypes",
+          "type": "tabular"
+        },
+        {
+          "name": "out_hapstats",
+          "type": "tabular"
+        },
+        {
+          "name": "out_populations_log",
+          "type": "tabular"
+        },
+        {
+          "name": "out_sumstats_sum",
+          "type": "tabular"
+        },
+        {
+          "name": "out_sumstats",
+          "type": "tabular"
+        },
+        {
+          "name": "out_sql",
+          "type": "tabular"
+        },
+        {
+          "name": "out_fstats",
+          "type": "tabular"
+        },
+        {
+          "name": "out_fasta",
+          "type": "tabular"
+        },
+        {
+          "name": "out_phylip_all_partitions",
+          "type": "tabular"
+        },
+        {
+          "name": "out_phylip_all_pop",
+          "type": "tabular"
+        },
+        {
+          "name": "out_phylip_all_loci",
+          "type": "tabular"
+        },
+        {
+          "name": "out_genepop",
+          "type": "tabular"
+        },
+        {
+          "name": "out_vcf_haplotypes",
+          "type": "tabular"
+        },
+        {
+          "name": "out_hzar",
+          "type": "tabular"
+        },
+        {
+          "name": "out_beagle_phased_haplotypes",
+          "type": "tabular"
+        },
+        {
+          "name": "out_beagle_phased_markers",
+          "type": "tabular"
+        },
+        {
+          "name": "out_beagle_haplotypes",
+          "type": "tabular"
+        },
+        {
+          "name": "out_beagle_markers",
+          "type": "tabular"
+        },
+        {
+          "name": "out_phylip_pop",
+          "type": "tabular"
+        },
+        {
+          "name": "out_phylip_loci",
+          "type": "tabular"
+        },
+        {
+          "name": "out_plink_markers",
+          "type": "tabular"
+        },
+        {
+          "name": "out_plink_genotypes",
+          "type": "tabular"
+        },
+        {
+          "name": "out_fasta_strict",
+          "type": "tabular"
+        },
+        {
+          "name": "out_structure",
+          "type": "tabular"
+        },
+        {
+          "name": "out_treemix_pop",
+          "type": "tabular"
+        },
+        {
+          "name": "out_treemix_loci",
+          "type": "tabular"
+        },
+        {
+          "name": "out_fastpĥase",
+          "type": "tabular"
+        },
+        {
+          "name": "out_phase",
+          "type": "tabular"
+        },
+        {
+          "name": "out_vcf",
+          "type": "tabular"
+        },
+        {
+          "name": "out_genomic",
+          "type": "tabular"
+        },
+        {
+          "name": "output_summary",
+          "type": "html"
+        }
+      ],
+      "position": {
+        "left": 860,
+        "top": 200
+      },
+      "post_job_actions": {},
+      "tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/stacks_populations/stacks_populations/1.46.0",
+      "tool_shed_repository": {
+        "changeset_revision": "45db1ba16163",
+        "name": "stacks_populations",
+        "owner": "iuc",
+        "tool_shed": "toolshed.g2.bx.psu.edu"
+      },
+      "tool_state": "{\"options_kernel\": \"{\\\"kernel\\\": \\\"false\\\", \\\"__current_case__\\\": 1}\", \"__page__\": null, \"populations_output\": \"{\\\"phylip_var_all\\\": \\\"false\\\", \\\"fasta_strict\\\": \\\"false\\\", \\\"hzar\\\": \\\"false\\\", \\\"phylip_var\\\": \\\"false\\\", \\\"plink\\\": \\\"false\\\", \\\"vcf\\\": \\\"true\\\", \\\"phylip\\\": \\\"false\\\", \\\"beagle_phased\\\": \\\"false\\\", \\\"vcf_haplotypes\\\": \\\"false\\\", \\\"options_genomic\\\": {\\\"genomic\\\": \\\"false\\\", \\\"__current_case__\\\": 1}, \\\"genepop\\\": \\\"false\\\", \\\"beagle\\\": \\\"false\\\", \\\"fastphase\\\": \\\"false\\\", \\\"ordered_export\\\": \\\"false\\\", \\\"phase\\\": \\\"false\\\", \\\"fasta\\\": \\\"false\\\", \\\"treemix\\\": \\\"false\\\", \\\"structure\\\": \\\"true\\\"}\", \"options_usage\": \"{\\\"input_type\\\": \\\"stacks\\\", \\\"popmap\\\": {\\\"__class__\\\": \\\"RuntimeValue\\\"}, \\\"input_col\\\": {\\\"__class__\\\": \\\"RuntimeValue\\\"}, \\\"__current_case__\\\": 0}\", \"bootstrap_resampling\": \"{\\\"bootstrap_wl\\\": {\\\"__class__\\\": \\\"RuntimeValue\\\"}, \\\"bootstrap_reps\\\": \\\"100\\\", \\\"bootstrap_resampling_mode\\\": {\\\"bootstrap_phist\\\": \\\"false\\\", \\\"bootstrap_fst\\\": \\\"false\\\", \\\"bootstrap_all\\\": \\\"false\\\", \\\"bootstrap_pifis\\\": \\\"false\\\", \\\"__current_case__\\\": 1, \\\"bootstrap_div\\\": \\\"false\\\"}}\", \"options_filtering\": \"{\\\"write_single_snp\\\": \\\"false\\\", \\\"mindepth\\\": \\\"1\\\", \\\"minpop\\\": \\\"2\\\", \\\"minminor\\\": \\\"0.25\\\", \\\"max_obs_het\\\": \\\"\\\", \\\"lnl\\\": \\\"\\\", \\\"correction_select\\\": {\\\"correction\\\": \\\"no_corr\\\", \\\"__current_case__\\\": 0}, \\\"minperc\\\": \\\"0.75\\\", \\\"write_random_snp\\\": \\\"false\\\"}\", \"advanced_options\": \"{\\\"blacklist\\\": {\\\"__class__\\\": \\\"RuntimeValue\\\"}, \\\"batchid\\\": \\\"1\\\", \\\"whitelist\\\": {\\\"__class__\\\": \\\"RuntimeValue\\\"}}\", \"__rerun_remap_job_id__\": null, \"chromInfo\": \"\\\"/usr/local/galaxy/galaxy-dist/tool-data/shared/ucsc/chrom/gasAcu1.len\\\"\", \"fstats\": \"\\\"true\\\"\"}",
+      "tool_version": "1.46.0",
+      "type": "tool",
+      "uuid": "34fb1b8e-9ca5-4b8a-9671-18877598a77a",
+      "workflow_outputs": []
+    }
+  },
+  "tags": [],
+  "uuid": "61fe11e8-8a9f-47b4-8d08-5936a818f364"
+}

--- a/topics/sequence-analysis/tutorials/ref-based-rad-seq/workflows/Galaxy-Workflow-Workflow_constructed_from_history__STACKS_RAD__population_genomics_with_reference_genome_.ga
+++ b/topics/sequence-analysis/tutorials/ref-based-rad-seq/workflows/Galaxy-Workflow-Workflow_constructed_from_history__STACKS_RAD__population_genomics_with_reference_genome_.ga
@@ -1,1 +1,1532 @@
-{"uuid": "759e08a8-429e-4681-bf05-a50c251e256b", "tags": [], "format-version": "0.1", "name": "Workflow constructed from history 'STACKS RAD: population genomics with reference genome'", "steps": {"0": {"tool_id": null, "tool_version": null, "outputs": [], "workflow_outputs": [], "input_connections": {}, "tool_state": "{\"name\": \"EBI SRA: SRR034310 File: ftp://ftp.sra.ebi.ac.uk/vol1/fastq/SRR034/SRR034310/SRR034310.fastq.gz\"}", "id": 0, "uuid": "4be2b939-61bf-4ed9-b134-5307c5127fe8", "errors": null, "name": "Input dataset", "label": "EBI SRA: SRR034310 File: ftp://ftp.sra.ebi.ac.uk/vol1/fastq/SRR034/SRR034310/SRR034310.fastq.gz", "inputs": [{"name": "EBI SRA: SRR034310 File: ftp://ftp.sra.ebi.ac.uk/vol1/fastq/SRR034/SRR034310/SRR034310.fastq.gz", "description": ""}], "position": {"top": 200.00001525878906, "left": 200.00001525878906}, "annotation": "", "content_id": null, "type": "data_input"}, "1": {"tool_id": null, "tool_version": null, "outputs": [], "workflow_outputs": [], "input_connections": {}, "tool_state": "{\"name\": \"https://zenodo.org/record/1134547/files/Barcode_SRR034310.txt\"}", "id": 1, "uuid": "95b8e56e-433d-4014-9dee-d9310863a20d", "errors": null, "name": "Input dataset", "label": "https://zenodo.org/record/1134547/files/Barcode_SRR034310.txt", "inputs": [{"name": "https://zenodo.org/record/1134547/files/Barcode_SRR034310.txt", "description": ""}], "position": {"top": 320.00001525878906, "left": 200.00001525878906}, "annotation": "", "content_id": null, "type": "data_input"}, "2": {"tool_id": null, "tool_version": null, "outputs": [], "workflow_outputs": [], "input_connections": {}, "tool_state": "{\"name\": \"https://zenodo.org/record/1134547/files/Details_Barcode_Population_SRR034310.txt\"}", "id": 2, "uuid": "43ca52f2-f60d-4fa6-9608-65ac4cc471b9", "errors": null, "name": "Input dataset", "label": "https://zenodo.org/record/1134547/files/Details_Barcode_Population_SRR034310.txt", "inputs": [{"name": "https://zenodo.org/record/1134547/files/Details_Barcode_Population_SRR034310.txt", "description": ""}], "position": {"top": 440.0000305175781, "left": 200.00001525878906}, "annotation": "", "content_id": null, "type": "data_input"}, "3": {"tool_id": null, "tool_version": null, "outputs": [], "workflow_outputs": [], "input_connections": {}, "tool_state": "{\"name\": \"https://zenodo.org/record/1134547/files/Reference_genome_11_chromosomes.fasta\"}", "id": 3, "uuid": "7c1d53db-b81d-40ab-8a75-221a94eb09ff", "errors": null, "name": "Input dataset", "label": "https://zenodo.org/record/1134547/files/Reference_genome_11_chromosomes.fasta", "inputs": [{"name": "https://zenodo.org/record/1134547/files/Reference_genome_11_chromosomes.fasta", "description": ""}], "position": {"top": 577.9861450195312, "left": 200.00001525878906}, "annotation": "", "content_id": null, "type": "data_input"}, "4": {"tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/stacks_procrad/stacks_procrad/1.46.0", "tool_version": "1.46.0", "outputs": [{"type": "input", "name": "demultiplexed"}, {"type": "input", "name": "remaining"}, {"type": "input", "name": "discarded"}, {"type": "txt", "name": "output_log"}], "workflow_outputs": [], "input_connections": {"barcode": {"output_name": "output", "id": 1}, "input_type|input_single": {"output_name": "output", "id": 0}}, "tool_state": "{\"capture\": \"\\\"true\\\"\", \"outype\": \"\\\"fastq\\\"\", \"options_enzyme\": \"{\\\"enzyme\\\": \\\"sbfI\\\", \\\"options_enzyme_selector\\\": \\\"1\\\", \\\"__current_case__\\\": 0}\", \"__page__\": null, \"input_type\": \"{\\\"input_single\\\": {\\\"__class__\\\": \\\"RuntimeValue\\\"}, \\\"barcode_encoding\\\": \\\"--inline_null\\\", \\\"__current_case__\\\": 0, \\\"options_type_selector\\\": \\\"single\\\"}\", \"__rerun_remap_job_id__\": null, \"barcode\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\", \"options_advanced\": \"{\\\"rescue\\\": \\\"false\\\", \\\"truncate\\\": \\\"\\\", \\\"remove\\\": \\\"false\\\", \\\"retain_header\\\": \\\"false\\\", \\\"score\\\": \\\"10\\\", \\\"discard\\\": \\\"false\\\", \\\"sliding\\\": \\\"0.15\\\"}\", \"chromInfo\": \"\\\"/data/dnb02/galaxy_db/files/007/567/dataset_7567924.dat\\\"\"}", "id": 4, "tool_shed_repository": {"owner": "iuc", "changeset_revision": "57910d476be9", "name": "stacks_procrad", "tool_shed": "toolshed.g2.bx.psu.edu"}, "uuid": "c146c40a-a6f1-4f96-8764-6403fb47f3e8", "errors": null, "name": "Stacks: process radtags", "post_job_actions": {}, "label": null, "inputs": [{"name": "input_type", "description": "runtime parameter for tool Stacks: process radtags"}, {"name": "barcode", "description": "runtime parameter for tool Stacks: process radtags"}], "position": {"top": 200.00001525878906, "left": 420.0000305175781}, "annotation": "", "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/stacks_procrad/stacks_procrad/1.46.0", "type": "tool"}, "5": {"tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/stacks_procrad/stacks_procrad/1.46.0", "tool_version": "1.46.0", "outputs": [{"type": "input", "name": "demultiplexed"}, {"type": "input", "name": "remaining"}, {"type": "input", "name": "discarded"}, {"type": "txt", "name": "output_log"}], "workflow_outputs": [], "input_connections": {"barcode": {"output_name": "output", "id": 1}, "input_type|input_single": {"output_name": "output", "id": 0}}, "tool_state": "{\"capture\": \"\\\"true\\\"\", \"outype\": \"\\\"fastq\\\"\", \"options_enzyme\": \"{\\\"enzyme\\\": \\\"sbfI\\\", \\\"options_enzyme_selector\\\": \\\"1\\\", \\\"__current_case__\\\": 0}\", \"__page__\": null, \"input_type\": \"{\\\"input_single\\\": {\\\"__class__\\\": \\\"RuntimeValue\\\"}, \\\"barcode_encoding\\\": \\\"--inline_null\\\", \\\"__current_case__\\\": 0, \\\"options_type_selector\\\": \\\"single\\\"}\", \"__rerun_remap_job_id__\": null, \"barcode\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\", \"options_advanced\": \"{\\\"rescue\\\": \\\"false\\\", \\\"truncate\\\": \\\"\\\", \\\"remove\\\": \\\"false\\\", \\\"retain_header\\\": \\\"false\\\", \\\"score\\\": \\\"10\\\", \\\"discard\\\": \\\"true\\\", \\\"sliding\\\": \\\"0.15\\\"}\", \"chromInfo\": \"\\\"/data/dnb02/galaxy_db/files/007/567/dataset_7567924.dat\\\"\"}", "id": 5, "tool_shed_repository": {"owner": "iuc", "changeset_revision": "57910d476be9", "name": "stacks_procrad", "tool_shed": "toolshed.g2.bx.psu.edu"}, "uuid": "31ba0988-fc83-4f5b-9a05-156521e882e8", "errors": null, "name": "Stacks: process radtags", "post_job_actions": {}, "label": null, "inputs": [{"name": "input_type", "description": "runtime parameter for tool Stacks: process radtags"}, {"name": "barcode", "description": "runtime parameter for tool Stacks: process radtags"}], "position": {"top": 320.00001525878906, "left": 420.0000305175781}, "annotation": "", "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/stacks_procrad/stacks_procrad/1.46.0", "type": "tool"}, "6": {"tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/stacks_procrad/stacks_procrad/1.46.0", "tool_version": "1.46.0", "outputs": [{"type": "input", "name": "demultiplexed"}, {"type": "input", "name": "remaining"}, {"type": "input", "name": "discarded"}, {"type": "txt", "name": "output_log"}], "workflow_outputs": [], "input_connections": {"barcode": {"output_name": "output", "id": 1}, "input_type|input_single": {"output_name": "output", "id": 0}}, "tool_state": "{\"capture\": \"\\\"true\\\"\", \"outype\": \"\\\"fastq\\\"\", \"options_enzyme\": \"{\\\"enzyme\\\": \\\"sbfI\\\", \\\"options_enzyme_selector\\\": \\\"1\\\", \\\"__current_case__\\\": 0}\", \"__page__\": null, \"input_type\": \"{\\\"input_single\\\": {\\\"__class__\\\": \\\"RuntimeValue\\\"}, \\\"barcode_encoding\\\": \\\"--inline_null\\\", \\\"__current_case__\\\": 0, \\\"options_type_selector\\\": \\\"single\\\"}\", \"__rerun_remap_job_id__\": null, \"barcode\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\", \"options_advanced\": \"{\\\"rescue\\\": \\\"false\\\", \\\"truncate\\\": \\\"\\\", \\\"remove\\\": \\\"false\\\", \\\"retain_header\\\": \\\"false\\\", \\\"score\\\": \\\"20\\\", \\\"discard\\\": \\\"true\\\", \\\"sliding\\\": \\\"0.15\\\"}\", \"chromInfo\": \"\\\"/data/dnb02/galaxy_db/files/007/567/dataset_7567924.dat\\\"\"}", "id": 6, "tool_shed_repository": {"owner": "iuc", "changeset_revision": "57910d476be9", "name": "stacks_procrad", "tool_shed": "toolshed.g2.bx.psu.edu"}, "uuid": "478beb7d-6109-435c-9fe0-c0d8d2919023", "errors": null, "name": "Stacks: process radtags", "post_job_actions": {}, "label": null, "inputs": [{"name": "input_type", "description": "runtime parameter for tool Stacks: process radtags"}, {"name": "barcode", "description": "runtime parameter for tool Stacks: process radtags"}], "position": {"top": 440.0000305175781, "left": 420.0000305175781}, "annotation": "", "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/stacks_procrad/stacks_procrad/1.46.0", "type": "tool"}, "7": {"tool_id": "toolshed.g2.bx.psu.edu/repos/bgruening/text_processing/tp_replace_in_line/1.1.1", "tool_version": "1.1.1", "outputs": [{"type": "input", "name": "outfile"}], "workflow_outputs": [], "input_connections": {"infile": {"output_name": "output", "id": 2}}, "tool_state": "{\"__page__\": null, \"find_pattern\": \"\\\"Bear Paw\\\"\", \"chromInfo\": \"\\\"/usr/local/galaxy/galaxy-dist/tool-data/shared/ucsc/chrom/?.len\\\"\", \"__rerun_remap_job_id__\": null, \"__workflow_invocation_uuid__\": \"\\\"cb306342cc9311e8993c984be15f9748\\\"\", \"replace_pattern\": \"\\\"1\\\"\", \"infile\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\"}", "id": 7, "tool_shed_repository": {"owner": "bgruening", "changeset_revision": "74a8bef53a00", "name": "text_processing", "tool_shed": "toolshed.g2.bx.psu.edu"}, "uuid": "e777e2f0-3cb1-4ca0-b26d-1c990b62ded8", "errors": null, "name": "Replace Text", "post_job_actions": {}, "label": null, "inputs": [{"name": "infile", "description": "runtime parameter for tool Replace Text"}], "position": {"top": 560.0000305175781, "left": 420.0000305175781}, "annotation": "", "content_id": "toolshed.g2.bx.psu.edu/repos/bgruening/text_processing/tp_replace_in_line/1.1.1", "type": "tool"}, "8": {"tool_id": "Grep1", "tool_version": "1.0.1", "outputs": [{"type": "input", "name": "out_file1"}], "workflow_outputs": [], "input_connections": {"input": {"output_name": "output_log", "id": 4}}, "tool_state": "{\"__page__\": null, \"pattern\": \"\\\"^R1.fq.gz\\\"\", \"invert\": \"\\\"false\\\"\", \"input\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\", \"chromInfo\": \"\\\"/data/dnb02/galaxy_db/files/007/567/dataset_7567924.dat\\\"\", \"__rerun_remap_job_id__\": null}", "id": 8, "uuid": "0fac4430-86a4-4b69-b57d-f3f16616a184", "errors": null, "name": "Select", "post_job_actions": {}, "label": null, "inputs": [{"name": "input", "description": "runtime parameter for tool Select"}], "position": {"top": 200.00001525878906, "left": 640.0000305175781}, "annotation": "", "content_id": "Grep1", "type": "tool"}, "9": {"tool_id": "Grep1", "tool_version": "1.0.1", "outputs": [{"type": "input", "name": "out_file1"}], "workflow_outputs": [], "input_connections": {"input": {"output_name": "output_log", "id": 5}}, "tool_state": "{\"__page__\": null, \"pattern\": \"\\\"^R1.fq.gz\\\"\", \"invert\": \"\\\"false\\\"\", \"input\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\", \"chromInfo\": \"\\\"/data/dnb02/galaxy_db/files/007/567/dataset_7567924.dat\\\"\", \"__rerun_remap_job_id__\": null}", "id": 9, "uuid": "d2500f6f-fc80-4d65-b41f-124b7d4dc85c", "errors": null, "name": "Select", "post_job_actions": {}, "label": null, "inputs": [{"name": "input", "description": "runtime parameter for tool Select"}], "position": {"top": 320.00001525878906, "left": 640.0000305175781}, "annotation": "", "content_id": "Grep1", "type": "tool"}, "10": {"tool_id": "toolshed.g2.bx.psu.edu/repos/devteam/fastqc/fastqc/0.71", "tool_version": "0.71", "outputs": [{"type": "html", "name": "html_file"}, {"type": "txt", "name": "text_file"}], "workflow_outputs": [], "input_connections": {"input_file": {"output_name": "demultiplexed", "id": 5}}, "tool_state": "{\"__page__\": null, \"limits\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\", \"input_file\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\", \"__rerun_remap_job_id__\": null, \"input_file|__identifier__\": \"\\\"sample_GGTT\\\"\", \"contaminants\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\", \"chromInfo\": \"\\\"/usr/local/galaxy/galaxy-dist/tool-data/shared/ucsc/chrom/?.len\\\"\"}", "id": 10, "tool_shed_repository": {"owner": "devteam", "changeset_revision": "ff9530579d1f", "name": "fastqc", "tool_shed": "toolshed.g2.bx.psu.edu"}, "uuid": "0cadb42c-09ca-4347-8a8f-ac05bf159bcd", "errors": null, "name": "FastQC", "post_job_actions": {}, "label": null, "inputs": [{"name": "contaminants", "description": "runtime parameter for tool FastQC"}, {"name": "limits", "description": "runtime parameter for tool FastQC"}, {"name": "input_file", "description": "runtime parameter for tool FastQC"}], "position": {"top": 680.0000610351562, "left": 640.0000305175781}, "annotation": "", "content_id": "toolshed.g2.bx.psu.edu/repos/devteam/fastqc/fastqc/0.71", "type": "tool"}, "11": {"tool_id": "toolshed.g2.bx.psu.edu/repos/devteam/bwa/bwa/0.7.17.4", "tool_version": "0.7.17.4", "outputs": [{"type": "bam", "name": "bam_output"}], "workflow_outputs": [], "input_connections": {"reference_source|ref_file": {"output_name": "output", "id": 3}, "input_type|fastq_input1": {"output_name": "demultiplexed", "id": 5}}, "tool_state": "{\"__page__\": null, \"input_type\": \"{\\\"adv_se_options\\\": {\\\"adv_se_options_selector\\\": \\\"do_not_set\\\", \\\"__current_case__\\\": 1}, \\\"__current_case__\\\": 2, \\\"input_type_selector\\\": \\\"single\\\", \\\"fastq_input1\\\": {\\\"__class__\\\": \\\"RuntimeValue\\\"}}\", \"__rerun_remap_job_id__\": null, \"rg\": \"{\\\"rg_selector\\\": \\\"do_not_set\\\", \\\"__current_case__\\\": 3}\", \"fastq_input1|__identifier__\": \"\\\"sample_GGTT\\\"\", \"analysis_type\": \"{\\\"analysis_type_selector\\\": \\\"illumina\\\", \\\"__current_case__\\\": 0}\", \"reference_source\": \"{\\\"ref_file\\\": {\\\"__class__\\\": \\\"RuntimeValue\\\"}, \\\"reference_source_selector\\\": \\\"history\\\", \\\"__current_case__\\\": 1, \\\"index_a\\\": \\\"auto\\\"}\", \"chromInfo\": \"\\\"/usr/local/galaxy/galaxy-dist/tool-data/shared/ucsc/chrom/?.len\\\"\"}", "id": 11, "tool_shed_repository": {"owner": "devteam", "changeset_revision": "8d2a528a9513", "name": "bwa", "tool_shed": "toolshed.g2.bx.psu.edu"}, "uuid": "e29a5320-6560-4183-b3bb-deca1696b0c1", "errors": null, "name": "Map with BWA", "post_job_actions": {}, "label": null, "inputs": [{"name": "input_type", "description": "runtime parameter for tool Map with BWA"}, {"name": "reference_source", "description": "runtime parameter for tool Map with BWA"}], "position": {"top": 805.0000610351562, "left": 638.9930725097656}, "annotation": "", "content_id": "toolshed.g2.bx.psu.edu/repos/devteam/bwa/bwa/0.7.17.4", "type": "tool"}, "12": {"tool_id": "Grep1", "tool_version": "1.0.1", "outputs": [{"type": "input", "name": "out_file1"}], "workflow_outputs": [], "input_connections": {"input": {"output_name": "output_log", "id": 6}}, "tool_state": "{\"__page__\": null, \"pattern\": \"\\\"^R1.fq.gz\\\"\", \"invert\": \"\\\"false\\\"\", \"input\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\", \"chromInfo\": \"\\\"/data/dnb02/galaxy_db/files/007/567/dataset_7567924.dat\\\"\", \"__rerun_remap_job_id__\": null}", "id": 12, "uuid": "b4817c49-2266-4a79-ac62-f9333895f3e9", "errors": null, "name": "Select", "post_job_actions": {}, "label": null, "inputs": [{"name": "input", "description": "runtime parameter for tool Select"}], "position": {"top": 440.0000305175781, "left": 640.0000305175781}, "annotation": "", "content_id": "Grep1", "type": "tool"}, "13": {"tool_id": "Grep1", "tool_version": "1.0.1", "outputs": [{"type": "input", "name": "out_file1"}], "workflow_outputs": [], "input_connections": {"input": {"output_name": "output_log", "id": 6}}, "tool_state": "{\"__page__\": null, \"pattern\": \"\\\"File\\\\\\\\tRetained Reads\\\"\", \"invert\": \"\\\"false\\\"\", \"input\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\", \"chromInfo\": \"\\\"/data/dnb02/galaxy_db/files/007/567/dataset_7567924.dat\\\"\", \"__rerun_remap_job_id__\": null}", "id": 13, "uuid": "01141294-ad16-4395-8277-4fb2e0082115", "errors": null, "name": "Select", "post_job_actions": {}, "label": null, "inputs": [{"name": "input", "description": "runtime parameter for tool Select"}], "position": {"top": 560.0000305175781, "left": 640.0000305175781}, "annotation": "", "content_id": "Grep1", "type": "tool"}, "14": {"tool_id": "toolshed.g2.bx.psu.edu/repos/bgruening/text_processing/tp_replace_in_line/1.1.1", "tool_version": "1.1.1", "outputs": [{"type": "input", "name": "outfile"}], "workflow_outputs": [], "input_connections": {"infile": {"output_name": "outfile", "id": 7}}, "tool_state": "{\"__page__\": null, \"find_pattern\": \"\\\"Rabbit Slough\\\"\", \"chromInfo\": \"\\\"/usr/local/galaxy/galaxy-dist/tool-data/shared/ucsc/chrom/?.len\\\"\", \"__rerun_remap_job_id__\": null, \"__workflow_invocation_uuid__\": \"\\\"cb306342cc9311e8993c984be15f9748\\\"\", \"replace_pattern\": \"\\\"2\\\"\", \"infile\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\"}", "id": 14, "tool_shed_repository": {"owner": "bgruening", "changeset_revision": "74a8bef53a00", "name": "text_processing", "tool_shed": "toolshed.g2.bx.psu.edu"}, "uuid": "d22558f3-b778-4093-b599-c04a9be53bf7", "errors": null, "name": "Replace Text", "post_job_actions": {}, "label": null, "inputs": [{"name": "infile", "description": "runtime parameter for tool Replace Text"}], "position": {"top": 986.99658203125, "left": 648.9930725097656}, "annotation": "", "content_id": "toolshed.g2.bx.psu.edu/repos/bgruening/text_processing/tp_replace_in_line/1.1.1", "type": "tool"}, "15": {"tool_id": "toolshed.g2.bx.psu.edu/repos/bgruening/text_processing/tp_replace_in_line/1.1.1", "tool_version": "1.1.1", "outputs": [{"type": "input", "name": "outfile"}], "workflow_outputs": [], "input_connections": {"infile": {"output_name": "out_file1", "id": 8}}, "tool_state": "{\"__page__\": null, \"find_pattern\": \"\\\"R1.fq.gz\\\"\", \"chromInfo\": \"\\\"/data/dnb02/galaxy_db/files/007/567/dataset_7567924.dat\\\"\", \"__rerun_remap_job_id__\": null, \"replace_pattern\": \"\\\"Lowquality\\\"\", \"infile\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\"}", "id": 15, "tool_shed_repository": {"owner": "bgruening", "changeset_revision": "74a8bef53a00", "name": "text_processing", "tool_shed": "toolshed.g2.bx.psu.edu"}, "uuid": "12d33b68-206a-4394-b81d-052df6726470", "errors": null, "name": "Replace Text", "post_job_actions": {}, "label": null, "inputs": [{"name": "infile", "description": "runtime parameter for tool Replace Text"}], "position": {"top": 200.00001525878906, "left": 860.0000305175781}, "annotation": "", "content_id": "toolshed.g2.bx.psu.edu/repos/bgruening/text_processing/tp_replace_in_line/1.1.1", "type": "tool"}, "16": {"tool_id": "toolshed.g2.bx.psu.edu/repos/bgruening/text_processing/tp_replace_in_line/1.1.1", "tool_version": "1.1.1", "outputs": [{"type": "input", "name": "outfile"}], "workflow_outputs": [], "input_connections": {"infile": {"output_name": "out_file1", "id": 9}}, "tool_state": "{\"__page__\": null, \"find_pattern\": \"\\\"R1.fq.gz\\\"\", \"chromInfo\": \"\\\"/data/dnb02/galaxy_db/files/007/567/dataset_7567924.dat\\\"\", \"__rerun_remap_job_id__\": null, \"replace_pattern\": \"\\\"Score10\\\"\", \"infile\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\"}", "id": 16, "tool_shed_repository": {"owner": "bgruening", "changeset_revision": "74a8bef53a00", "name": "text_processing", "tool_shed": "toolshed.g2.bx.psu.edu"}, "uuid": "526d8582-8893-4ffa-911b-a0151ad3f8d1", "errors": null, "name": "Replace Text", "post_job_actions": {}, "label": null, "inputs": [{"name": "infile", "description": "runtime parameter for tool Replace Text"}], "position": {"top": 320.00001525878906, "left": 860.0000305175781}, "annotation": "", "content_id": "toolshed.g2.bx.psu.edu/repos/bgruening/text_processing/tp_replace_in_line/1.1.1", "type": "tool"}, "17": {"tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/multiqc/multiqc/1.6", "tool_version": "1.6", "outputs": [{"type": "input", "name": "stats"}, {"type": "html", "name": "html_report"}, {"type": "txt", "name": "log"}], "workflow_outputs": [], "input_connections": {"results_0|software_cond|output_0|input": {"output_name": "text_file", "id": 10}}, "tool_state": "{\"comment\": \"\\\"\\\"\", \"__page__\": null, \"title\": \"\\\"SRR034310 Demultiplexed reads quality\\\"\", \"__rerun_remap_job_id__\": null, \"results\": \"[{\\\"__index__\\\": 0, \\\"software_cond\\\": {\\\"output\\\": [{\\\"__index__\\\": 0, \\\"type\\\": \\\"data\\\", \\\"input\\\": {\\\"__class__\\\": \\\"RuntimeValue\\\"}}], \\\"__current_case__\\\": 8, \\\"software\\\": \\\"fastqc\\\"}}]\", \"saveLog\": \"\\\"false\\\"\", \"chromInfo\": \"\\\"/usr/local/galaxy/galaxy-dist/tool-data/shared/ucsc/chrom/?.len\\\"\"}", "id": 17, "tool_shed_repository": {"owner": "iuc", "changeset_revision": "1c2db0054039", "name": "multiqc", "tool_shed": "toolshed.g2.bx.psu.edu"}, "uuid": "c77645e3-32ef-4316-bff4-c56c9b13cbee", "errors": null, "name": "MultiQC", "post_job_actions": {}, "label": null, "inputs": [], "position": {"top": 613.9931030273438, "left": 1237.9861145019531}, "annotation": "", "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/multiqc/multiqc/1.6", "type": "tool"}, "18": {"tool_id": "toolshed.g2.bx.psu.edu/repos/bgruening/text_processing/tp_replace_in_line/1.1.1", "tool_version": "1.1.1", "outputs": [{"type": "input", "name": "outfile"}], "workflow_outputs": [], "input_connections": {"infile": {"output_name": "out_file1", "id": 12}}, "tool_state": "{\"__page__\": null, \"find_pattern\": \"\\\"R1.fq.gz\\\"\", \"chromInfo\": \"\\\"/data/dnb02/galaxy_db/files/007/567/dataset_7567924.dat\\\"\", \"__rerun_remap_job_id__\": null, \"replace_pattern\": \"\\\"Score20\\\"\", \"infile\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\"}", "id": 18, "tool_shed_repository": {"owner": "bgruening", "changeset_revision": "74a8bef53a00", "name": "text_processing", "tool_shed": "toolshed.g2.bx.psu.edu"}, "uuid": "ee75d418-40b1-4cc7-acff-bb7b0c4b9d09", "errors": null, "name": "Replace Text", "post_job_actions": {}, "label": null, "inputs": [{"name": "infile", "description": "runtime parameter for tool Replace Text"}], "position": {"top": 440.0000305175781, "left": 860.0000305175781}, "annotation": "", "content_id": "toolshed.g2.bx.psu.edu/repos/bgruening/text_processing/tp_replace_in_line/1.1.1", "type": "tool"}, "19": {"tool_id": "toolshed.g2.bx.psu.edu/repos/bgruening/text_processing/tp_replace_in_line/1.1.1", "tool_version": "1.1.1", "outputs": [{"type": "input", "name": "outfile"}], "workflow_outputs": [], "input_connections": {"infile": {"output_name": "out_file1", "id": 13}}, "tool_state": "{\"__page__\": null, \"find_pattern\": \"\\\"File\\\"\", \"chromInfo\": \"\\\"/data/dnb02/galaxy_db/files/007/567/dataset_7567924.dat\\\"\", \"__rerun_remap_job_id__\": null, \"replace_pattern\": \"\\\"#\\\"\", \"infile\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\"}", "id": 19, "tool_shed_repository": {"owner": "bgruening", "changeset_revision": "74a8bef53a00", "name": "text_processing", "tool_shed": "toolshed.g2.bx.psu.edu"}, "uuid": "52ee490b-266e-4569-a98f-8ca23b389fe4", "errors": null, "name": "Replace Text", "post_job_actions": {}, "label": null, "inputs": [{"name": "infile", "description": "runtime parameter for tool Replace Text"}], "position": {"top": 560.0000305175781, "left": 860.0000305175781}, "annotation": "", "content_id": "toolshed.g2.bx.psu.edu/repos/bgruening/text_processing/tp_replace_in_line/1.1.1", "type": "tool"}, "20": {"tool_id": "addValue", "tool_version": "1.0.0", "outputs": [{"type": "input", "name": "out_file1"}], "workflow_outputs": [], "input_connections": {"input": {"output_name": "outfile", "id": 14}}, "tool_state": "{\"__page__\": null, \"__rerun_remap_job_id__\": null, \"__workflow_invocation_uuid__\": \"\\\"cb306342cc9311e8993c984be15f9748\\\"\", \"exp\": \"\\\"sample_\\\"\", \"input\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\", \"iterate\": \"\\\"no\\\"\", \"chromInfo\": \"\\\"/usr/local/galaxy/galaxy-dist/tool-data/shared/ucsc/chrom/?.len\\\"\"}", "id": 20, "uuid": "1aeba21f-04ae-4f67-8aed-dd309d168bab", "errors": null, "name": "Add column", "post_job_actions": {}, "label": null, "inputs": [{"name": "input", "description": "runtime parameter for tool Add column"}], "position": {"top": 925.9896240234375, "left": 999.9826965332031}, "annotation": "", "content_id": "addValue", "type": "tool"}, "21": {"tool_id": "cat1", "tool_version": "1.0.0", "outputs": [{"type": "input", "name": "out_file1"}], "workflow_outputs": [], "input_connections": {"input1": {"output_name": "outfile", "id": 19}, "queries_2|input2": {"output_name": "outfile", "id": 18}, "queries_0|input2": {"output_name": "outfile", "id": 15}, "queries_1|input2": {"output_name": "outfile", "id": 16}}, "tool_state": "{\"__page__\": null, \"__rerun_remap_job_id__\": null, \"input1\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\", \"chromInfo\": \"\\\"/data/dnb02/galaxy_db/files/007/567/dataset_7567924.dat\\\"\", \"queries\": \"[{\\\"input2\\\": {\\\"__class__\\\": \\\"RuntimeValue\\\"}, \\\"__index__\\\": 0}, {\\\"input2\\\": {\\\"__class__\\\": \\\"RuntimeValue\\\"}, \\\"__index__\\\": 1}, {\\\"input2\\\": {\\\"__class__\\\": \\\"RuntimeValue\\\"}, \\\"__index__\\\": 2}]\"}", "id": 21, "uuid": "9055e00b-0d94-4137-93ff-5c23b1b2e2cc", "errors": null, "name": "Concatenate datasets", "post_job_actions": {}, "label": null, "inputs": [{"name": "input1", "description": "runtime parameter for tool Concatenate datasets"}], "position": {"top": 200.00001525878906, "left": 1080.0000305175781}, "annotation": "", "content_id": "cat1", "type": "tool"}, "22": {"tool_id": "Cut1", "tool_version": "1.0.2", "outputs": [{"type": "tabular", "name": "out_file1"}], "workflow_outputs": [], "input_connections": {"input": {"output_name": "out_file1", "id": 20}}, "tool_state": "{\"__page__\": null, \"__rerun_remap_job_id__\": null, \"__workflow_invocation_uuid__\": \"\\\"cb306342cc9311e8993c984be15f9748\\\"\", \"delimiter\": \"\\\"T\\\"\", \"columnList\": \"\\\"c5,c1,c2\\\"\", \"input\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\", \"chromInfo\": \"\\\"/usr/local/galaxy/galaxy-dist/tool-data/shared/ucsc/chrom/?.len\\\"\"}", "id": 22, "uuid": "6819a301-338a-4372-b325-5e3c0f40ce11", "errors": null, "name": "Cut", "post_job_actions": {}, "label": null, "inputs": [{"name": "input", "description": "runtime parameter for tool Cut"}], "position": {"top": 320.00001525878906, "left": 1080.0000305175781}, "annotation": "", "content_id": "Cut1", "type": "tool"}, "23": {"tool_id": "Convert characters1", "tool_version": "1.0.0", "outputs": [{"type": "tabular", "name": "out_file1"}], "workflow_outputs": [], "input_connections": {"input": {"output_name": "out_file1", "id": 21}}, "tool_state": "{\"__page__\": null, \"chromInfo\": \"\\\"/data/dnb02/galaxy_db/files/007/567/dataset_7567924.dat\\\"\", \"__rerun_remap_job_id__\": null, \"condense\": \"\\\"true\\\"\", \"strip\": \"\\\"true\\\"\", \"input\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\", \"convert_from\": \"\\\"T\\\"\"}", "id": 23, "uuid": "dd488717-7ba9-46b0-821a-77989f63ff62", "errors": null, "name": "Convert", "post_job_actions": {}, "label": null, "inputs": [{"name": "input", "description": "runtime parameter for tool Convert"}], "position": {"top": 200.00001525878906, "left": 1300.0000305175781}, "annotation": "", "content_id": "Convert characters1", "type": "tool"}, "24": {"tool_id": "toolshed.g2.bx.psu.edu/repos/kellrott/regex_replace/regex_replace/1.0.0", "tool_version": "1.0.0", "outputs": [{"type": "txt", "name": "outfile"}], "workflow_outputs": [], "input_connections": {"infile": {"output_name": "out_file1", "id": 22}}, "tool_state": "{\"__page__\": null, \"ignore_case\": \"\\\"false\\\"\", \"search_str\": \"\\\"(sample_)\\\\\\\\t\\\"\", \"__rerun_remap_job_id__\": null, \"replace_str\": \"\\\"\\\\\\\\1\\\"\", \"__workflow_invocation_uuid__\": \"\\\"cb306342cc9311e8993c984be15f9748\\\"\", \"replace_count\": \"\\\"0\\\"\", \"multiline\": \"\\\"true\\\"\", \"chromInfo\": \"\\\"/usr/local/galaxy/galaxy-dist/tool-data/shared/ucsc/chrom/?.len\\\"\", \"infile\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\", \"dot_all\": \"\\\"false\\\"\"}", "id": 24, "tool_shed_repository": {"owner": "kellrott", "changeset_revision": "9a77d5fca67c", "name": "regex_replace", "tool_shed": "toolshed.g2.bx.psu.edu"}, "uuid": "a8768549-4c14-4a97-abc3-63b6341bb8b3", "errors": null, "name": "Regex Replace", "post_job_actions": {}, "label": null, "inputs": [{"name": "infile", "description": "runtime parameter for tool Regex Replace"}], "position": {"top": 320.00001525878906, "left": 1300.0000305175781}, "annotation": "", "content_id": "toolshed.g2.bx.psu.edu/repos/kellrott/regex_replace/regex_replace/1.0.0", "type": "tool"}, "25": {"tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/stacks_refmap/stacks_refmap/1.46.0", "tool_version": "1.46.0", "outputs": [{"type": "input", "name": "tags"}, {"type": "input", "name": "snps"}, {"type": "input", "name": "alleles"}, {"type": "input", "name": "matches"}, {"type": "input", "name": "all_output"}, {"type": "txt", "name": "output_log"}, {"type": "html", "name": "output_summary"}, {"type": "tabular", "name": "catalogtags"}, {"type": "tabular", "name": "catalogsnps"}, {"type": "tabular", "name": "catalogalleles"}, {"type": "txt", "name": "out_joinmap"}, {"type": "tabular", "name": "out_generic_haplo"}, {"type": "tabular", "name": "out_generic_geno"}, {"type": "tabular", "name": "out_sql_markers"}, {"type": "tabular", "name": "out_sql_genotypes"}, {"type": "tabular", "name": "out_haplotypes"}, {"type": "tabular", "name": "out_hapstats"}, {"type": "tabular", "name": "out_populations_log"}, {"type": "tabular", "name": "out_sumstats_sum"}, {"type": "tabular", "name": "out_sumstats"}, {"type": "tabular", "name": "out_sql"}], "workflow_outputs": [], "input_connections": {"options_usage|individual_sample": {"output_name": "bam_output", "id": 11}, "options_usage|popmap": {"output_name": "outfile", "id": 24}}, "tool_state": "{\"__page__\": null, \"P\": \"\\\"\\\"\", \"__rerun_remap_job_id__\": null, \"options_usage\": \"{\\\"rad_analysis_type\\\": \\\"population\\\", \\\"individual_sample\\\": {\\\"__class__\\\": \\\"RuntimeValue\\\"}, \\\"__current_case__\\\": 1, \\\"popmap\\\": {\\\"__class__\\\": \\\"RuntimeValue\\\"}}\", \"m\": \"\\\"3\\\"\", \"snp_options\": \"{\\\"select_model\\\": {\\\"model_type\\\": \\\"snp\\\", \\\"alpha\\\": \\\"0.05\\\", \\\"__current_case__\\\": 0}}\", \"chromInfo\": \"\\\"/usr/local/galaxy/galaxy-dist/tool-data/shared/ucsc/chrom/?.len\\\"\"}", "id": 25, "tool_shed_repository": {"owner": "iuc", "changeset_revision": "4ee074ca88fb", "name": "stacks_refmap", "tool_shed": "toolshed.g2.bx.psu.edu"}, "uuid": "31fc5dbe-7c05-4b10-bf73-98ad85dc7bd6", "errors": null, "name": "Stacks: reference map", "post_job_actions": {}, "label": null, "inputs": [{"name": "options_usage", "description": "runtime parameter for tool Stacks: reference map"}, {"name": "options_usage", "description": "runtime parameter for tool Stacks: reference map"}], "position": {"top": 200.00001525878906, "left": 1520.0000305175781}, "annotation": "", "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/stacks_refmap/stacks_refmap/1.46.0", "type": "tool"}, "26": {"tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/stacks_populations/stacks_populations/1.46.0", "tool_version": "1.46.0", "outputs": [{"type": "tabular", "name": "out_haplotypes"}, {"type": "tabular", "name": "out_hapstats"}, {"type": "tabular", "name": "out_populations_log"}, {"type": "tabular", "name": "out_sumstats_sum"}, {"type": "tabular", "name": "out_sumstats"}, {"type": "tabular", "name": "out_sql"}, {"type": "tabular", "name": "out_fstats"}, {"type": "tabular", "name": "out_fasta"}, {"type": "tabular", "name": "out_phylip_all_partitions"}, {"type": "tabular", "name": "out_phylip_all_pop"}, {"type": "tabular", "name": "out_phylip_all_loci"}, {"type": "tabular", "name": "out_genepop"}, {"type": "tabular", "name": "out_vcf_haplotypes"}, {"type": "tabular", "name": "out_hzar"}, {"type": "tabular", "name": "out_beagle_phased_haplotypes"}, {"type": "tabular", "name": "out_beagle_phased_markers"}, {"type": "tabular", "name": "out_beagle_haplotypes"}, {"type": "tabular", "name": "out_beagle_markers"}, {"type": "tabular", "name": "out_phylip_pop"}, {"type": "tabular", "name": "out_phylip_loci"}, {"type": "tabular", "name": "out_plink_markers"}, {"type": "tabular", "name": "out_plink_genotypes"}, {"type": "tabular", "name": "out_fasta_strict"}, {"type": "tabular", "name": "out_structure"}, {"type": "tabular", "name": "out_treemix_pop"}, {"type": "tabular", "name": "out_treemix_loci"}, {"type": "tabular", "name": "out_fastp\u0125ase"}, {"type": "tabular", "name": "out_phase"}, {"type": "tabular", "name": "out_vcf"}, {"type": "tabular", "name": "out_genomic"}, {"type": "html", "name": "output_summary"}], "workflow_outputs": [], "input_connections": {"options_usage|popmap": {"output_name": "outfile", "id": 24}, "options_usage|input_col": {"output_name": "all_output", "id": 25}}, "tool_state": "{\"options_kernel\": \"{\\\"kernel\\\": \\\"false\\\", \\\"__current_case__\\\": 1}\", \"__page__\": null, \"populations_output\": \"{\\\"phylip_var_all\\\": \\\"false\\\", \\\"fasta_strict\\\": \\\"false\\\", \\\"hzar\\\": \\\"false\\\", \\\"phylip_var\\\": \\\"false\\\", \\\"plink\\\": \\\"false\\\", \\\"vcf\\\": \\\"true\\\", \\\"phylip\\\": \\\"false\\\", \\\"beagle_phased\\\": \\\"false\\\", \\\"vcf_haplotypes\\\": \\\"false\\\", \\\"options_genomic\\\": {\\\"genomic\\\": \\\"false\\\", \\\"__current_case__\\\": 1}, \\\"genepop\\\": \\\"false\\\", \\\"beagle\\\": \\\"false\\\", \\\"fastphase\\\": \\\"false\\\", \\\"ordered_export\\\": \\\"false\\\", \\\"phase\\\": \\\"false\\\", \\\"fasta\\\": \\\"false\\\", \\\"treemix\\\": \\\"false\\\", \\\"structure\\\": \\\"true\\\"}\", \"options_usage\": \"{\\\"input_type\\\": \\\"stacks\\\", \\\"popmap\\\": {\\\"__class__\\\": \\\"RuntimeValue\\\"}, \\\"input_col\\\": {\\\"__class__\\\": \\\"RuntimeValue\\\"}, \\\"__current_case__\\\": 0}\", \"bootstrap_resampling\": \"{\\\"bootstrap_wl\\\": {\\\"__class__\\\": \\\"RuntimeValue\\\"}, \\\"bootstrap_reps\\\": \\\"100\\\", \\\"bootstrap_resampling_mode\\\": {\\\"bootstrap_phist\\\": \\\"false\\\", \\\"bootstrap_fst\\\": \\\"false\\\", \\\"bootstrap_all\\\": \\\"false\\\", \\\"bootstrap_pifis\\\": \\\"false\\\", \\\"__current_case__\\\": 1, \\\"bootstrap_div\\\": \\\"false\\\"}}\", \"options_filtering\": \"{\\\"write_single_snp\\\": \\\"false\\\", \\\"mindepth\\\": \\\"1\\\", \\\"minpop\\\": \\\"2\\\", \\\"minminor\\\": \\\"0.25\\\", \\\"max_obs_het\\\": \\\"\\\", \\\"lnl\\\": \\\"\\\", \\\"correction_select\\\": {\\\"correction\\\": \\\"no_corr\\\", \\\"__current_case__\\\": 0}, \\\"minperc\\\": \\\"0.75\\\", \\\"write_random_snp\\\": \\\"false\\\"}\", \"advanced_options\": \"{\\\"blacklist\\\": {\\\"__class__\\\": \\\"RuntimeValue\\\"}, \\\"batchid\\\": \\\"1\\\", \\\"whitelist\\\": {\\\"__class__\\\": \\\"RuntimeValue\\\"}}\", \"__rerun_remap_job_id__\": null, \"chromInfo\": \"\\\"/usr/local/galaxy/galaxy-dist/tool-data/shared/ucsc/chrom/?.len\\\"\", \"fstats\": \"\\\"true\\\"\"}", "id": 26, "tool_shed_repository": {"owner": "iuc", "changeset_revision": "45db1ba16163", "name": "stacks_populations", "tool_shed": "toolshed.g2.bx.psu.edu"}, "uuid": "dbc1c496-40a8-4334-b02c-a6d7dfa098df", "errors": null, "name": "Stacks: populations", "post_job_actions": {}, "label": null, "inputs": [{"name": "options_usage", "description": "runtime parameter for tool Stacks: populations"}, {"name": "options_usage", "description": "runtime parameter for tool Stacks: populations"}, {"name": "bootstrap_resampling", "description": "runtime parameter for tool Stacks: populations"}, {"name": "advanced_options", "description": "runtime parameter for tool Stacks: populations"}, {"name": "advanced_options", "description": "runtime parameter for tool Stacks: populations"}], "position": {"top": 200.00001525878906, "left": 1740.0000305175781}, "annotation": "", "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/stacks_populations/stacks_populations/1.46.0", "type": "tool"}, "27": {"tool_id": "Summary_Statistics1", "tool_version": "1.1.1", "outputs": [{"type": "tabular", "name": "out_file1"}], "workflow_outputs": [], "input_connections": {"input": {"output_name": "out_fstats", "id": 26}}, "tool_state": "{\"__page__\": null, \"__rerun_remap_job_id__\": null, \"__workflow_invocation_uuid__\": \"\\\"a6f0faf0cca211e8a11b984be15f9748\\\"\", \"cond\": \"\\\"c30\\\"\", \"input\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\", \"chromInfo\": \"\\\"/usr/local/galaxy/galaxy-dist/tool-data/shared/ucsc/chrom/?.len\\\"\"}", "id": 27, "uuid": "188816cd-1847-4e57-874c-32ebbf8174ee", "errors": null, "name": "Summary Statistics", "post_job_actions": {}, "label": null, "inputs": [{"name": "input", "description": "runtime parameter for tool Summary Statistics"}], "position": {"top": 200.00001525878906, "left": 1960.0001525878906}, "annotation": "", "content_id": "Summary_Statistics1", "type": "tool"}, "28": {"tool_id": "toolshed.g2.bx.psu.edu/repos/bgruening/text_processing/tp_sort_header_tool/1.1.1", "tool_version": "1.1.1", "outputs": [{"type": "input", "name": "outfile"}], "workflow_outputs": [], "input_connections": {"infile": {"output_name": "out_fstats", "id": 26}}, "tool_state": "{\"sortkeys\": \"[{\\\"column\\\": \\\"30\\\", \\\"__index__\\\": 0, \\\"style\\\": \\\"n\\\", \\\"order\\\": \\\"r\\\"}]\", \"__page__\": null, \"ignore_case\": \"\\\"false\\\"\", \"__rerun_remap_job_id__\": null, \"__workflow_invocation_uuid__\": \"\\\"a6f0faf0cca211e8a11b984be15f9748\\\"\", \"header\": \"\\\"4\\\"\", \"unique\": \"\\\"false\\\"\", \"chromInfo\": \"\\\"/usr/local/galaxy/galaxy-dist/tool-data/shared/ucsc/chrom/?.len\\\"\", \"infile\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\"}", "id": 28, "tool_shed_repository": {"owner": "bgruening", "changeset_revision": "74a8bef53a00", "name": "text_processing", "tool_shed": "toolshed.g2.bx.psu.edu"}, "uuid": "5ea04279-dca9-4911-8279-011731b3ce71", "errors": null, "name": "Sort", "post_job_actions": {}, "label": null, "inputs": [{"name": "infile", "description": "runtime parameter for tool Sort"}], "position": {"top": 320.00001525878906, "left": 1960.0001525878906}, "annotation": "", "content_id": "toolshed.g2.bx.psu.edu/repos/bgruening/text_processing/tp_sort_header_tool/1.1.1", "type": "tool"}, "29": {"tool_id": "Count1", "tool_version": "1.0.2", "outputs": [{"type": "tabular", "name": "out_file1"}], "workflow_outputs": [], "input_connections": {"input": {"output_name": "out_fstats", "id": 26}}, "tool_state": "{\"__page__\": null, \"sorting\": \"\\\"value\\\"\", \"column\": \"[\\\"30\\\"]\", \"__rerun_remap_job_id__\": null, \"delim\": \"\\\"T\\\"\", \"__workflow_invocation_uuid__\": \"\\\"a6f0faf0cca211e8a11b984be15f9748\\\"\", \"input\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\", \"chromInfo\": \"\\\"/usr/local/galaxy/galaxy-dist/tool-data/shared/ucsc/chrom/?.len\\\"\"}", "id": 29, "uuid": "462ddec3-117f-4320-b97a-5264cad35b3c", "errors": null, "name": "Count", "post_job_actions": {}, "label": null, "inputs": [{"name": "input", "description": "runtime parameter for tool Count"}], "position": {"top": 440.0000305175781, "left": 1960.0001525878906}, "annotation": "", "content_id": "Count1", "type": "tool"}, "30": {"tool_id": "Filter1", "tool_version": "1.1.0", "outputs": [{"type": "input", "name": "out_file1"}], "workflow_outputs": [], "input_connections": {"input": {"output_name": "out_fstats", "id": 26}}, "tool_state": "{\"__page__\": null, \"__rerun_remap_job_id__\": null, \"__workflow_invocation_uuid__\": \"\\\"a6f0faf0cca211e8a11b984be15f9748\\\"\", \"cond\": \"\\\"c30==1\\\"\", \"input\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\", \"header_lines\": \"\\\"4\\\"\", \"chromInfo\": \"\\\"/usr/local/galaxy/galaxy-dist/tool-data/shared/ucsc/chrom/?.len\\\"\"}", "id": 30, "uuid": "1df32fa8-eda6-49ef-88b3-54544adb9bc3", "errors": null, "name": "Filter", "post_job_actions": {}, "label": null, "inputs": [{"name": "input", "description": "runtime parameter for tool Filter"}], "position": {"top": 560.0000305175781, "left": 1960.0001525878906}, "annotation": "", "content_id": "Filter1", "type": "tool"}}, "annotation": "", "a_galaxy_workflow": "true"}
+{
+  "a_galaxy_workflow": "true",
+  "annotation": "",
+  "format-version": "0.1",
+  "name": "Workflow constructed from history 'STACKS RAD: population genomics with reference genome'",
+  "steps": {
+    "0": {
+      "annotation": "",
+      "content_id": null,
+      "errors": null,
+      "id": 0,
+      "input_connections": {},
+      "inputs": [
+        {
+          "description": "",
+          "name": "EBI SRA: SRR034310 File: ftp://ftp.sra.ebi.ac.uk/vol1/fastq/SRR034/SRR034310/SRR034310.fastq.gz"
+        }
+      ],
+      "label": "EBI SRA: SRR034310 File: ftp://ftp.sra.ebi.ac.uk/vol1/fastq/SRR034/SRR034310/SRR034310.fastq.gz",
+      "name": "Input dataset",
+      "outputs": [],
+      "position": {
+        "left": 200.00001525878906,
+        "top": 200.00001525878906
+      },
+      "tool_id": null,
+      "tool_state": "{\"name\": \"EBI SRA: SRR034310 File: ftp://ftp.sra.ebi.ac.uk/vol1/fastq/SRR034/SRR034310/SRR034310.fastq.gz\"}",
+      "tool_version": null,
+      "type": "data_input",
+      "uuid": "4be2b939-61bf-4ed9-b134-5307c5127fe8",
+      "workflow_outputs": []
+    },
+    "1": {
+      "annotation": "",
+      "content_id": null,
+      "errors": null,
+      "id": 1,
+      "input_connections": {},
+      "inputs": [
+        {
+          "description": "",
+          "name": "https://zenodo.org/record/1134547/files/Barcode_SRR034310.txt"
+        }
+      ],
+      "label": "https://zenodo.org/record/1134547/files/Barcode_SRR034310.txt",
+      "name": "Input dataset",
+      "outputs": [],
+      "position": {
+        "left": 200.00001525878906,
+        "top": 320.00001525878906
+      },
+      "tool_id": null,
+      "tool_state": "{\"name\": \"https://zenodo.org/record/1134547/files/Barcode_SRR034310.txt\"}",
+      "tool_version": null,
+      "type": "data_input",
+      "uuid": "95b8e56e-433d-4014-9dee-d9310863a20d",
+      "workflow_outputs": []
+    },
+    "10": {
+      "annotation": "",
+      "content_id": "toolshed.g2.bx.psu.edu/repos/devteam/fastqc/fastqc/0.71",
+      "errors": null,
+      "id": 10,
+      "input_connections": {
+        "input_file": {
+          "id": 5,
+          "output_name": "demultiplexed"
+        }
+      },
+      "inputs": [
+        {
+          "description": "runtime parameter for tool FastQC",
+          "name": "contaminants"
+        },
+        {
+          "description": "runtime parameter for tool FastQC",
+          "name": "limits"
+        },
+        {
+          "description": "runtime parameter for tool FastQC",
+          "name": "input_file"
+        }
+      ],
+      "label": null,
+      "name": "FastQC",
+      "outputs": [
+        {
+          "name": "html_file",
+          "type": "html"
+        },
+        {
+          "name": "text_file",
+          "type": "txt"
+        }
+      ],
+      "position": {
+        "left": 640.0000305175781,
+        "top": 680.0000610351562
+      },
+      "post_job_actions": {},
+      "tool_id": "toolshed.g2.bx.psu.edu/repos/devteam/fastqc/fastqc/0.71",
+      "tool_shed_repository": {
+        "changeset_revision": "ff9530579d1f",
+        "name": "fastqc",
+        "owner": "devteam",
+        "tool_shed": "toolshed.g2.bx.psu.edu"
+      },
+      "tool_state": "{\"__page__\": null, \"limits\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\", \"input_file\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\", \"__rerun_remap_job_id__\": null, \"input_file|__identifier__\": \"\\\"sample_GGTT\\\"\", \"contaminants\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\", \"chromInfo\": \"\\\"/usr/local/galaxy/galaxy-dist/tool-data/shared/ucsc/chrom/?.len\\\"\"}",
+      "tool_version": "0.71",
+      "type": "tool",
+      "uuid": "0cadb42c-09ca-4347-8a8f-ac05bf159bcd",
+      "workflow_outputs": []
+    },
+    "11": {
+      "annotation": "",
+      "content_id": "toolshed.g2.bx.psu.edu/repos/devteam/bwa/bwa/0.7.17.4",
+      "errors": null,
+      "id": 11,
+      "input_connections": {
+        "input_type|fastq_input1": {
+          "id": 5,
+          "output_name": "demultiplexed"
+        },
+        "reference_source|ref_file": {
+          "id": 3,
+          "output_name": "output"
+        }
+      },
+      "inputs": [
+        {
+          "description": "runtime parameter for tool Map with BWA",
+          "name": "input_type"
+        },
+        {
+          "description": "runtime parameter for tool Map with BWA",
+          "name": "reference_source"
+        }
+      ],
+      "label": null,
+      "name": "Map with BWA",
+      "outputs": [
+        {
+          "name": "bam_output",
+          "type": "bam"
+        }
+      ],
+      "position": {
+        "left": 638.9930725097656,
+        "top": 805.0000610351562
+      },
+      "post_job_actions": {},
+      "tool_id": "toolshed.g2.bx.psu.edu/repos/devteam/bwa/bwa/0.7.17.4",
+      "tool_shed_repository": {
+        "changeset_revision": "8d2a528a9513",
+        "name": "bwa",
+        "owner": "devteam",
+        "tool_shed": "toolshed.g2.bx.psu.edu"
+      },
+      "tool_state": "{\"__page__\": null, \"input_type\": \"{\\\"adv_se_options\\\": {\\\"adv_se_options_selector\\\": \\\"do_not_set\\\", \\\"__current_case__\\\": 1}, \\\"__current_case__\\\": 2, \\\"input_type_selector\\\": \\\"single\\\", \\\"fastq_input1\\\": {\\\"__class__\\\": \\\"RuntimeValue\\\"}}\", \"__rerun_remap_job_id__\": null, \"rg\": \"{\\\"rg_selector\\\": \\\"do_not_set\\\", \\\"__current_case__\\\": 3}\", \"fastq_input1|__identifier__\": \"\\\"sample_GGTT\\\"\", \"analysis_type\": \"{\\\"analysis_type_selector\\\": \\\"illumina\\\", \\\"__current_case__\\\": 0}\", \"reference_source\": \"{\\\"ref_file\\\": {\\\"__class__\\\": \\\"RuntimeValue\\\"}, \\\"reference_source_selector\\\": \\\"history\\\", \\\"__current_case__\\\": 1, \\\"index_a\\\": \\\"auto\\\"}\", \"chromInfo\": \"\\\"/usr/local/galaxy/galaxy-dist/tool-data/shared/ucsc/chrom/?.len\\\"\"}",
+      "tool_version": "0.7.17.4",
+      "type": "tool",
+      "uuid": "e29a5320-6560-4183-b3bb-deca1696b0c1",
+      "workflow_outputs": []
+    },
+    "12": {
+      "annotation": "",
+      "content_id": "Grep1",
+      "errors": null,
+      "id": 12,
+      "input_connections": {
+        "input": {
+          "id": 6,
+          "output_name": "output_log"
+        }
+      },
+      "inputs": [
+        {
+          "description": "runtime parameter for tool Select",
+          "name": "input"
+        }
+      ],
+      "label": null,
+      "name": "Select",
+      "outputs": [
+        {
+          "name": "out_file1",
+          "type": "input"
+        }
+      ],
+      "position": {
+        "left": 640.0000305175781,
+        "top": 440.0000305175781
+      },
+      "post_job_actions": {},
+      "tool_id": "Grep1",
+      "tool_state": "{\"__page__\": null, \"pattern\": \"\\\"^R1.fq.gz\\\"\", \"invert\": \"\\\"false\\\"\", \"input\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\", \"chromInfo\": \"\\\"/data/dnb02/galaxy_db/files/007/567/dataset_7567924.dat\\\"\", \"__rerun_remap_job_id__\": null}",
+      "tool_version": "1.0.1",
+      "type": "tool",
+      "uuid": "b4817c49-2266-4a79-ac62-f9333895f3e9",
+      "workflow_outputs": []
+    },
+    "13": {
+      "annotation": "",
+      "content_id": "Grep1",
+      "errors": null,
+      "id": 13,
+      "input_connections": {
+        "input": {
+          "id": 6,
+          "output_name": "output_log"
+        }
+      },
+      "inputs": [
+        {
+          "description": "runtime parameter for tool Select",
+          "name": "input"
+        }
+      ],
+      "label": null,
+      "name": "Select",
+      "outputs": [
+        {
+          "name": "out_file1",
+          "type": "input"
+        }
+      ],
+      "position": {
+        "left": 640.0000305175781,
+        "top": 560.0000305175781
+      },
+      "post_job_actions": {},
+      "tool_id": "Grep1",
+      "tool_state": "{\"__page__\": null, \"pattern\": \"\\\"File\\\\\\\\tRetained Reads\\\"\", \"invert\": \"\\\"false\\\"\", \"input\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\", \"chromInfo\": \"\\\"/data/dnb02/galaxy_db/files/007/567/dataset_7567924.dat\\\"\", \"__rerun_remap_job_id__\": null}",
+      "tool_version": "1.0.1",
+      "type": "tool",
+      "uuid": "01141294-ad16-4395-8277-4fb2e0082115",
+      "workflow_outputs": []
+    },
+    "14": {
+      "annotation": "",
+      "content_id": "toolshed.g2.bx.psu.edu/repos/bgruening/text_processing/tp_replace_in_line/1.1.1",
+      "errors": null,
+      "id": 14,
+      "input_connections": {
+        "infile": {
+          "id": 7,
+          "output_name": "outfile"
+        }
+      },
+      "inputs": [
+        {
+          "description": "runtime parameter for tool Replace Text",
+          "name": "infile"
+        }
+      ],
+      "label": null,
+      "name": "Replace Text",
+      "outputs": [
+        {
+          "name": "outfile",
+          "type": "input"
+        }
+      ],
+      "position": {
+        "left": 648.9930725097656,
+        "top": 986.99658203125
+      },
+      "post_job_actions": {},
+      "tool_id": "toolshed.g2.bx.psu.edu/repos/bgruening/text_processing/tp_replace_in_line/1.1.1",
+      "tool_shed_repository": {
+        "changeset_revision": "74a8bef53a00",
+        "name": "text_processing",
+        "owner": "bgruening",
+        "tool_shed": "toolshed.g2.bx.psu.edu"
+      },
+      "tool_state": "{\"__page__\": null, \"find_pattern\": \"\\\"Rabbit Slough\\\"\", \"chromInfo\": \"\\\"/usr/local/galaxy/galaxy-dist/tool-data/shared/ucsc/chrom/?.len\\\"\", \"__rerun_remap_job_id__\": null, \"__workflow_invocation_uuid__\": \"\\\"cb306342cc9311e8993c984be15f9748\\\"\", \"replace_pattern\": \"\\\"2\\\"\", \"infile\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\"}",
+      "tool_version": "1.1.1",
+      "type": "tool",
+      "uuid": "d22558f3-b778-4093-b599-c04a9be53bf7",
+      "workflow_outputs": []
+    },
+    "15": {
+      "annotation": "",
+      "content_id": "toolshed.g2.bx.psu.edu/repos/bgruening/text_processing/tp_replace_in_line/1.1.1",
+      "errors": null,
+      "id": 15,
+      "input_connections": {
+        "infile": {
+          "id": 8,
+          "output_name": "out_file1"
+        }
+      },
+      "inputs": [
+        {
+          "description": "runtime parameter for tool Replace Text",
+          "name": "infile"
+        }
+      ],
+      "label": null,
+      "name": "Replace Text",
+      "outputs": [
+        {
+          "name": "outfile",
+          "type": "input"
+        }
+      ],
+      "position": {
+        "left": 860.0000305175781,
+        "top": 200.00001525878906
+      },
+      "post_job_actions": {},
+      "tool_id": "toolshed.g2.bx.psu.edu/repos/bgruening/text_processing/tp_replace_in_line/1.1.1",
+      "tool_shed_repository": {
+        "changeset_revision": "74a8bef53a00",
+        "name": "text_processing",
+        "owner": "bgruening",
+        "tool_shed": "toolshed.g2.bx.psu.edu"
+      },
+      "tool_state": "{\"__page__\": null, \"find_pattern\": \"\\\"R1.fq.gz\\\"\", \"chromInfo\": \"\\\"/data/dnb02/galaxy_db/files/007/567/dataset_7567924.dat\\\"\", \"__rerun_remap_job_id__\": null, \"replace_pattern\": \"\\\"Lowquality\\\"\", \"infile\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\"}",
+      "tool_version": "1.1.1",
+      "type": "tool",
+      "uuid": "12d33b68-206a-4394-b81d-052df6726470",
+      "workflow_outputs": []
+    },
+    "16": {
+      "annotation": "",
+      "content_id": "toolshed.g2.bx.psu.edu/repos/bgruening/text_processing/tp_replace_in_line/1.1.1",
+      "errors": null,
+      "id": 16,
+      "input_connections": {
+        "infile": {
+          "id": 9,
+          "output_name": "out_file1"
+        }
+      },
+      "inputs": [
+        {
+          "description": "runtime parameter for tool Replace Text",
+          "name": "infile"
+        }
+      ],
+      "label": null,
+      "name": "Replace Text",
+      "outputs": [
+        {
+          "name": "outfile",
+          "type": "input"
+        }
+      ],
+      "position": {
+        "left": 860.0000305175781,
+        "top": 320.00001525878906
+      },
+      "post_job_actions": {},
+      "tool_id": "toolshed.g2.bx.psu.edu/repos/bgruening/text_processing/tp_replace_in_line/1.1.1",
+      "tool_shed_repository": {
+        "changeset_revision": "74a8bef53a00",
+        "name": "text_processing",
+        "owner": "bgruening",
+        "tool_shed": "toolshed.g2.bx.psu.edu"
+      },
+      "tool_state": "{\"__page__\": null, \"find_pattern\": \"\\\"R1.fq.gz\\\"\", \"chromInfo\": \"\\\"/data/dnb02/galaxy_db/files/007/567/dataset_7567924.dat\\\"\", \"__rerun_remap_job_id__\": null, \"replace_pattern\": \"\\\"Score10\\\"\", \"infile\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\"}",
+      "tool_version": "1.1.1",
+      "type": "tool",
+      "uuid": "526d8582-8893-4ffa-911b-a0151ad3f8d1",
+      "workflow_outputs": []
+    },
+    "17": {
+      "annotation": "",
+      "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/multiqc/multiqc/1.6",
+      "errors": null,
+      "id": 17,
+      "input_connections": {
+        "results_0|software_cond|output_0|input": {
+          "id": 10,
+          "output_name": "text_file"
+        }
+      },
+      "inputs": [],
+      "label": null,
+      "name": "MultiQC",
+      "outputs": [
+        {
+          "name": "stats",
+          "type": "input"
+        },
+        {
+          "name": "html_report",
+          "type": "html"
+        },
+        {
+          "name": "log",
+          "type": "txt"
+        }
+      ],
+      "position": {
+        "left": 1237.9861145019531,
+        "top": 613.9931030273438
+      },
+      "post_job_actions": {},
+      "tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/multiqc/multiqc/1.6",
+      "tool_shed_repository": {
+        "changeset_revision": "1c2db0054039",
+        "name": "multiqc",
+        "owner": "iuc",
+        "tool_shed": "toolshed.g2.bx.psu.edu"
+      },
+      "tool_state": "{\"comment\": \"\\\"\\\"\", \"__page__\": null, \"title\": \"\\\"SRR034310 Demultiplexed reads quality\\\"\", \"__rerun_remap_job_id__\": null, \"results\": \"[{\\\"__index__\\\": 0, \\\"software_cond\\\": {\\\"output\\\": [{\\\"__index__\\\": 0, \\\"type\\\": \\\"data\\\", \\\"input\\\": {\\\"__class__\\\": \\\"RuntimeValue\\\"}}], \\\"__current_case__\\\": 8, \\\"software\\\": \\\"fastqc\\\"}}]\", \"saveLog\": \"\\\"false\\\"\", \"chromInfo\": \"\\\"/usr/local/galaxy/galaxy-dist/tool-data/shared/ucsc/chrom/?.len\\\"\"}",
+      "tool_version": "1.6",
+      "type": "tool",
+      "uuid": "c77645e3-32ef-4316-bff4-c56c9b13cbee",
+      "workflow_outputs": []
+    },
+    "18": {
+      "annotation": "",
+      "content_id": "toolshed.g2.bx.psu.edu/repos/bgruening/text_processing/tp_replace_in_line/1.1.1",
+      "errors": null,
+      "id": 18,
+      "input_connections": {
+        "infile": {
+          "id": 12,
+          "output_name": "out_file1"
+        }
+      },
+      "inputs": [
+        {
+          "description": "runtime parameter for tool Replace Text",
+          "name": "infile"
+        }
+      ],
+      "label": null,
+      "name": "Replace Text",
+      "outputs": [
+        {
+          "name": "outfile",
+          "type": "input"
+        }
+      ],
+      "position": {
+        "left": 860.0000305175781,
+        "top": 440.0000305175781
+      },
+      "post_job_actions": {},
+      "tool_id": "toolshed.g2.bx.psu.edu/repos/bgruening/text_processing/tp_replace_in_line/1.1.1",
+      "tool_shed_repository": {
+        "changeset_revision": "74a8bef53a00",
+        "name": "text_processing",
+        "owner": "bgruening",
+        "tool_shed": "toolshed.g2.bx.psu.edu"
+      },
+      "tool_state": "{\"__page__\": null, \"find_pattern\": \"\\\"R1.fq.gz\\\"\", \"chromInfo\": \"\\\"/data/dnb02/galaxy_db/files/007/567/dataset_7567924.dat\\\"\", \"__rerun_remap_job_id__\": null, \"replace_pattern\": \"\\\"Score20\\\"\", \"infile\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\"}",
+      "tool_version": "1.1.1",
+      "type": "tool",
+      "uuid": "ee75d418-40b1-4cc7-acff-bb7b0c4b9d09",
+      "workflow_outputs": []
+    },
+    "19": {
+      "annotation": "",
+      "content_id": "toolshed.g2.bx.psu.edu/repos/bgruening/text_processing/tp_replace_in_line/1.1.1",
+      "errors": null,
+      "id": 19,
+      "input_connections": {
+        "infile": {
+          "id": 13,
+          "output_name": "out_file1"
+        }
+      },
+      "inputs": [
+        {
+          "description": "runtime parameter for tool Replace Text",
+          "name": "infile"
+        }
+      ],
+      "label": null,
+      "name": "Replace Text",
+      "outputs": [
+        {
+          "name": "outfile",
+          "type": "input"
+        }
+      ],
+      "position": {
+        "left": 860.0000305175781,
+        "top": 560.0000305175781
+      },
+      "post_job_actions": {},
+      "tool_id": "toolshed.g2.bx.psu.edu/repos/bgruening/text_processing/tp_replace_in_line/1.1.1",
+      "tool_shed_repository": {
+        "changeset_revision": "74a8bef53a00",
+        "name": "text_processing",
+        "owner": "bgruening",
+        "tool_shed": "toolshed.g2.bx.psu.edu"
+      },
+      "tool_state": "{\"__page__\": null, \"find_pattern\": \"\\\"File\\\"\", \"chromInfo\": \"\\\"/data/dnb02/galaxy_db/files/007/567/dataset_7567924.dat\\\"\", \"__rerun_remap_job_id__\": null, \"replace_pattern\": \"\\\"#\\\"\", \"infile\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\"}",
+      "tool_version": "1.1.1",
+      "type": "tool",
+      "uuid": "52ee490b-266e-4569-a98f-8ca23b389fe4",
+      "workflow_outputs": []
+    },
+    "2": {
+      "annotation": "",
+      "content_id": null,
+      "errors": null,
+      "id": 2,
+      "input_connections": {},
+      "inputs": [
+        {
+          "description": "",
+          "name": "https://zenodo.org/record/1134547/files/Details_Barcode_Population_SRR034310.txt"
+        }
+      ],
+      "label": "https://zenodo.org/record/1134547/files/Details_Barcode_Population_SRR034310.txt",
+      "name": "Input dataset",
+      "outputs": [],
+      "position": {
+        "left": 200.00001525878906,
+        "top": 440.0000305175781
+      },
+      "tool_id": null,
+      "tool_state": "{\"name\": \"https://zenodo.org/record/1134547/files/Details_Barcode_Population_SRR034310.txt\"}",
+      "tool_version": null,
+      "type": "data_input",
+      "uuid": "43ca52f2-f60d-4fa6-9608-65ac4cc471b9",
+      "workflow_outputs": []
+    },
+    "20": {
+      "annotation": "",
+      "content_id": "addValue",
+      "errors": null,
+      "id": 20,
+      "input_connections": {
+        "input": {
+          "id": 14,
+          "output_name": "outfile"
+        }
+      },
+      "inputs": [
+        {
+          "description": "runtime parameter for tool Add column",
+          "name": "input"
+        }
+      ],
+      "label": null,
+      "name": "Add column",
+      "outputs": [
+        {
+          "name": "out_file1",
+          "type": "input"
+        }
+      ],
+      "position": {
+        "left": 999.9826965332031,
+        "top": 925.9896240234375
+      },
+      "post_job_actions": {},
+      "tool_id": "addValue",
+      "tool_state": "{\"__page__\": null, \"__rerun_remap_job_id__\": null, \"__workflow_invocation_uuid__\": \"\\\"cb306342cc9311e8993c984be15f9748\\\"\", \"exp\": \"\\\"sample_\\\"\", \"input\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\", \"iterate\": \"\\\"no\\\"\", \"chromInfo\": \"\\\"/usr/local/galaxy/galaxy-dist/tool-data/shared/ucsc/chrom/?.len\\\"\"}",
+      "tool_version": "1.0.0",
+      "type": "tool",
+      "uuid": "1aeba21f-04ae-4f67-8aed-dd309d168bab",
+      "workflow_outputs": []
+    },
+    "21": {
+      "annotation": "",
+      "content_id": "cat1",
+      "errors": null,
+      "id": 21,
+      "input_connections": {
+        "input1": {
+          "id": 19,
+          "output_name": "outfile"
+        },
+        "queries_0|input2": {
+          "id": 15,
+          "output_name": "outfile"
+        },
+        "queries_1|input2": {
+          "id": 16,
+          "output_name": "outfile"
+        },
+        "queries_2|input2": {
+          "id": 18,
+          "output_name": "outfile"
+        }
+      },
+      "inputs": [
+        {
+          "description": "runtime parameter for tool Concatenate datasets",
+          "name": "input1"
+        }
+      ],
+      "label": null,
+      "name": "Concatenate datasets",
+      "outputs": [
+        {
+          "name": "out_file1",
+          "type": "input"
+        }
+      ],
+      "position": {
+        "left": 1080.0000305175781,
+        "top": 200.00001525878906
+      },
+      "post_job_actions": {},
+      "tool_id": "cat1",
+      "tool_state": "{\"__page__\": null, \"__rerun_remap_job_id__\": null, \"input1\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\", \"chromInfo\": \"\\\"/data/dnb02/galaxy_db/files/007/567/dataset_7567924.dat\\\"\", \"queries\": \"[{\\\"input2\\\": {\\\"__class__\\\": \\\"RuntimeValue\\\"}, \\\"__index__\\\": 0}, {\\\"input2\\\": {\\\"__class__\\\": \\\"RuntimeValue\\\"}, \\\"__index__\\\": 1}, {\\\"input2\\\": {\\\"__class__\\\": \\\"RuntimeValue\\\"}, \\\"__index__\\\": 2}]\"}",
+      "tool_version": "1.0.0",
+      "type": "tool",
+      "uuid": "9055e00b-0d94-4137-93ff-5c23b1b2e2cc",
+      "workflow_outputs": []
+    },
+    "22": {
+      "annotation": "",
+      "content_id": "Cut1",
+      "errors": null,
+      "id": 22,
+      "input_connections": {
+        "input": {
+          "id": 20,
+          "output_name": "out_file1"
+        }
+      },
+      "inputs": [
+        {
+          "description": "runtime parameter for tool Cut",
+          "name": "input"
+        }
+      ],
+      "label": null,
+      "name": "Cut",
+      "outputs": [
+        {
+          "name": "out_file1",
+          "type": "tabular"
+        }
+      ],
+      "position": {
+        "left": 1080.0000305175781,
+        "top": 320.00001525878906
+      },
+      "post_job_actions": {},
+      "tool_id": "Cut1",
+      "tool_state": "{\"__page__\": null, \"__rerun_remap_job_id__\": null, \"__workflow_invocation_uuid__\": \"\\\"cb306342cc9311e8993c984be15f9748\\\"\", \"delimiter\": \"\\\"T\\\"\", \"columnList\": \"\\\"c5,c1,c2\\\"\", \"input\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\", \"chromInfo\": \"\\\"/usr/local/galaxy/galaxy-dist/tool-data/shared/ucsc/chrom/?.len\\\"\"}",
+      "tool_version": "1.0.2",
+      "type": "tool",
+      "uuid": "6819a301-338a-4372-b325-5e3c0f40ce11",
+      "workflow_outputs": []
+    },
+    "23": {
+      "annotation": "",
+      "content_id": "Convert characters1",
+      "errors": null,
+      "id": 23,
+      "input_connections": {
+        "input": {
+          "id": 21,
+          "output_name": "out_file1"
+        }
+      },
+      "inputs": [
+        {
+          "description": "runtime parameter for tool Convert",
+          "name": "input"
+        }
+      ],
+      "label": null,
+      "name": "Convert",
+      "outputs": [
+        {
+          "name": "out_file1",
+          "type": "tabular"
+        }
+      ],
+      "position": {
+        "left": 1300.0000305175781,
+        "top": 200.00001525878906
+      },
+      "post_job_actions": {},
+      "tool_id": "Convert characters1",
+      "tool_state": "{\"__page__\": null, \"chromInfo\": \"\\\"/data/dnb02/galaxy_db/files/007/567/dataset_7567924.dat\\\"\", \"__rerun_remap_job_id__\": null, \"condense\": \"\\\"true\\\"\", \"strip\": \"\\\"true\\\"\", \"input\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\", \"convert_from\": \"\\\"T\\\"\"}",
+      "tool_version": "1.0.0",
+      "type": "tool",
+      "uuid": "dd488717-7ba9-46b0-821a-77989f63ff62",
+      "workflow_outputs": []
+    },
+    "24": {
+      "annotation": "",
+      "content_id": "toolshed.g2.bx.psu.edu/repos/kellrott/regex_replace/regex_replace/1.0.0",
+      "errors": null,
+      "id": 24,
+      "input_connections": {
+        "infile": {
+          "id": 22,
+          "output_name": "out_file1"
+        }
+      },
+      "inputs": [
+        {
+          "description": "runtime parameter for tool Regex Replace",
+          "name": "infile"
+        }
+      ],
+      "label": null,
+      "name": "Regex Replace",
+      "outputs": [
+        {
+          "name": "outfile",
+          "type": "txt"
+        }
+      ],
+      "position": {
+        "left": 1300.0000305175781,
+        "top": 320.00001525878906
+      },
+      "post_job_actions": {},
+      "tool_id": "toolshed.g2.bx.psu.edu/repos/kellrott/regex_replace/regex_replace/1.0.0",
+      "tool_shed_repository": {
+        "changeset_revision": "9a77d5fca67c",
+        "name": "regex_replace",
+        "owner": "kellrott",
+        "tool_shed": "toolshed.g2.bx.psu.edu"
+      },
+      "tool_state": "{\"__page__\": null, \"ignore_case\": \"\\\"false\\\"\", \"search_str\": \"\\\"(sample_)\\\\\\\\t\\\"\", \"__rerun_remap_job_id__\": null, \"replace_str\": \"\\\"\\\\\\\\1\\\"\", \"__workflow_invocation_uuid__\": \"\\\"cb306342cc9311e8993c984be15f9748\\\"\", \"replace_count\": \"\\\"0\\\"\", \"multiline\": \"\\\"true\\\"\", \"chromInfo\": \"\\\"/usr/local/galaxy/galaxy-dist/tool-data/shared/ucsc/chrom/?.len\\\"\", \"infile\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\", \"dot_all\": \"\\\"false\\\"\"}",
+      "tool_version": "1.0.0",
+      "type": "tool",
+      "uuid": "a8768549-4c14-4a97-abc3-63b6341bb8b3",
+      "workflow_outputs": []
+    },
+    "25": {
+      "annotation": "",
+      "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/stacks_refmap/stacks_refmap/1.46.0",
+      "errors": null,
+      "id": 25,
+      "input_connections": {
+        "options_usage|individual_sample": {
+          "id": 11,
+          "output_name": "bam_output"
+        },
+        "options_usage|popmap": {
+          "id": 24,
+          "output_name": "outfile"
+        }
+      },
+      "inputs": [
+        {
+          "description": "runtime parameter for tool Stacks: reference map",
+          "name": "options_usage"
+        },
+        {
+          "description": "runtime parameter for tool Stacks: reference map",
+          "name": "options_usage"
+        }
+      ],
+      "label": null,
+      "name": "Stacks: reference map",
+      "outputs": [
+        {
+          "name": "tags",
+          "type": "input"
+        },
+        {
+          "name": "snps",
+          "type": "input"
+        },
+        {
+          "name": "alleles",
+          "type": "input"
+        },
+        {
+          "name": "matches",
+          "type": "input"
+        },
+        {
+          "name": "all_output",
+          "type": "input"
+        },
+        {
+          "name": "output_log",
+          "type": "txt"
+        },
+        {
+          "name": "output_summary",
+          "type": "html"
+        },
+        {
+          "name": "catalogtags",
+          "type": "tabular"
+        },
+        {
+          "name": "catalogsnps",
+          "type": "tabular"
+        },
+        {
+          "name": "catalogalleles",
+          "type": "tabular"
+        },
+        {
+          "name": "out_joinmap",
+          "type": "txt"
+        },
+        {
+          "name": "out_generic_haplo",
+          "type": "tabular"
+        },
+        {
+          "name": "out_generic_geno",
+          "type": "tabular"
+        },
+        {
+          "name": "out_sql_markers",
+          "type": "tabular"
+        },
+        {
+          "name": "out_sql_genotypes",
+          "type": "tabular"
+        },
+        {
+          "name": "out_haplotypes",
+          "type": "tabular"
+        },
+        {
+          "name": "out_hapstats",
+          "type": "tabular"
+        },
+        {
+          "name": "out_populations_log",
+          "type": "tabular"
+        },
+        {
+          "name": "out_sumstats_sum",
+          "type": "tabular"
+        },
+        {
+          "name": "out_sumstats",
+          "type": "tabular"
+        },
+        {
+          "name": "out_sql",
+          "type": "tabular"
+        }
+      ],
+      "position": {
+        "left": 1520.0000305175781,
+        "top": 200.00001525878906
+      },
+      "post_job_actions": {},
+      "tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/stacks_refmap/stacks_refmap/1.46.0",
+      "tool_shed_repository": {
+        "changeset_revision": "4ee074ca88fb",
+        "name": "stacks_refmap",
+        "owner": "iuc",
+        "tool_shed": "toolshed.g2.bx.psu.edu"
+      },
+      "tool_state": "{\"__page__\": null, \"P\": \"\\\"\\\"\", \"__rerun_remap_job_id__\": null, \"options_usage\": \"{\\\"rad_analysis_type\\\": \\\"population\\\", \\\"individual_sample\\\": {\\\"__class__\\\": \\\"RuntimeValue\\\"}, \\\"__current_case__\\\": 1, \\\"popmap\\\": {\\\"__class__\\\": \\\"RuntimeValue\\\"}}\", \"m\": \"\\\"3\\\"\", \"snp_options\": \"{\\\"select_model\\\": {\\\"model_type\\\": \\\"snp\\\", \\\"alpha\\\": \\\"0.05\\\", \\\"__current_case__\\\": 0}}\", \"chromInfo\": \"\\\"/usr/local/galaxy/galaxy-dist/tool-data/shared/ucsc/chrom/?.len\\\"\"}",
+      "tool_version": "1.46.0",
+      "type": "tool",
+      "uuid": "31fc5dbe-7c05-4b10-bf73-98ad85dc7bd6",
+      "workflow_outputs": []
+    },
+    "26": {
+      "annotation": "",
+      "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/stacks_populations/stacks_populations/1.46.0",
+      "errors": null,
+      "id": 26,
+      "input_connections": {
+        "options_usage|input_col": {
+          "id": 25,
+          "output_name": "all_output"
+        },
+        "options_usage|popmap": {
+          "id": 24,
+          "output_name": "outfile"
+        }
+      },
+      "inputs": [
+        {
+          "description": "runtime parameter for tool Stacks: populations",
+          "name": "options_usage"
+        },
+        {
+          "description": "runtime parameter for tool Stacks: populations",
+          "name": "options_usage"
+        },
+        {
+          "description": "runtime parameter for tool Stacks: populations",
+          "name": "bootstrap_resampling"
+        },
+        {
+          "description": "runtime parameter for tool Stacks: populations",
+          "name": "advanced_options"
+        },
+        {
+          "description": "runtime parameter for tool Stacks: populations",
+          "name": "advanced_options"
+        }
+      ],
+      "label": null,
+      "name": "Stacks: populations",
+      "outputs": [
+        {
+          "name": "out_haplotypes",
+          "type": "tabular"
+        },
+        {
+          "name": "out_hapstats",
+          "type": "tabular"
+        },
+        {
+          "name": "out_populations_log",
+          "type": "tabular"
+        },
+        {
+          "name": "out_sumstats_sum",
+          "type": "tabular"
+        },
+        {
+          "name": "out_sumstats",
+          "type": "tabular"
+        },
+        {
+          "name": "out_sql",
+          "type": "tabular"
+        },
+        {
+          "name": "out_fstats",
+          "type": "tabular"
+        },
+        {
+          "name": "out_fasta",
+          "type": "tabular"
+        },
+        {
+          "name": "out_phylip_all_partitions",
+          "type": "tabular"
+        },
+        {
+          "name": "out_phylip_all_pop",
+          "type": "tabular"
+        },
+        {
+          "name": "out_phylip_all_loci",
+          "type": "tabular"
+        },
+        {
+          "name": "out_genepop",
+          "type": "tabular"
+        },
+        {
+          "name": "out_vcf_haplotypes",
+          "type": "tabular"
+        },
+        {
+          "name": "out_hzar",
+          "type": "tabular"
+        },
+        {
+          "name": "out_beagle_phased_haplotypes",
+          "type": "tabular"
+        },
+        {
+          "name": "out_beagle_phased_markers",
+          "type": "tabular"
+        },
+        {
+          "name": "out_beagle_haplotypes",
+          "type": "tabular"
+        },
+        {
+          "name": "out_beagle_markers",
+          "type": "tabular"
+        },
+        {
+          "name": "out_phylip_pop",
+          "type": "tabular"
+        },
+        {
+          "name": "out_phylip_loci",
+          "type": "tabular"
+        },
+        {
+          "name": "out_plink_markers",
+          "type": "tabular"
+        },
+        {
+          "name": "out_plink_genotypes",
+          "type": "tabular"
+        },
+        {
+          "name": "out_fasta_strict",
+          "type": "tabular"
+        },
+        {
+          "name": "out_structure",
+          "type": "tabular"
+        },
+        {
+          "name": "out_treemix_pop",
+          "type": "tabular"
+        },
+        {
+          "name": "out_treemix_loci",
+          "type": "tabular"
+        },
+        {
+          "name": "out_fastpĥase",
+          "type": "tabular"
+        },
+        {
+          "name": "out_phase",
+          "type": "tabular"
+        },
+        {
+          "name": "out_vcf",
+          "type": "tabular"
+        },
+        {
+          "name": "out_genomic",
+          "type": "tabular"
+        },
+        {
+          "name": "output_summary",
+          "type": "html"
+        }
+      ],
+      "position": {
+        "left": 1740.0000305175781,
+        "top": 200.00001525878906
+      },
+      "post_job_actions": {},
+      "tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/stacks_populations/stacks_populations/1.46.0",
+      "tool_shed_repository": {
+        "changeset_revision": "45db1ba16163",
+        "name": "stacks_populations",
+        "owner": "iuc",
+        "tool_shed": "toolshed.g2.bx.psu.edu"
+      },
+      "tool_state": "{\"options_kernel\": \"{\\\"kernel\\\": \\\"false\\\", \\\"__current_case__\\\": 1}\", \"__page__\": null, \"populations_output\": \"{\\\"phylip_var_all\\\": \\\"false\\\", \\\"fasta_strict\\\": \\\"false\\\", \\\"hzar\\\": \\\"false\\\", \\\"phylip_var\\\": \\\"false\\\", \\\"plink\\\": \\\"false\\\", \\\"vcf\\\": \\\"true\\\", \\\"phylip\\\": \\\"false\\\", \\\"beagle_phased\\\": \\\"false\\\", \\\"vcf_haplotypes\\\": \\\"false\\\", \\\"options_genomic\\\": {\\\"genomic\\\": \\\"false\\\", \\\"__current_case__\\\": 1}, \\\"genepop\\\": \\\"false\\\", \\\"beagle\\\": \\\"false\\\", \\\"fastphase\\\": \\\"false\\\", \\\"ordered_export\\\": \\\"false\\\", \\\"phase\\\": \\\"false\\\", \\\"fasta\\\": \\\"false\\\", \\\"treemix\\\": \\\"false\\\", \\\"structure\\\": \\\"true\\\"}\", \"options_usage\": \"{\\\"input_type\\\": \\\"stacks\\\", \\\"popmap\\\": {\\\"__class__\\\": \\\"RuntimeValue\\\"}, \\\"input_col\\\": {\\\"__class__\\\": \\\"RuntimeValue\\\"}, \\\"__current_case__\\\": 0}\", \"bootstrap_resampling\": \"{\\\"bootstrap_wl\\\": {\\\"__class__\\\": \\\"RuntimeValue\\\"}, \\\"bootstrap_reps\\\": \\\"100\\\", \\\"bootstrap_resampling_mode\\\": {\\\"bootstrap_phist\\\": \\\"false\\\", \\\"bootstrap_fst\\\": \\\"false\\\", \\\"bootstrap_all\\\": \\\"false\\\", \\\"bootstrap_pifis\\\": \\\"false\\\", \\\"__current_case__\\\": 1, \\\"bootstrap_div\\\": \\\"false\\\"}}\", \"options_filtering\": \"{\\\"write_single_snp\\\": \\\"false\\\", \\\"mindepth\\\": \\\"1\\\", \\\"minpop\\\": \\\"2\\\", \\\"minminor\\\": \\\"0.25\\\", \\\"max_obs_het\\\": \\\"\\\", \\\"lnl\\\": \\\"\\\", \\\"correction_select\\\": {\\\"correction\\\": \\\"no_corr\\\", \\\"__current_case__\\\": 0}, \\\"minperc\\\": \\\"0.75\\\", \\\"write_random_snp\\\": \\\"false\\\"}\", \"advanced_options\": \"{\\\"blacklist\\\": {\\\"__class__\\\": \\\"RuntimeValue\\\"}, \\\"batchid\\\": \\\"1\\\", \\\"whitelist\\\": {\\\"__class__\\\": \\\"RuntimeValue\\\"}}\", \"__rerun_remap_job_id__\": null, \"chromInfo\": \"\\\"/usr/local/galaxy/galaxy-dist/tool-data/shared/ucsc/chrom/?.len\\\"\", \"fstats\": \"\\\"true\\\"\"}",
+      "tool_version": "1.46.0",
+      "type": "tool",
+      "uuid": "dbc1c496-40a8-4334-b02c-a6d7dfa098df",
+      "workflow_outputs": []
+    },
+    "27": {
+      "annotation": "",
+      "content_id": "Summary_Statistics1",
+      "errors": null,
+      "id": 27,
+      "input_connections": {
+        "input": {
+          "id": 26,
+          "output_name": "out_fstats"
+        }
+      },
+      "inputs": [
+        {
+          "description": "runtime parameter for tool Summary Statistics",
+          "name": "input"
+        }
+      ],
+      "label": null,
+      "name": "Summary Statistics",
+      "outputs": [
+        {
+          "name": "out_file1",
+          "type": "tabular"
+        }
+      ],
+      "position": {
+        "left": 1960.0001525878906,
+        "top": 200.00001525878906
+      },
+      "post_job_actions": {},
+      "tool_id": "Summary_Statistics1",
+      "tool_state": "{\"__page__\": null, \"__rerun_remap_job_id__\": null, \"__workflow_invocation_uuid__\": \"\\\"a6f0faf0cca211e8a11b984be15f9748\\\"\", \"cond\": \"\\\"c30\\\"\", \"input\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\", \"chromInfo\": \"\\\"/usr/local/galaxy/galaxy-dist/tool-data/shared/ucsc/chrom/?.len\\\"\"}",
+      "tool_version": "1.1.1",
+      "type": "tool",
+      "uuid": "188816cd-1847-4e57-874c-32ebbf8174ee",
+      "workflow_outputs": []
+    },
+    "28": {
+      "annotation": "",
+      "content_id": "toolshed.g2.bx.psu.edu/repos/bgruening/text_processing/tp_sort_header_tool/1.1.1",
+      "errors": null,
+      "id": 28,
+      "input_connections": {
+        "infile": {
+          "id": 26,
+          "output_name": "out_fstats"
+        }
+      },
+      "inputs": [
+        {
+          "description": "runtime parameter for tool Sort",
+          "name": "infile"
+        }
+      ],
+      "label": null,
+      "name": "Sort",
+      "outputs": [
+        {
+          "name": "outfile",
+          "type": "input"
+        }
+      ],
+      "position": {
+        "left": 1960.0001525878906,
+        "top": 320.00001525878906
+      },
+      "post_job_actions": {},
+      "tool_id": "toolshed.g2.bx.psu.edu/repos/bgruening/text_processing/tp_sort_header_tool/1.1.1",
+      "tool_shed_repository": {
+        "changeset_revision": "74a8bef53a00",
+        "name": "text_processing",
+        "owner": "bgruening",
+        "tool_shed": "toolshed.g2.bx.psu.edu"
+      },
+      "tool_state": "{\"sortkeys\": \"[{\\\"column\\\": \\\"30\\\", \\\"__index__\\\": 0, \\\"style\\\": \\\"n\\\", \\\"order\\\": \\\"r\\\"}]\", \"__page__\": null, \"ignore_case\": \"\\\"false\\\"\", \"__rerun_remap_job_id__\": null, \"__workflow_invocation_uuid__\": \"\\\"a6f0faf0cca211e8a11b984be15f9748\\\"\", \"header\": \"\\\"4\\\"\", \"unique\": \"\\\"false\\\"\", \"chromInfo\": \"\\\"/usr/local/galaxy/galaxy-dist/tool-data/shared/ucsc/chrom/?.len\\\"\", \"infile\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\"}",
+      "tool_version": "1.1.1",
+      "type": "tool",
+      "uuid": "5ea04279-dca9-4911-8279-011731b3ce71",
+      "workflow_outputs": []
+    },
+    "29": {
+      "annotation": "",
+      "content_id": "Count1",
+      "errors": null,
+      "id": 29,
+      "input_connections": {
+        "input": {
+          "id": 26,
+          "output_name": "out_fstats"
+        }
+      },
+      "inputs": [
+        {
+          "description": "runtime parameter for tool Count",
+          "name": "input"
+        }
+      ],
+      "label": null,
+      "name": "Count",
+      "outputs": [
+        {
+          "name": "out_file1",
+          "type": "tabular"
+        }
+      ],
+      "position": {
+        "left": 1960.0001525878906,
+        "top": 440.0000305175781
+      },
+      "post_job_actions": {},
+      "tool_id": "Count1",
+      "tool_state": "{\"__page__\": null, \"sorting\": \"\\\"value\\\"\", \"column\": \"[\\\"30\\\"]\", \"__rerun_remap_job_id__\": null, \"delim\": \"\\\"T\\\"\", \"__workflow_invocation_uuid__\": \"\\\"a6f0faf0cca211e8a11b984be15f9748\\\"\", \"input\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\", \"chromInfo\": \"\\\"/usr/local/galaxy/galaxy-dist/tool-data/shared/ucsc/chrom/?.len\\\"\"}",
+      "tool_version": "1.0.2",
+      "type": "tool",
+      "uuid": "462ddec3-117f-4320-b97a-5264cad35b3c",
+      "workflow_outputs": []
+    },
+    "3": {
+      "annotation": "",
+      "content_id": null,
+      "errors": null,
+      "id": 3,
+      "input_connections": {},
+      "inputs": [
+        {
+          "description": "",
+          "name": "https://zenodo.org/record/1134547/files/Reference_genome_11_chromosomes.fasta"
+        }
+      ],
+      "label": "https://zenodo.org/record/1134547/files/Reference_genome_11_chromosomes.fasta",
+      "name": "Input dataset",
+      "outputs": [],
+      "position": {
+        "left": 200.00001525878906,
+        "top": 577.9861450195312
+      },
+      "tool_id": null,
+      "tool_state": "{\"name\": \"https://zenodo.org/record/1134547/files/Reference_genome_11_chromosomes.fasta\"}",
+      "tool_version": null,
+      "type": "data_input",
+      "uuid": "7c1d53db-b81d-40ab-8a75-221a94eb09ff",
+      "workflow_outputs": []
+    },
+    "30": {
+      "annotation": "",
+      "content_id": "Filter1",
+      "errors": null,
+      "id": 30,
+      "input_connections": {
+        "input": {
+          "id": 26,
+          "output_name": "out_fstats"
+        }
+      },
+      "inputs": [
+        {
+          "description": "runtime parameter for tool Filter",
+          "name": "input"
+        }
+      ],
+      "label": null,
+      "name": "Filter",
+      "outputs": [
+        {
+          "name": "out_file1",
+          "type": "input"
+        }
+      ],
+      "position": {
+        "left": 1960.0001525878906,
+        "top": 560.0000305175781
+      },
+      "post_job_actions": {},
+      "tool_id": "Filter1",
+      "tool_state": "{\"__page__\": null, \"__rerun_remap_job_id__\": null, \"__workflow_invocation_uuid__\": \"\\\"a6f0faf0cca211e8a11b984be15f9748\\\"\", \"cond\": \"\\\"c30==1\\\"\", \"input\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\", \"header_lines\": \"\\\"4\\\"\", \"chromInfo\": \"\\\"/usr/local/galaxy/galaxy-dist/tool-data/shared/ucsc/chrom/?.len\\\"\"}",
+      "tool_version": "1.1.0",
+      "type": "tool",
+      "uuid": "1df32fa8-eda6-49ef-88b3-54544adb9bc3",
+      "workflow_outputs": []
+    },
+    "4": {
+      "annotation": "",
+      "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/stacks_procrad/stacks_procrad/1.46.0",
+      "errors": null,
+      "id": 4,
+      "input_connections": {
+        "barcode": {
+          "id": 1,
+          "output_name": "output"
+        },
+        "input_type|input_single": {
+          "id": 0,
+          "output_name": "output"
+        }
+      },
+      "inputs": [
+        {
+          "description": "runtime parameter for tool Stacks: process radtags",
+          "name": "input_type"
+        },
+        {
+          "description": "runtime parameter for tool Stacks: process radtags",
+          "name": "barcode"
+        }
+      ],
+      "label": null,
+      "name": "Stacks: process radtags",
+      "outputs": [
+        {
+          "name": "demultiplexed",
+          "type": "input"
+        },
+        {
+          "name": "remaining",
+          "type": "input"
+        },
+        {
+          "name": "discarded",
+          "type": "input"
+        },
+        {
+          "name": "output_log",
+          "type": "txt"
+        }
+      ],
+      "position": {
+        "left": 420.0000305175781,
+        "top": 200.00001525878906
+      },
+      "post_job_actions": {},
+      "tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/stacks_procrad/stacks_procrad/1.46.0",
+      "tool_shed_repository": {
+        "changeset_revision": "57910d476be9",
+        "name": "stacks_procrad",
+        "owner": "iuc",
+        "tool_shed": "toolshed.g2.bx.psu.edu"
+      },
+      "tool_state": "{\"capture\": \"\\\"true\\\"\", \"outype\": \"\\\"fastq\\\"\", \"options_enzyme\": \"{\\\"enzyme\\\": \\\"sbfI\\\", \\\"options_enzyme_selector\\\": \\\"1\\\", \\\"__current_case__\\\": 0}\", \"__page__\": null, \"input_type\": \"{\\\"input_single\\\": {\\\"__class__\\\": \\\"RuntimeValue\\\"}, \\\"barcode_encoding\\\": \\\"--inline_null\\\", \\\"__current_case__\\\": 0, \\\"options_type_selector\\\": \\\"single\\\"}\", \"__rerun_remap_job_id__\": null, \"barcode\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\", \"options_advanced\": \"{\\\"rescue\\\": \\\"false\\\", \\\"truncate\\\": \\\"\\\", \\\"remove\\\": \\\"false\\\", \\\"retain_header\\\": \\\"false\\\", \\\"score\\\": \\\"10\\\", \\\"discard\\\": \\\"false\\\", \\\"sliding\\\": \\\"0.15\\\"}\", \"chromInfo\": \"\\\"/data/dnb02/galaxy_db/files/007/567/dataset_7567924.dat\\\"\"}",
+      "tool_version": "1.46.0",
+      "type": "tool",
+      "uuid": "c146c40a-a6f1-4f96-8764-6403fb47f3e8",
+      "workflow_outputs": []
+    },
+    "5": {
+      "annotation": "",
+      "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/stacks_procrad/stacks_procrad/1.46.0",
+      "errors": null,
+      "id": 5,
+      "input_connections": {
+        "barcode": {
+          "id": 1,
+          "output_name": "output"
+        },
+        "input_type|input_single": {
+          "id": 0,
+          "output_name": "output"
+        }
+      },
+      "inputs": [
+        {
+          "description": "runtime parameter for tool Stacks: process radtags",
+          "name": "input_type"
+        },
+        {
+          "description": "runtime parameter for tool Stacks: process radtags",
+          "name": "barcode"
+        }
+      ],
+      "label": null,
+      "name": "Stacks: process radtags",
+      "outputs": [
+        {
+          "name": "demultiplexed",
+          "type": "input"
+        },
+        {
+          "name": "remaining",
+          "type": "input"
+        },
+        {
+          "name": "discarded",
+          "type": "input"
+        },
+        {
+          "name": "output_log",
+          "type": "txt"
+        }
+      ],
+      "position": {
+        "left": 420.0000305175781,
+        "top": 320.00001525878906
+      },
+      "post_job_actions": {},
+      "tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/stacks_procrad/stacks_procrad/1.46.0",
+      "tool_shed_repository": {
+        "changeset_revision": "57910d476be9",
+        "name": "stacks_procrad",
+        "owner": "iuc",
+        "tool_shed": "toolshed.g2.bx.psu.edu"
+      },
+      "tool_state": "{\"capture\": \"\\\"true\\\"\", \"outype\": \"\\\"fastq\\\"\", \"options_enzyme\": \"{\\\"enzyme\\\": \\\"sbfI\\\", \\\"options_enzyme_selector\\\": \\\"1\\\", \\\"__current_case__\\\": 0}\", \"__page__\": null, \"input_type\": \"{\\\"input_single\\\": {\\\"__class__\\\": \\\"RuntimeValue\\\"}, \\\"barcode_encoding\\\": \\\"--inline_null\\\", \\\"__current_case__\\\": 0, \\\"options_type_selector\\\": \\\"single\\\"}\", \"__rerun_remap_job_id__\": null, \"barcode\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\", \"options_advanced\": \"{\\\"rescue\\\": \\\"false\\\", \\\"truncate\\\": \\\"\\\", \\\"remove\\\": \\\"false\\\", \\\"retain_header\\\": \\\"false\\\", \\\"score\\\": \\\"10\\\", \\\"discard\\\": \\\"true\\\", \\\"sliding\\\": \\\"0.15\\\"}\", \"chromInfo\": \"\\\"/data/dnb02/galaxy_db/files/007/567/dataset_7567924.dat\\\"\"}",
+      "tool_version": "1.46.0",
+      "type": "tool",
+      "uuid": "31ba0988-fc83-4f5b-9a05-156521e882e8",
+      "workflow_outputs": []
+    },
+    "6": {
+      "annotation": "",
+      "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/stacks_procrad/stacks_procrad/1.46.0",
+      "errors": null,
+      "id": 6,
+      "input_connections": {
+        "barcode": {
+          "id": 1,
+          "output_name": "output"
+        },
+        "input_type|input_single": {
+          "id": 0,
+          "output_name": "output"
+        }
+      },
+      "inputs": [
+        {
+          "description": "runtime parameter for tool Stacks: process radtags",
+          "name": "input_type"
+        },
+        {
+          "description": "runtime parameter for tool Stacks: process radtags",
+          "name": "barcode"
+        }
+      ],
+      "label": null,
+      "name": "Stacks: process radtags",
+      "outputs": [
+        {
+          "name": "demultiplexed",
+          "type": "input"
+        },
+        {
+          "name": "remaining",
+          "type": "input"
+        },
+        {
+          "name": "discarded",
+          "type": "input"
+        },
+        {
+          "name": "output_log",
+          "type": "txt"
+        }
+      ],
+      "position": {
+        "left": 420.0000305175781,
+        "top": 440.0000305175781
+      },
+      "post_job_actions": {},
+      "tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/stacks_procrad/stacks_procrad/1.46.0",
+      "tool_shed_repository": {
+        "changeset_revision": "57910d476be9",
+        "name": "stacks_procrad",
+        "owner": "iuc",
+        "tool_shed": "toolshed.g2.bx.psu.edu"
+      },
+      "tool_state": "{\"capture\": \"\\\"true\\\"\", \"outype\": \"\\\"fastq\\\"\", \"options_enzyme\": \"{\\\"enzyme\\\": \\\"sbfI\\\", \\\"options_enzyme_selector\\\": \\\"1\\\", \\\"__current_case__\\\": 0}\", \"__page__\": null, \"input_type\": \"{\\\"input_single\\\": {\\\"__class__\\\": \\\"RuntimeValue\\\"}, \\\"barcode_encoding\\\": \\\"--inline_null\\\", \\\"__current_case__\\\": 0, \\\"options_type_selector\\\": \\\"single\\\"}\", \"__rerun_remap_job_id__\": null, \"barcode\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\", \"options_advanced\": \"{\\\"rescue\\\": \\\"false\\\", \\\"truncate\\\": \\\"\\\", \\\"remove\\\": \\\"false\\\", \\\"retain_header\\\": \\\"false\\\", \\\"score\\\": \\\"20\\\", \\\"discard\\\": \\\"true\\\", \\\"sliding\\\": \\\"0.15\\\"}\", \"chromInfo\": \"\\\"/data/dnb02/galaxy_db/files/007/567/dataset_7567924.dat\\\"\"}",
+      "tool_version": "1.46.0",
+      "type": "tool",
+      "uuid": "478beb7d-6109-435c-9fe0-c0d8d2919023",
+      "workflow_outputs": []
+    },
+    "7": {
+      "annotation": "",
+      "content_id": "toolshed.g2.bx.psu.edu/repos/bgruening/text_processing/tp_replace_in_line/1.1.1",
+      "errors": null,
+      "id": 7,
+      "input_connections": {
+        "infile": {
+          "id": 2,
+          "output_name": "output"
+        }
+      },
+      "inputs": [
+        {
+          "description": "runtime parameter for tool Replace Text",
+          "name": "infile"
+        }
+      ],
+      "label": null,
+      "name": "Replace Text",
+      "outputs": [
+        {
+          "name": "outfile",
+          "type": "input"
+        }
+      ],
+      "position": {
+        "left": 420.0000305175781,
+        "top": 560.0000305175781
+      },
+      "post_job_actions": {},
+      "tool_id": "toolshed.g2.bx.psu.edu/repos/bgruening/text_processing/tp_replace_in_line/1.1.1",
+      "tool_shed_repository": {
+        "changeset_revision": "74a8bef53a00",
+        "name": "text_processing",
+        "owner": "bgruening",
+        "tool_shed": "toolshed.g2.bx.psu.edu"
+      },
+      "tool_state": "{\"__page__\": null, \"find_pattern\": \"\\\"Bear Paw\\\"\", \"chromInfo\": \"\\\"/usr/local/galaxy/galaxy-dist/tool-data/shared/ucsc/chrom/?.len\\\"\", \"__rerun_remap_job_id__\": null, \"__workflow_invocation_uuid__\": \"\\\"cb306342cc9311e8993c984be15f9748\\\"\", \"replace_pattern\": \"\\\"1\\\"\", \"infile\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\"}",
+      "tool_version": "1.1.1",
+      "type": "tool",
+      "uuid": "e777e2f0-3cb1-4ca0-b26d-1c990b62ded8",
+      "workflow_outputs": []
+    },
+    "8": {
+      "annotation": "",
+      "content_id": "Grep1",
+      "errors": null,
+      "id": 8,
+      "input_connections": {
+        "input": {
+          "id": 4,
+          "output_name": "output_log"
+        }
+      },
+      "inputs": [
+        {
+          "description": "runtime parameter for tool Select",
+          "name": "input"
+        }
+      ],
+      "label": null,
+      "name": "Select",
+      "outputs": [
+        {
+          "name": "out_file1",
+          "type": "input"
+        }
+      ],
+      "position": {
+        "left": 640.0000305175781,
+        "top": 200.00001525878906
+      },
+      "post_job_actions": {},
+      "tool_id": "Grep1",
+      "tool_state": "{\"__page__\": null, \"pattern\": \"\\\"^R1.fq.gz\\\"\", \"invert\": \"\\\"false\\\"\", \"input\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\", \"chromInfo\": \"\\\"/data/dnb02/galaxy_db/files/007/567/dataset_7567924.dat\\\"\", \"__rerun_remap_job_id__\": null}",
+      "tool_version": "1.0.1",
+      "type": "tool",
+      "uuid": "0fac4430-86a4-4b69-b57d-f3f16616a184",
+      "workflow_outputs": []
+    },
+    "9": {
+      "annotation": "",
+      "content_id": "Grep1",
+      "errors": null,
+      "id": 9,
+      "input_connections": {
+        "input": {
+          "id": 5,
+          "output_name": "output_log"
+        }
+      },
+      "inputs": [
+        {
+          "description": "runtime parameter for tool Select",
+          "name": "input"
+        }
+      ],
+      "label": null,
+      "name": "Select",
+      "outputs": [
+        {
+          "name": "out_file1",
+          "type": "input"
+        }
+      ],
+      "position": {
+        "left": 640.0000305175781,
+        "top": 320.00001525878906
+      },
+      "post_job_actions": {},
+      "tool_id": "Grep1",
+      "tool_state": "{\"__page__\": null, \"pattern\": \"\\\"^R1.fq.gz\\\"\", \"invert\": \"\\\"false\\\"\", \"input\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\", \"chromInfo\": \"\\\"/data/dnb02/galaxy_db/files/007/567/dataset_7567924.dat\\\"\", \"__rerun_remap_job_id__\": null}",
+      "tool_version": "1.0.1",
+      "type": "tool",
+      "uuid": "d2500f6f-fc80-4d65-b41f-124b7d4dc85c",
+      "workflow_outputs": []
+    }
+  },
+  "tags": [],
+  "uuid": "759e08a8-429e-4681-bf05-a50c251e256b"
+}

--- a/topics/sequence-analysis/tutorials/ref-based-rad-seq/workflows/workflow.ga
+++ b/topics/sequence-analysis/tutorials/ref-based-rad-seq/workflows/workflow.ga
@@ -1,1 +1,668 @@
-{"uuid": "733d4e4d-5650-400a-8707-6778773a9afd", "tags": [], "format-version": "0.1", "name": "ref-based-rad-seq (imported from uploaded file)", "steps": {"0": {"tool_id": null, "tool_version": null, "outputs": [], "workflow_outputs": [], "input_connections": {}, "tool_state": "{\"name\": \"ref_genome_chromFa.tar\"}", "id": 0, "uuid": "d41b8a08-8893-4fe4-86c1-21caa8e95cb9", "errors": null, "name": "Input dataset", "label": "ref_genome_chromFa.tar", "inputs": [{"name": "ref_genome_chromFa.tar", "description": ""}], "position": {"top": 200.00001525878906, "left": 200.00001525878906}, "annotation": "", "content_id": null, "type": "data_input"}, "1": {"tool_id": null, "tool_version": null, "outputs": [], "workflow_outputs": [], "input_connections": {}, "tool_state": "{\"name\": \"Population_map.txt\"}", "id": 1, "uuid": "59b48fd7-4a76-4683-8e5b-b8db033e4f5d", "errors": null, "name": "Input dataset", "label": "Population_map.txt", "inputs": [{"name": "Population_map.txt", "description": ""}], "position": {"top": 320.00001525878906, "left": 200.00001525878906}, "annotation": "", "content_id": null, "type": "data_input"}, "2": {"tool_id": null, "tool_version": null, "outputs": [], "workflow_outputs": [], "input_connections": {}, "tool_state": "{\"name\": \"Barcodes_SRR034310.tabular\"}", "id": 2, "uuid": "c7ea916e-f493-4e53-bbf5-1d9b0ab34c18", "errors": null, "name": "Input dataset", "label": "Barcodes_SRR034310.tabular", "inputs": [{"name": "Barcodes_SRR034310.tabular", "description": ""}], "position": {"top": 440.00001525878906, "left": 200.00001525878906}, "annotation": "", "content_id": null, "type": "data_input"}, "3": {"tool_id": null, "tool_version": null, "outputs": [], "workflow_outputs": [], "input_connections": {}, "tool_state": "{\"name\": \"SRR034310.fastq\"}", "id": 3, "uuid": "8dcf8e48-fc08-4c2c-9aad-477de98b41d1", "errors": null, "name": "Input dataset", "label": "SRR034310.fastq", "inputs": [{"name": "SRR034310.fastq", "description": ""}], "position": {"top": 560.0000457763672, "left": 200.00001525878906}, "annotation": "", "content_id": null, "type": "data_input"}, "4": {"tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/stacks_procrad/stacks_procrad/1.46.0", "tool_version": "1.46.0", "outputs": [{"type": "input", "name": "demultiplexed"}, {"type": "input", "name": "remaining"}, {"type": "input", "name": "discarded"}, {"type": "txt", "name": "output_log"}], "workflow_outputs": [], "input_connections": {"barcode": {"output_name": "output", "id": 2}, "input_type|input_single": {"output_name": "output", "id": 3}}, "tool_state": "{\"capture\": \"\\\"true\\\"\", \"outype\": \"\\\"fastq\\\"\", \"options_enzyme\": \"{\\\"enzyme\\\": \\\"sbfI\\\", \\\"options_enzyme_selector\\\": \\\"1\\\", \\\"__current_case__\\\": 0}\", \"__page__\": null, \"input_type\": \"{\\\"input_single\\\": {\\\"__class__\\\": \\\"RuntimeValue\\\"}, \\\"barcode_encoding\\\": \\\"--inline_null\\\", \\\"__current_case__\\\": 0, \\\"options_type_selector\\\": \\\"single\\\"}\", \"__rerun_remap_job_id__\": null, \"barcode\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\", \"options_advanced\": \"{\\\"rescue\\\": \\\"false\\\", \\\"truncate\\\": \\\"\\\", \\\"remove\\\": \\\"false\\\", \\\"retain_header\\\": \\\"false\\\", \\\"score\\\": \\\"10\\\", \\\"discard\\\": \\\"false\\\", \\\"sliding\\\": \\\"0.15\\\"}\", \"chromInfo\": \"\\\"/usr/local/galaxy/galaxy-dist/tool-data/shared/ucsc/chrom/gasAcu1.len\\\"\"}", "id": 4, "tool_shed_repository": {"owner": "iuc", "changeset_revision": "57910d476be9", "name": "stacks_procrad", "tool_shed": "toolshed.g2.bx.psu.edu"}, "uuid": "5383a9fb-0c93-42ea-b6dd-87d565917c17", "errors": null, "name": "Stacks: process radtags", "post_job_actions": {}, "label": null, "inputs": [{"name": "input_type", "description": "runtime parameter for tool Stacks: process radtags"}, {"name": "barcode", "description": "runtime parameter for tool Stacks: process radtags"}], "position": {"top": 200.00001525878906, "left": 420.0000457763672}, "annotation": "", "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/stacks_procrad/stacks_procrad/1.46.0", "type": "tool"}, "5": {"tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/stacks_procrad/stacks_procrad/1.46.0", "tool_version": "1.46.0", "outputs": [{"type": "input", "name": "demultiplexed"}, {"type": "input", "name": "remaining"}, {"type": "input", "name": "discarded"}, {"type": "txt", "name": "output_log"}], "workflow_outputs": [], "input_connections": {"barcode": {"output_name": "output", "id": 2}, "input_type|input_single": {"output_name": "output", "id": 3}}, "tool_state": "{\"capture\": \"\\\"true\\\"\", \"outype\": \"\\\"fastq\\\"\", \"options_enzyme\": \"{\\\"enzyme\\\": \\\"sbfI\\\", \\\"options_enzyme_selector\\\": \\\"1\\\", \\\"__current_case__\\\": 0}\", \"__page__\": null, \"input_type\": \"{\\\"input_single\\\": {\\\"__class__\\\": \\\"RuntimeValue\\\"}, \\\"barcode_encoding\\\": \\\"--inline_null\\\", \\\"__current_case__\\\": 0, \\\"options_type_selector\\\": \\\"single\\\"}\", \"__rerun_remap_job_id__\": null, \"barcode\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\", \"options_advanced\": \"{\\\"rescue\\\": \\\"false\\\", \\\"truncate\\\": \\\"\\\", \\\"remove\\\": \\\"false\\\", \\\"retain_header\\\": \\\"false\\\", \\\"score\\\": \\\"10\\\", \\\"discard\\\": \\\"true\\\", \\\"sliding\\\": \\\"0.15\\\"}\", \"chromInfo\": \"\\\"/usr/local/galaxy/galaxy-dist/tool-data/shared/ucsc/chrom/gasAcu1.len\\\"\"}", "id": 5, "tool_shed_repository": {"owner": "iuc", "changeset_revision": "57910d476be9", "name": "stacks_procrad", "tool_shed": "toolshed.g2.bx.psu.edu"}, "uuid": "b736c8fc-4f62-4535-ab6d-4a3f4cb1dc4c", "errors": null, "name": "Stacks: process radtags", "post_job_actions": {}, "label": null, "inputs": [{"name": "input_type", "description": "runtime parameter for tool Stacks: process radtags"}, {"name": "barcode", "description": "runtime parameter for tool Stacks: process radtags"}], "position": {"top": 320.00001525878906, "left": 420.0000457763672}, "annotation": "", "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/stacks_procrad/stacks_procrad/1.46.0", "type": "tool"}, "6": {"tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/stacks_procrad/stacks_procrad/1.46.0", "tool_version": "1.46.0", "outputs": [{"type": "input", "name": "demultiplexed"}, {"type": "input", "name": "remaining"}, {"type": "input", "name": "discarded"}, {"type": "txt", "name": "output_log"}], "workflow_outputs": [], "input_connections": {"barcode": {"output_name": "output", "id": 2}, "input_type|input_single": {"output_name": "output", "id": 3}}, "tool_state": "{\"capture\": \"\\\"true\\\"\", \"outype\": \"\\\"fastq\\\"\", \"options_enzyme\": \"{\\\"enzyme\\\": \\\"sbfI\\\", \\\"options_enzyme_selector\\\": \\\"1\\\", \\\"__current_case__\\\": 0}\", \"__page__\": null, \"input_type\": \"{\\\"input_single\\\": {\\\"__class__\\\": \\\"RuntimeValue\\\"}, \\\"barcode_encoding\\\": \\\"--inline_null\\\", \\\"__current_case__\\\": 0, \\\"options_type_selector\\\": \\\"single\\\"}\", \"__rerun_remap_job_id__\": null, \"barcode\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\", \"options_advanced\": \"{\\\"rescue\\\": \\\"false\\\", \\\"truncate\\\": \\\"\\\", \\\"remove\\\": \\\"false\\\", \\\"retain_header\\\": \\\"false\\\", \\\"score\\\": \\\"20\\\", \\\"discard\\\": \\\"true\\\", \\\"sliding\\\": \\\"0.15\\\"}\", \"chromInfo\": \"\\\"/usr/local/galaxy/galaxy-dist/tool-data/shared/ucsc/chrom/gasAcu1.len\\\"\"}", "id": 6, "tool_shed_repository": {"owner": "iuc", "changeset_revision": "57910d476be9", "name": "stacks_procrad", "tool_shed": "toolshed.g2.bx.psu.edu"}, "uuid": "3774972a-3761-4572-9732-6f522dded358", "errors": null, "name": "Stacks: process radtags", "post_job_actions": {}, "label": null, "inputs": [{"name": "input_type", "description": "runtime parameter for tool Stacks: process radtags"}, {"name": "barcode", "description": "runtime parameter for tool Stacks: process radtags"}], "position": {"top": 440.00001525878906, "left": 420.0000457763672}, "annotation": "", "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/stacks_procrad/stacks_procrad/1.46.0", "type": "tool"}, "7": {"tool_id": "toolshed.g2.bx.psu.edu/repos/devteam/bwa_wrappers/bwa_wrapper/1.2.3", "tool_version": "1.2.3", "outputs": [{"type": "sam", "name": "output"}], "workflow_outputs": [], "input_connections": {"paired|input1": {"output_name": "demultiplexed", "id": 4}, "genomeSource|ownFile": {"output_name": "output", "id": 0}}, "tool_state": "{\"genomeSource\": \"{\\\"refGenomeSource\\\": \\\"history\\\", \\\"ownFile\\\": {\\\"__class__\\\": \\\"RuntimeValue\\\"}, \\\"__current_case__\\\": 1}\", \"__page__\": null, \"__rerun_remap_job_id__\": null, \"paired\": \"{\\\"sPaired\\\": \\\"single\\\", \\\"input1\\\": {\\\"__class__\\\": \\\"RuntimeValue\\\"}, \\\"__current_case__\\\": 0}\", \"input1|__identifier__\": \"\\\"SRR034310_GGTT\\\"\", \"params\": \"{\\\"__current_case__\\\": 0, \\\"source_select\\\": \\\"pre_set\\\"}\", \"suppressHeader\": \"\\\"false\\\"\", \"chromInfo\": \"\\\"/usr/local/galaxy/galaxy-dist/tool-data/shared/ucsc/chrom/gasAcu1.len\\\"\"}", "id": 7, "tool_shed_repository": {"owner": "devteam", "changeset_revision": "b4427dbb6ced", "name": "bwa_wrappers", "tool_shed": "toolshed.g2.bx.psu.edu"}, "uuid": "41cab8e8-a8fd-46dc-b175-d4bf8b55f163", "errors": null, "name": "Map with BWA for Illumina", "post_job_actions": {}, "label": null, "inputs": [{"name": "genomeSource", "description": "runtime parameter for tool Map with BWA for Illumina"}, {"name": "paired", "description": "runtime parameter for tool Map with BWA for Illumina"}], "position": {"top": 200.00001525878906, "left": 640.0000457763672}, "annotation": "", "content_id": "toolshed.g2.bx.psu.edu/repos/devteam/bwa_wrappers/bwa_wrapper/1.2.3", "type": "tool"}, "8": {"tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/stacks_refmap/stacks_refmap/1.46.0", "tool_version": "1.46.0", "outputs": [{"type": "input", "name": "tags"}, {"type": "input", "name": "snps"}, {"type": "input", "name": "alleles"}, {"type": "input", "name": "matches"}, {"type": "input", "name": "all_output"}, {"type": "txt", "name": "output_log"}, {"type": "html", "name": "output_summary"}, {"type": "tabular", "name": "catalogtags"}, {"type": "tabular", "name": "catalogsnps"}, {"type": "tabular", "name": "catalogalleles"}, {"type": "txt", "name": "out_joinmap"}, {"type": "tabular", "name": "out_generic_haplo"}, {"type": "tabular", "name": "out_generic_geno"}, {"type": "tabular", "name": "out_sql_markers"}, {"type": "tabular", "name": "out_sql_genotypes"}, {"type": "tabular", "name": "out_haplotypes"}, {"type": "tabular", "name": "out_hapstats"}, {"type": "tabular", "name": "out_populations_log"}, {"type": "tabular", "name": "out_sumstats_sum"}, {"type": "tabular", "name": "out_sumstats"}, {"type": "tabular", "name": "out_sql"}], "workflow_outputs": [], "input_connections": {"options_usage|individual_sample": {"output_name": "output", "id": 7}, "options_usage|popmap": {"output_name": "output", "id": 1}}, "tool_state": "{\"__page__\": null, \"P\": \"\\\"\\\"\", \"__rerun_remap_job_id__\": null, \"options_usage\": \"{\\\"rad_analysis_type\\\": \\\"population\\\", \\\"individual_sample\\\": {\\\"__class__\\\": \\\"RuntimeValue\\\"}, \\\"__current_case__\\\": 1, \\\"popmap\\\": {\\\"__class__\\\": \\\"RuntimeValue\\\"}}\", \"m\": \"\\\"3\\\"\", \"snp_options\": \"{\\\"select_model\\\": {\\\"model_type\\\": \\\"snp\\\", \\\"alpha\\\": \\\"0.05\\\", \\\"__current_case__\\\": 0}}\", \"chromInfo\": \"\\\"/usr/local/galaxy/galaxy-dist/tool-data/shared/ucsc/chrom/gasAcu1.len\\\"\"}", "id": 8, "tool_shed_repository": {"owner": "iuc", "changeset_revision": "4ee074ca88fb", "name": "stacks_refmap", "tool_shed": "toolshed.g2.bx.psu.edu"}, "uuid": "89c6f146-6f35-4b04-a427-ab9b271caf9d", "errors": null, "name": "Stacks: reference map", "post_job_actions": {}, "label": null, "inputs": [{"name": "options_usage", "description": "runtime parameter for tool Stacks: reference map"}, {"name": "options_usage", "description": "runtime parameter for tool Stacks: reference map"}], "position": {"top": 200.00001525878906, "left": 859.9826507568359}, "annotation": "", "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/stacks_refmap/stacks_refmap/1.46.0", "type": "tool"}, "9": {"tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/stacks_populations/stacks_populations/1.46.0", "tool_version": "1.46.0", "outputs": [{"type": "tabular", "name": "out_haplotypes"}, {"type": "tabular", "name": "out_hapstats"}, {"type": "tabular", "name": "out_populations_log"}, {"type": "tabular", "name": "out_sumstats_sum"}, {"type": "tabular", "name": "out_sumstats"}, {"type": "tabular", "name": "out_sql"}, {"type": "tabular", "name": "out_fstats"}, {"type": "tabular", "name": "out_fasta"}, {"type": "tabular", "name": "out_phylip_all_partitions"}, {"type": "tabular", "name": "out_phylip_all_pop"}, {"type": "tabular", "name": "out_phylip_all_loci"}, {"type": "tabular", "name": "out_genepop"}, {"type": "tabular", "name": "out_vcf_haplotypes"}, {"type": "tabular", "name": "out_hzar"}, {"type": "tabular", "name": "out_beagle_phased_haplotypes"}, {"type": "tabular", "name": "out_beagle_phased_markers"}, {"type": "tabular", "name": "out_beagle_haplotypes"}, {"type": "tabular", "name": "out_beagle_markers"}, {"type": "tabular", "name": "out_phylip_pop"}, {"type": "tabular", "name": "out_phylip_loci"}, {"type": "tabular", "name": "out_plink_markers"}, {"type": "tabular", "name": "out_plink_genotypes"}, {"type": "tabular", "name": "out_fasta_strict"}, {"type": "tabular", "name": "out_structure"}, {"type": "tabular", "name": "out_treemix_pop"}, {"type": "tabular", "name": "out_treemix_loci"}, {"type": "tabular", "name": "out_fastp\u0125ase"}, {"type": "tabular", "name": "out_phase"}, {"type": "tabular", "name": "out_vcf"}, {"type": "tabular", "name": "out_genomic"}, {"type": "html", "name": "output_summary"}], "workflow_outputs": [], "input_connections": {"options_usage|popmap": {"output_name": "output", "id": 1}, "options_usage|input_col": {"output_name": "all_output", "id": 8}}, "tool_state": "{\"options_kernel\": \"{\\\"kernel\\\": \\\"false\\\", \\\"__current_case__\\\": 1}\", \"__page__\": null, \"populations_output\": \"{\\\"phylip_var_all\\\": \\\"false\\\", \\\"fasta_strict\\\": \\\"false\\\", \\\"hzar\\\": \\\"false\\\", \\\"phylip_var\\\": \\\"false\\\", \\\"plink\\\": \\\"false\\\", \\\"vcf\\\": \\\"false\\\", \\\"phylip\\\": \\\"false\\\", \\\"beagle_phased\\\": \\\"false\\\", \\\"vcf_haplotypes\\\": \\\"false\\\", \\\"options_genomic\\\": {\\\"genomic\\\": \\\"false\\\", \\\"__current_case__\\\": 1}, \\\"genepop\\\": \\\"false\\\", \\\"beagle\\\": \\\"false\\\", \\\"fastphase\\\": \\\"false\\\", \\\"ordered_export\\\": \\\"false\\\", \\\"phase\\\": \\\"false\\\", \\\"fasta\\\": \\\"false\\\", \\\"treemix\\\": \\\"false\\\", \\\"structure\\\": \\\"false\\\"}\", \"options_usage\": \"{\\\"input_type\\\": \\\"stacks\\\", \\\"popmap\\\": {\\\"__class__\\\": \\\"RuntimeValue\\\"}, \\\"input_col\\\": {\\\"__class__\\\": \\\"RuntimeValue\\\"}, \\\"__current_case__\\\": 0}\", \"bootstrap_resampling\": \"{\\\"bootstrap_wl\\\": {\\\"__class__\\\": \\\"RuntimeValue\\\"}, \\\"bootstrap_reps\\\": \\\"100\\\", \\\"bootstrap_resampling_mode\\\": {\\\"bootstrap_phist\\\": \\\"false\\\", \\\"bootstrap_fst\\\": \\\"false\\\", \\\"bootstrap_all\\\": \\\"false\\\", \\\"bootstrap_pifis\\\": \\\"false\\\", \\\"__current_case__\\\": 1, \\\"bootstrap_div\\\": \\\"false\\\"}}\", \"options_filtering\": \"{\\\"write_single_snp\\\": \\\"false\\\", \\\"mindepth\\\": \\\"1\\\", \\\"minpop\\\": \\\"2\\\", \\\"minminor\\\": \\\"0.25\\\", \\\"max_obs_het\\\": \\\"\\\", \\\"lnl\\\": \\\"\\\", \\\"correction_select\\\": {\\\"correction\\\": \\\"no_corr\\\", \\\"__current_case__\\\": 0}, \\\"minperc\\\": \\\"0.5\\\", \\\"write_random_snp\\\": \\\"false\\\"}\", \"advanced_options\": \"{\\\"blacklist\\\": {\\\"__class__\\\": \\\"RuntimeValue\\\"}, \\\"batchid\\\": \\\"1\\\", \\\"whitelist\\\": {\\\"__class__\\\": \\\"RuntimeValue\\\"}}\", \"__rerun_remap_job_id__\": null, \"chromInfo\": \"\\\"/usr/local/galaxy/galaxy-dist/tool-data/shared/ucsc/chrom/gasAcu1.len\\\"\", \"fstats\": \"\\\"false\\\"\"}", "id": 9, "tool_shed_repository": {"owner": "iuc", "changeset_revision": "45db1ba16163", "name": "stacks_populations", "tool_shed": "toolshed.g2.bx.psu.edu"}, "uuid": "1ae9361c-d5a0-4068-b94a-f958e11e76e6", "errors": null, "name": "Stacks: populations", "post_job_actions": {}, "label": null, "inputs": [{"name": "options_usage", "description": "runtime parameter for tool Stacks: populations"}, {"name": "options_usage", "description": "runtime parameter for tool Stacks: populations"}, {"name": "bootstrap_resampling", "description": "runtime parameter for tool Stacks: populations"}, {"name": "advanced_options", "description": "runtime parameter for tool Stacks: populations"}, {"name": "advanced_options", "description": "runtime parameter for tool Stacks: populations"}], "position": {"top": 200.00001525878906, "left": 1080.0001068115234}, "annotation": "", "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/stacks_populations/stacks_populations/1.46.0", "type": "tool"}}, "annotation": "", "a_galaxy_workflow": "true"}
+{
+  "a_galaxy_workflow": "true",
+  "annotation": "",
+  "format-version": "0.1",
+  "name": "ref-based-rad-seq (imported from uploaded file)",
+  "steps": {
+    "0": {
+      "annotation": "",
+      "content_id": null,
+      "errors": null,
+      "id": 0,
+      "input_connections": {},
+      "inputs": [
+        {
+          "description": "",
+          "name": "ref_genome_chromFa.tar"
+        }
+      ],
+      "label": "ref_genome_chromFa.tar",
+      "name": "Input dataset",
+      "outputs": [],
+      "position": {
+        "left": 200.00001525878906,
+        "top": 200.00001525878906
+      },
+      "tool_id": null,
+      "tool_state": "{\"name\": \"ref_genome_chromFa.tar\"}",
+      "tool_version": null,
+      "type": "data_input",
+      "uuid": "d41b8a08-8893-4fe4-86c1-21caa8e95cb9",
+      "workflow_outputs": []
+    },
+    "1": {
+      "annotation": "",
+      "content_id": null,
+      "errors": null,
+      "id": 1,
+      "input_connections": {},
+      "inputs": [
+        {
+          "description": "",
+          "name": "Population_map.txt"
+        }
+      ],
+      "label": "Population_map.txt",
+      "name": "Input dataset",
+      "outputs": [],
+      "position": {
+        "left": 200.00001525878906,
+        "top": 320.00001525878906
+      },
+      "tool_id": null,
+      "tool_state": "{\"name\": \"Population_map.txt\"}",
+      "tool_version": null,
+      "type": "data_input",
+      "uuid": "59b48fd7-4a76-4683-8e5b-b8db033e4f5d",
+      "workflow_outputs": []
+    },
+    "2": {
+      "annotation": "",
+      "content_id": null,
+      "errors": null,
+      "id": 2,
+      "input_connections": {},
+      "inputs": [
+        {
+          "description": "",
+          "name": "Barcodes_SRR034310.tabular"
+        }
+      ],
+      "label": "Barcodes_SRR034310.tabular",
+      "name": "Input dataset",
+      "outputs": [],
+      "position": {
+        "left": 200.00001525878906,
+        "top": 440.00001525878906
+      },
+      "tool_id": null,
+      "tool_state": "{\"name\": \"Barcodes_SRR034310.tabular\"}",
+      "tool_version": null,
+      "type": "data_input",
+      "uuid": "c7ea916e-f493-4e53-bbf5-1d9b0ab34c18",
+      "workflow_outputs": []
+    },
+    "3": {
+      "annotation": "",
+      "content_id": null,
+      "errors": null,
+      "id": 3,
+      "input_connections": {},
+      "inputs": [
+        {
+          "description": "",
+          "name": "SRR034310.fastq"
+        }
+      ],
+      "label": "SRR034310.fastq",
+      "name": "Input dataset",
+      "outputs": [],
+      "position": {
+        "left": 200.00001525878906,
+        "top": 560.0000457763672
+      },
+      "tool_id": null,
+      "tool_state": "{\"name\": \"SRR034310.fastq\"}",
+      "tool_version": null,
+      "type": "data_input",
+      "uuid": "8dcf8e48-fc08-4c2c-9aad-477de98b41d1",
+      "workflow_outputs": []
+    },
+    "4": {
+      "annotation": "",
+      "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/stacks_procrad/stacks_procrad/1.46.0",
+      "errors": null,
+      "id": 4,
+      "input_connections": {
+        "barcode": {
+          "id": 2,
+          "output_name": "output"
+        },
+        "input_type|input_single": {
+          "id": 3,
+          "output_name": "output"
+        }
+      },
+      "inputs": [
+        {
+          "description": "runtime parameter for tool Stacks: process radtags",
+          "name": "input_type"
+        },
+        {
+          "description": "runtime parameter for tool Stacks: process radtags",
+          "name": "barcode"
+        }
+      ],
+      "label": null,
+      "name": "Stacks: process radtags",
+      "outputs": [
+        {
+          "name": "demultiplexed",
+          "type": "input"
+        },
+        {
+          "name": "remaining",
+          "type": "input"
+        },
+        {
+          "name": "discarded",
+          "type": "input"
+        },
+        {
+          "name": "output_log",
+          "type": "txt"
+        }
+      ],
+      "position": {
+        "left": 420.0000457763672,
+        "top": 200.00001525878906
+      },
+      "post_job_actions": {},
+      "tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/stacks_procrad/stacks_procrad/1.46.0",
+      "tool_shed_repository": {
+        "changeset_revision": "57910d476be9",
+        "name": "stacks_procrad",
+        "owner": "iuc",
+        "tool_shed": "toolshed.g2.bx.psu.edu"
+      },
+      "tool_state": "{\"capture\": \"\\\"true\\\"\", \"outype\": \"\\\"fastq\\\"\", \"options_enzyme\": \"{\\\"enzyme\\\": \\\"sbfI\\\", \\\"options_enzyme_selector\\\": \\\"1\\\", \\\"__current_case__\\\": 0}\", \"__page__\": null, \"input_type\": \"{\\\"input_single\\\": {\\\"__class__\\\": \\\"RuntimeValue\\\"}, \\\"barcode_encoding\\\": \\\"--inline_null\\\", \\\"__current_case__\\\": 0, \\\"options_type_selector\\\": \\\"single\\\"}\", \"__rerun_remap_job_id__\": null, \"barcode\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\", \"options_advanced\": \"{\\\"rescue\\\": \\\"false\\\", \\\"truncate\\\": \\\"\\\", \\\"remove\\\": \\\"false\\\", \\\"retain_header\\\": \\\"false\\\", \\\"score\\\": \\\"10\\\", \\\"discard\\\": \\\"false\\\", \\\"sliding\\\": \\\"0.15\\\"}\", \"chromInfo\": \"\\\"/usr/local/galaxy/galaxy-dist/tool-data/shared/ucsc/chrom/gasAcu1.len\\\"\"}",
+      "tool_version": "1.46.0",
+      "type": "tool",
+      "uuid": "5383a9fb-0c93-42ea-b6dd-87d565917c17",
+      "workflow_outputs": []
+    },
+    "5": {
+      "annotation": "",
+      "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/stacks_procrad/stacks_procrad/1.46.0",
+      "errors": null,
+      "id": 5,
+      "input_connections": {
+        "barcode": {
+          "id": 2,
+          "output_name": "output"
+        },
+        "input_type|input_single": {
+          "id": 3,
+          "output_name": "output"
+        }
+      },
+      "inputs": [
+        {
+          "description": "runtime parameter for tool Stacks: process radtags",
+          "name": "input_type"
+        },
+        {
+          "description": "runtime parameter for tool Stacks: process radtags",
+          "name": "barcode"
+        }
+      ],
+      "label": null,
+      "name": "Stacks: process radtags",
+      "outputs": [
+        {
+          "name": "demultiplexed",
+          "type": "input"
+        },
+        {
+          "name": "remaining",
+          "type": "input"
+        },
+        {
+          "name": "discarded",
+          "type": "input"
+        },
+        {
+          "name": "output_log",
+          "type": "txt"
+        }
+      ],
+      "position": {
+        "left": 420.0000457763672,
+        "top": 320.00001525878906
+      },
+      "post_job_actions": {},
+      "tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/stacks_procrad/stacks_procrad/1.46.0",
+      "tool_shed_repository": {
+        "changeset_revision": "57910d476be9",
+        "name": "stacks_procrad",
+        "owner": "iuc",
+        "tool_shed": "toolshed.g2.bx.psu.edu"
+      },
+      "tool_state": "{\"capture\": \"\\\"true\\\"\", \"outype\": \"\\\"fastq\\\"\", \"options_enzyme\": \"{\\\"enzyme\\\": \\\"sbfI\\\", \\\"options_enzyme_selector\\\": \\\"1\\\", \\\"__current_case__\\\": 0}\", \"__page__\": null, \"input_type\": \"{\\\"input_single\\\": {\\\"__class__\\\": \\\"RuntimeValue\\\"}, \\\"barcode_encoding\\\": \\\"--inline_null\\\", \\\"__current_case__\\\": 0, \\\"options_type_selector\\\": \\\"single\\\"}\", \"__rerun_remap_job_id__\": null, \"barcode\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\", \"options_advanced\": \"{\\\"rescue\\\": \\\"false\\\", \\\"truncate\\\": \\\"\\\", \\\"remove\\\": \\\"false\\\", \\\"retain_header\\\": \\\"false\\\", \\\"score\\\": \\\"10\\\", \\\"discard\\\": \\\"true\\\", \\\"sliding\\\": \\\"0.15\\\"}\", \"chromInfo\": \"\\\"/usr/local/galaxy/galaxy-dist/tool-data/shared/ucsc/chrom/gasAcu1.len\\\"\"}",
+      "tool_version": "1.46.0",
+      "type": "tool",
+      "uuid": "b736c8fc-4f62-4535-ab6d-4a3f4cb1dc4c",
+      "workflow_outputs": []
+    },
+    "6": {
+      "annotation": "",
+      "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/stacks_procrad/stacks_procrad/1.46.0",
+      "errors": null,
+      "id": 6,
+      "input_connections": {
+        "barcode": {
+          "id": 2,
+          "output_name": "output"
+        },
+        "input_type|input_single": {
+          "id": 3,
+          "output_name": "output"
+        }
+      },
+      "inputs": [
+        {
+          "description": "runtime parameter for tool Stacks: process radtags",
+          "name": "input_type"
+        },
+        {
+          "description": "runtime parameter for tool Stacks: process radtags",
+          "name": "barcode"
+        }
+      ],
+      "label": null,
+      "name": "Stacks: process radtags",
+      "outputs": [
+        {
+          "name": "demultiplexed",
+          "type": "input"
+        },
+        {
+          "name": "remaining",
+          "type": "input"
+        },
+        {
+          "name": "discarded",
+          "type": "input"
+        },
+        {
+          "name": "output_log",
+          "type": "txt"
+        }
+      ],
+      "position": {
+        "left": 420.0000457763672,
+        "top": 440.00001525878906
+      },
+      "post_job_actions": {},
+      "tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/stacks_procrad/stacks_procrad/1.46.0",
+      "tool_shed_repository": {
+        "changeset_revision": "57910d476be9",
+        "name": "stacks_procrad",
+        "owner": "iuc",
+        "tool_shed": "toolshed.g2.bx.psu.edu"
+      },
+      "tool_state": "{\"capture\": \"\\\"true\\\"\", \"outype\": \"\\\"fastq\\\"\", \"options_enzyme\": \"{\\\"enzyme\\\": \\\"sbfI\\\", \\\"options_enzyme_selector\\\": \\\"1\\\", \\\"__current_case__\\\": 0}\", \"__page__\": null, \"input_type\": \"{\\\"input_single\\\": {\\\"__class__\\\": \\\"RuntimeValue\\\"}, \\\"barcode_encoding\\\": \\\"--inline_null\\\", \\\"__current_case__\\\": 0, \\\"options_type_selector\\\": \\\"single\\\"}\", \"__rerun_remap_job_id__\": null, \"barcode\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\", \"options_advanced\": \"{\\\"rescue\\\": \\\"false\\\", \\\"truncate\\\": \\\"\\\", \\\"remove\\\": \\\"false\\\", \\\"retain_header\\\": \\\"false\\\", \\\"score\\\": \\\"20\\\", \\\"discard\\\": \\\"true\\\", \\\"sliding\\\": \\\"0.15\\\"}\", \"chromInfo\": \"\\\"/usr/local/galaxy/galaxy-dist/tool-data/shared/ucsc/chrom/gasAcu1.len\\\"\"}",
+      "tool_version": "1.46.0",
+      "type": "tool",
+      "uuid": "3774972a-3761-4572-9732-6f522dded358",
+      "workflow_outputs": []
+    },
+    "7": {
+      "annotation": "",
+      "content_id": "toolshed.g2.bx.psu.edu/repos/devteam/bwa_wrappers/bwa_wrapper/1.2.3",
+      "errors": null,
+      "id": 7,
+      "input_connections": {
+        "genomeSource|ownFile": {
+          "id": 0,
+          "output_name": "output"
+        },
+        "paired|input1": {
+          "id": 4,
+          "output_name": "demultiplexed"
+        }
+      },
+      "inputs": [
+        {
+          "description": "runtime parameter for tool Map with BWA for Illumina",
+          "name": "genomeSource"
+        },
+        {
+          "description": "runtime parameter for tool Map with BWA for Illumina",
+          "name": "paired"
+        }
+      ],
+      "label": null,
+      "name": "Map with BWA for Illumina",
+      "outputs": [
+        {
+          "name": "output",
+          "type": "sam"
+        }
+      ],
+      "position": {
+        "left": 640.0000457763672,
+        "top": 200.00001525878906
+      },
+      "post_job_actions": {},
+      "tool_id": "toolshed.g2.bx.psu.edu/repos/devteam/bwa_wrappers/bwa_wrapper/1.2.3",
+      "tool_shed_repository": {
+        "changeset_revision": "b4427dbb6ced",
+        "name": "bwa_wrappers",
+        "owner": "devteam",
+        "tool_shed": "toolshed.g2.bx.psu.edu"
+      },
+      "tool_state": "{\"genomeSource\": \"{\\\"refGenomeSource\\\": \\\"history\\\", \\\"ownFile\\\": {\\\"__class__\\\": \\\"RuntimeValue\\\"}, \\\"__current_case__\\\": 1}\", \"__page__\": null, \"__rerun_remap_job_id__\": null, \"paired\": \"{\\\"sPaired\\\": \\\"single\\\", \\\"input1\\\": {\\\"__class__\\\": \\\"RuntimeValue\\\"}, \\\"__current_case__\\\": 0}\", \"input1|__identifier__\": \"\\\"SRR034310_GGTT\\\"\", \"params\": \"{\\\"__current_case__\\\": 0, \\\"source_select\\\": \\\"pre_set\\\"}\", \"suppressHeader\": \"\\\"false\\\"\", \"chromInfo\": \"\\\"/usr/local/galaxy/galaxy-dist/tool-data/shared/ucsc/chrom/gasAcu1.len\\\"\"}",
+      "tool_version": "1.2.3",
+      "type": "tool",
+      "uuid": "41cab8e8-a8fd-46dc-b175-d4bf8b55f163",
+      "workflow_outputs": []
+    },
+    "8": {
+      "annotation": "",
+      "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/stacks_refmap/stacks_refmap/1.46.0",
+      "errors": null,
+      "id": 8,
+      "input_connections": {
+        "options_usage|individual_sample": {
+          "id": 7,
+          "output_name": "output"
+        },
+        "options_usage|popmap": {
+          "id": 1,
+          "output_name": "output"
+        }
+      },
+      "inputs": [
+        {
+          "description": "runtime parameter for tool Stacks: reference map",
+          "name": "options_usage"
+        },
+        {
+          "description": "runtime parameter for tool Stacks: reference map",
+          "name": "options_usage"
+        }
+      ],
+      "label": null,
+      "name": "Stacks: reference map",
+      "outputs": [
+        {
+          "name": "tags",
+          "type": "input"
+        },
+        {
+          "name": "snps",
+          "type": "input"
+        },
+        {
+          "name": "alleles",
+          "type": "input"
+        },
+        {
+          "name": "matches",
+          "type": "input"
+        },
+        {
+          "name": "all_output",
+          "type": "input"
+        },
+        {
+          "name": "output_log",
+          "type": "txt"
+        },
+        {
+          "name": "output_summary",
+          "type": "html"
+        },
+        {
+          "name": "catalogtags",
+          "type": "tabular"
+        },
+        {
+          "name": "catalogsnps",
+          "type": "tabular"
+        },
+        {
+          "name": "catalogalleles",
+          "type": "tabular"
+        },
+        {
+          "name": "out_joinmap",
+          "type": "txt"
+        },
+        {
+          "name": "out_generic_haplo",
+          "type": "tabular"
+        },
+        {
+          "name": "out_generic_geno",
+          "type": "tabular"
+        },
+        {
+          "name": "out_sql_markers",
+          "type": "tabular"
+        },
+        {
+          "name": "out_sql_genotypes",
+          "type": "tabular"
+        },
+        {
+          "name": "out_haplotypes",
+          "type": "tabular"
+        },
+        {
+          "name": "out_hapstats",
+          "type": "tabular"
+        },
+        {
+          "name": "out_populations_log",
+          "type": "tabular"
+        },
+        {
+          "name": "out_sumstats_sum",
+          "type": "tabular"
+        },
+        {
+          "name": "out_sumstats",
+          "type": "tabular"
+        },
+        {
+          "name": "out_sql",
+          "type": "tabular"
+        }
+      ],
+      "position": {
+        "left": 859.9826507568359,
+        "top": 200.00001525878906
+      },
+      "post_job_actions": {},
+      "tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/stacks_refmap/stacks_refmap/1.46.0",
+      "tool_shed_repository": {
+        "changeset_revision": "4ee074ca88fb",
+        "name": "stacks_refmap",
+        "owner": "iuc",
+        "tool_shed": "toolshed.g2.bx.psu.edu"
+      },
+      "tool_state": "{\"__page__\": null, \"P\": \"\\\"\\\"\", \"__rerun_remap_job_id__\": null, \"options_usage\": \"{\\\"rad_analysis_type\\\": \\\"population\\\", \\\"individual_sample\\\": {\\\"__class__\\\": \\\"RuntimeValue\\\"}, \\\"__current_case__\\\": 1, \\\"popmap\\\": {\\\"__class__\\\": \\\"RuntimeValue\\\"}}\", \"m\": \"\\\"3\\\"\", \"snp_options\": \"{\\\"select_model\\\": {\\\"model_type\\\": \\\"snp\\\", \\\"alpha\\\": \\\"0.05\\\", \\\"__current_case__\\\": 0}}\", \"chromInfo\": \"\\\"/usr/local/galaxy/galaxy-dist/tool-data/shared/ucsc/chrom/gasAcu1.len\\\"\"}",
+      "tool_version": "1.46.0",
+      "type": "tool",
+      "uuid": "89c6f146-6f35-4b04-a427-ab9b271caf9d",
+      "workflow_outputs": []
+    },
+    "9": {
+      "annotation": "",
+      "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/stacks_populations/stacks_populations/1.46.0",
+      "errors": null,
+      "id": 9,
+      "input_connections": {
+        "options_usage|input_col": {
+          "id": 8,
+          "output_name": "all_output"
+        },
+        "options_usage|popmap": {
+          "id": 1,
+          "output_name": "output"
+        }
+      },
+      "inputs": [
+        {
+          "description": "runtime parameter for tool Stacks: populations",
+          "name": "options_usage"
+        },
+        {
+          "description": "runtime parameter for tool Stacks: populations",
+          "name": "options_usage"
+        },
+        {
+          "description": "runtime parameter for tool Stacks: populations",
+          "name": "bootstrap_resampling"
+        },
+        {
+          "description": "runtime parameter for tool Stacks: populations",
+          "name": "advanced_options"
+        },
+        {
+          "description": "runtime parameter for tool Stacks: populations",
+          "name": "advanced_options"
+        }
+      ],
+      "label": null,
+      "name": "Stacks: populations",
+      "outputs": [
+        {
+          "name": "out_haplotypes",
+          "type": "tabular"
+        },
+        {
+          "name": "out_hapstats",
+          "type": "tabular"
+        },
+        {
+          "name": "out_populations_log",
+          "type": "tabular"
+        },
+        {
+          "name": "out_sumstats_sum",
+          "type": "tabular"
+        },
+        {
+          "name": "out_sumstats",
+          "type": "tabular"
+        },
+        {
+          "name": "out_sql",
+          "type": "tabular"
+        },
+        {
+          "name": "out_fstats",
+          "type": "tabular"
+        },
+        {
+          "name": "out_fasta",
+          "type": "tabular"
+        },
+        {
+          "name": "out_phylip_all_partitions",
+          "type": "tabular"
+        },
+        {
+          "name": "out_phylip_all_pop",
+          "type": "tabular"
+        },
+        {
+          "name": "out_phylip_all_loci",
+          "type": "tabular"
+        },
+        {
+          "name": "out_genepop",
+          "type": "tabular"
+        },
+        {
+          "name": "out_vcf_haplotypes",
+          "type": "tabular"
+        },
+        {
+          "name": "out_hzar",
+          "type": "tabular"
+        },
+        {
+          "name": "out_beagle_phased_haplotypes",
+          "type": "tabular"
+        },
+        {
+          "name": "out_beagle_phased_markers",
+          "type": "tabular"
+        },
+        {
+          "name": "out_beagle_haplotypes",
+          "type": "tabular"
+        },
+        {
+          "name": "out_beagle_markers",
+          "type": "tabular"
+        },
+        {
+          "name": "out_phylip_pop",
+          "type": "tabular"
+        },
+        {
+          "name": "out_phylip_loci",
+          "type": "tabular"
+        },
+        {
+          "name": "out_plink_markers",
+          "type": "tabular"
+        },
+        {
+          "name": "out_plink_genotypes",
+          "type": "tabular"
+        },
+        {
+          "name": "out_fasta_strict",
+          "type": "tabular"
+        },
+        {
+          "name": "out_structure",
+          "type": "tabular"
+        },
+        {
+          "name": "out_treemix_pop",
+          "type": "tabular"
+        },
+        {
+          "name": "out_treemix_loci",
+          "type": "tabular"
+        },
+        {
+          "name": "out_fastpĥase",
+          "type": "tabular"
+        },
+        {
+          "name": "out_phase",
+          "type": "tabular"
+        },
+        {
+          "name": "out_vcf",
+          "type": "tabular"
+        },
+        {
+          "name": "out_genomic",
+          "type": "tabular"
+        },
+        {
+          "name": "output_summary",
+          "type": "html"
+        }
+      ],
+      "position": {
+        "left": 1080.0001068115234,
+        "top": 200.00001525878906
+      },
+      "post_job_actions": {},
+      "tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/stacks_populations/stacks_populations/1.46.0",
+      "tool_shed_repository": {
+        "changeset_revision": "45db1ba16163",
+        "name": "stacks_populations",
+        "owner": "iuc",
+        "tool_shed": "toolshed.g2.bx.psu.edu"
+      },
+      "tool_state": "{\"options_kernel\": \"{\\\"kernel\\\": \\\"false\\\", \\\"__current_case__\\\": 1}\", \"__page__\": null, \"populations_output\": \"{\\\"phylip_var_all\\\": \\\"false\\\", \\\"fasta_strict\\\": \\\"false\\\", \\\"hzar\\\": \\\"false\\\", \\\"phylip_var\\\": \\\"false\\\", \\\"plink\\\": \\\"false\\\", \\\"vcf\\\": \\\"false\\\", \\\"phylip\\\": \\\"false\\\", \\\"beagle_phased\\\": \\\"false\\\", \\\"vcf_haplotypes\\\": \\\"false\\\", \\\"options_genomic\\\": {\\\"genomic\\\": \\\"false\\\", \\\"__current_case__\\\": 1}, \\\"genepop\\\": \\\"false\\\", \\\"beagle\\\": \\\"false\\\", \\\"fastphase\\\": \\\"false\\\", \\\"ordered_export\\\": \\\"false\\\", \\\"phase\\\": \\\"false\\\", \\\"fasta\\\": \\\"false\\\", \\\"treemix\\\": \\\"false\\\", \\\"structure\\\": \\\"false\\\"}\", \"options_usage\": \"{\\\"input_type\\\": \\\"stacks\\\", \\\"popmap\\\": {\\\"__class__\\\": \\\"RuntimeValue\\\"}, \\\"input_col\\\": {\\\"__class__\\\": \\\"RuntimeValue\\\"}, \\\"__current_case__\\\": 0}\", \"bootstrap_resampling\": \"{\\\"bootstrap_wl\\\": {\\\"__class__\\\": \\\"RuntimeValue\\\"}, \\\"bootstrap_reps\\\": \\\"100\\\", \\\"bootstrap_resampling_mode\\\": {\\\"bootstrap_phist\\\": \\\"false\\\", \\\"bootstrap_fst\\\": \\\"false\\\", \\\"bootstrap_all\\\": \\\"false\\\", \\\"bootstrap_pifis\\\": \\\"false\\\", \\\"__current_case__\\\": 1, \\\"bootstrap_div\\\": \\\"false\\\"}}\", \"options_filtering\": \"{\\\"write_single_snp\\\": \\\"false\\\", \\\"mindepth\\\": \\\"1\\\", \\\"minpop\\\": \\\"2\\\", \\\"minminor\\\": \\\"0.25\\\", \\\"max_obs_het\\\": \\\"\\\", \\\"lnl\\\": \\\"\\\", \\\"correction_select\\\": {\\\"correction\\\": \\\"no_corr\\\", \\\"__current_case__\\\": 0}, \\\"minperc\\\": \\\"0.5\\\", \\\"write_random_snp\\\": \\\"false\\\"}\", \"advanced_options\": \"{\\\"blacklist\\\": {\\\"__class__\\\": \\\"RuntimeValue\\\"}, \\\"batchid\\\": \\\"1\\\", \\\"whitelist\\\": {\\\"__class__\\\": \\\"RuntimeValue\\\"}}\", \"__rerun_remap_job_id__\": null, \"chromInfo\": \"\\\"/usr/local/galaxy/galaxy-dist/tool-data/shared/ucsc/chrom/gasAcu1.len\\\"\", \"fstats\": \"\\\"false\\\"\"}",
+      "tool_version": "1.46.0",
+      "type": "tool",
+      "uuid": "1ae9361c-d5a0-4068-b94a-f958e11e76e6",
+      "workflow_outputs": []
+    }
+  },
+  "tags": [],
+  "uuid": "733d4e4d-5650-400a-8707-6778773a9afd"
+}

--- a/topics/statistics/tutorials/classification_regression/workflows/GradientBoostingRegression_TutorialWorkflow.ga
+++ b/topics/statistics/tutorials/classification_regression/workflows/GradientBoostingRegression_TutorialWorkflow.ga
@@ -1,1 +1,289 @@
-{"uuid": "d07ef670-c79a-4316-95b6-e70964745d94", "tags": [], "format-version": "0.1", "name": "GradientBoostingRegression_TutorialWorkflow", "steps": {"0": {"tool_id": null, "tool_version": null, "outputs": [], "workflow_outputs": [{"output_name": "output", "uuid": "54c338e0-718a-4133-98fe-e53ddb1d9fb1", "label": null}], "input_connections": {}, "tool_state": "{}", "id": 0, "uuid": "c592e42e-5316-49e6-9f4e-3e2835b06d1d", "errors": null, "name": "Input dataset", "label": "Training_data", "inputs": [], "position": {"top": 149, "left": 138}, "annotation": "", "content_id": null, "type": "data_input"}, "1": {"tool_id": null, "tool_version": null, "outputs": [], "workflow_outputs": [{"output_name": "output", "uuid": "dbf9f770-dfda-477c-9024-f7bacb5a3860", "label": null}], "input_connections": {}, "tool_state": "{}", "id": 1, "uuid": "7191fc22-d573-4a3e-a676-43dd63cb5d18", "errors": null, "name": "Input dataset", "label": "Test_data", "inputs": [], "position": {"top": 286, "left": 162}, "annotation": "", "content_id": null, "type": "data_input"}, "2": {"tool_id": null, "tool_version": null, "outputs": [], "workflow_outputs": [{"output_name": "output", "uuid": "ddba0d95-8465-472f-86e1-62fe5c1bdd9b", "label": null}], "input_connections": {}, "tool_state": "{}", "id": 2, "uuid": "b373e60e-af2b-450a-9e9d-d2d48839a692", "errors": null, "name": "Input dataset", "label": "Test_data_targets", "inputs": [], "position": {"top": 149, "left": 706}, "annotation": "", "content_id": null, "type": "data_input"}, "3": {"tool_id": "toolshed.g2.bx.psu.edu/repos/bgruening/sklearn_ensemble/sklearn_ensemble/0.9", "tool_version": "0.9", "outputs": [{"type": "tabular", "name": "outfile_predict"}, {"type": "zip", "name": "outfile_fit"}], "workflow_outputs": [], "input_connections": {"selected_tasks|selected_algorithms|input_options|infile2": {"output_name": "output", "id": 0}, "selected_tasks|selected_algorithms|input_options|infile1": {"output_name": "output", "id": 0}}, "tool_state": "{\"__page__\": null, \"selected_tasks\": \"{\\\"selected_task\\\": \\\"train\\\", \\\"__current_case__\\\": 1, \\\"selected_algorithms\\\": {\\\"options\\\": {\\\"warm_start\\\": \\\"false\\\", \\\"loss\\\": \\\"ls\\\", \\\"min_impurity_decrease\\\": \\\"0.0\\\", \\\"verbose\\\": \\\"0\\\", \\\"max_leaf_nodes\\\": \\\"\\\", \\\"learning_rate\\\": \\\"0.1\\\", \\\"presort\\\": \\\"auto\\\", \\\"min_samples_leaf\\\": \\\"1.0\\\", \\\"n_estimators\\\": \\\"100\\\", \\\"subsample\\\": \\\"1.0\\\", \\\"min_weight_fraction_leaf\\\": \\\"0.0\\\", \\\"criterion\\\": \\\"friedman_mse\\\", \\\"random_state\\\": \\\"\\\", \\\"alpha\\\": \\\"0.9\\\", \\\"min_samples_split\\\": \\\"2.0\\\", \\\"select_max_features\\\": {\\\"max_features\\\": \\\"auto\\\", \\\"__current_case__\\\": 0}, \\\"max_depth\\\": \\\"3\\\"}, \\\"input_options\\\": {\\\"infile2\\\": {\\\"__class__\\\": \\\"RuntimeValue\\\"}, \\\"infile1\\\": {\\\"__class__\\\": \\\"RuntimeValue\\\"}, \\\"column_selector_options_1\\\": {\\\"col1\\\": \\\"target\\\", \\\"__current_case__\\\": 3, \\\"selected_column_selector_option\\\": \\\"all_but_by_header_name\\\"}, \\\"column_selector_options_2\\\": {\\\"selected_column_selector_option2\\\": \\\"by_header_name\\\", \\\"col2\\\": \\\"target\\\", \\\"__current_case__\\\": 1}, \\\"header2\\\": \\\"true\\\", \\\"header1\\\": \\\"true\\\", \\\"__current_case__\\\": 0, \\\"selected_input\\\": \\\"tabular\\\"}, \\\"__current_case__\\\": 5, \\\"selected_algorithm\\\": \\\"GradientBoostingRegressor\\\"}}\", \"__rerun_remap_job_id__\": null}", "id": 3, "tool_shed_repository": {"owner": "bgruening", "changeset_revision": "9ce3e347506c", "name": "sklearn_ensemble", "tool_shed": "toolshed.g2.bx.psu.edu"}, "uuid": "4829cede-e0b0-46f1-9922-c3d629902d58", "errors": null, "name": "Ensemble methods", "post_job_actions": {"HideDatasetActionoutfile_fit": {"output_name": "outfile_fit", "action_type": "HideDatasetAction", "action_arguments": {}}, "HideDatasetActionoutfile_predict": {"output_name": "outfile_predict", "action_type": "HideDatasetAction", "action_arguments": {}}}, "label": "Regressor", "inputs": [], "position": {"top": 138, "left": 390.5}, "annotation": "", "content_id": "toolshed.g2.bx.psu.edu/repos/bgruening/sklearn_ensemble/sklearn_ensemble/0.9", "type": "tool"}, "4": {"tool_id": "toolshed.g2.bx.psu.edu/repos/bgruening/sklearn_ensemble/sklearn_ensemble/0.9", "tool_version": "0.9", "outputs": [{"type": "tabular", "name": "outfile_predict"}, {"type": "zip", "name": "outfile_fit"}], "workflow_outputs": [], "input_connections": {"selected_tasks|infile_data": {"output_name": "output", "id": 1}, "selected_tasks|infile_model": {"output_name": "outfile_fit", "id": 3}}, "tool_state": "{\"__page__\": null, \"selected_tasks\": \"{\\\"header\\\": \\\"true\\\", \\\"selected_task\\\": \\\"load\\\", \\\"infile_model\\\": {\\\"__class__\\\": \\\"RuntimeValue\\\"}, \\\"prediction_options\\\": {\\\"prediction_option\\\": \\\"predict\\\", \\\"__current_case__\\\": 0}, \\\"infile_data\\\": {\\\"__class__\\\": \\\"RuntimeValue\\\"}, \\\"__current_case__\\\": 0}\", \"__rerun_remap_job_id__\": null}", "id": 4, "tool_shed_repository": {"owner": "bgruening", "changeset_revision": "9ce3e347506c", "name": "sklearn_ensemble", "tool_shed": "toolshed.g2.bx.psu.edu"}, "uuid": "07395cc6-3069-4aea-b136-5d2f55ce76e2", "errors": null, "name": "Ensemble methods", "post_job_actions": {"HideDatasetActionoutfile_fit": {"output_name": "outfile_fit", "action_type": "HideDatasetAction", "action_arguments": {}}, "HideDatasetActionoutfile_predict": {"output_name": "outfile_predict", "action_type": "HideDatasetAction", "action_arguments": {}}}, "label": "Predictor", "inputs": [{"name": "selected_tasks", "description": "runtime parameter for tool Ensemble methods"}, {"name": "selected_tasks", "description": "runtime parameter for tool Ensemble methods"}], "position": {"top": 352, "left": 389.5}, "annotation": "", "content_id": "toolshed.g2.bx.psu.edu/repos/bgruening/sklearn_ensemble/sklearn_ensemble/0.9", "type": "tool"}, "5": {"tool_id": "toolshed.g2.bx.psu.edu/repos/bgruening/plotly_regression_performance_plots/plotly_regression_performance_plots/0.1", "tool_version": "0.1", "outputs": [{"type": "html", "name": "output_actual_vs_pred"}, {"type": "html", "name": "output_scatter_plot"}, {"type": "html", "name": "output_residual_plot"}], "workflow_outputs": [{"output_name": "output_scatter_plot", "uuid": "b473c830-fea7-490d-828d-0b4ca8e4f9d8", "label": null}, {"output_name": "output_actual_vs_pred", "uuid": "bb982de6-621a-4627-a798-388a5a5b89d6", "label": null}, {"output_name": "output_residual_plot", "uuid": "238ccf1a-604d-41e0-b6fd-4d0f44d160a2", "label": null}], "input_connections": {"infile_output": {"output_name": "outfile_predict", "id": 4}, "infile_input": {"output_name": "output", "id": 2}}, "tool_state": "{\"__page__\": null, \"__rerun_remap_job_id__\": null, \"infile_output\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\", \"infile_input\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\"}", "id": 5, "tool_shed_repository": {"owner": "bgruening", "changeset_revision": "0800a1b66bbd", "name": "plotly_regression_performance_plots", "tool_shed": "toolshed.g2.bx.psu.edu"}, "uuid": "d55ea504-2a65-4cee-8dbe-1f541d10a757", "errors": null, "name": "Plot actual vs predicted curves and residual plots", "post_job_actions": {}, "label": null, "inputs": [{"name": "infile_output", "description": "runtime parameter for tool Plot actual vs predicted curves and residual plots"}, {"name": "infile_input", "description": "runtime parameter for tool Plot actual vs predicted curves and residual plots"}], "position": {"top": 247, "left": 699}, "annotation": "", "content_id": "toolshed.g2.bx.psu.edu/repos/bgruening/plotly_regression_performance_plots/plotly_regression_performance_plots/0.1", "type": "tool"}}, "annotation": "", "a_galaxy_workflow": "true"}
+{
+  "a_galaxy_workflow": "true",
+  "annotation": "",
+  "format-version": "0.1",
+  "name": "GradientBoostingRegression_TutorialWorkflow",
+  "steps": {
+    "0": {
+      "annotation": "",
+      "content_id": null,
+      "errors": null,
+      "id": 0,
+      "input_connections": {},
+      "inputs": [],
+      "label": "Training_data",
+      "name": "Input dataset",
+      "outputs": [],
+      "position": {
+        "left": 138,
+        "top": 149
+      },
+      "tool_id": null,
+      "tool_state": "{}",
+      "tool_version": null,
+      "type": "data_input",
+      "uuid": "c592e42e-5316-49e6-9f4e-3e2835b06d1d",
+      "workflow_outputs": [
+        {
+          "label": null,
+          "output_name": "output",
+          "uuid": "54c338e0-718a-4133-98fe-e53ddb1d9fb1"
+        }
+      ]
+    },
+    "1": {
+      "annotation": "",
+      "content_id": null,
+      "errors": null,
+      "id": 1,
+      "input_connections": {},
+      "inputs": [],
+      "label": "Test_data",
+      "name": "Input dataset",
+      "outputs": [],
+      "position": {
+        "left": 162,
+        "top": 286
+      },
+      "tool_id": null,
+      "tool_state": "{}",
+      "tool_version": null,
+      "type": "data_input",
+      "uuid": "7191fc22-d573-4a3e-a676-43dd63cb5d18",
+      "workflow_outputs": [
+        {
+          "label": null,
+          "output_name": "output",
+          "uuid": "dbf9f770-dfda-477c-9024-f7bacb5a3860"
+        }
+      ]
+    },
+    "2": {
+      "annotation": "",
+      "content_id": null,
+      "errors": null,
+      "id": 2,
+      "input_connections": {},
+      "inputs": [],
+      "label": "Test_data_targets",
+      "name": "Input dataset",
+      "outputs": [],
+      "position": {
+        "left": 706,
+        "top": 149
+      },
+      "tool_id": null,
+      "tool_state": "{}",
+      "tool_version": null,
+      "type": "data_input",
+      "uuid": "b373e60e-af2b-450a-9e9d-d2d48839a692",
+      "workflow_outputs": [
+        {
+          "label": null,
+          "output_name": "output",
+          "uuid": "ddba0d95-8465-472f-86e1-62fe5c1bdd9b"
+        }
+      ]
+    },
+    "3": {
+      "annotation": "",
+      "content_id": "toolshed.g2.bx.psu.edu/repos/bgruening/sklearn_ensemble/sklearn_ensemble/0.9",
+      "errors": null,
+      "id": 3,
+      "input_connections": {
+        "selected_tasks|selected_algorithms|input_options|infile1": {
+          "id": 0,
+          "output_name": "output"
+        },
+        "selected_tasks|selected_algorithms|input_options|infile2": {
+          "id": 0,
+          "output_name": "output"
+        }
+      },
+      "inputs": [],
+      "label": "Regressor",
+      "name": "Ensemble methods",
+      "outputs": [
+        {
+          "name": "outfile_predict",
+          "type": "tabular"
+        },
+        {
+          "name": "outfile_fit",
+          "type": "zip"
+        }
+      ],
+      "position": {
+        "left": 390.5,
+        "top": 138
+      },
+      "post_job_actions": {
+        "HideDatasetActionoutfile_fit": {
+          "action_arguments": {},
+          "action_type": "HideDatasetAction",
+          "output_name": "outfile_fit"
+        },
+        "HideDatasetActionoutfile_predict": {
+          "action_arguments": {},
+          "action_type": "HideDatasetAction",
+          "output_name": "outfile_predict"
+        }
+      },
+      "tool_id": "toolshed.g2.bx.psu.edu/repos/bgruening/sklearn_ensemble/sklearn_ensemble/0.9",
+      "tool_shed_repository": {
+        "changeset_revision": "9ce3e347506c",
+        "name": "sklearn_ensemble",
+        "owner": "bgruening",
+        "tool_shed": "toolshed.g2.bx.psu.edu"
+      },
+      "tool_state": "{\"__page__\": null, \"selected_tasks\": \"{\\\"selected_task\\\": \\\"train\\\", \\\"__current_case__\\\": 1, \\\"selected_algorithms\\\": {\\\"options\\\": {\\\"warm_start\\\": \\\"false\\\", \\\"loss\\\": \\\"ls\\\", \\\"min_impurity_decrease\\\": \\\"0.0\\\", \\\"verbose\\\": \\\"0\\\", \\\"max_leaf_nodes\\\": \\\"\\\", \\\"learning_rate\\\": \\\"0.1\\\", \\\"presort\\\": \\\"auto\\\", \\\"min_samples_leaf\\\": \\\"1.0\\\", \\\"n_estimators\\\": \\\"100\\\", \\\"subsample\\\": \\\"1.0\\\", \\\"min_weight_fraction_leaf\\\": \\\"0.0\\\", \\\"criterion\\\": \\\"friedman_mse\\\", \\\"random_state\\\": \\\"\\\", \\\"alpha\\\": \\\"0.9\\\", \\\"min_samples_split\\\": \\\"2.0\\\", \\\"select_max_features\\\": {\\\"max_features\\\": \\\"auto\\\", \\\"__current_case__\\\": 0}, \\\"max_depth\\\": \\\"3\\\"}, \\\"input_options\\\": {\\\"infile2\\\": {\\\"__class__\\\": \\\"RuntimeValue\\\"}, \\\"infile1\\\": {\\\"__class__\\\": \\\"RuntimeValue\\\"}, \\\"column_selector_options_1\\\": {\\\"col1\\\": \\\"target\\\", \\\"__current_case__\\\": 3, \\\"selected_column_selector_option\\\": \\\"all_but_by_header_name\\\"}, \\\"column_selector_options_2\\\": {\\\"selected_column_selector_option2\\\": \\\"by_header_name\\\", \\\"col2\\\": \\\"target\\\", \\\"__current_case__\\\": 1}, \\\"header2\\\": \\\"true\\\", \\\"header1\\\": \\\"true\\\", \\\"__current_case__\\\": 0, \\\"selected_input\\\": \\\"tabular\\\"}, \\\"__current_case__\\\": 5, \\\"selected_algorithm\\\": \\\"GradientBoostingRegressor\\\"}}\", \"__rerun_remap_job_id__\": null}",
+      "tool_version": "0.9",
+      "type": "tool",
+      "uuid": "4829cede-e0b0-46f1-9922-c3d629902d58",
+      "workflow_outputs": []
+    },
+    "4": {
+      "annotation": "",
+      "content_id": "toolshed.g2.bx.psu.edu/repos/bgruening/sklearn_ensemble/sklearn_ensemble/0.9",
+      "errors": null,
+      "id": 4,
+      "input_connections": {
+        "selected_tasks|infile_data": {
+          "id": 1,
+          "output_name": "output"
+        },
+        "selected_tasks|infile_model": {
+          "id": 3,
+          "output_name": "outfile_fit"
+        }
+      },
+      "inputs": [
+        {
+          "description": "runtime parameter for tool Ensemble methods",
+          "name": "selected_tasks"
+        },
+        {
+          "description": "runtime parameter for tool Ensemble methods",
+          "name": "selected_tasks"
+        }
+      ],
+      "label": "Predictor",
+      "name": "Ensemble methods",
+      "outputs": [
+        {
+          "name": "outfile_predict",
+          "type": "tabular"
+        },
+        {
+          "name": "outfile_fit",
+          "type": "zip"
+        }
+      ],
+      "position": {
+        "left": 389.5,
+        "top": 352
+      },
+      "post_job_actions": {
+        "HideDatasetActionoutfile_fit": {
+          "action_arguments": {},
+          "action_type": "HideDatasetAction",
+          "output_name": "outfile_fit"
+        },
+        "HideDatasetActionoutfile_predict": {
+          "action_arguments": {},
+          "action_type": "HideDatasetAction",
+          "output_name": "outfile_predict"
+        }
+      },
+      "tool_id": "toolshed.g2.bx.psu.edu/repos/bgruening/sklearn_ensemble/sklearn_ensemble/0.9",
+      "tool_shed_repository": {
+        "changeset_revision": "9ce3e347506c",
+        "name": "sklearn_ensemble",
+        "owner": "bgruening",
+        "tool_shed": "toolshed.g2.bx.psu.edu"
+      },
+      "tool_state": "{\"__page__\": null, \"selected_tasks\": \"{\\\"header\\\": \\\"true\\\", \\\"selected_task\\\": \\\"load\\\", \\\"infile_model\\\": {\\\"__class__\\\": \\\"RuntimeValue\\\"}, \\\"prediction_options\\\": {\\\"prediction_option\\\": \\\"predict\\\", \\\"__current_case__\\\": 0}, \\\"infile_data\\\": {\\\"__class__\\\": \\\"RuntimeValue\\\"}, \\\"__current_case__\\\": 0}\", \"__rerun_remap_job_id__\": null}",
+      "tool_version": "0.9",
+      "type": "tool",
+      "uuid": "07395cc6-3069-4aea-b136-5d2f55ce76e2",
+      "workflow_outputs": []
+    },
+    "5": {
+      "annotation": "",
+      "content_id": "toolshed.g2.bx.psu.edu/repos/bgruening/plotly_regression_performance_plots/plotly_regression_performance_plots/0.1",
+      "errors": null,
+      "id": 5,
+      "input_connections": {
+        "infile_input": {
+          "id": 2,
+          "output_name": "output"
+        },
+        "infile_output": {
+          "id": 4,
+          "output_name": "outfile_predict"
+        }
+      },
+      "inputs": [
+        {
+          "description": "runtime parameter for tool Plot actual vs predicted curves and residual plots",
+          "name": "infile_output"
+        },
+        {
+          "description": "runtime parameter for tool Plot actual vs predicted curves and residual plots",
+          "name": "infile_input"
+        }
+      ],
+      "label": null,
+      "name": "Plot actual vs predicted curves and residual plots",
+      "outputs": [
+        {
+          "name": "output_actual_vs_pred",
+          "type": "html"
+        },
+        {
+          "name": "output_scatter_plot",
+          "type": "html"
+        },
+        {
+          "name": "output_residual_plot",
+          "type": "html"
+        }
+      ],
+      "position": {
+        "left": 699,
+        "top": 247
+      },
+      "post_job_actions": {},
+      "tool_id": "toolshed.g2.bx.psu.edu/repos/bgruening/plotly_regression_performance_plots/plotly_regression_performance_plots/0.1",
+      "tool_shed_repository": {
+        "changeset_revision": "0800a1b66bbd",
+        "name": "plotly_regression_performance_plots",
+        "owner": "bgruening",
+        "tool_shed": "toolshed.g2.bx.psu.edu"
+      },
+      "tool_state": "{\"__page__\": null, \"__rerun_remap_job_id__\": null, \"infile_output\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\", \"infile_input\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\"}",
+      "tool_version": "0.1",
+      "type": "tool",
+      "uuid": "d55ea504-2a65-4cee-8dbe-1f541d10a757",
+      "workflow_outputs": [
+        {
+          "label": null,
+          "output_name": "output_scatter_plot",
+          "uuid": "b473c830-fea7-490d-828d-0b4ca8e4f9d8"
+        },
+        {
+          "label": null,
+          "output_name": "output_actual_vs_pred",
+          "uuid": "bb982de6-621a-4627-a798-388a5a5b89d6"
+        },
+        {
+          "label": null,
+          "output_name": "output_residual_plot",
+          "uuid": "238ccf1a-604d-41e0-b6fd-4d0f44d160a2"
+        }
+      ]
+    }
+  },
+  "tags": [],
+  "uuid": "d07ef670-c79a-4316-95b6-e70964745d94"
+}

--- a/topics/statistics/tutorials/classification_regression/workflows/LinearSupportVectorClassifier_TutorialWorkflow.ga
+++ b/topics/statistics/tutorials/classification_regression/workflows/LinearSupportVectorClassifier_TutorialWorkflow.ga
@@ -1,1 +1,312 @@
-{"uuid": "8fdb7a9b-8850-4543-b17f-7e34e3457557", "tags": [], "format-version": "0.1", "name": "LinearSupportVectorClassifier_TutorialWorkflow", "steps": {"0": {"tool_id": null, "tool_version": null, "outputs": [], "workflow_outputs": [{"output_name": "output", "uuid": "b117e099-2ab4-40e0-8ecf-8e20f7c6555a", "label": null}], "input_connections": {}, "tool_state": "{\"name\": \"breast_w_train\"}", "id": 0, "uuid": "f8e9ec52-4c2a-47a1-ad91-f192169ed348", "errors": null, "name": "Input dataset", "label": "Training_data", "inputs": [{"name": "breast_w_train", "description": ""}], "position": {"top": 567.2166748046875, "left": 200}, "annotation": "", "content_id": null, "type": "data_input"}, "1": {"tool_id": null, "tool_version": null, "outputs": [], "workflow_outputs": [{"output_name": "output", "uuid": "2cd44b21-475e-4bb9-ad1b-d8c2d65d6d90", "label": null}], "input_connections": {}, "tool_state": "{\"name\": \"breast_w_targets\"}", "id": 1, "uuid": "46af2a1b-8f8b-4e5a-a520-2f7d95386222", "errors": null, "name": "Input dataset", "label": "Test_data_targets", "inputs": [{"name": "breast_w_targets", "description": ""}], "position": {"top": 200, "left": 588.5}, "annotation": "", "content_id": null, "type": "data_input"}, "2": {"tool_id": null, "tool_version": null, "outputs": [], "workflow_outputs": [{"output_name": "output", "uuid": "103e5e5a-5922-4df3-9c12-37da46cd147f", "label": null}], "input_connections": {}, "tool_state": "{\"name\": \"breast_w_test\"}", "id": 2, "uuid": "3f9950f5-1e5d-45aa-87b2-001e98136671", "errors": null, "name": "Input dataset", "label": "Test_data", "inputs": [{"name": "breast_w_test", "description": ""}], "position": {"top": 706.2166748046875, "left": 217}, "annotation": "", "content_id": null, "type": "data_input"}, "3": {"tool_id": "toolshed.g2.bx.psu.edu/repos/bgruening/sklearn_svm_classifier/sklearn_svm_classifier/0.9", "tool_version": "0.9", "outputs": [{"type": "tabular", "name": "outfile_predict"}, {"type": "zip", "name": "outfile_fit"}], "workflow_outputs": [], "input_connections": {"selected_tasks|selected_algorithms|input_options|infile2": {"output_name": "output", "id": 0}, "selected_tasks|selected_algorithms|input_options|infile1": {"output_name": "output", "id": 0}}, "tool_state": "{\"__page__\": null, \"selected_tasks\": \"{\\\"selected_task\\\": \\\"train\\\", \\\"__current_case__\\\": 1, \\\"selected_algorithms\\\": {\\\"options\\\": {\\\"loss\\\": \\\"squared_hinge\\\", \\\"C\\\": \\\"1.0\\\", \\\"dual\\\": \\\"true\\\", \\\"fit_intercept\\\": \\\"true\\\", \\\"max_iter\\\": \\\"1000\\\", \\\"penalty\\\": \\\"l2\\\", \\\"multi_class\\\": \\\"ovr\\\", \\\"random_state\\\": \\\"\\\", \\\"tol\\\": \\\"0.001\\\", \\\"intercept_scaling\\\": \\\"1.0\\\"}, \\\"input_options\\\": {\\\"infile2\\\": {\\\"__class__\\\": \\\"RuntimeValue\\\"}, \\\"infile1\\\": {\\\"__class__\\\": \\\"RuntimeValue\\\"}, \\\"column_selector_options_1\\\": {\\\"col1\\\": \\\"target\\\", \\\"__current_case__\\\": 3, \\\"selected_column_selector_option\\\": \\\"all_but_by_header_name\\\"}, \\\"column_selector_options_2\\\": {\\\"selected_column_selector_option2\\\": \\\"by_header_name\\\", \\\"col2\\\": \\\"target\\\", \\\"__current_case__\\\": 1}, \\\"header2\\\": \\\"true\\\", \\\"header1\\\": \\\"true\\\", \\\"__current_case__\\\": 0, \\\"selected_input\\\": \\\"tabular\\\"}, \\\"__current_case__\\\": 2, \\\"selected_algorithm\\\": \\\"LinearSVC\\\"}}\", \"__rerun_remap_job_id__\": null}", "id": 3, "tool_shed_repository": {"owner": "bgruening", "changeset_revision": "1c5989b930e3", "name": "sklearn_svm_classifier", "tool_shed": "toolshed.g2.bx.psu.edu"}, "uuid": "da3f2105-e399-4e2b-92ba-55ffd9b3abaf", "errors": null, "name": "Support vector machines (SVMs)", "post_job_actions": {"HideDatasetActionoutfile_fit": {"output_name": "outfile_fit", "action_type": "HideDatasetAction", "action_arguments": {}}, "HideDatasetActionoutfile_predict": {"output_name": "outfile_predict", "action_type": "HideDatasetAction", "action_arguments": {}}}, "label": "Classifier", "inputs": [], "position": {"top": 381.5, "left": 386.76666259765625}, "annotation": "", "content_id": "toolshed.g2.bx.psu.edu/repos/bgruening/sklearn_svm_classifier/sklearn_svm_classifier/0.9", "type": "tool"}, "4": {"tool_id": "toolshed.g2.bx.psu.edu/repos/bgruening/sklearn_svm_classifier/sklearn_svm_classifier/0.9", "tool_version": "0.9", "outputs": [{"type": "tabular", "name": "outfile_predict"}, {"type": "zip", "name": "outfile_fit"}], "workflow_outputs": [], "input_connections": {"selected_tasks|infile_data": {"output_name": "output", "id": 2}, "selected_tasks|infile_model": {"output_name": "outfile_fit", "id": 3}}, "tool_state": "{\"__page__\": null, \"selected_tasks\": \"{\\\"header\\\": \\\"true\\\", \\\"selected_task\\\": \\\"load\\\", \\\"infile_model\\\": {\\\"__class__\\\": \\\"RuntimeValue\\\"}, \\\"prediction_options\\\": {\\\"prediction_option\\\": \\\"predict\\\", \\\"__current_case__\\\": 0}, \\\"infile_data\\\": {\\\"__class__\\\": \\\"RuntimeValue\\\"}, \\\"__current_case__\\\": 0}\", \"__rerun_remap_job_id__\": null}", "id": 4, "tool_shed_repository": {"owner": "bgruening", "changeset_revision": "1c5989b930e3", "name": "sklearn_svm_classifier", "tool_shed": "toolshed.g2.bx.psu.edu"}, "uuid": "5e9337d0-f239-4c69-91bd-5e0356f05a03", "errors": null, "name": "Support vector machines (SVMs)", "post_job_actions": {"HideDatasetActionoutfile_fit": {"output_name": "outfile_fit", "action_type": "HideDatasetAction", "action_arguments": {}}, "HideDatasetActionoutfile_predict": {"output_name": "outfile_predict", "action_type": "HideDatasetAction", "action_arguments": {}}}, "label": "Predictor", "inputs": [{"name": "selected_tasks", "description": "runtime parameter for tool Support vector machines (SVMs)"}, {"name": "selected_tasks", "description": "runtime parameter for tool Support vector machines (SVMs)"}], "position": {"top": 651.5, "left": 580.2666625976562}, "annotation": "", "content_id": "toolshed.g2.bx.psu.edu/repos/bgruening/sklearn_svm_classifier/sklearn_svm_classifier/0.9", "type": "tool"}, "5": {"tool_id": "toolshed.g2.bx.psu.edu/repos/bgruening/plotly_ml_performance_plots/plotly_ml_performance_plots/0.1", "tool_version": "0.1", "outputs": [{"type": "html", "name": "output_confusion"}, {"type": "html", "name": "output_prf"}, {"type": "html", "name": "output_roc"}], "workflow_outputs": [{"output_name": "output_roc", "uuid": "20fef7b0-bf08-4fe1-82b4-38182b6f9b35", "label": "output_roc"}, {"output_name": "output_confusion", "uuid": "77159398-68fc-4998-b4a4-2fc5f4d487b6", "label": "output_confusion"}, {"output_name": "output_prf", "uuid": "9fe7923a-5e99-4eb5-bbba-f4f8143edf59", "label": "output_prf"}], "input_connections": {"infile_trained_model": {"output_name": "outfile_fit", "id": 3}, "infile_output": {"output_name": "outfile_predict", "id": 4}, "infile_input": {"output_name": "output", "id": 1}}, "tool_state": "{\"infile_trained_model\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\", \"__rerun_remap_job_id__\": null, \"infile_output\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\", \"infile_input\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\", \"__page__\": null}", "id": 5, "tool_shed_repository": {"owner": "bgruening", "changeset_revision": "4fac53da862f", "name": "plotly_ml_performance_plots", "tool_shed": "toolshed.g2.bx.psu.edu"}, "uuid": "a59b41e5-d512-4ccb-9383-7d10746c8a67", "errors": null, "name": "Plot confusion matrix, precision, recall and ROC and AUC curves", "post_job_actions": {}, "label": null, "inputs": [{"name": "infile_trained_model", "description": "runtime parameter for tool Plot confusion matrix, precision, recall and ROC and AUC curves"}, {"name": "infile_output", "description": "runtime parameter for tool Plot confusion matrix, precision, recall and ROC and AUC curves"}, {"name": "infile_input", "description": "runtime parameter for tool Plot confusion matrix, precision, recall and ROC and AUC curves"}], "position": {"top": 333.26666259765625, "left": 787.7666625976562}, "annotation": "", "content_id": "toolshed.g2.bx.psu.edu/repos/bgruening/plotly_ml_performance_plots/plotly_ml_performance_plots/0.1", "type": "tool"}}, "annotation": "", "a_galaxy_workflow": "true"}
+{
+  "a_galaxy_workflow": "true",
+  "annotation": "",
+  "format-version": "0.1",
+  "name": "LinearSupportVectorClassifier_TutorialWorkflow",
+  "steps": {
+    "0": {
+      "annotation": "",
+      "content_id": null,
+      "errors": null,
+      "id": 0,
+      "input_connections": {},
+      "inputs": [
+        {
+          "description": "",
+          "name": "breast_w_train"
+        }
+      ],
+      "label": "Training_data",
+      "name": "Input dataset",
+      "outputs": [],
+      "position": {
+        "left": 200,
+        "top": 567.2166748046875
+      },
+      "tool_id": null,
+      "tool_state": "{\"name\": \"breast_w_train\"}",
+      "tool_version": null,
+      "type": "data_input",
+      "uuid": "f8e9ec52-4c2a-47a1-ad91-f192169ed348",
+      "workflow_outputs": [
+        {
+          "label": null,
+          "output_name": "output",
+          "uuid": "b117e099-2ab4-40e0-8ecf-8e20f7c6555a"
+        }
+      ]
+    },
+    "1": {
+      "annotation": "",
+      "content_id": null,
+      "errors": null,
+      "id": 1,
+      "input_connections": {},
+      "inputs": [
+        {
+          "description": "",
+          "name": "breast_w_targets"
+        }
+      ],
+      "label": "Test_data_targets",
+      "name": "Input dataset",
+      "outputs": [],
+      "position": {
+        "left": 588.5,
+        "top": 200
+      },
+      "tool_id": null,
+      "tool_state": "{\"name\": \"breast_w_targets\"}",
+      "tool_version": null,
+      "type": "data_input",
+      "uuid": "46af2a1b-8f8b-4e5a-a520-2f7d95386222",
+      "workflow_outputs": [
+        {
+          "label": null,
+          "output_name": "output",
+          "uuid": "2cd44b21-475e-4bb9-ad1b-d8c2d65d6d90"
+        }
+      ]
+    },
+    "2": {
+      "annotation": "",
+      "content_id": null,
+      "errors": null,
+      "id": 2,
+      "input_connections": {},
+      "inputs": [
+        {
+          "description": "",
+          "name": "breast_w_test"
+        }
+      ],
+      "label": "Test_data",
+      "name": "Input dataset",
+      "outputs": [],
+      "position": {
+        "left": 217,
+        "top": 706.2166748046875
+      },
+      "tool_id": null,
+      "tool_state": "{\"name\": \"breast_w_test\"}",
+      "tool_version": null,
+      "type": "data_input",
+      "uuid": "3f9950f5-1e5d-45aa-87b2-001e98136671",
+      "workflow_outputs": [
+        {
+          "label": null,
+          "output_name": "output",
+          "uuid": "103e5e5a-5922-4df3-9c12-37da46cd147f"
+        }
+      ]
+    },
+    "3": {
+      "annotation": "",
+      "content_id": "toolshed.g2.bx.psu.edu/repos/bgruening/sklearn_svm_classifier/sklearn_svm_classifier/0.9",
+      "errors": null,
+      "id": 3,
+      "input_connections": {
+        "selected_tasks|selected_algorithms|input_options|infile1": {
+          "id": 0,
+          "output_name": "output"
+        },
+        "selected_tasks|selected_algorithms|input_options|infile2": {
+          "id": 0,
+          "output_name": "output"
+        }
+      },
+      "inputs": [],
+      "label": "Classifier",
+      "name": "Support vector machines (SVMs)",
+      "outputs": [
+        {
+          "name": "outfile_predict",
+          "type": "tabular"
+        },
+        {
+          "name": "outfile_fit",
+          "type": "zip"
+        }
+      ],
+      "position": {
+        "left": 386.76666259765625,
+        "top": 381.5
+      },
+      "post_job_actions": {
+        "HideDatasetActionoutfile_fit": {
+          "action_arguments": {},
+          "action_type": "HideDatasetAction",
+          "output_name": "outfile_fit"
+        },
+        "HideDatasetActionoutfile_predict": {
+          "action_arguments": {},
+          "action_type": "HideDatasetAction",
+          "output_name": "outfile_predict"
+        }
+      },
+      "tool_id": "toolshed.g2.bx.psu.edu/repos/bgruening/sklearn_svm_classifier/sklearn_svm_classifier/0.9",
+      "tool_shed_repository": {
+        "changeset_revision": "1c5989b930e3",
+        "name": "sklearn_svm_classifier",
+        "owner": "bgruening",
+        "tool_shed": "toolshed.g2.bx.psu.edu"
+      },
+      "tool_state": "{\"__page__\": null, \"selected_tasks\": \"{\\\"selected_task\\\": \\\"train\\\", \\\"__current_case__\\\": 1, \\\"selected_algorithms\\\": {\\\"options\\\": {\\\"loss\\\": \\\"squared_hinge\\\", \\\"C\\\": \\\"1.0\\\", \\\"dual\\\": \\\"true\\\", \\\"fit_intercept\\\": \\\"true\\\", \\\"max_iter\\\": \\\"1000\\\", \\\"penalty\\\": \\\"l2\\\", \\\"multi_class\\\": \\\"ovr\\\", \\\"random_state\\\": \\\"\\\", \\\"tol\\\": \\\"0.001\\\", \\\"intercept_scaling\\\": \\\"1.0\\\"}, \\\"input_options\\\": {\\\"infile2\\\": {\\\"__class__\\\": \\\"RuntimeValue\\\"}, \\\"infile1\\\": {\\\"__class__\\\": \\\"RuntimeValue\\\"}, \\\"column_selector_options_1\\\": {\\\"col1\\\": \\\"target\\\", \\\"__current_case__\\\": 3, \\\"selected_column_selector_option\\\": \\\"all_but_by_header_name\\\"}, \\\"column_selector_options_2\\\": {\\\"selected_column_selector_option2\\\": \\\"by_header_name\\\", \\\"col2\\\": \\\"target\\\", \\\"__current_case__\\\": 1}, \\\"header2\\\": \\\"true\\\", \\\"header1\\\": \\\"true\\\", \\\"__current_case__\\\": 0, \\\"selected_input\\\": \\\"tabular\\\"}, \\\"__current_case__\\\": 2, \\\"selected_algorithm\\\": \\\"LinearSVC\\\"}}\", \"__rerun_remap_job_id__\": null}",
+      "tool_version": "0.9",
+      "type": "tool",
+      "uuid": "da3f2105-e399-4e2b-92ba-55ffd9b3abaf",
+      "workflow_outputs": []
+    },
+    "4": {
+      "annotation": "",
+      "content_id": "toolshed.g2.bx.psu.edu/repos/bgruening/sklearn_svm_classifier/sklearn_svm_classifier/0.9",
+      "errors": null,
+      "id": 4,
+      "input_connections": {
+        "selected_tasks|infile_data": {
+          "id": 2,
+          "output_name": "output"
+        },
+        "selected_tasks|infile_model": {
+          "id": 3,
+          "output_name": "outfile_fit"
+        }
+      },
+      "inputs": [
+        {
+          "description": "runtime parameter for tool Support vector machines (SVMs)",
+          "name": "selected_tasks"
+        },
+        {
+          "description": "runtime parameter for tool Support vector machines (SVMs)",
+          "name": "selected_tasks"
+        }
+      ],
+      "label": "Predictor",
+      "name": "Support vector machines (SVMs)",
+      "outputs": [
+        {
+          "name": "outfile_predict",
+          "type": "tabular"
+        },
+        {
+          "name": "outfile_fit",
+          "type": "zip"
+        }
+      ],
+      "position": {
+        "left": 580.2666625976562,
+        "top": 651.5
+      },
+      "post_job_actions": {
+        "HideDatasetActionoutfile_fit": {
+          "action_arguments": {},
+          "action_type": "HideDatasetAction",
+          "output_name": "outfile_fit"
+        },
+        "HideDatasetActionoutfile_predict": {
+          "action_arguments": {},
+          "action_type": "HideDatasetAction",
+          "output_name": "outfile_predict"
+        }
+      },
+      "tool_id": "toolshed.g2.bx.psu.edu/repos/bgruening/sklearn_svm_classifier/sklearn_svm_classifier/0.9",
+      "tool_shed_repository": {
+        "changeset_revision": "1c5989b930e3",
+        "name": "sklearn_svm_classifier",
+        "owner": "bgruening",
+        "tool_shed": "toolshed.g2.bx.psu.edu"
+      },
+      "tool_state": "{\"__page__\": null, \"selected_tasks\": \"{\\\"header\\\": \\\"true\\\", \\\"selected_task\\\": \\\"load\\\", \\\"infile_model\\\": {\\\"__class__\\\": \\\"RuntimeValue\\\"}, \\\"prediction_options\\\": {\\\"prediction_option\\\": \\\"predict\\\", \\\"__current_case__\\\": 0}, \\\"infile_data\\\": {\\\"__class__\\\": \\\"RuntimeValue\\\"}, \\\"__current_case__\\\": 0}\", \"__rerun_remap_job_id__\": null}",
+      "tool_version": "0.9",
+      "type": "tool",
+      "uuid": "5e9337d0-f239-4c69-91bd-5e0356f05a03",
+      "workflow_outputs": []
+    },
+    "5": {
+      "annotation": "",
+      "content_id": "toolshed.g2.bx.psu.edu/repos/bgruening/plotly_ml_performance_plots/plotly_ml_performance_plots/0.1",
+      "errors": null,
+      "id": 5,
+      "input_connections": {
+        "infile_input": {
+          "id": 1,
+          "output_name": "output"
+        },
+        "infile_output": {
+          "id": 4,
+          "output_name": "outfile_predict"
+        },
+        "infile_trained_model": {
+          "id": 3,
+          "output_name": "outfile_fit"
+        }
+      },
+      "inputs": [
+        {
+          "description": "runtime parameter for tool Plot confusion matrix, precision, recall and ROC and AUC curves",
+          "name": "infile_trained_model"
+        },
+        {
+          "description": "runtime parameter for tool Plot confusion matrix, precision, recall and ROC and AUC curves",
+          "name": "infile_output"
+        },
+        {
+          "description": "runtime parameter for tool Plot confusion matrix, precision, recall and ROC and AUC curves",
+          "name": "infile_input"
+        }
+      ],
+      "label": null,
+      "name": "Plot confusion matrix, precision, recall and ROC and AUC curves",
+      "outputs": [
+        {
+          "name": "output_confusion",
+          "type": "html"
+        },
+        {
+          "name": "output_prf",
+          "type": "html"
+        },
+        {
+          "name": "output_roc",
+          "type": "html"
+        }
+      ],
+      "position": {
+        "left": 787.7666625976562,
+        "top": 333.26666259765625
+      },
+      "post_job_actions": {},
+      "tool_id": "toolshed.g2.bx.psu.edu/repos/bgruening/plotly_ml_performance_plots/plotly_ml_performance_plots/0.1",
+      "tool_shed_repository": {
+        "changeset_revision": "4fac53da862f",
+        "name": "plotly_ml_performance_plots",
+        "owner": "bgruening",
+        "tool_shed": "toolshed.g2.bx.psu.edu"
+      },
+      "tool_state": "{\"infile_trained_model\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\", \"__rerun_remap_job_id__\": null, \"infile_output\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\", \"infile_input\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\", \"__page__\": null}",
+      "tool_version": "0.1",
+      "type": "tool",
+      "uuid": "a59b41e5-d512-4ccb-9383-7d10746c8a67",
+      "workflow_outputs": [
+        {
+          "label": "output_roc",
+          "output_name": "output_roc",
+          "uuid": "20fef7b0-bf08-4fe1-82b4-38182b6f9b35"
+        },
+        {
+          "label": "output_confusion",
+          "output_name": "output_confusion",
+          "uuid": "77159398-68fc-4998-b4a4-2fc5f4d487b6"
+        },
+        {
+          "label": "output_prf",
+          "output_name": "output_prf",
+          "uuid": "9fe7923a-5e99-4eb5-bbba-f4f8143edf59"
+        }
+      ]
+    }
+  },
+  "tags": [],
+  "uuid": "8fdb7a9b-8850-4543-b17f-7e34e3457557"
+}

--- a/topics/statistics/tutorials/iwtomics/workflows/IWTomics_Workflow.ga
+++ b/topics/statistics/tutorials/iwtomics/workflows/IWTomics_Workflow.ga
@@ -1,1 +1,375 @@
-{"uuid": "036582d8-7c3a-4d48-89e7-bbc547ca8724", "tags": ["genomics", "iwtomics", "statistics"], "format-version": "0.1", "name": "Workflow constructed from history 'IWTomics Workflow'", "steps": {"0": {"tool_id": null, "tool_version": null, "outputs": [], "workflow_outputs": [], "input_connections": {}, "tool_state": "{\"name\": \"https://zenodo.org/record/1288429/files/ETn_fixed.bed\"}", "id": 0, "uuid": "7709e0ee-56fc-491d-afad-b10c18758c07", "errors": null, "name": "Input dataset", "label": "https://zenodo.org/record/1288429/files/ETn_fixed.bed", "inputs": [{"name": "https://zenodo.org/record/1288429/files/ETn_fixed.bed", "description": ""}], "position": {"top": 200, "left": 200}, "annotation": "", "content_id": null, "type": "data_input"}, "1": {"tool_id": null, "tool_version": null, "outputs": [], "workflow_outputs": [], "input_connections": {}, "tool_state": "{\"name\": \"https://zenodo.org/record/1288429/files/Control.bed\"}", "id": 1, "uuid": "9c4be2e1-6f14-4ec4-a0e8-3ec4e21a6523", "errors": null, "name": "Input dataset", "label": "https://zenodo.org/record/1288429/files/Control.bed", "inputs": [{"name": "https://zenodo.org/record/1288429/files/Control.bed", "description": ""}], "position": {"top": 320, "left": 200}, "annotation": "", "content_id": null, "type": "data_input"}, "2": {"tool_id": null, "tool_version": null, "outputs": [], "workflow_outputs": [], "input_connections": {}, "tool_state": "{\"name\": \"https://zenodo.org/record/1288429/files/features_header.tabular\"}", "id": 2, "uuid": "4a071a64-59d3-481d-8d84-f063c38ddac7", "errors": null, "name": "Input dataset", "label": "https://zenodo.org/record/1288429/files/features_header.tabular", "inputs": [{"name": "https://zenodo.org/record/1288429/files/features_header.tabular", "description": ""}], "position": {"top": 680, "left": 200}, "annotation": "", "content_id": null, "type": "data_input"}, "3": {"tool_id": null, "tool_version": null, "outputs": [], "workflow_outputs": [], "input_connections": {}, "tool_state": "{\"name\": \"https://zenodo.org/record/1288429/files/regions_header.tabular\"}", "id": 3, "uuid": "ac9cf2c6-9bbc-42b4-b4fb-f0fcf92dcee6", "errors": null, "name": "Input dataset", "label": "https://zenodo.org/record/1288429/files/regions_header.tabular", "inputs": [{"name": "https://zenodo.org/record/1288429/files/regions_header.tabular", "description": ""}], "position": {"top": 560, "left": 200}, "annotation": "", "content_id": null, "type": "data_input"}, "4": {"tool_id": null, "tool_version": null, "outputs": [], "workflow_outputs": [], "input_connections": {}, "tool_state": "{\"name\": \"https://zenodo.org/record/1288429/files/Recombination_hotspots.txt\"}", "id": 4, "uuid": "946f863d-0ef4-42b1-bb87-25247e31d4d9", "errors": null, "name": "Input dataset", "label": "https://zenodo.org/record/1288429/files/Recombination_hotspots.txt", "inputs": [{"name": "https://zenodo.org/record/1288429/files/Recombination_hotspots.txt", "description": ""}], "position": {"top": 440, "left": 200}, "annotation": "", "content_id": null, "type": "data_input"}, "5": {"tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/iwtomics_loadandplot/iwtomics_loadandplot/1.0.0.0", "tool_version": "1.0.0.0", "outputs": [{"type": "rdata", "name": "outrdata"}, {"type": "tabular", "name": "outregions"}, {"type": "tabular", "name": "outfeatures"}, {"type": "pdf", "name": "outpdf"}], "workflow_outputs": [], "input_connections": {"regions": [{"output_name": "output", "id": 0}, {"output_name": "output", "id": 1}], "featuresheader": {"output_name": "output", "id": 2}, "regionsheader": {"output_name": "output", "id": 3}, "features": {"output_name": "output", "id": 4}}, "tool_state": "{\"__page__\": null, \"plotres\": \"{\\\"average\\\": \\\"true\\\", \\\"conditionalplottype\\\": {\\\"probabilitiessection\\\": {\\\"probabilities\\\": [], \\\"prob2\\\": \\\"0.75\\\", \\\"prob0\\\": \\\"0.25\\\", \\\"prob1\\\": \\\"0.5\\\"}, \\\"plottype\\\": \\\"boxplot\\\", \\\"__current_case__\\\": 0}, \\\"size\\\": \\\"true\\\"}\", \"featuresheader\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\", \"features\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\", \"__rerun_remap_job_id__\": null, \"regions\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\", \"zerobased\": \"\\\"TRUE\\\"\", \"conditionaltype\": \"{\\\"alignment\\\": \\\"center\\\", \\\"__current_case__\\\": 0, \\\"smoothing\\\": \\\"no\\\"}\", \"chromInfo\": \"\\\"/cvmfs/data.galaxyproject.org/managed/len/ucsc/?.len\\\"\", \"regionsheader\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\"}", "id": 5, "tool_shed_repository": {"owner": "iuc", "changeset_revision": "ee7dd07a530e", "name": "iwtomics_loadandplot", "tool_shed": "toolshed.g2.bx.psu.edu"}, "uuid": "3b515115-0327-4fa6-ae1b-50c7ef55e005", "errors": null, "name": "IWTomics Load", "post_job_actions": {}, "label": null, "inputs": [{"name": "featuresheader", "description": "runtime parameter for tool IWTomics Load"}, {"name": "features", "description": "runtime parameter for tool IWTomics Load"}, {"name": "regions", "description": "runtime parameter for tool IWTomics Load"}, {"name": "regionsheader", "description": "runtime parameter for tool IWTomics Load"}], "position": {"top": 201, "left": 420}, "annotation": "", "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/iwtomics_loadandplot/iwtomics_loadandplot/1.0.0.0", "type": "tool"}, "6": {"tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/iwtomics_testandplot/iwtomics_testandplot/1.0.0.0", "tool_version": "1.0.0.0", "outputs": [{"type": "txt", "name": "adjustedpvaluematrix"}, {"type": "pdf", "name": "iwtomicsrespdf"}, {"type": "pdf", "name": "iwtomicssumpdf"}, {"type": "rdata", "name": "iwtomicsrdata"}, {"type": "tabular", "name": "iwtomicstests"}, {"type": "tabular", "name": "iwtomicsselectedfeatures"}], "workflow_outputs": [], "input_connections": {"featureids": {"output_name": "outfeatures", "id": 5}, "regionids": {"output_name": "outregions", "id": 5}, "rdata": {"output_name": "outrdata", "id": 5}}, "tool_state": "{\"__page__\": null, \"plotres\": \"{\\\"alpha\\\": \\\"0.05\\\", \\\"average\\\": \\\"true\\\", \\\"conditionalplottype\\\": {\\\"probabilitiessection\\\": {\\\"probabilities\\\": [], \\\"prob2\\\": \\\"0.75\\\", \\\"prob0\\\": \\\"0.25\\\", \\\"prob1\\\": \\\"0.5\\\"}, \\\"plottype\\\": \\\"boxplot\\\", \\\"__current_case__\\\": 0}, \\\"size\\\": \\\"true\\\"}\", \"plotsum\": \"{\\\"conditionalgroupby\\\": {\\\"groupby\\\": \\\"none\\\", \\\"__current_case__\\\": 2}}\", \"regionssection\": \"{\\\"regions\\\": [{\\\"__index__\\\": 0, \\\"region1\\\": \\\"2\\\", \\\"region0\\\": \\\"1\\\"}]}\", \"permutations\": \"\\\"1000\\\"\", \"regionids\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\", \"rdata\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\", \"featureslist\": \"\\\"1\\\"\", \"featureids\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\", \"conditionalstatistics\": \"{\\\"statistics\\\": \\\"mean\\\", \\\"__current_case__\\\": 3}\", \"__rerun_remap_job_id__\": null}", "id": 6, "tool_shed_repository": {"owner": "iuc", "changeset_revision": "800c7e974e3b", "name": "iwtomics_testandplot", "tool_shed": "toolshed.g2.bx.psu.edu"}, "uuid": "732d3192-7f1a-40b0-bb17-db34801cd90c", "errors": null, "name": "IWTomics Test", "post_job_actions": {}, "label": null, "inputs": [{"name": "regionids", "description": "runtime parameter for tool IWTomics Test"}, {"name": "rdata", "description": "runtime parameter for tool IWTomics Test"}, {"name": "featureids", "description": "runtime parameter for tool IWTomics Test"}], "position": {"top": 200, "left": 640}, "annotation": "", "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/iwtomics_testandplot/iwtomics_testandplot/1.0.0.0", "type": "tool"}, "7": {"tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/iwtomics_plotwithscale/iwtomics_plotwithscale/1.0.0.0", "tool_version": "1.0.0.0", "outputs": [{"type": "txt", "name": "adjustedpvalue"}, {"type": "pdf", "name": "iwtomicsrespdf"}, {"type": "pdf", "name": "iwtomicssumpdf"}], "workflow_outputs": [], "input_connections": {"featureids": {"output_name": "iwtomicsselectedfeatures", "id": 6}, "testids": {"output_name": "iwtomicstests", "id": 6}, "rdata": {"output_name": "iwtomicsrdata", "id": 6}}, "tool_state": "{\"__page__\": null, \"plotres\": \"{\\\"alpha\\\": \\\"0.05\\\", \\\"average\\\": \\\"true\\\", \\\"conditionalplottype\\\": {\\\"probabilitiessection\\\": {\\\"probabilities\\\": [], \\\"prob2\\\": \\\"0.75\\\", \\\"prob0\\\": \\\"0.25\\\", \\\"prob1\\\": \\\"0.5\\\"}, \\\"plottype\\\": \\\"boxplot\\\", \\\"__current_case__\\\": 0}, \\\"size\\\": \\\"true\\\"}\", \"plotsum\": \"{\\\"conditionalgroupby\\\": {\\\"groupby\\\": \\\"none\\\", \\\"__current_case__\\\": 2}}\", \"__rerun_remap_job_id__\": null, \"testids\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\", \"scalesection\": \"{\\\"thresholdontestscale\\\": [{\\\"test\\\": \\\"1\\\", \\\"__index__\\\": 0, \\\"scale\\\": \\\"8\\\", \\\"feature\\\": \\\"1\\\"}]}\", \"rdata\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\", \"featureids\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\"}", "id": 7, "tool_shed_repository": {"owner": "iuc", "changeset_revision": "25030f0d1154", "name": "iwtomics_plotwithscale", "tool_shed": "toolshed.g2.bx.psu.edu"}, "uuid": "e6840b31-252b-40d7-b7a1-6d7c97772d63", "errors": null, "name": "IWTomics Plot with Threshold", "post_job_actions": {}, "label": null, "inputs": [{"name": "testids", "description": "runtime parameter for tool IWTomics Plot with Threshold"}, {"name": "rdata", "description": "runtime parameter for tool IWTomics Plot with Threshold"}, {"name": "featureids", "description": "runtime parameter for tool IWTomics Plot with Threshold"}], "position": {"top": 200, "left": 860}, "annotation": "", "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/iwtomics_plotwithscale/iwtomics_plotwithscale/1.0.0.0", "type": "tool"}}, "annotation": "", "a_galaxy_workflow": "true"}
+{
+  "a_galaxy_workflow": "true",
+  "annotation": "",
+  "format-version": "0.1",
+  "name": "Workflow constructed from history 'IWTomics Workflow'",
+  "steps": {
+    "0": {
+      "annotation": "",
+      "content_id": null,
+      "errors": null,
+      "id": 0,
+      "input_connections": {},
+      "inputs": [
+        {
+          "description": "",
+          "name": "https://zenodo.org/record/1288429/files/ETn_fixed.bed"
+        }
+      ],
+      "label": "https://zenodo.org/record/1288429/files/ETn_fixed.bed",
+      "name": "Input dataset",
+      "outputs": [],
+      "position": {
+        "left": 200,
+        "top": 200
+      },
+      "tool_id": null,
+      "tool_state": "{\"name\": \"https://zenodo.org/record/1288429/files/ETn_fixed.bed\"}",
+      "tool_version": null,
+      "type": "data_input",
+      "uuid": "7709e0ee-56fc-491d-afad-b10c18758c07",
+      "workflow_outputs": []
+    },
+    "1": {
+      "annotation": "",
+      "content_id": null,
+      "errors": null,
+      "id": 1,
+      "input_connections": {},
+      "inputs": [
+        {
+          "description": "",
+          "name": "https://zenodo.org/record/1288429/files/Control.bed"
+        }
+      ],
+      "label": "https://zenodo.org/record/1288429/files/Control.bed",
+      "name": "Input dataset",
+      "outputs": [],
+      "position": {
+        "left": 200,
+        "top": 320
+      },
+      "tool_id": null,
+      "tool_state": "{\"name\": \"https://zenodo.org/record/1288429/files/Control.bed\"}",
+      "tool_version": null,
+      "type": "data_input",
+      "uuid": "9c4be2e1-6f14-4ec4-a0e8-3ec4e21a6523",
+      "workflow_outputs": []
+    },
+    "2": {
+      "annotation": "",
+      "content_id": null,
+      "errors": null,
+      "id": 2,
+      "input_connections": {},
+      "inputs": [
+        {
+          "description": "",
+          "name": "https://zenodo.org/record/1288429/files/features_header.tabular"
+        }
+      ],
+      "label": "https://zenodo.org/record/1288429/files/features_header.tabular",
+      "name": "Input dataset",
+      "outputs": [],
+      "position": {
+        "left": 200,
+        "top": 680
+      },
+      "tool_id": null,
+      "tool_state": "{\"name\": \"https://zenodo.org/record/1288429/files/features_header.tabular\"}",
+      "tool_version": null,
+      "type": "data_input",
+      "uuid": "4a071a64-59d3-481d-8d84-f063c38ddac7",
+      "workflow_outputs": []
+    },
+    "3": {
+      "annotation": "",
+      "content_id": null,
+      "errors": null,
+      "id": 3,
+      "input_connections": {},
+      "inputs": [
+        {
+          "description": "",
+          "name": "https://zenodo.org/record/1288429/files/regions_header.tabular"
+        }
+      ],
+      "label": "https://zenodo.org/record/1288429/files/regions_header.tabular",
+      "name": "Input dataset",
+      "outputs": [],
+      "position": {
+        "left": 200,
+        "top": 560
+      },
+      "tool_id": null,
+      "tool_state": "{\"name\": \"https://zenodo.org/record/1288429/files/regions_header.tabular\"}",
+      "tool_version": null,
+      "type": "data_input",
+      "uuid": "ac9cf2c6-9bbc-42b4-b4fb-f0fcf92dcee6",
+      "workflow_outputs": []
+    },
+    "4": {
+      "annotation": "",
+      "content_id": null,
+      "errors": null,
+      "id": 4,
+      "input_connections": {},
+      "inputs": [
+        {
+          "description": "",
+          "name": "https://zenodo.org/record/1288429/files/Recombination_hotspots.txt"
+        }
+      ],
+      "label": "https://zenodo.org/record/1288429/files/Recombination_hotspots.txt",
+      "name": "Input dataset",
+      "outputs": [],
+      "position": {
+        "left": 200,
+        "top": 440
+      },
+      "tool_id": null,
+      "tool_state": "{\"name\": \"https://zenodo.org/record/1288429/files/Recombination_hotspots.txt\"}",
+      "tool_version": null,
+      "type": "data_input",
+      "uuid": "946f863d-0ef4-42b1-bb87-25247e31d4d9",
+      "workflow_outputs": []
+    },
+    "5": {
+      "annotation": "",
+      "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/iwtomics_loadandplot/iwtomics_loadandplot/1.0.0.0",
+      "errors": null,
+      "id": 5,
+      "input_connections": {
+        "features": {
+          "id": 4,
+          "output_name": "output"
+        },
+        "featuresheader": {
+          "id": 2,
+          "output_name": "output"
+        },
+        "regions": [
+          {
+            "id": 0,
+            "output_name": "output"
+          },
+          {
+            "id": 1,
+            "output_name": "output"
+          }
+        ],
+        "regionsheader": {
+          "id": 3,
+          "output_name": "output"
+        }
+      },
+      "inputs": [
+        {
+          "description": "runtime parameter for tool IWTomics Load",
+          "name": "featuresheader"
+        },
+        {
+          "description": "runtime parameter for tool IWTomics Load",
+          "name": "features"
+        },
+        {
+          "description": "runtime parameter for tool IWTomics Load",
+          "name": "regions"
+        },
+        {
+          "description": "runtime parameter for tool IWTomics Load",
+          "name": "regionsheader"
+        }
+      ],
+      "label": null,
+      "name": "IWTomics Load",
+      "outputs": [
+        {
+          "name": "outrdata",
+          "type": "rdata"
+        },
+        {
+          "name": "outregions",
+          "type": "tabular"
+        },
+        {
+          "name": "outfeatures",
+          "type": "tabular"
+        },
+        {
+          "name": "outpdf",
+          "type": "pdf"
+        }
+      ],
+      "position": {
+        "left": 420,
+        "top": 201
+      },
+      "post_job_actions": {},
+      "tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/iwtomics_loadandplot/iwtomics_loadandplot/1.0.0.0",
+      "tool_shed_repository": {
+        "changeset_revision": "ee7dd07a530e",
+        "name": "iwtomics_loadandplot",
+        "owner": "iuc",
+        "tool_shed": "toolshed.g2.bx.psu.edu"
+      },
+      "tool_state": "{\"__page__\": null, \"plotres\": \"{\\\"average\\\": \\\"true\\\", \\\"conditionalplottype\\\": {\\\"probabilitiessection\\\": {\\\"probabilities\\\": [], \\\"prob2\\\": \\\"0.75\\\", \\\"prob0\\\": \\\"0.25\\\", \\\"prob1\\\": \\\"0.5\\\"}, \\\"plottype\\\": \\\"boxplot\\\", \\\"__current_case__\\\": 0}, \\\"size\\\": \\\"true\\\"}\", \"featuresheader\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\", \"features\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\", \"__rerun_remap_job_id__\": null, \"regions\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\", \"zerobased\": \"\\\"TRUE\\\"\", \"conditionaltype\": \"{\\\"alignment\\\": \\\"center\\\", \\\"__current_case__\\\": 0, \\\"smoothing\\\": \\\"no\\\"}\", \"chromInfo\": \"\\\"/cvmfs/data.galaxyproject.org/managed/len/ucsc/?.len\\\"\", \"regionsheader\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\"}",
+      "tool_version": "1.0.0.0",
+      "type": "tool",
+      "uuid": "3b515115-0327-4fa6-ae1b-50c7ef55e005",
+      "workflow_outputs": []
+    },
+    "6": {
+      "annotation": "",
+      "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/iwtomics_testandplot/iwtomics_testandplot/1.0.0.0",
+      "errors": null,
+      "id": 6,
+      "input_connections": {
+        "featureids": {
+          "id": 5,
+          "output_name": "outfeatures"
+        },
+        "rdata": {
+          "id": 5,
+          "output_name": "outrdata"
+        },
+        "regionids": {
+          "id": 5,
+          "output_name": "outregions"
+        }
+      },
+      "inputs": [
+        {
+          "description": "runtime parameter for tool IWTomics Test",
+          "name": "regionids"
+        },
+        {
+          "description": "runtime parameter for tool IWTomics Test",
+          "name": "rdata"
+        },
+        {
+          "description": "runtime parameter for tool IWTomics Test",
+          "name": "featureids"
+        }
+      ],
+      "label": null,
+      "name": "IWTomics Test",
+      "outputs": [
+        {
+          "name": "adjustedpvaluematrix",
+          "type": "txt"
+        },
+        {
+          "name": "iwtomicsrespdf",
+          "type": "pdf"
+        },
+        {
+          "name": "iwtomicssumpdf",
+          "type": "pdf"
+        },
+        {
+          "name": "iwtomicsrdata",
+          "type": "rdata"
+        },
+        {
+          "name": "iwtomicstests",
+          "type": "tabular"
+        },
+        {
+          "name": "iwtomicsselectedfeatures",
+          "type": "tabular"
+        }
+      ],
+      "position": {
+        "left": 640,
+        "top": 200
+      },
+      "post_job_actions": {},
+      "tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/iwtomics_testandplot/iwtomics_testandplot/1.0.0.0",
+      "tool_shed_repository": {
+        "changeset_revision": "800c7e974e3b",
+        "name": "iwtomics_testandplot",
+        "owner": "iuc",
+        "tool_shed": "toolshed.g2.bx.psu.edu"
+      },
+      "tool_state": "{\"__page__\": null, \"plotres\": \"{\\\"alpha\\\": \\\"0.05\\\", \\\"average\\\": \\\"true\\\", \\\"conditionalplottype\\\": {\\\"probabilitiessection\\\": {\\\"probabilities\\\": [], \\\"prob2\\\": \\\"0.75\\\", \\\"prob0\\\": \\\"0.25\\\", \\\"prob1\\\": \\\"0.5\\\"}, \\\"plottype\\\": \\\"boxplot\\\", \\\"__current_case__\\\": 0}, \\\"size\\\": \\\"true\\\"}\", \"plotsum\": \"{\\\"conditionalgroupby\\\": {\\\"groupby\\\": \\\"none\\\", \\\"__current_case__\\\": 2}}\", \"regionssection\": \"{\\\"regions\\\": [{\\\"__index__\\\": 0, \\\"region1\\\": \\\"2\\\", \\\"region0\\\": \\\"1\\\"}]}\", \"permutations\": \"\\\"1000\\\"\", \"regionids\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\", \"rdata\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\", \"featureslist\": \"\\\"1\\\"\", \"featureids\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\", \"conditionalstatistics\": \"{\\\"statistics\\\": \\\"mean\\\", \\\"__current_case__\\\": 3}\", \"__rerun_remap_job_id__\": null}",
+      "tool_version": "1.0.0.0",
+      "type": "tool",
+      "uuid": "732d3192-7f1a-40b0-bb17-db34801cd90c",
+      "workflow_outputs": []
+    },
+    "7": {
+      "annotation": "",
+      "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/iwtomics_plotwithscale/iwtomics_plotwithscale/1.0.0.0",
+      "errors": null,
+      "id": 7,
+      "input_connections": {
+        "featureids": {
+          "id": 6,
+          "output_name": "iwtomicsselectedfeatures"
+        },
+        "rdata": {
+          "id": 6,
+          "output_name": "iwtomicsrdata"
+        },
+        "testids": {
+          "id": 6,
+          "output_name": "iwtomicstests"
+        }
+      },
+      "inputs": [
+        {
+          "description": "runtime parameter for tool IWTomics Plot with Threshold",
+          "name": "testids"
+        },
+        {
+          "description": "runtime parameter for tool IWTomics Plot with Threshold",
+          "name": "rdata"
+        },
+        {
+          "description": "runtime parameter for tool IWTomics Plot with Threshold",
+          "name": "featureids"
+        }
+      ],
+      "label": null,
+      "name": "IWTomics Plot with Threshold",
+      "outputs": [
+        {
+          "name": "adjustedpvalue",
+          "type": "txt"
+        },
+        {
+          "name": "iwtomicsrespdf",
+          "type": "pdf"
+        },
+        {
+          "name": "iwtomicssumpdf",
+          "type": "pdf"
+        }
+      ],
+      "position": {
+        "left": 860,
+        "top": 200
+      },
+      "post_job_actions": {},
+      "tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/iwtomics_plotwithscale/iwtomics_plotwithscale/1.0.0.0",
+      "tool_shed_repository": {
+        "changeset_revision": "25030f0d1154",
+        "name": "iwtomics_plotwithscale",
+        "owner": "iuc",
+        "tool_shed": "toolshed.g2.bx.psu.edu"
+      },
+      "tool_state": "{\"__page__\": null, \"plotres\": \"{\\\"alpha\\\": \\\"0.05\\\", \\\"average\\\": \\\"true\\\", \\\"conditionalplottype\\\": {\\\"probabilitiessection\\\": {\\\"probabilities\\\": [], \\\"prob2\\\": \\\"0.75\\\", \\\"prob0\\\": \\\"0.25\\\", \\\"prob1\\\": \\\"0.5\\\"}, \\\"plottype\\\": \\\"boxplot\\\", \\\"__current_case__\\\": 0}, \\\"size\\\": \\\"true\\\"}\", \"plotsum\": \"{\\\"conditionalgroupby\\\": {\\\"groupby\\\": \\\"none\\\", \\\"__current_case__\\\": 2}}\", \"__rerun_remap_job_id__\": null, \"testids\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\", \"scalesection\": \"{\\\"thresholdontestscale\\\": [{\\\"test\\\": \\\"1\\\", \\\"__index__\\\": 0, \\\"scale\\\": \\\"8\\\", \\\"feature\\\": \\\"1\\\"}]}\", \"rdata\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\", \"featureids\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\"}",
+      "tool_version": "1.0.0.0",
+      "type": "tool",
+      "uuid": "e6840b31-252b-40d7-b7a1-6d7c97772d63",
+      "workflow_outputs": []
+    }
+  },
+  "tags": [
+    "genomics",
+    "iwtomics",
+    "statistics"
+  ],
+  "uuid": "036582d8-7c3a-4d48-89e7-bbc547ca8724"
+}

--- a/topics/transcriptomics/tutorials/clipseq/workflows/init_workflow.ga
+++ b/topics/transcriptomics/tutorials/clipseq/workflows/init_workflow.ga
@@ -1,1 +1,2743 @@
-{"uuid": "5c350c2e-f8d1-433f-8627-e68608f226d3", "tags": [], "format-version": "0.1", "name": "Tutorial_1_CLIPseq-Explorer_demultiplexed_PEAKachu_eCLIP_hg38_N5", "version": 24, "steps": {"0": {"tool_id": null, "tool_version": null, "outputs": [], "workflow_outputs": [{"output_name": "output", "uuid": "9c4c342d-c349-4e47-a3dc-4c0af26d5bd1", "label": null}], "input_connections": {}, "tool_state": "{\"collection_type\": \"list:paired\"}", "id": 0, "uuid": "df3c15f5-99c5-47de-a3de-c0f6149ee2d7", "errors": null, "name": "Input dataset collection", "label": "Background", "inputs": [], "position": {"top": 402.75, "left": 256.921875}, "annotation": "", "content_id": null, "type": "data_collection_input"}, "1": {"tool_id": null, "tool_version": null, "outputs": [], "workflow_outputs": [{"output_name": "output", "uuid": "f641b9f9-e780-44fd-9223-c6177274d7ad", "label": null}], "input_connections": {}, "tool_state": "{\"collection_type\": \"list:paired\", \"name\": \"Input Dataset Collection\"}", "id": 1, "uuid": "3f9e968c-b7c5-4630-8108-b31d348b0587", "errors": null, "name": "Input dataset collection", "label": "Paired-end reads collection", "inputs": [{"name": "Input Dataset Collection", "description": ""}], "position": {"top": 1190.84375, "left": 200}, "annotation": "", "content_id": null, "type": "data_collection_input"}, "2": {"tool_id": null, "tool_version": null, "outputs": [], "workflow_outputs": [{"output_name": "output", "uuid": "0cc59b7e-0dda-4d98-8123-a9b211cdc658", "label": null}], "input_connections": {}, "tool_state": "{}", "id": 2, "uuid": "ec701e9f-810c-4f9e-98a5-073cd9408dc1", "errors": null, "name": "Input dataset", "label": "Genome Chromosome Sizes", "inputs": [], "position": {"top": 838.53125, "left": 3458.921875}, "annotation": "", "content_id": null, "type": "data_input"}, "3": {"tool_id": null, "tool_version": null, "outputs": [], "workflow_outputs": [{"output_name": "output", "uuid": "3d02905f-3c8b-4c38-a5d7-e6df07a0b0e6", "label": null}], "input_connections": {}, "tool_state": "{}", "id": 3, "uuid": "61afe886-f6eb-4ed7-b964-63959c132be0", "errors": null, "name": "Input dataset", "label": "Annotation Reference File for RCAS", "inputs": [], "position": {"top": 322.9375, "left": 3737.015625}, "annotation": "", "content_id": null, "type": "data_input"}, "4": {"tool_id": "__UNZIP_COLLECTION__", "tool_version": "1.0.0", "outputs": [{"type": "data", "name": "forward"}, {"type": "data", "name": "reverse"}], "workflow_outputs": [], "input_connections": {"input": {"output_name": "output", "id": 0}}, "tool_state": "{\"input\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\", \"__rerun_remap_job_id__\": null, \"__page__\": null}", "id": 4, "uuid": "69da121d-9386-4502-aebb-85bd4ea76c2e", "errors": null, "name": "Unzip Collection", "post_job_actions": {"HideDatasetActionreverse": {"output_name": "reverse", "action_type": "HideDatasetAction", "action_arguments": {}}, "HideDatasetActionforward": {"output_name": "forward", "action_type": "HideDatasetAction", "action_arguments": {}}, "ChangeDatatypeActionforward": {"output_name": "forward", "action_type": "ChangeDatatypeAction", "action_arguments": {"newtype": "fastqsanger"}}, "ChangeDatatypeActionreverse": {"output_name": "reverse", "action_type": "ChangeDatatypeAction", "action_arguments": {"newtype": "fastqsanger"}}}, "label": null, "inputs": [{"name": "input", "description": "runtime parameter for tool Unzip Collection"}], "position": {"top": 412.625, "left": 513.5625}, "annotation": "", "content_id": "__UNZIP_COLLECTION__", "type": "tool"}, "5": {"tool_id": "toolshed.g2.bx.psu.edu/repos/devteam/fastqc/fastqc/0.71", "tool_version": "0.71", "outputs": [{"type": "html", "name": "html_file"}, {"type": "txt", "name": "text_file"}], "workflow_outputs": [{"output_name": "html_file", "uuid": "28b01599-4f4d-4ed9-ba14-ab897d181c40", "label": null}], "input_connections": {"input_file": {"output_name": "output", "id": 0}}, "tool_state": "{\"__page__\": null, \"contaminants\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\", \"__rerun_remap_job_id__\": null, \"limits\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\", \"input_file\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\"}", "id": 5, "tool_shed_repository": {"owner": "devteam", "changeset_revision": "ff9530579d1f", "name": "fastqc", "tool_shed": "toolshed.g2.bx.psu.edu"}, "uuid": "160075d4-e7d5-45a6-a29c-4ab604b8b1e0", "errors": null, "name": "FastQC", "post_job_actions": {"HideDatasetActiontext_file": {"output_name": "text_file", "action_type": "HideDatasetAction", "action_arguments": {}}}, "label": null, "inputs": [{"name": "contaminants", "description": "runtime parameter for tool FastQC"}, {"name": "limits", "description": "runtime parameter for tool FastQC"}, {"name": "input_file", "description": "runtime parameter for tool FastQC"}], "position": {"top": 648.9375, "left": 296.96875}, "annotation": "", "content_id": "toolshed.g2.bx.psu.edu/repos/devteam/fastqc/fastqc/0.71", "type": "tool"}, "6": {"tool_id": "__UNZIP_COLLECTION__", "tool_version": "1.0.0", "outputs": [{"type": "data", "name": "forward"}, {"type": "data", "name": "reverse"}], "workflow_outputs": [], "input_connections": {"input": {"output_name": "output", "id": 1}}, "tool_state": "{\"input\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\", \"__rerun_remap_job_id__\": null, \"__page__\": null}", "id": 6, "uuid": "61b987e1-abcb-4660-8881-6c8de1c76334", "errors": null, "name": "Unzip Collection", "post_job_actions": {"HideDatasetActionreverse": {"output_name": "reverse", "action_type": "HideDatasetAction", "action_arguments": {}}, "HideDatasetActionforward": {"output_name": "forward", "action_type": "HideDatasetAction", "action_arguments": {}}, "ChangeDatatypeActionforward": {"output_name": "forward", "action_type": "ChangeDatatypeAction", "action_arguments": {"newtype": "fastq"}}, "ChangeDatatypeActionreverse": {"output_name": "reverse", "action_type": "ChangeDatatypeAction", "action_arguments": {"newtype": "fastq"}}}, "label": null, "inputs": [{"name": "input", "description": "runtime parameter for tool Unzip Collection"}], "position": {"top": 1193.75, "left": 471.078125}, "annotation": "", "content_id": "__UNZIP_COLLECTION__", "type": "tool"}, "7": {"tool_id": "toolshed.g2.bx.psu.edu/repos/devteam/fastqc/fastqc/0.71", "tool_version": "0.71", "outputs": [{"type": "html", "name": "html_file"}, {"type": "txt", "name": "text_file"}], "workflow_outputs": [{"output_name": "html_file", "uuid": "eb520228-351d-480e-bac2-964967f6aac1", "label": null}], "input_connections": {"input_file": {"output_name": "output", "id": 1}}, "tool_state": "{\"__page__\": null, \"contaminants\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\", \"__rerun_remap_job_id__\": null, \"limits\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\", \"input_file\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\"}", "id": 7, "tool_shed_repository": {"owner": "devteam", "changeset_revision": "ff9530579d1f", "name": "fastqc", "tool_shed": "toolshed.g2.bx.psu.edu"}, "uuid": "b91bbfc0-45ec-4798-9fba-50fc99861989", "errors": null, "name": "FastQC", "post_job_actions": {"HideDatasetActiontext_file": {"output_name": "text_file", "action_type": "HideDatasetAction", "action_arguments": {}}}, "label": null, "inputs": [{"name": "contaminants", "description": "runtime parameter for tool FastQC"}, {"name": "limits", "description": "runtime parameter for tool FastQC"}, {"name": "input_file", "description": "runtime parameter for tool FastQC"}], "position": {"top": 1405.984375, "left": 260}, "annotation": "", "content_id": "toolshed.g2.bx.psu.edu/repos/devteam/fastqc/fastqc/0.71", "type": "tool"}, "8": {"tool_id": "toolshed.g2.bx.psu.edu/repos/lparsons/cutadapt/cutadapt/1.6", "tool_version": "1.6", "outputs": [{"type": "txt", "name": "report"}, {"type": "input", "name": "output"}, {"type": "input", "name": "paired_output"}, {"type": "input", "name": "rest_output"}, {"type": "input", "name": "wild_output"}, {"type": "input", "name": "too_short_output"}, {"type": "input", "name": "too_long_output"}, {"type": "input", "name": "untrimmed_output"}, {"type": "input", "name": "untrimmed_paired_output"}, {"type": "input", "name": "info_file"}], "workflow_outputs": [], "input_connections": {"paired_end|input2": {"output_name": "reverse", "id": 4}, "input": {"output_name": "forward", "id": 4}}, "tool_state": "{\"count\": \"\\\"1\\\"\", \"error_rate\": \"\\\"0.1\\\"\", \"match_read_wildcards\": \"\\\"false\\\"\", \"paired_end\": \"{\\\"__current_case__\\\": 0, \\\"input2\\\": {\\\"__class__\\\": \\\"RuntimeValue\\\"}, \\\"paired_end_boolean\\\": \\\"true\\\"}\", \"__page__\": null, \"output_params\": \"{\\\"__current_case__\\\": 0, \\\"output_type\\\": \\\"default\\\"}\", \"__rerun_remap_job_id__\": null, \"overlap\": \"\\\"5\\\"\", \"front_adapters\": \"[{\\\"__index__\\\": 0, \\\"front_adapter_source\\\": {\\\"__current_case__\\\": 0, \\\"front_adapter\\\": \\\"CTTCCGATCTACAAGTT\\\", \\\"front_adapter_name\\\": \\\"\\\", \\\"front_adapter_source_list\\\": \\\"user\\\"}}, {\\\"__index__\\\": 1, \\\"front_adapter_source\\\": {\\\"__current_case__\\\": 0, \\\"front_adapter\\\": \\\"CTTCCGATCTTGGTCCT\\\", \\\"front_adapter_name\\\": \\\"\\\", \\\"front_adapter_source_list\\\": \\\"user\\\"}}]\", \"input\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\", \"no_indels\": \"\\\"false\\\"\", \"anywhere_adapters\": \"[]\", \"adapters\": \"[{\\\"__index__\\\": 0, \\\"adapter_source\\\": {\\\"__current_case__\\\": 0, \\\"adapter\\\": \\\"AACTTGTAGATCGGA\\\", \\\"adapter_name\\\": \\\"\\\", \\\"adapter_source_list\\\": \\\"user\\\"}}, {\\\"__index__\\\": 1, \\\"adapter_source\\\": {\\\"__current_case__\\\": 0, \\\"adapter\\\": \\\"AGGACCAAGATCGGA\\\", \\\"adapter_name\\\": \\\"\\\", \\\"adapter_source_list\\\": \\\"user\\\"}}]\", \"read_modification_params\": \"{\\\"__current_case__\\\": 1, \\\"cut\\\": \\\"-5\\\", \\\"length_tag\\\": \\\"\\\", \\\"prefix\\\": \\\"\\\", \\\"quality_cutoff\\\": \\\"0\\\", \\\"read_modification\\\": \\\"modify\\\", \\\"strip_suffix\\\": \\\"\\\", \\\"suffix\\\": \\\"\\\", \\\"zero_cap\\\": \\\"false\\\"}\", \"output_filtering_options\": \"{\\\"__current_case__\\\": 1, \\\"discard\\\": \\\"false\\\", \\\"discard_untrimmed\\\": \\\"false\\\", \\\"mask_adapter\\\": \\\"false\\\", \\\"max\\\": \\\"0\\\", \\\"min\\\": \\\"10\\\", \\\"no_trim\\\": \\\"false\\\", \\\"output_filtering\\\": \\\"filter\\\"}\"}", "id": 8, "tool_shed_repository": {"owner": "lparsons", "changeset_revision": "01d94df2e32a", "name": "cutadapt", "tool_shed": "toolshed.g2.bx.psu.edu"}, "uuid": "051e5c15-50ee-4dea-8ca6-1e237dba4e6a", "errors": null, "name": "Cutadapt", "post_job_actions": {"HideDatasetActioninfo_file": {"output_name": "info_file", "action_type": "HideDatasetAction", "action_arguments": {}}, "HideDatasetActiontoo_long_output": {"output_name": "too_long_output", "action_type": "HideDatasetAction", "action_arguments": {}}, "HideDatasetActionoutput": {"output_name": "output", "action_type": "HideDatasetAction", "action_arguments": {}}, "HideDatasetActionwild_output": {"output_name": "wild_output", "action_type": "HideDatasetAction", "action_arguments": {}}, "HideDatasetActiontoo_short_output": {"output_name": "too_short_output", "action_type": "HideDatasetAction", "action_arguments": {}}, "HideDatasetActionpaired_output": {"output_name": "paired_output", "action_type": "HideDatasetAction", "action_arguments": {}}, "HideDatasetActionuntrimmed_output": {"output_name": "untrimmed_output", "action_type": "HideDatasetAction", "action_arguments": {}}, "HideDatasetActionrest_output": {"output_name": "rest_output", "action_type": "HideDatasetAction", "action_arguments": {}}, "HideDatasetActionuntrimmed_paired_output": {"output_name": "untrimmed_paired_output", "action_type": "HideDatasetAction", "action_arguments": {}}, "HideDatasetActionreport": {"output_name": "report", "action_type": "HideDatasetAction", "action_arguments": {}}}, "label": null, "inputs": [{"name": "paired_end", "description": "runtime parameter for tool Cutadapt"}, {"name": "input", "description": "runtime parameter for tool Cutadapt"}], "position": {"top": 416.5, "left": 727.4375}, "annotation": "", "content_id": "toolshed.g2.bx.psu.edu/repos/lparsons/cutadapt/cutadapt/1.6", "type": "tool"}, "9": {"tool_id": "toolshed.g2.bx.psu.edu/repos/lparsons/cutadapt/cutadapt/1.6", "tool_version": "1.6", "outputs": [{"type": "txt", "name": "report"}, {"type": "input", "name": "output"}, {"type": "input", "name": "paired_output"}, {"type": "input", "name": "rest_output"}, {"type": "input", "name": "wild_output"}, {"type": "input", "name": "too_short_output"}, {"type": "input", "name": "too_long_output"}, {"type": "input", "name": "untrimmed_output"}, {"type": "input", "name": "untrimmed_paired_output"}, {"type": "input", "name": "info_file"}], "workflow_outputs": [], "input_connections": {"paired_end|input2": {"output_name": "reverse", "id": 6}, "input": {"output_name": "forward", "id": 6}}, "tool_state": "{\"count\": \"\\\"1\\\"\", \"error_rate\": \"\\\"0.1\\\"\", \"match_read_wildcards\": \"\\\"false\\\"\", \"paired_end\": \"{\\\"__current_case__\\\": 0, \\\"input2\\\": {\\\"__class__\\\": \\\"RuntimeValue\\\"}, \\\"paired_end_boolean\\\": \\\"true\\\"}\", \"__page__\": null, \"output_params\": \"{\\\"__current_case__\\\": 0, \\\"output_type\\\": \\\"default\\\"}\", \"__rerun_remap_job_id__\": null, \"overlap\": \"\\\"5\\\"\", \"front_adapters\": \"[{\\\"__index__\\\": 0, \\\"front_adapter_source\\\": {\\\"__current_case__\\\": 0, \\\"front_adapter\\\": \\\"CTTCCGATCTACAAGTT\\\", \\\"front_adapter_name\\\": \\\"\\\", \\\"front_adapter_source_list\\\": \\\"user\\\"}}, {\\\"__index__\\\": 1, \\\"front_adapter_source\\\": {\\\"__current_case__\\\": 0, \\\"front_adapter\\\": \\\"CTTCCGATCTTGGTCCT\\\", \\\"front_adapter_name\\\": \\\"\\\", \\\"front_adapter_source_list\\\": \\\"user\\\"}}]\", \"input\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\", \"no_indels\": \"\\\"false\\\"\", \"anywhere_adapters\": \"[]\", \"adapters\": \"[{\\\"__index__\\\": 0, \\\"adapter_source\\\": {\\\"__current_case__\\\": 0, \\\"adapter\\\": \\\"AACTTGTAGATCGGA\\\", \\\"adapter_name\\\": \\\"\\\", \\\"adapter_source_list\\\": \\\"user\\\"}}, {\\\"__index__\\\": 1, \\\"adapter_source\\\": {\\\"__current_case__\\\": 0, \\\"adapter\\\": \\\"AGGACCAAGATCGGA\\\", \\\"adapter_name\\\": \\\"\\\", \\\"adapter_source_list\\\": \\\"user\\\"}}]\", \"read_modification_params\": \"{\\\"__current_case__\\\": 1, \\\"cut\\\": \\\"-5\\\", \\\"length_tag\\\": \\\"\\\", \\\"prefix\\\": \\\"\\\", \\\"quality_cutoff\\\": \\\"0\\\", \\\"read_modification\\\": \\\"modify\\\", \\\"strip_suffix\\\": \\\"\\\", \\\"suffix\\\": \\\"\\\", \\\"zero_cap\\\": \\\"false\\\"}\", \"output_filtering_options\": \"{\\\"__current_case__\\\": 1, \\\"discard\\\": \\\"false\\\", \\\"discard_untrimmed\\\": \\\"false\\\", \\\"mask_adapter\\\": \\\"false\\\", \\\"max\\\": \\\"0\\\", \\\"min\\\": \\\"10\\\", \\\"no_trim\\\": \\\"false\\\", \\\"output_filtering\\\": \\\"filter\\\"}\"}", "id": 9, "tool_shed_repository": {"owner": "lparsons", "changeset_revision": "01d94df2e32a", "name": "cutadapt", "tool_shed": "toolshed.g2.bx.psu.edu"}, "uuid": "f1af723e-4c41-4cc2-8baf-080650f758e7", "errors": null, "name": "Cutadapt", "post_job_actions": {"HideDatasetActioninfo_file": {"output_name": "info_file", "action_type": "HideDatasetAction", "action_arguments": {}}, "HideDatasetActiontoo_long_output": {"output_name": "too_long_output", "action_type": "HideDatasetAction", "action_arguments": {}}, "HideDatasetActionoutput": {"output_name": "output", "action_type": "HideDatasetAction", "action_arguments": {}}, "HideDatasetActionwild_output": {"output_name": "wild_output", "action_type": "HideDatasetAction", "action_arguments": {}}, "HideDatasetActiontoo_short_output": {"output_name": "too_short_output", "action_type": "HideDatasetAction", "action_arguments": {}}, "HideDatasetActionpaired_output": {"output_name": "paired_output", "action_type": "HideDatasetAction", "action_arguments": {}}, "HideDatasetActionuntrimmed_output": {"output_name": "untrimmed_output", "action_type": "HideDatasetAction", "action_arguments": {}}, "HideDatasetActionrest_output": {"output_name": "rest_output", "action_type": "HideDatasetAction", "action_arguments": {}}, "HideDatasetActionuntrimmed_paired_output": {"output_name": "untrimmed_paired_output", "action_type": "HideDatasetAction", "action_arguments": {}}, "HideDatasetActionreport": {"output_name": "report", "action_type": "HideDatasetAction", "action_arguments": {}}}, "label": null, "inputs": [{"name": "paired_end", "description": "runtime parameter for tool Cutadapt"}, {"name": "input", "description": "runtime parameter for tool Cutadapt"}], "position": {"top": 1197.5, "left": 709.4375}, "annotation": "", "content_id": "toolshed.g2.bx.psu.edu/repos/lparsons/cutadapt/cutadapt/1.6", "type": "tool"}, "10": {"tool_id": "toolshed.g2.bx.psu.edu/repos/lparsons/cutadapt/cutadapt/1.6", "tool_version": "1.6", "outputs": [{"type": "txt", "name": "report"}, {"type": "input", "name": "output"}, {"type": "input", "name": "paired_output"}, {"type": "input", "name": "rest_output"}, {"type": "input", "name": "wild_output"}, {"type": "input", "name": "too_short_output"}, {"type": "input", "name": "too_long_output"}, {"type": "input", "name": "untrimmed_output"}, {"type": "input", "name": "untrimmed_paired_output"}, {"type": "input", "name": "info_file"}], "workflow_outputs": [], "input_connections": {"paired_end|input2": {"output_name": "output", "id": 8}, "input": {"output_name": "paired_output", "id": 8}}, "tool_state": "{\"count\": \"\\\"1\\\"\", \"error_rate\": \"\\\"0.1\\\"\", \"match_read_wildcards\": \"\\\"false\\\"\", \"paired_end\": \"{\\\"__current_case__\\\": 0, \\\"input2\\\": {\\\"__class__\\\": \\\"RuntimeValue\\\"}, \\\"paired_end_boolean\\\": \\\"true\\\"}\", \"__page__\": null, \"output_params\": \"{\\\"__current_case__\\\": 0, \\\"output_type\\\": \\\"default\\\"}\", \"__rerun_remap_job_id__\": null, \"overlap\": \"\\\"5\\\"\", \"front_adapters\": \"[{\\\"__index__\\\": 0, \\\"front_adapter_source\\\": {\\\"__current_case__\\\": 0, \\\"front_adapter\\\": \\\"CTTCCGATCTACAAGTT\\\", \\\"front_adapter_name\\\": \\\"\\\", \\\"front_adapter_source_list\\\": \\\"user\\\"}}, {\\\"__index__\\\": 1, \\\"front_adapter_source\\\": {\\\"__current_case__\\\": 0, \\\"front_adapter\\\": \\\"CTTCCGATCTTGGTCCT\\\", \\\"front_adapter_name\\\": \\\"\\\", \\\"front_adapter_source_list\\\": \\\"user\\\"}}]\", \"input\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\", \"no_indels\": \"\\\"false\\\"\", \"anywhere_adapters\": \"[]\", \"adapters\": \"[{\\\"__index__\\\": 0, \\\"adapter_source\\\": {\\\"__current_case__\\\": 0, \\\"adapter\\\": \\\"AACTTGTAGATCGGA\\\", \\\"adapter_name\\\": \\\"\\\", \\\"adapter_source_list\\\": \\\"user\\\"}}, {\\\"__index__\\\": 1, \\\"adapter_source\\\": {\\\"__current_case__\\\": 0, \\\"adapter\\\": \\\"AGGACCAAGATCGGA\\\", \\\"adapter_name\\\": \\\"\\\", \\\"adapter_source_list\\\": \\\"user\\\"}}]\", \"read_modification_params\": \"{\\\"__current_case__\\\": 0, \\\"read_modification\\\": \\\"none\\\"}\", \"output_filtering_options\": \"{\\\"__current_case__\\\": 1, \\\"discard\\\": \\\"false\\\", \\\"discard_untrimmed\\\": \\\"false\\\", \\\"mask_adapter\\\": \\\"false\\\", \\\"max\\\": \\\"0\\\", \\\"min\\\": \\\"10\\\", \\\"no_trim\\\": \\\"false\\\", \\\"output_filtering\\\": \\\"filter\\\"}\"}", "id": 10, "tool_shed_repository": {"owner": "lparsons", "changeset_revision": "01d94df2e32a", "name": "cutadapt", "tool_shed": "toolshed.g2.bx.psu.edu"}, "uuid": "20521c9a-2d3d-4b43-b9fb-53a69716dc15", "errors": null, "name": "Cutadapt", "post_job_actions": {"HideDatasetActioninfo_file": {"output_name": "info_file", "action_type": "HideDatasetAction", "action_arguments": {}}, "HideDatasetActiontoo_long_output": {"output_name": "too_long_output", "action_type": "HideDatasetAction", "action_arguments": {}}, "HideDatasetActionoutput": {"output_name": "output", "action_type": "HideDatasetAction", "action_arguments": {}}, "HideDatasetActionwild_output": {"output_name": "wild_output", "action_type": "HideDatasetAction", "action_arguments": {}}, "HideDatasetActiontoo_short_output": {"output_name": "too_short_output", "action_type": "HideDatasetAction", "action_arguments": {}}, "HideDatasetActionpaired_output": {"output_name": "paired_output", "action_type": "HideDatasetAction", "action_arguments": {}}, "HideDatasetActionuntrimmed_output": {"output_name": "untrimmed_output", "action_type": "HideDatasetAction", "action_arguments": {}}, "HideDatasetActionrest_output": {"output_name": "rest_output", "action_type": "HideDatasetAction", "action_arguments": {}}, "HideDatasetActionuntrimmed_paired_output": {"output_name": "untrimmed_paired_output", "action_type": "HideDatasetAction", "action_arguments": {}}, "HideDatasetActionreport": {"output_name": "report", "action_type": "HideDatasetAction", "action_arguments": {}}}, "label": null, "inputs": [{"name": "paired_end", "description": "runtime parameter for tool Cutadapt"}, {"name": "input", "description": "runtime parameter for tool Cutadapt"}], "position": {"top": 413.453125, "left": 955.484375}, "annotation": "", "content_id": "toolshed.g2.bx.psu.edu/repos/lparsons/cutadapt/cutadapt/1.6", "type": "tool"}, "11": {"tool_id": "toolshed.g2.bx.psu.edu/repos/lparsons/cutadapt/cutadapt/1.6", "tool_version": "1.6", "outputs": [{"type": "txt", "name": "report"}, {"type": "input", "name": "output"}, {"type": "input", "name": "paired_output"}, {"type": "input", "name": "rest_output"}, {"type": "input", "name": "wild_output"}, {"type": "input", "name": "too_short_output"}, {"type": "input", "name": "too_long_output"}, {"type": "input", "name": "untrimmed_output"}, {"type": "input", "name": "untrimmed_paired_output"}, {"type": "input", "name": "info_file"}], "workflow_outputs": [], "input_connections": {"paired_end|input2": {"output_name": "output", "id": 9}, "input": {"output_name": "paired_output", "id": 9}}, "tool_state": "{\"count\": \"\\\"1\\\"\", \"error_rate\": \"\\\"0.1\\\"\", \"match_read_wildcards\": \"\\\"false\\\"\", \"paired_end\": \"{\\\"__current_case__\\\": 0, \\\"input2\\\": {\\\"__class__\\\": \\\"RuntimeValue\\\"}, \\\"paired_end_boolean\\\": \\\"true\\\"}\", \"__page__\": null, \"output_params\": \"{\\\"__current_case__\\\": 0, \\\"output_type\\\": \\\"default\\\"}\", \"__rerun_remap_job_id__\": null, \"overlap\": \"\\\"5\\\"\", \"front_adapters\": \"[{\\\"__index__\\\": 0, \\\"front_adapter_source\\\": {\\\"__current_case__\\\": 0, \\\"front_adapter\\\": \\\"CTTCCGATCTACAAGTT\\\", \\\"front_adapter_name\\\": \\\"\\\", \\\"front_adapter_source_list\\\": \\\"user\\\"}}, {\\\"__index__\\\": 1, \\\"front_adapter_source\\\": {\\\"__current_case__\\\": 0, \\\"front_adapter\\\": \\\"CTTCCGATCTTGGTCCT\\\", \\\"front_adapter_name\\\": \\\"\\\", \\\"front_adapter_source_list\\\": \\\"user\\\"}}]\", \"input\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\", \"no_indels\": \"\\\"false\\\"\", \"anywhere_adapters\": \"[]\", \"adapters\": \"[{\\\"__index__\\\": 0, \\\"adapter_source\\\": {\\\"__current_case__\\\": 0, \\\"adapter\\\": \\\"AACTTGTAGATCGGA\\\", \\\"adapter_name\\\": \\\"\\\", \\\"adapter_source_list\\\": \\\"user\\\"}}, {\\\"__index__\\\": 1, \\\"adapter_source\\\": {\\\"__current_case__\\\": 0, \\\"adapter\\\": \\\"AGGACCAAGATCGGA\\\", \\\"adapter_name\\\": \\\"\\\", \\\"adapter_source_list\\\": \\\"user\\\"}}]\", \"read_modification_params\": \"{\\\"__current_case__\\\": 0, \\\"read_modification\\\": \\\"none\\\"}\", \"output_filtering_options\": \"{\\\"__current_case__\\\": 1, \\\"discard\\\": \\\"false\\\", \\\"discard_untrimmed\\\": \\\"false\\\", \\\"mask_adapter\\\": \\\"false\\\", \\\"max\\\": \\\"0\\\", \\\"min\\\": \\\"10\\\", \\\"no_trim\\\": \\\"false\\\", \\\"output_filtering\\\": \\\"filter\\\"}\"}", "id": 11, "tool_shed_repository": {"owner": "lparsons", "changeset_revision": "01d94df2e32a", "name": "cutadapt", "tool_shed": "toolshed.g2.bx.psu.edu"}, "uuid": "b72bd8da-b2c9-49fb-a263-567afb5b876e", "errors": null, "name": "Cutadapt", "post_job_actions": {"HideDatasetActioninfo_file": {"output_name": "info_file", "action_type": "HideDatasetAction", "action_arguments": {}}, "HideDatasetActiontoo_long_output": {"output_name": "too_long_output", "action_type": "HideDatasetAction", "action_arguments": {}}, "HideDatasetActionoutput": {"output_name": "output", "action_type": "HideDatasetAction", "action_arguments": {}}, "HideDatasetActionwild_output": {"output_name": "wild_output", "action_type": "HideDatasetAction", "action_arguments": {}}, "HideDatasetActiontoo_short_output": {"output_name": "too_short_output", "action_type": "HideDatasetAction", "action_arguments": {}}, "HideDatasetActionpaired_output": {"output_name": "paired_output", "action_type": "HideDatasetAction", "action_arguments": {}}, "HideDatasetActionuntrimmed_output": {"output_name": "untrimmed_output", "action_type": "HideDatasetAction", "action_arguments": {}}, "HideDatasetActionrest_output": {"output_name": "rest_output", "action_type": "HideDatasetAction", "action_arguments": {}}, "HideDatasetActionuntrimmed_paired_output": {"output_name": "untrimmed_paired_output", "action_type": "HideDatasetAction", "action_arguments": {}}, "HideDatasetActionreport": {"output_name": "report", "action_type": "HideDatasetAction", "action_arguments": {}}}, "label": null, "inputs": [{"name": "paired_end", "description": "runtime parameter for tool Cutadapt"}, {"name": "input", "description": "runtime parameter for tool Cutadapt"}], "position": {"top": 1203.5, "left": 947.4375}, "annotation": "", "content_id": "toolshed.g2.bx.psu.edu/repos/lparsons/cutadapt/cutadapt/1.6", "type": "tool"}, "12": {"tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/umi_tools_extract/umi_tools_extract/0.5.3.2", "tool_version": "0.5.3.2", "outputs": [{"type": "input", "name": "out"}, {"type": "input", "name": "out1"}, {"type": "input", "name": "out2"}, {"type": "txt", "name": "out_log"}], "workflow_outputs": [], "input_connections": {"input_type|input_read1": {"output_name": "output", "id": 10}, "input_type|input_read2": {"output_name": "paired_output", "id": 10}}, "tool_state": "{\"__page__\": null, \"extract_method\": \"\\\"string\\\"\", \"input_type\": \"{\\\"__current_case__\\\": 1, \\\"barcode\\\": {\\\"__current_case__\\\": 0, \\\"barcode_select\\\": \\\"first_read_only\\\"}, \\\"input_read1\\\": {\\\"__class__\\\": \\\"RuntimeValue\\\"}, \\\"input_read2\\\": {\\\"__class__\\\": \\\"RuntimeValue\\\"}, \\\"type\\\": \\\"paired\\\"}\", \"__rerun_remap_job_id__\": null, \"bc_pattern\": \"\\\"NNNNN\\\"\", \"print_log\": \"\\\"true\\\"\", \"prime3\": \"\\\"true\\\"\", \"quality\": \"{\\\"__current_case__\\\": 0, \\\"quality_selector\\\": \\\"false\\\"}\", \"barcodes\": \"{\\\"__current_case__\\\": 0, \\\"use_barcodes\\\": \\\"no\\\"}\"}", "id": 12, "tool_shed_repository": {"owner": "iuc", "changeset_revision": "828dba98cdb4", "name": "umi_tools_extract", "tool_shed": "toolshed.g2.bx.psu.edu"}, "uuid": "9f1ac00b-1c4b-4f2a-b7b6-3ef0bfa6b38c", "errors": null, "name": "UMI-tools extract", "post_job_actions": {"HideDatasetActionout_log": {"output_name": "out_log", "action_type": "HideDatasetAction", "action_arguments": {}}, "HideDatasetActionout1": {"output_name": "out1", "action_type": "HideDatasetAction", "action_arguments": {}}, "HideDatasetActionout": {"output_name": "out", "action_type": "HideDatasetAction", "action_arguments": {}}, "HideDatasetActionout2": {"output_name": "out2", "action_type": "HideDatasetAction", "action_arguments": {}}}, "label": null, "inputs": [{"name": "input_type", "description": "runtime parameter for tool UMI-tools extract"}, {"name": "input_type", "description": "runtime parameter for tool UMI-tools extract"}], "position": {"top": 419.5, "left": 1214.4375}, "annotation": "", "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/umi_tools_extract/umi_tools_extract/0.5.3.2", "type": "tool"}, "13": {"tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/umi_tools_extract/umi_tools_extract/0.5.3.2", "tool_version": "0.5.3.2", "outputs": [{"type": "input", "name": "out"}, {"type": "input", "name": "out1"}, {"type": "input", "name": "out2"}, {"type": "txt", "name": "out_log"}], "workflow_outputs": [], "input_connections": {"input_type|input_read1": {"output_name": "output", "id": 11}, "input_type|input_read2": {"output_name": "paired_output", "id": 11}}, "tool_state": "{\"__page__\": null, \"extract_method\": \"\\\"string\\\"\", \"input_type\": \"{\\\"__current_case__\\\": 1, \\\"barcode\\\": {\\\"__current_case__\\\": 0, \\\"barcode_select\\\": \\\"first_read_only\\\"}, \\\"input_read1\\\": {\\\"__class__\\\": \\\"RuntimeValue\\\"}, \\\"input_read2\\\": {\\\"__class__\\\": \\\"RuntimeValue\\\"}, \\\"type\\\": \\\"paired\\\"}\", \"__rerun_remap_job_id__\": null, \"bc_pattern\": \"\\\"NNNNN\\\"\", \"print_log\": \"\\\"true\\\"\", \"prime3\": \"\\\"true\\\"\", \"quality\": \"{\\\"__current_case__\\\": 0, \\\"quality_selector\\\": \\\"false\\\"}\", \"barcodes\": \"{\\\"__current_case__\\\": 0, \\\"use_barcodes\\\": \\\"no\\\"}\"}", "id": 13, "tool_shed_repository": {"owner": "iuc", "changeset_revision": "828dba98cdb4", "name": "umi_tools_extract", "tool_shed": "toolshed.g2.bx.psu.edu"}, "uuid": "e5040195-08ec-45d3-8910-53f2b72a5b2b", "errors": null, "name": "UMI-tools extract", "post_job_actions": {"HideDatasetActionout_log": {"output_name": "out_log", "action_type": "HideDatasetAction", "action_arguments": {}}, "HideDatasetActionout1": {"output_name": "out1", "action_type": "HideDatasetAction", "action_arguments": {}}, "HideDatasetActionout": {"output_name": "out", "action_type": "HideDatasetAction", "action_arguments": {}}, "HideDatasetActionout2": {"output_name": "out2", "action_type": "HideDatasetAction", "action_arguments": {}}}, "label": null, "inputs": [{"name": "input_type", "description": "runtime parameter for tool UMI-tools extract"}, {"name": "input_type", "description": "runtime parameter for tool UMI-tools extract"}], "position": {"top": 1202.5, "left": 1241.4375}, "annotation": "", "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/umi_tools_extract/umi_tools_extract/0.5.3.2", "type": "tool"}, "14": {"tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/rgrnastar/rna_star/2.5.2b-2", "tool_version": "2.5.2b-2", "outputs": [{"type": "txt", "name": "output_log"}, {"type": "interval", "name": "chimeric_junctions"}, {"type": "bam", "name": "chimeric_reads"}, {"type": "interval", "name": "splice_junctions"}, {"type": "bam", "name": "mapped_reads"}, {"type": "tabular", "name": "reads_per_gene"}], "workflow_outputs": [], "input_connections": {"singlePaired|input2": {"output_name": "out2", "id": 12}, "singlePaired|input1": {"output_name": "out1", "id": 12}}, "tool_state": "{\"__page__\": null, \"singlePaired\": \"{\\\"__current_case__\\\": 1, \\\"input1\\\": {\\\"__class__\\\": \\\"RuntimeValue\\\"}, \\\"input2\\\": {\\\"__class__\\\": \\\"RuntimeValue\\\"}, \\\"sPaired\\\": \\\"paired\\\"}\", \"output_params\": \"{\\\"__current_case__\\\": 0, \\\"outFilterIntronMotifs\\\": \\\"None\\\", \\\"outSAMattributes\\\": \\\"All\\\", \\\"outSAMstrandField\\\": \\\"intronMotif\\\", \\\"output_params2\\\": {\\\"__current_case__\\\": 0, \\\"outFilterMatchNmin\\\": \\\"0\\\", \\\"outFilterMatchNminOverLread\\\": \\\"0.66\\\", \\\"outFilterMismatchNmax\\\": \\\"10\\\", \\\"outFilterMismatchNoverLmax\\\": \\\"0.3\\\", \\\"outFilterMismatchNoverReadLmax\\\": \\\"1.0\\\", \\\"outFilterMultimapNmax\\\": \\\"10\\\", \\\"outFilterMultimapScoreRange\\\": \\\"1\\\", \\\"outFilterScoreMin\\\": \\\"0\\\", \\\"outFilterScoreMinOverLread\\\": \\\"0.66\\\", \\\"outFilterType\\\": \\\"false\\\", \\\"outSAMmapqUnique\\\": \\\"255\\\", \\\"outSAMprimaryFlag\\\": \\\"false\\\", \\\"outSAMunmapped\\\": \\\"false\\\", \\\"output_select2\\\": \\\"yes\\\"}, \\\"output_select\\\": \\\"yes\\\"}\", \"__rerun_remap_job_id__\": null, \"params\": \"{\\\"__current_case__\\\": 2, \\\"align\\\": {\\\"alignEndsType\\\": \\\"true\\\", \\\"alignIntronMax\\\": \\\"0\\\", \\\"alignIntronMin\\\": \\\"21\\\", \\\"alignMatesGapMax\\\": \\\"0\\\", \\\"alignSJDBoverhangMin\\\": \\\"3\\\", \\\"alignSJoverhangMin\\\": \\\"5\\\", \\\"alignSplicedMateMapLmin\\\": \\\"0\\\", \\\"alignSplicedMateMapLminOverLmate\\\": \\\"0.66\\\", \\\"alignTranscriptsPerReadNmax\\\": \\\"10000\\\", \\\"alignTranscriptsPerWindowNmax\\\": \\\"100\\\", \\\"alignWindowsPerReadNmax\\\": \\\"10000\\\"}, \\\"chim\\\": {\\\"__current_case__\\\": 1, \\\"chim_select\\\": \\\"no\\\"}, \\\"limits\\\": {\\\"limitBAMsortRAM\\\": \\\"0\\\", \\\"limitOutSJcollapsed\\\": \\\"1000000\\\", \\\"limitOutSJoneRead\\\": \\\"1000\\\", \\\"limitSjdbInsertNsj\\\": \\\"1000000\\\"}, \\\"seed\\\": {\\\"seedMultimapNmax\\\": \\\"10000\\\", \\\"seedNoneLociPerWindow\\\": \\\"10\\\", \\\"seedPerReadNmax\\\": \\\"1000\\\", \\\"seedPerWindowNmax\\\": \\\"50\\\", \\\"seedSearchLmax\\\": \\\"0\\\", \\\"seedSearchStartLmax\\\": \\\"50\\\", \\\"seedSearchStartLmaxOverLread\\\": \\\"1.0\\\"}, \\\"settingsType\\\": \\\"full\\\", \\\"twopass\\\": {\\\"twopass1readsN\\\": \\\"-1\\\", \\\"twopassMode\\\": \\\"false\\\"}}\", \"refGenomeSource\": \"{\\\"GTFconditional\\\": {\\\"GTFselect\\\": \\\"with-gtf\\\", \\\"__current_case__\\\": 0, \\\"genomeDir\\\": \\\"hg38\\\"}, \\\"__current_case__\\\": 0, \\\"geneSource\\\": \\\"indexed\\\"}\", \"quantMode\": \"\\\"false\\\"\"}", "id": 14, "tool_shed_repository": {"owner": "iuc", "changeset_revision": "2055c2667eb3", "name": "rgrnastar", "tool_shed": "toolshed.g2.bx.psu.edu"}, "uuid": "41e5fce4-f49d-4bae-b0ef-2a76782ac7b7", "errors": null, "name": "RNA STAR", "post_job_actions": {"HideDatasetActionmapped_reads": {"output_name": "mapped_reads", "action_type": "HideDatasetAction", "action_arguments": {}}, "HideDatasetActionchimeric_junctions": {"output_name": "chimeric_junctions", "action_type": "HideDatasetAction", "action_arguments": {}}, "HideDatasetActionreads_per_gene": {"output_name": "reads_per_gene", "action_type": "HideDatasetAction", "action_arguments": {}}, "HideDatasetActionchimeric_reads": {"output_name": "chimeric_reads", "action_type": "HideDatasetAction", "action_arguments": {}}, "HideDatasetActionsplice_junctions": {"output_name": "splice_junctions", "action_type": "HideDatasetAction", "action_arguments": {}}, "HideDatasetActionoutput_log": {"output_name": "output_log", "action_type": "HideDatasetAction", "action_arguments": {}}}, "label": null, "inputs": [{"name": "singlePaired", "description": "runtime parameter for tool RNA STAR"}, {"name": "singlePaired", "description": "runtime parameter for tool RNA STAR"}], "position": {"top": 588.515625, "left": 1916.921875}, "annotation": "", "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/rgrnastar/rna_star/2.5.2b-2", "type": "tool"}, "15": {"tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/rgrnastar/rna_star/2.5.2b-2", "tool_version": "2.5.2b-2", "outputs": [{"type": "txt", "name": "output_log"}, {"type": "interval", "name": "chimeric_junctions"}, {"type": "bam", "name": "chimeric_reads"}, {"type": "interval", "name": "splice_junctions"}, {"type": "bam", "name": "mapped_reads"}, {"type": "tabular", "name": "reads_per_gene"}], "workflow_outputs": [], "input_connections": {"singlePaired|input2": {"output_name": "out2", "id": 13}, "singlePaired|input1": {"output_name": "out1", "id": 13}}, "tool_state": "{\"__page__\": null, \"singlePaired\": \"{\\\"__current_case__\\\": 1, \\\"input1\\\": {\\\"__class__\\\": \\\"RuntimeValue\\\"}, \\\"input2\\\": {\\\"__class__\\\": \\\"RuntimeValue\\\"}, \\\"sPaired\\\": \\\"paired\\\"}\", \"output_params\": \"{\\\"__current_case__\\\": 0, \\\"outFilterIntronMotifs\\\": \\\"None\\\", \\\"outSAMattributes\\\": \\\"All\\\", \\\"outSAMstrandField\\\": \\\"intronMotif\\\", \\\"output_params2\\\": {\\\"__current_case__\\\": 0, \\\"outFilterMatchNmin\\\": \\\"0\\\", \\\"outFilterMatchNminOverLread\\\": \\\"0.66\\\", \\\"outFilterMismatchNmax\\\": \\\"10\\\", \\\"outFilterMismatchNoverLmax\\\": \\\"0.3\\\", \\\"outFilterMismatchNoverReadLmax\\\": \\\"1.0\\\", \\\"outFilterMultimapNmax\\\": \\\"10\\\", \\\"outFilterMultimapScoreRange\\\": \\\"1\\\", \\\"outFilterScoreMin\\\": \\\"0\\\", \\\"outFilterScoreMinOverLread\\\": \\\"0.66\\\", \\\"outFilterType\\\": \\\"false\\\", \\\"outSAMmapqUnique\\\": \\\"255\\\", \\\"outSAMprimaryFlag\\\": \\\"false\\\", \\\"outSAMunmapped\\\": \\\"false\\\", \\\"output_select2\\\": \\\"yes\\\"}, \\\"output_select\\\": \\\"yes\\\"}\", \"__rerun_remap_job_id__\": null, \"params\": \"{\\\"__current_case__\\\": 2, \\\"align\\\": {\\\"alignEndsType\\\": \\\"true\\\", \\\"alignIntronMax\\\": \\\"0\\\", \\\"alignIntronMin\\\": \\\"21\\\", \\\"alignMatesGapMax\\\": \\\"0\\\", \\\"alignSJDBoverhangMin\\\": \\\"3\\\", \\\"alignSJoverhangMin\\\": \\\"5\\\", \\\"alignSplicedMateMapLmin\\\": \\\"0\\\", \\\"alignSplicedMateMapLminOverLmate\\\": \\\"0.66\\\", \\\"alignTranscriptsPerReadNmax\\\": \\\"10000\\\", \\\"alignTranscriptsPerWindowNmax\\\": \\\"100\\\", \\\"alignWindowsPerReadNmax\\\": \\\"10000\\\"}, \\\"chim\\\": {\\\"__current_case__\\\": 1, \\\"chim_select\\\": \\\"no\\\"}, \\\"limits\\\": {\\\"limitBAMsortRAM\\\": \\\"0\\\", \\\"limitOutSJcollapsed\\\": \\\"1000000\\\", \\\"limitOutSJoneRead\\\": \\\"1000\\\", \\\"limitSjdbInsertNsj\\\": \\\"1000000\\\"}, \\\"seed\\\": {\\\"seedMultimapNmax\\\": \\\"10000\\\", \\\"seedNoneLociPerWindow\\\": \\\"10\\\", \\\"seedPerReadNmax\\\": \\\"1000\\\", \\\"seedPerWindowNmax\\\": \\\"50\\\", \\\"seedSearchLmax\\\": \\\"0\\\", \\\"seedSearchStartLmax\\\": \\\"50\\\", \\\"seedSearchStartLmaxOverLread\\\": \\\"1.0\\\"}, \\\"settingsType\\\": \\\"full\\\", \\\"twopass\\\": {\\\"twopass1readsN\\\": \\\"-1\\\", \\\"twopassMode\\\": \\\"false\\\"}}\", \"refGenomeSource\": \"{\\\"GTFconditional\\\": {\\\"GTFselect\\\": \\\"with-gtf\\\", \\\"__current_case__\\\": 0, \\\"genomeDir\\\": \\\"hg38\\\"}, \\\"__current_case__\\\": 0, \\\"geneSource\\\": \\\"indexed\\\"}\", \"quantMode\": \"\\\"false\\\"\"}", "id": 15, "tool_shed_repository": {"owner": "iuc", "changeset_revision": "2055c2667eb3", "name": "rgrnastar", "tool_shed": "toolshed.g2.bx.psu.edu"}, "uuid": "e4ebcf65-a6f3-44e9-b9be-297255954a28", "errors": null, "name": "RNA STAR", "post_job_actions": {"HideDatasetActionmapped_reads": {"output_name": "mapped_reads", "action_type": "HideDatasetAction", "action_arguments": {}}, "HideDatasetActionchimeric_junctions": {"output_name": "chimeric_junctions", "action_type": "HideDatasetAction", "action_arguments": {}}, "HideDatasetActionreads_per_gene": {"output_name": "reads_per_gene", "action_type": "HideDatasetAction", "action_arguments": {}}, "HideDatasetActionchimeric_reads": {"output_name": "chimeric_reads", "action_type": "HideDatasetAction", "action_arguments": {}}, "HideDatasetActionsplice_junctions": {"output_name": "splice_junctions", "action_type": "HideDatasetAction", "action_arguments": {}}, "HideDatasetActionoutput_log": {"output_name": "output_log", "action_type": "HideDatasetAction", "action_arguments": {}}}, "label": null, "inputs": [{"name": "singlePaired", "description": "runtime parameter for tool RNA STAR"}, {"name": "singlePaired", "description": "runtime parameter for tool RNA STAR"}], "position": {"top": 1418.5, "left": 1760.921875}, "annotation": "", "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/rgrnastar/rna_star/2.5.2b-2", "type": "tool"}, "16": {"tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/umi_tools_dedup/umi_tools_dedup/0.5.3.0", "tool_version": "0.5.3.0", "outputs": [{"type": "bam", "name": "output"}], "workflow_outputs": [], "input_connections": {"input": {"output_name": "mapped_reads", "id": 14}}, "tool_state": "{\"subset\": \"\\\"1.0\\\"\", \"__page__\": null, \"extract_umi_method\": \"\\\"read_id\\\"\", \"read_length\": \"\\\"false\\\"\", \"chrom\": \"\\\"false\\\"\", \"gene_tag\": \"\\\"\\\"\", \"edit_distance_threshold\": \"\\\"1\\\"\", \"per_contig\": \"\\\"false\\\"\", \"per_gene\": \"\\\"false\\\"\", \"paired\": \"\\\"true\\\"\", \"__rerun_remap_job_id__\": null, \"gene_transcript_map\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\", \"spliced_is_unique\": \"\\\"false\\\"\", \"soft_clip_threshold\": \"\\\"4\\\"\", \"input\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\", \"whole_contig\": \"\\\"false\\\"\", \"method\": \"\\\"adjacency\\\"\", \"umi_separator\": \"\\\"_\\\"\", \"umi_tag\": \"\\\"\\\"\"}", "id": 16, "tool_shed_repository": {"owner": "iuc", "changeset_revision": "e9256e2e22e0", "name": "umi_tools_dedup", "tool_shed": "toolshed.g2.bx.psu.edu"}, "uuid": "44909d26-6d13-496d-ab5e-8ac270ba7142", "errors": null, "name": "UMI-tools deduplicate", "post_job_actions": {"HideDatasetActionoutput": {"output_name": "output", "action_type": "HideDatasetAction", "action_arguments": {}}}, "label": null, "inputs": [{"name": "gene_transcript_map", "description": "runtime parameter for tool UMI-tools deduplicate"}, {"name": "input", "description": "runtime parameter for tool UMI-tools deduplicate"}], "position": {"top": 790.46875, "left": 2236.015625}, "annotation": "", "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/umi_tools_dedup/umi_tools_dedup/0.5.3.0", "type": "tool"}, "17": {"tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/umi_tools_dedup/umi_tools_dedup/0.5.3.0", "tool_version": "0.5.3.0", "outputs": [{"type": "bam", "name": "output"}], "workflow_outputs": [], "input_connections": {"input": {"output_name": "mapped_reads", "id": 15}}, "tool_state": "{\"subset\": \"\\\"1.0\\\"\", \"__page__\": null, \"extract_umi_method\": \"\\\"read_id\\\"\", \"read_length\": \"\\\"false\\\"\", \"chrom\": \"\\\"false\\\"\", \"gene_tag\": \"\\\"\\\"\", \"edit_distance_threshold\": \"\\\"1\\\"\", \"per_contig\": \"\\\"false\\\"\", \"per_gene\": \"\\\"false\\\"\", \"paired\": \"\\\"true\\\"\", \"__rerun_remap_job_id__\": null, \"gene_transcript_map\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\", \"spliced_is_unique\": \"\\\"false\\\"\", \"soft_clip_threshold\": \"\\\"4\\\"\", \"input\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\", \"whole_contig\": \"\\\"false\\\"\", \"method\": \"\\\"adjacency\\\"\", \"umi_separator\": \"\\\"_\\\"\", \"umi_tag\": \"\\\"\\\"\"}", "id": 17, "tool_shed_repository": {"owner": "iuc", "changeset_revision": "e9256e2e22e0", "name": "umi_tools_dedup", "tool_shed": "toolshed.g2.bx.psu.edu"}, "uuid": "49786cc4-e78a-4488-9946-507ed9740bb8", "errors": null, "name": "UMI-tools deduplicate", "post_job_actions": {"HideDatasetActionoutput": {"output_name": "output", "action_type": "HideDatasetAction", "action_arguments": {}}}, "label": null, "inputs": [{"name": "gene_transcript_map", "description": "runtime parameter for tool UMI-tools deduplicate"}, {"name": "input", "description": "runtime parameter for tool UMI-tools deduplicate"}], "position": {"top": 1557.6875, "left": 2132.171875}, "annotation": "", "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/umi_tools_dedup/umi_tools_dedup/0.5.3.0", "type": "tool"}, "18": {"tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/bctools_extract_alignment_ends/bctools_extract_alignment_ends/0.2.2", "tool_version": "0.2.2", "outputs": [{"type": "bed", "name": "alignment_ends"}], "workflow_outputs": [], "input_connections": {"alignments": {"output_name": "output", "id": 16}}, "tool_state": "{\"__page__\": null, \"__rerun_remap_job_id__\": null, \"alignments\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\"}", "id": 18, "tool_shed_repository": {"owner": "iuc", "changeset_revision": "8076141a76a7", "name": "bctools_extract_alignment_ends", "tool_shed": "toolshed.g2.bx.psu.edu"}, "uuid": "20010654-0f50-482b-a9f9-7e7f8919bf32", "errors": null, "name": "Extract alignment ends", "post_job_actions": {"HideDatasetActionalignment_ends": {"output_name": "alignment_ends", "action_type": "HideDatasetAction", "action_arguments": {}}}, "label": null, "inputs": [{"name": "alignments", "description": "runtime parameter for tool Extract alignment ends"}], "position": {"top": 459.9375, "left": 2312.140625}, "annotation": "", "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/bctools_extract_alignment_ends/bctools_extract_alignment_ends/0.2.2", "type": "tool"}, "19": {"tool_id": "toolshed.g2.bx.psu.edu/repos/devteam/fastqc/fastqc/0.71", "tool_version": "0.71", "outputs": [{"type": "html", "name": "html_file"}, {"type": "txt", "name": "text_file"}], "workflow_outputs": [{"output_name": "html_file", "uuid": "40dd1734-fe88-4754-be95-fce11fc1a242", "label": null}], "input_connections": {"input_file": {"output_name": "output", "id": 16}}, "tool_state": "{\"__page__\": null, \"contaminants\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\", \"__rerun_remap_job_id__\": null, \"limits\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\", \"input_file\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\"}", "id": 19, "tool_shed_repository": {"owner": "devteam", "changeset_revision": "ff9530579d1f", "name": "fastqc", "tool_shed": "toolshed.g2.bx.psu.edu"}, "uuid": "d24623ab-91a1-46fd-993f-f3fa0fba3470", "errors": null, "name": "FastQC", "post_job_actions": {"HideDatasetActiontext_file": {"output_name": "text_file", "action_type": "HideDatasetAction", "action_arguments": {}}}, "label": null, "inputs": [{"name": "contaminants", "description": "runtime parameter for tool FastQC"}, {"name": "limits", "description": "runtime parameter for tool FastQC"}, {"name": "input_file", "description": "runtime parameter for tool FastQC"}], "position": {"top": 899, "left": 2764.9375}, "annotation": "", "content_id": "toolshed.g2.bx.psu.edu/repos/devteam/fastqc/fastqc/0.71", "type": "tool"}, "20": {"tool_id": "__MERGE_COLLECTION__", "tool_version": "1.0.0", "outputs": [{"type": "input", "name": "output"}], "workflow_outputs": [], "input_connections": {"inputs_0|input": {"output_name": "output", "id": 16}, "inputs_1|input": {"output_name": "output", "id": 17}}, "tool_state": "{\"inputs\": \"[{\\\"__index__\\\": 0, \\\"input\\\": {\\\"__class__\\\": \\\"RuntimeValue\\\"}}, {\\\"__index__\\\": 1, \\\"input\\\": {\\\"__class__\\\": \\\"RuntimeValue\\\"}}]\", \"__rerun_remap_job_id__\": null, \"advanced\": \"{\\\"conflict\\\": {\\\"__current_case__\\\": 3, \\\"duplicate_options\\\": \\\"keep_first\\\"}}\", \"__page__\": null}", "id": 20, "uuid": "0a011f4f-2014-4e2e-8f15-46bc6aa823a0", "errors": null, "name": "Merge Collections", "post_job_actions": {"HideDatasetActionoutput": {"output_name": "output", "action_type": "HideDatasetAction", "action_arguments": {}}}, "label": null, "inputs": [], "position": {"top": 1212.609375, "left": 2376.34375}, "annotation": "", "content_id": "__MERGE_COLLECTION__", "type": "tool"}, "21": {"tool_id": "toolshed.g2.bx.psu.edu/repos/devteam/fastqc/fastqc/0.67", "tool_version": "0.67", "outputs": [{"type": "html", "name": "html_file"}, {"type": "txt", "name": "text_file"}], "workflow_outputs": [{"output_name": "html_file", "uuid": "bc201824-7d20-4c9c-aaab-611237f1d68f", "label": null}], "input_connections": {"input_file": {"output_name": "output", "id": 17}}, "tool_state": "{\"__page__\": null, \"contaminants\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\", \"__rerun_remap_job_id__\": null, \"limits\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\", \"input_file\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\"}", "id": 21, "tool_shed_repository": {"owner": "devteam", "changeset_revision": "3a458e268066", "name": "fastqc", "tool_shed": "toolshed.g2.bx.psu.edu"}, "uuid": "45253c70-37a4-4f55-a449-f170407f2ed4", "errors": null, "name": "FastQC", "post_job_actions": {"HideDatasetActiontext_file": {"output_name": "text_file", "action_type": "HideDatasetAction", "action_arguments": {}}}, "label": null, "inputs": [{"name": "contaminants", "description": "runtime parameter for tool FastQC"}, {"name": "limits", "description": "runtime parameter for tool FastQC"}, {"name": "input_file", "description": "runtime parameter for tool FastQC"}], "position": {"top": 1850.453125, "left": 2585.984375}, "annotation": "", "content_id": "toolshed.g2.bx.psu.edu/repos/devteam/fastqc/fastqc/0.67", "type": "tool"}, "22": {"tool_id": "toolshed.g2.bx.psu.edu/repos/rnateam/peakachu/peakachu/0.1.0.2", "tool_version": "0.1.0.2", "outputs": [{"type": "tabular", "name": "peak_tables"}, {"type": "gff", "name": "peak_annotations"}, {"type": "png", "name": "MA_plot"}], "workflow_outputs": [{"output_name": "peak_tables", "uuid": "7c7ac458-a885-4d56-9919-4e4be2e9ed24", "label": null}, {"output_name": "peak_annotations", "uuid": "d26c67e0-a493-4045-a21e-6af8ec2547e5", "label": null}, {"output_name": "MA_plot", "uuid": "4658c80f-2c75-4768-b4a2-4caa04d8422a", "label": null}], "input_connections": {"controlLibs": {"output_name": "output", "id": 16}, "experimentLibs": {"output_name": "output", "id": 17}}, "tool_state": "{\"padj_threshold\": \"\\\"0.05\\\"\", \"paired_end\": \"\\\"true\\\"\", \"sub_features\": \"\\\"\\\"\", \"features\": \"\\\"\\\"\", \"__page__\": null, \"mad_multiplier\": \"\\\"0.0\\\"\", \"fc_cutoff\": \"\\\"2.0\\\"\", \"controlLibs\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\", \"max_insert_size\": \"\\\"200\\\"\", \"pairwise_replicates\": \"\\\"false\\\"\", \"experimentLibs\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\", \"__rerun_remap_job_id__\": null, \"mode\": \"{\\\"__current_case__\\\": 0, \\\"min_block_overlap\\\": \\\"0.5\\\", \\\"min_cluster_expr_frac\\\": \\\"0.01\\\", \\\"min_max_block_expr\\\": \\\"0.1\\\", \\\"mode_selector\\\": \\\"adaptive\\\", \\\"norm_method\\\": {\\\"__current_case__\\\": 0, \\\"norm_method_selector\\\": \\\"deseq\\\"}}\"}", "id": 22, "tool_shed_repository": {"owner": "rnateam", "changeset_revision": "886f5adba83d", "name": "peakachu", "tool_shed": "toolshed.g2.bx.psu.edu"}, "uuid": "a3532c26-f5dc-4b4b-8af2-35084e8c34cb", "errors": null, "name": "PEAKachu", "post_job_actions": {}, "label": null, "inputs": [{"name": "controlLibs", "description": "runtime parameter for tool PEAKachu"}, {"name": "experimentLibs", "description": "runtime parameter for tool PEAKachu"}], "position": {"top": 1205.359375, "left": 3310.875}, "annotation": "", "content_id": "toolshed.g2.bx.psu.edu/repos/rnateam/peakachu/peakachu/0.1.0.2", "type": "tool"}, "23": {"tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/bctools_extract_alignment_ends/bctools_extract_alignment_ends/0.2.2", "tool_version": "0.2.2", "outputs": [{"type": "bed", "name": "alignment_ends"}], "workflow_outputs": [], "input_connections": {"alignments": {"output_name": "output", "id": 17}}, "tool_state": "{\"__page__\": null, \"__rerun_remap_job_id__\": null, \"alignments\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\"}", "id": 23, "tool_shed_repository": {"owner": "iuc", "changeset_revision": "8076141a76a7", "name": "bctools_extract_alignment_ends", "tool_shed": "toolshed.g2.bx.psu.edu"}, "uuid": "c9b71593-6fcd-4dc9-90e0-f5b391aea332", "errors": null, "name": "Extract alignment ends", "post_job_actions": {"HideDatasetActionalignment_ends": {"output_name": "alignment_ends", "action_type": "HideDatasetAction", "action_arguments": {}}}, "label": null, "inputs": [{"name": "alignments", "description": "runtime parameter for tool Extract alignment ends"}], "position": {"top": 1929.953125, "left": 3185.984375}, "annotation": "", "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/bctools_extract_alignment_ends/bctools_extract_alignment_ends/0.2.2", "type": "tool"}, "24": {"tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/bedtools/bedtools_sortbed/2.27.0.0", "tool_version": "2.27.0.0", "outputs": [{"type": "input", "name": "output"}], "workflow_outputs": [], "input_connections": {"input": {"output_name": "alignment_ends", "id": 18}}, "tool_state": "{\"input\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\", \"__rerun_remap_job_id__\": null, \"option\": \"\\\"\\\"\", \"__page__\": null}", "id": 24, "tool_shed_repository": {"owner": "iuc", "changeset_revision": "e19bebe96cd2", "name": "bedtools", "tool_shed": "toolshed.g2.bx.psu.edu"}, "uuid": "d7fa6a5d-b2cf-4e5a-9d26-7fd830e8b493", "errors": null, "name": "SortBED", "post_job_actions": {"HideDatasetActionoutput": {"output_name": "output", "action_type": "HideDatasetAction", "action_arguments": {}}}, "label": null, "inputs": [{"name": "input", "description": "runtime parameter for tool SortBED"}], "position": {"top": 457.125, "left": 2553.65625}, "annotation": "", "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/bedtools/bedtools_sortbed/2.27.0.0", "type": "tool"}, "25": {"tool_id": "__SORTLIST__", "tool_version": "1.0.0", "outputs": [{"type": "input", "name": "output"}], "workflow_outputs": [], "input_connections": {"input": {"output_name": "output", "id": 20}}, "tool_state": "{\"input\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\", \"sort_type\": \"{\\\"__current_case__\\\": 1, \\\"sort_type\\\": \\\"alpha\\\"}\", \"__rerun_remap_job_id__\": null, \"__page__\": null}", "id": 25, "uuid": "8079eb59-d1dc-40fb-9ab2-901d9d080c67", "errors": null, "name": "Sort Collection", "post_job_actions": {"HideDatasetActionoutput": {"output_name": "output", "action_type": "HideDatasetAction", "action_arguments": {}}}, "label": null, "inputs": [{"name": "input", "description": "runtime parameter for tool Sort Collection"}], "position": {"top": 1287.609375, "left": 2697.34375}, "annotation": "", "content_id": "__SORTLIST__", "type": "tool"}, "26": {"tool_id": "toolshed.g2.bx.psu.edu/repos/bgruening/text_processing/tp_awk_tool/1.1.1", "tool_version": "1.1.1", "outputs": [{"type": "input", "name": "outfile"}], "workflow_outputs": [], "input_connections": {"infile": {"output_name": "peak_tables", "id": 22}}, "tool_state": "{\"__page__\": null, \"__rerun_remap_job_id__\": null, \"code\": \"\\\"NR>1{\\\\nif ($3 < $4) {\\\\n   print $1,$3,$4,\\\\\\\"clip_peak_\\\\\\\"NR-1,$9,$5;\\\\n}\\\\nelse {\\\\n   print $1,$4,$3,\\\\\\\"clip_peak_\\\\\\\"NR-1,$9,$5;\\\\n}\\\\n}\\\"\", \"infile\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\"}", "id": 26, "tool_shed_repository": {"owner": "bgruening", "changeset_revision": "a6f147a050a2", "name": "text_processing", "tool_shed": "toolshed.g2.bx.psu.edu"}, "uuid": "fcc68faf-228f-4226-bbf5-ff5048df555e", "errors": null, "name": "Text reformatting", "post_job_actions": {"HideDatasetActionoutfile": {"output_name": "outfile", "action_type": "HideDatasetAction", "action_arguments": {}}, "ChangeDatatypeActionoutfile": {"output_name": "outfile", "action_type": "ChangeDatatypeAction", "action_arguments": {"newtype": "bed"}}}, "label": null, "inputs": [{"name": "infile", "description": "runtime parameter for tool Text reformatting"}], "position": {"top": 1211.984375, "left": 3538.5}, "annotation": "", "content_id": "toolshed.g2.bx.psu.edu/repos/bgruening/text_processing/tp_awk_tool/1.1.1", "type": "tool"}, "27": {"tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/bedtools/bedtools_sortbed/2.27.0.0", "tool_version": "2.27.0.0", "outputs": [{"type": "input", "name": "output"}], "workflow_outputs": [], "input_connections": {"input": {"output_name": "alignment_ends", "id": 23}}, "tool_state": "{\"input\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\", \"__rerun_remap_job_id__\": null, \"option\": \"\\\"\\\"\", \"__page__\": null}", "id": 27, "tool_shed_repository": {"owner": "iuc", "changeset_revision": "e19bebe96cd2", "name": "bedtools", "tool_shed": "toolshed.g2.bx.psu.edu"}, "uuid": "ca43b913-4fb5-4fc9-a9d5-100a2493121b", "errors": null, "name": "SortBED", "post_job_actions": {"HideDatasetActionoutput": {"output_name": "output", "action_type": "HideDatasetAction", "action_arguments": {}}}, "label": null, "inputs": [{"name": "input", "description": "runtime parameter for tool SortBED"}], "position": {"top": 1902.296875, "left": 3481.6875}, "annotation": "", "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/bedtools/bedtools_sortbed/2.27.0.0", "type": "tool"}, "28": {"tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/bedtools/bedtools_genomecoveragebed_bedgraph/2.19.0", "tool_version": "2.19.0", "outputs": [{"type": "bedgraph", "name": "output"}], "workflow_outputs": [], "input_connections": {"input": {"output_name": "output", "id": 24}}, "tool_state": "{\"zero_regions\": \"\\\"false\\\"\", \"__page__\": null, \"scale\": \"\\\"\\\"\", \"__rerun_remap_job_id__\": null, \"split\": \"\\\"false\\\"\", \"input\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\", \"strand\": \"\\\"\\\"\"}", "id": 28, "tool_shed_repository": {"owner": "iuc", "changeset_revision": "b8348686a0b9", "name": "bedtools", "tool_shed": "toolshed.g2.bx.psu.edu"}, "uuid": "35c6aeff-1a74-4dcb-a47d-ec9577e1cd55", "errors": null, "name": "Create a BedGraph of genome coverage", "post_job_actions": {"HideDatasetActionoutput": {"output_name": "output", "action_type": "HideDatasetAction", "action_arguments": {}}}, "label": null, "inputs": [{"name": "input", "description": "runtime parameter for tool Create a BedGraph of genome coverage"}], "position": {"top": 446.015625, "left": 2755.171875}, "annotation": "", "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/bedtools/bedtools_genomecoveragebed_bedgraph/2.19.0", "type": "tool"}, "29": {"tool_id": "toolshed.g2.bx.psu.edu/repos/bgruening/deeptools_multi_bam_summary/deeptools_multi_bam_summary/2.5.7.0", "tool_version": "2.5.7.0", "outputs": [{"type": "deeptools_coverage_matrix", "name": "outFile"}, {"type": "tabular", "name": "outFileRawCounts"}], "workflow_outputs": [], "input_connections": {"multibam_conditional|bamfiles": {"output_name": "output", "id": 25}}, "tool_state": "{\"__page__\": null, \"region\": \"\\\"\\\"\", \"mode\": \"{\\\"__current_case__\\\": 0, \\\"binSize\\\": \\\"1000\\\", \\\"distanceBetweenBins\\\": \\\"0\\\", \\\"modeOpt\\\": \\\"bins\\\"}\", \"multibam_conditional\": \"{\\\"__current_case__\\\": 0, \\\"bamfiles\\\": {\\\"__class__\\\": \\\"RuntimeValue\\\"}, \\\"orderMatters\\\": \\\"No\\\"}\", \"advancedOpt\": \"{\\\"__current_case__\\\": 0, \\\"showAdvancedOpt\\\": \\\"no\\\"}\", \"__rerun_remap_job_id__\": null, \"outRawCounts\": \"\\\"false\\\"\"}", "id": 29, "tool_shed_repository": {"owner": "bgruening", "changeset_revision": "a2c5c5f87dd4", "name": "deeptools_multi_bam_summary", "tool_shed": "toolshed.g2.bx.psu.edu"}, "uuid": "7a11d286-15b8-48ac-877e-8b1ffc91646d", "errors": null, "name": "multiBamSummary", "post_job_actions": {"HideDatasetActionoutFile": {"output_name": "outFile", "action_type": "HideDatasetAction", "action_arguments": {}}, "HideDatasetActionoutFileRawCounts": {"output_name": "outFileRawCounts", "action_type": "HideDatasetAction", "action_arguments": {}}}, "label": null, "inputs": [{"name": "multibam_conditional", "description": "runtime parameter for tool multiBamSummary"}], "position": {"top": 1637.984375, "left": 2794.46875}, "annotation": "", "content_id": "toolshed.g2.bx.psu.edu/repos/bgruening/deeptools_multi_bam_summary/deeptools_multi_bam_summary/2.5.7.0", "type": "tool"}, "30": {"tool_id": "toolshed.g2.bx.psu.edu/repos/bgruening/deeptools_plot_fingerprint/deeptools_plot_fingerprint/2.5.7.0", "tool_version": "2.5.7.0", "outputs": [{"type": "png", "name": "outFileName"}, {"type": "tabular", "name": "outFileRawCounts"}, {"type": "tabular", "name": "outFileQualityMetrics"}], "workflow_outputs": [{"output_name": "outFileName", "uuid": "136a872a-d662-4908-995e-73cf91995c80", "label": null}], "input_connections": {"multibam_conditional|bamfiles": {"output_name": "output", "id": 25}}, "tool_state": "{\"__page__\": null, \"__rerun_remap_job_id__\": null, \"multibam_conditional\": \"{\\\"__current_case__\\\": 0, \\\"bamfiles\\\": {\\\"__class__\\\": \\\"RuntimeValue\\\"}, \\\"orderMatters\\\": \\\"No\\\"}\", \"output\": \"{\\\"__current_case__\\\": 0, \\\"showOutputSettings\\\": \\\"no\\\"}\", \"advancedOpt\": \"{\\\"__current_case__\\\": 1, \\\"binSize\\\": \\\"100\\\", \\\"blackListFileName\\\": {\\\"__class__\\\": \\\"RuntimeValue\\\"}, \\\"centerReads\\\": \\\"false\\\", \\\"doExtendCustom\\\": {\\\"__current_case__\\\": 0, \\\"doExtend\\\": \\\"no\\\"}, \\\"ignoreDuplicates\\\": \\\"false\\\", \\\"maxFragmentLength\\\": \\\"0\\\", \\\"minFragmentLength\\\": \\\"0\\\", \\\"minMappingQuality\\\": \\\"1\\\", \\\"numberOfSamples\\\": \\\"100000\\\", \\\"plotTitle\\\": \\\"\\\", \\\"samFlagExclude\\\": \\\"\\\", \\\"samFlagInclude\\\": \\\"\\\", \\\"showAdvancedOpt\\\": \\\"yes\\\", \\\"skipZeros\\\": \\\"false\\\"}\", \"region\": \"\\\"\\\"\"}", "id": 30, "tool_shed_repository": {"owner": "bgruening", "changeset_revision": "ba5ce5ec93aa", "name": "deeptools_plot_fingerprint", "tool_shed": "toolshed.g2.bx.psu.edu"}, "uuid": "b56ca1bf-65bd-4c3f-87af-3865ca422cec", "errors": null, "name": "plotFingerprint", "post_job_actions": {"HideDatasetActionoutFileQualityMetrics": {"output_name": "outFileQualityMetrics", "action_type": "HideDatasetAction", "action_arguments": {}}, "HideDatasetActionoutFileRawCounts": {"output_name": "outFileRawCounts", "action_type": "HideDatasetAction", "action_arguments": {}}}, "label": null, "inputs": [{"name": "multibam_conditional", "description": "runtime parameter for tool plotFingerprint"}, {"name": "advancedOpt", "description": "runtime parameter for tool plotFingerprint"}], "position": {"top": 1371.9375, "left": 3021.96875}, "annotation": "", "content_id": "toolshed.g2.bx.psu.edu/repos/bgruening/deeptools_plot_fingerprint/deeptools_plot_fingerprint/2.5.7.0", "type": "tool"}, "31": {"tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/bedtools/bedtools_slopbed/2.27.0.0", "tool_version": "2.27.0.0", "outputs": [{"type": "bed", "name": "output"}], "workflow_outputs": [], "input_connections": {"inputA": {"output_name": "outfile", "id": 26}, "genome_file_opts|genome": {"output_name": "output", "id": 2}}, "tool_state": "{\"__page__\": null, \"addition\": \"{\\\"__current_case__\\\": 0, \\\"addition_select\\\": \\\"b\\\", \\\"b\\\": \\\"20\\\"}\", \"__rerun_remap_job_id__\": null, \"genome_file_opts\": \"{\\\"__current_case__\\\": 1, \\\"genome\\\": {\\\"__class__\\\": \\\"RuntimeValue\\\"}, \\\"genome_file_opts_selector\\\": \\\"hist\\\"}\", \"pct\": \"\\\"false\\\"\", \"header\": \"\\\"false\\\"\", \"inputA\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\", \"strand\": \"\\\"false\\\"\"}", "id": 31, "tool_shed_repository": {"owner": "iuc", "changeset_revision": "e19bebe96cd2", "name": "bedtools", "tool_shed": "toolshed.g2.bx.psu.edu"}, "uuid": "809f8eb8-cf0e-4c2c-90c1-b6d47dfa33e2", "errors": null, "name": "SlopBed", "post_job_actions": {"ChangeDatatypeActionoutput": {"output_name": "output", "action_type": "ChangeDatatypeAction", "action_arguments": {"newtype": "bed"}}, "HideDatasetActionoutput": {"output_name": "output", "action_type": "HideDatasetAction", "action_arguments": {}}}, "label": null, "inputs": [{"name": "genome_file_opts", "description": "runtime parameter for tool SlopBed"}, {"name": "inputA", "description": "runtime parameter for tool SlopBed"}], "position": {"top": 1045.53125, "left": 3677.921875}, "annotation": "", "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/bedtools/bedtools_slopbed/2.27.0.0", "type": "tool"}, "32": {"tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/bedtools/bedtools_genomecoveragebed_bedgraph/2.19.0", "tool_version": "2.19.0", "outputs": [{"type": "bedgraph", "name": "output"}], "workflow_outputs": [], "input_connections": {"input": {"output_name": "output", "id": 27}}, "tool_state": "{\"zero_regions\": \"\\\"false\\\"\", \"__page__\": null, \"scale\": \"\\\"\\\"\", \"__rerun_remap_job_id__\": null, \"split\": \"\\\"false\\\"\", \"input\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\", \"strand\": \"\\\"\\\"\"}", "id": 32, "tool_shed_repository": {"owner": "iuc", "changeset_revision": "b8348686a0b9", "name": "bedtools", "tool_shed": "toolshed.g2.bx.psu.edu"}, "uuid": "f9928bb4-737a-4fe0-b4b1-6a5f7c305aac", "errors": null, "name": "Create a BedGraph of genome coverage", "post_job_actions": {"HideDatasetActionoutput": {"output_name": "output", "action_type": "HideDatasetAction", "action_arguments": {}}}, "label": null, "inputs": [{"name": "input", "description": "runtime parameter for tool Create a BedGraph of genome coverage"}], "position": {"top": 1881.4375, "left": 3760}, "annotation": "", "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/bedtools/bedtools_genomecoveragebed_bedgraph/2.19.0", "type": "tool"}, "33": {"tool_id": "wig_to_bigWig", "tool_version": "1.1.1", "outputs": [{"type": "bigwig", "name": "out_file1"}], "workflow_outputs": [], "input_connections": {"input1": {"output_name": "output", "id": 28}}, "tool_state": "{\"__page__\": null, \"__rerun_remap_job_id__\": null, \"input1\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\", \"settings\": \"{\\\"__current_case__\\\": 0, \\\"settingsType\\\": \\\"preset\\\"}\"}", "id": 33, "uuid": "b3c594b9-b83e-4990-a4d4-2f1bbc2ddbec", "errors": null, "name": "Wig/BedGraph-to-bigWig", "post_job_actions": {"HideDatasetActionout_file1": {"output_name": "out_file1", "action_type": "HideDatasetAction", "action_arguments": {}}}, "label": null, "inputs": [{"name": "input1", "description": "runtime parameter for tool Wig/BedGraph-to-bigWig"}], "position": {"top": 466.859375, "left": 3051.3125}, "annotation": "", "content_id": "wig_to_bigWig", "type": "tool"}, "34": {"tool_id": "toolshed.g2.bx.psu.edu/repos/bgruening/deeptools_plot_correlation/deeptools_plot_correlation/2.5.7.0", "tool_version": "2.5.7.0", "outputs": [{"type": "png", "name": "outFileName"}, {"type": "tabular", "name": "matrix"}], "workflow_outputs": [{"output_name": "outFileName", "uuid": "7ca293a1-c55d-4778-92ae-50b0fdfc4d5f", "label": null}], "input_connections": {"corData": {"output_name": "outFile", "id": 29}}, "tool_state": "{\"__page__\": null, \"removeOutliers\": \"\\\"false\\\"\", \"outFileFormat\": \"\\\"png\\\"\", \"__rerun_remap_job_id__\": null, \"corMethod\": \"\\\"spearman\\\"\", \"skipZeros\": \"\\\"true\\\"\", \"plotting_type\": \"{\\\"__current_case__\\\": 0, \\\"colorMap\\\": [\\\"RdYlBu\\\"], \\\"plotHeight\\\": \\\"9.5\\\", \\\"plotNumbers\\\": \\\"false\\\", \\\"plotTitle\\\": \\\"\\\", \\\"plotWidth\\\": \\\"11.0\\\", \\\"whatToPlot\\\": \\\"heatmap\\\", \\\"zMax\\\": \\\"\\\", \\\"zMin\\\": \\\"\\\"}\", \"corData\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\", \"outFileCorMatrix\": \"\\\"false\\\"\"}", "id": 34, "tool_shed_repository": {"owner": "bgruening", "changeset_revision": "a165d1e95d7d", "name": "deeptools_plot_correlation", "tool_shed": "toolshed.g2.bx.psu.edu"}, "uuid": "89870514-b435-4c27-84b7-f62cca48cb74", "errors": null, "name": "plotCorrelation", "post_job_actions": {"HideDatasetActionmatrix": {"output_name": "matrix", "action_type": "HideDatasetAction", "action_arguments": {}}}, "label": null, "inputs": [{"name": "corData", "description": "runtime parameter for tool plotCorrelation"}], "position": {"top": 1641.9375, "left": 3114.96875}, "annotation": "", "content_id": "toolshed.g2.bx.psu.edu/repos/bgruening/deeptools_plot_correlation/deeptools_plot_correlation/2.5.7.0", "type": "tool"}, "35": {"tool_id": "toolshed.g2.bx.psu.edu/repos/bgruening/text_processing/tp_awk_tool/1.1.1", "tool_version": "1.1.1", "outputs": [{"type": "input", "name": "outfile"}], "workflow_outputs": [], "input_connections": {"infile": {"output_name": "output", "id": 31}}, "tool_state": "{\"__page__\": null, \"__rerun_remap_job_id__\": null, \"code\": \"\\\"{print $0}\\\"\", \"infile\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\"}", "id": 35, "tool_shed_repository": {"owner": "bgruening", "changeset_revision": "a6f147a050a2", "name": "text_processing", "tool_shed": "toolshed.g2.bx.psu.edu"}, "uuid": "d3001faf-3df4-4ba8-bb65-874cd8c82038", "errors": null, "name": "Text reformatting", "post_job_actions": {"HideDatasetActionoutfile": {"output_name": "outfile", "action_type": "HideDatasetAction", "action_arguments": {}}, "ChangeDatatypeActionoutfile": {"output_name": "outfile", "action_type": "ChangeDatatypeAction", "action_arguments": {"newtype": "bed"}}}, "label": null, "inputs": [{"name": "infile", "description": "runtime parameter for tool Text reformatting"}], "position": {"top": 206.53125, "left": 3742.4375}, "annotation": "", "content_id": "toolshed.g2.bx.psu.edu/repos/bgruening/text_processing/tp_awk_tool/1.1.1", "type": "tool"}, "36": {"tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/extract_genomic_dna/Extract genomic DNA 1/3.0.0", "tool_version": "3.0.0", "outputs": [{"type": "gff", "name": "output"}], "workflow_outputs": [], "input_connections": {"input": {"output_name": "output", "id": 31}}, "tool_state": "{\"__page__\": null, \"interpret_features\": \"\\\"yes\\\"\", \"output_format\": \"\\\"fasta\\\"\", \"reference_genome_cond\": \"{\\\"__current_case__\\\": 0, \\\"reference_genome\\\": \\\"hg38\\\", \\\"reference_genome_source\\\": \\\"cached\\\"}\", \"input\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\", \"__rerun_remap_job_id__\": null}", "id": 36, "tool_shed_repository": {"owner": "iuc", "changeset_revision": "8dd8e89c0603", "name": "extract_genomic_dna", "tool_shed": "toolshed.g2.bx.psu.edu"}, "uuid": "fe61aa32-4ada-47bb-9595-0745f4da75de", "errors": null, "name": "Extract Genomic DNA", "post_job_actions": {"ChangeDatatypeActionoutput": {"output_name": "output", "action_type": "ChangeDatatypeAction", "action_arguments": {"newtype": "fasta"}}, "HideDatasetActionoutput": {"output_name": "output", "action_type": "HideDatasetAction", "action_arguments": {}}}, "label": null, "inputs": [{"name": "input", "description": "runtime parameter for tool Extract Genomic DNA"}], "position": {"top": 1043.53125, "left": 3924.4375}, "annotation": "", "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/extract_genomic_dna/Extract genomic DNA 1/3.0.0", "type": "tool"}, "37": {"tool_id": "wig_to_bigWig", "tool_version": "1.1.1", "outputs": [{"type": "bigwig", "name": "out_file1"}], "workflow_outputs": [], "input_connections": {"input1": {"output_name": "output", "id": 32}}, "tool_state": "{\"__page__\": null, \"__rerun_remap_job_id__\": null, \"input1\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\", \"settings\": \"{\\\"__current_case__\\\": 0, \\\"settingsType\\\": \\\"preset\\\"}\"}", "id": 37, "uuid": "155b7227-de37-466b-8265-8ad016ab4b60", "errors": null, "name": "Wig/BedGraph-to-bigWig", "post_job_actions": {"HideDatasetActionout_file1": {"output_name": "out_file1", "action_type": "HideDatasetAction", "action_arguments": {}}}, "label": null, "inputs": [{"name": "input1", "description": "runtime parameter for tool Wig/BedGraph-to-bigWig"}], "position": {"top": 1901.453125, "left": 4063.515625}, "annotation": "", "content_id": "wig_to_bigWig", "type": "tool"}, "38": {"tool_id": "toolshed.g2.bx.psu.edu/repos/rnateam/rcas/rcas/1.5.4", "tool_version": "1.5.4", "outputs": [{"type": "html", "name": "report"}, {"type": "tsv", "name": "summarizeQueryRegions"}, {"type": "tsv", "name": "query_gene_types"}, {"type": "tsv", "name": "transcriptBoundaryCoverage.fiveprime"}, {"type": "tsv", "name": "transcriptBoundaryCoverage.threeprime"}, {"type": "tsv", "name": "exonIntronBoundaryCoverage.fiveprime"}, {"type": "tsv", "name": "exonIntronBoundaryCoverage.threeprime"}, {"type": "tsv", "name": "coverageprofilelist"}, {"type": "tsv", "name": "getTargetedGenesTable"}, {"type": "tsv", "name": "goCC"}, {"type": "tsv", "name": "goBP"}, {"type": "tsv", "name": "goMF"}, {"type": "tsv", "name": "GSEA"}, {"type": "html", "name": "multi_report"}], "workflow_outputs": [{"output_name": "report", "uuid": "52630a89-59cf-4d0d-b9b0-ee901433a3fc", "label": null}], "input_connections": {"input_gtf_file": {"output_name": "output", "id": 3}, "analysis_type|single_bed_file": {"output_name": "outfile", "id": 35}}, "tool_state": "{\"__page__\": null, \"run_annot\": \"\\\"true\\\"\", \"__rerun_remap_job_id__\": null, \"input_gtf_file\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\", \"run_motif\": \"\\\"false\\\"\", \"genome_version\": \"\\\"hg38\\\"\", \"analysis_type\": \"{\\\"__current_case__\\\": 0, \\\"analysis_type_selector\\\": \\\"single_set_analysis\\\", \\\"downsampling\\\": \\\"0\\\", \\\"gsea_set\\\": {\\\"__current_case__\\\": 0, \\\"run_gsea\\\": \\\"false\\\"}, \\\"output_raw_tables\\\": \\\"true\\\", \\\"run_go\\\": \\\"true\\\", \\\"single_bed_file\\\": {\\\"__class__\\\": \\\"RuntimeValue\\\"}}\"}", "id": 38, "tool_shed_repository": {"owner": "rnateam", "changeset_revision": "7c7a2a381dfe", "name": "rcas", "tool_shed": "toolshed.g2.bx.psu.edu"}, "uuid": "70579628-4754-48f2-b85d-2f4969e226de", "errors": null, "name": "RCAS", "post_job_actions": {"HideDatasetActiontranscriptBoundaryCoverage.threeprime": {"output_name": "transcriptBoundaryCoverage.threeprime", "action_type": "HideDatasetAction", "action_arguments": {}}, "HideDatasetActiongoBP": {"output_name": "goBP", "action_type": "HideDatasetAction", "action_arguments": {}}, "HideDatasetActionsummarizeQueryRegions": {"output_name": "summarizeQueryRegions", "action_type": "HideDatasetAction", "action_arguments": {}}, "HideDatasetActionGSEA": {"output_name": "GSEA", "action_type": "HideDatasetAction", "action_arguments": {}}, "HideDatasetActiongetTargetedGenesTable": {"output_name": "getTargetedGenesTable", "action_type": "HideDatasetAction", "action_arguments": {}}, "HideDatasetActiongoCC": {"output_name": "goCC", "action_type": "HideDatasetAction", "action_arguments": {}}, "HideDatasetActionmulti_report": {"output_name": "multi_report", "action_type": "HideDatasetAction", "action_arguments": {}}, "HideDatasetActionexonIntronBoundaryCoverage.fiveprime": {"output_name": "exonIntronBoundaryCoverage.fiveprime", "action_type": "HideDatasetAction", "action_arguments": {}}, "HideDatasetActiontranscriptBoundaryCoverage.fiveprime": {"output_name": "transcriptBoundaryCoverage.fiveprime", "action_type": "HideDatasetAction", "action_arguments": {}}, "HideDatasetActiongoMF": {"output_name": "goMF", "action_type": "HideDatasetAction", "action_arguments": {}}, "HideDatasetActionquery_gene_types": {"output_name": "query_gene_types", "action_type": "HideDatasetAction", "action_arguments": {}}, "HideDatasetActionexonIntronBoundaryCoverage.threeprime": {"output_name": "exonIntronBoundaryCoverage.threeprime", "action_type": "HideDatasetAction", "action_arguments": {}}, "HideDatasetActioncoverageprofilelist": {"output_name": "coverageprofilelist", "action_type": "HideDatasetAction", "action_arguments": {}}}, "label": null, "inputs": [{"name": "analysis_type", "description": "runtime parameter for tool RCAS"}, {"name": "input_gtf_file", "description": "runtime parameter for tool RCAS"}], "position": {"top": 200, "left": 3972.03125}, "annotation": "", "content_id": "toolshed.g2.bx.psu.edu/repos/rnateam/rcas/rcas/1.5.4", "type": "tool"}, "39": {"tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/meme_chip/meme_chip/4.11.2", "tool_version": "4.11.2", "outputs": [{"type": "html", "name": "output"}], "workflow_outputs": [{"output_name": "output", "uuid": "40ccb74c-6f03-41c4-a93b-26bc548b08e1", "label": null}], "input_connections": {"input": {"output_name": "output", "id": 36}}, "tool_state": "{\"control\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\", \"__page__\": null, \"sequence_alphabet\": \"\\\"-dna\\\"\", \"__rerun_remap_job_id__\": null, \"non_commercial_use\": \"\\\"true\\\"\", \"input\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\", \"options_type_cond\": \"{\\\"__current_case__\\\": 1, \\\"background_model_order\\\": \\\"1\\\", \\\"ccut\\\": \\\"0\\\", \\\"dreme_e\\\": \\\"0.05\\\", \\\"dreme_m\\\": \\\"5\\\", \\\"filter_thresh\\\": \\\"0.05\\\", \\\"group_threash\\\": \\\"0.05\\\", \\\"group_weak\\\": \\\"0.0\\\", \\\"meme_maxsites\\\": \\\"0\\\", \\\"meme_maxw\\\": \\\"20\\\", \\\"meme_minsites\\\": \\\"0\\\", \\\"meme_minw\\\": \\\"5\\\", \\\"meme_mod\\\": \\\"zoops\\\", \\\"meme_nmotifs\\\": \\\"20\\\", \\\"meme_pal\\\": \\\"false\\\", \\\"nmeme\\\": \\\"100\\\", \\\"old_clustering\\\": \\\"false\\\", \\\"options_type\\\": \\\"advanced\\\", \\\"search_given_strand\\\": \\\"true\\\", \\\"subsampling_cond\\\": {\\\"__current_case__\\\": 0, \\\"seed\\\": \\\"123\\\", \\\"subsampling\\\": \\\"yes\\\"}}\"}", "id": 39, "tool_shed_repository": {"owner": "iuc", "changeset_revision": "6095db402811", "name": "meme_chip", "tool_shed": "toolshed.g2.bx.psu.edu"}, "uuid": "be9c97a4-9ba8-478d-858f-f98e36695343", "errors": null, "name": "MEME-ChIP", "post_job_actions": {}, "label": null, "inputs": [{"name": "control", "description": "runtime parameter for tool MEME-ChIP"}, {"name": "input", "description": "runtime parameter for tool MEME-ChIP"}], "position": {"top": 1035.984375, "left": 4176.921875}, "annotation": "", "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/meme_chip/meme_chip/4.11.2", "type": "tool"}}, "annotation": "", "a_galaxy_workflow": "true"}
+{
+  "a_galaxy_workflow": "true",
+  "annotation": "",
+  "format-version": "0.1",
+  "name": "Tutorial_1_CLIPseq-Explorer_demultiplexed_PEAKachu_eCLIP_hg38_N5",
+  "steps": {
+    "0": {
+      "annotation": "",
+      "content_id": null,
+      "errors": null,
+      "id": 0,
+      "input_connections": {},
+      "inputs": [],
+      "label": "Background",
+      "name": "Input dataset collection",
+      "outputs": [],
+      "position": {
+        "left": 256.921875,
+        "top": 402.75
+      },
+      "tool_id": null,
+      "tool_state": "{\"collection_type\": \"list:paired\"}",
+      "tool_version": null,
+      "type": "data_collection_input",
+      "uuid": "df3c15f5-99c5-47de-a3de-c0f6149ee2d7",
+      "workflow_outputs": [
+        {
+          "label": null,
+          "output_name": "output",
+          "uuid": "9c4c342d-c349-4e47-a3dc-4c0af26d5bd1"
+        }
+      ]
+    },
+    "1": {
+      "annotation": "",
+      "content_id": null,
+      "errors": null,
+      "id": 1,
+      "input_connections": {},
+      "inputs": [
+        {
+          "description": "",
+          "name": "Input Dataset Collection"
+        }
+      ],
+      "label": "Paired-end reads collection",
+      "name": "Input dataset collection",
+      "outputs": [],
+      "position": {
+        "left": 200,
+        "top": 1190.84375
+      },
+      "tool_id": null,
+      "tool_state": "{\"collection_type\": \"list:paired\", \"name\": \"Input Dataset Collection\"}",
+      "tool_version": null,
+      "type": "data_collection_input",
+      "uuid": "3f9e968c-b7c5-4630-8108-b31d348b0587",
+      "workflow_outputs": [
+        {
+          "label": null,
+          "output_name": "output",
+          "uuid": "f641b9f9-e780-44fd-9223-c6177274d7ad"
+        }
+      ]
+    },
+    "10": {
+      "annotation": "",
+      "content_id": "toolshed.g2.bx.psu.edu/repos/lparsons/cutadapt/cutadapt/1.6",
+      "errors": null,
+      "id": 10,
+      "input_connections": {
+        "input": {
+          "id": 8,
+          "output_name": "paired_output"
+        },
+        "paired_end|input2": {
+          "id": 8,
+          "output_name": "output"
+        }
+      },
+      "inputs": [
+        {
+          "description": "runtime parameter for tool Cutadapt",
+          "name": "paired_end"
+        },
+        {
+          "description": "runtime parameter for tool Cutadapt",
+          "name": "input"
+        }
+      ],
+      "label": null,
+      "name": "Cutadapt",
+      "outputs": [
+        {
+          "name": "report",
+          "type": "txt"
+        },
+        {
+          "name": "output",
+          "type": "input"
+        },
+        {
+          "name": "paired_output",
+          "type": "input"
+        },
+        {
+          "name": "rest_output",
+          "type": "input"
+        },
+        {
+          "name": "wild_output",
+          "type": "input"
+        },
+        {
+          "name": "too_short_output",
+          "type": "input"
+        },
+        {
+          "name": "too_long_output",
+          "type": "input"
+        },
+        {
+          "name": "untrimmed_output",
+          "type": "input"
+        },
+        {
+          "name": "untrimmed_paired_output",
+          "type": "input"
+        },
+        {
+          "name": "info_file",
+          "type": "input"
+        }
+      ],
+      "position": {
+        "left": 955.484375,
+        "top": 413.453125
+      },
+      "post_job_actions": {
+        "HideDatasetActioninfo_file": {
+          "action_arguments": {},
+          "action_type": "HideDatasetAction",
+          "output_name": "info_file"
+        },
+        "HideDatasetActionoutput": {
+          "action_arguments": {},
+          "action_type": "HideDatasetAction",
+          "output_name": "output"
+        },
+        "HideDatasetActionpaired_output": {
+          "action_arguments": {},
+          "action_type": "HideDatasetAction",
+          "output_name": "paired_output"
+        },
+        "HideDatasetActionreport": {
+          "action_arguments": {},
+          "action_type": "HideDatasetAction",
+          "output_name": "report"
+        },
+        "HideDatasetActionrest_output": {
+          "action_arguments": {},
+          "action_type": "HideDatasetAction",
+          "output_name": "rest_output"
+        },
+        "HideDatasetActiontoo_long_output": {
+          "action_arguments": {},
+          "action_type": "HideDatasetAction",
+          "output_name": "too_long_output"
+        },
+        "HideDatasetActiontoo_short_output": {
+          "action_arguments": {},
+          "action_type": "HideDatasetAction",
+          "output_name": "too_short_output"
+        },
+        "HideDatasetActionuntrimmed_output": {
+          "action_arguments": {},
+          "action_type": "HideDatasetAction",
+          "output_name": "untrimmed_output"
+        },
+        "HideDatasetActionuntrimmed_paired_output": {
+          "action_arguments": {},
+          "action_type": "HideDatasetAction",
+          "output_name": "untrimmed_paired_output"
+        },
+        "HideDatasetActionwild_output": {
+          "action_arguments": {},
+          "action_type": "HideDatasetAction",
+          "output_name": "wild_output"
+        }
+      },
+      "tool_id": "toolshed.g2.bx.psu.edu/repos/lparsons/cutadapt/cutadapt/1.6",
+      "tool_shed_repository": {
+        "changeset_revision": "01d94df2e32a",
+        "name": "cutadapt",
+        "owner": "lparsons",
+        "tool_shed": "toolshed.g2.bx.psu.edu"
+      },
+      "tool_state": "{\"count\": \"\\\"1\\\"\", \"error_rate\": \"\\\"0.1\\\"\", \"match_read_wildcards\": \"\\\"false\\\"\", \"paired_end\": \"{\\\"__current_case__\\\": 0, \\\"input2\\\": {\\\"__class__\\\": \\\"RuntimeValue\\\"}, \\\"paired_end_boolean\\\": \\\"true\\\"}\", \"__page__\": null, \"output_params\": \"{\\\"__current_case__\\\": 0, \\\"output_type\\\": \\\"default\\\"}\", \"__rerun_remap_job_id__\": null, \"overlap\": \"\\\"5\\\"\", \"front_adapters\": \"[{\\\"__index__\\\": 0, \\\"front_adapter_source\\\": {\\\"__current_case__\\\": 0, \\\"front_adapter\\\": \\\"CTTCCGATCTACAAGTT\\\", \\\"front_adapter_name\\\": \\\"\\\", \\\"front_adapter_source_list\\\": \\\"user\\\"}}, {\\\"__index__\\\": 1, \\\"front_adapter_source\\\": {\\\"__current_case__\\\": 0, \\\"front_adapter\\\": \\\"CTTCCGATCTTGGTCCT\\\", \\\"front_adapter_name\\\": \\\"\\\", \\\"front_adapter_source_list\\\": \\\"user\\\"}}]\", \"input\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\", \"no_indels\": \"\\\"false\\\"\", \"anywhere_adapters\": \"[]\", \"adapters\": \"[{\\\"__index__\\\": 0, \\\"adapter_source\\\": {\\\"__current_case__\\\": 0, \\\"adapter\\\": \\\"AACTTGTAGATCGGA\\\", \\\"adapter_name\\\": \\\"\\\", \\\"adapter_source_list\\\": \\\"user\\\"}}, {\\\"__index__\\\": 1, \\\"adapter_source\\\": {\\\"__current_case__\\\": 0, \\\"adapter\\\": \\\"AGGACCAAGATCGGA\\\", \\\"adapter_name\\\": \\\"\\\", \\\"adapter_source_list\\\": \\\"user\\\"}}]\", \"read_modification_params\": \"{\\\"__current_case__\\\": 0, \\\"read_modification\\\": \\\"none\\\"}\", \"output_filtering_options\": \"{\\\"__current_case__\\\": 1, \\\"discard\\\": \\\"false\\\", \\\"discard_untrimmed\\\": \\\"false\\\", \\\"mask_adapter\\\": \\\"false\\\", \\\"max\\\": \\\"0\\\", \\\"min\\\": \\\"10\\\", \\\"no_trim\\\": \\\"false\\\", \\\"output_filtering\\\": \\\"filter\\\"}\"}",
+      "tool_version": "1.6",
+      "type": "tool",
+      "uuid": "20521c9a-2d3d-4b43-b9fb-53a69716dc15",
+      "workflow_outputs": []
+    },
+    "11": {
+      "annotation": "",
+      "content_id": "toolshed.g2.bx.psu.edu/repos/lparsons/cutadapt/cutadapt/1.6",
+      "errors": null,
+      "id": 11,
+      "input_connections": {
+        "input": {
+          "id": 9,
+          "output_name": "paired_output"
+        },
+        "paired_end|input2": {
+          "id": 9,
+          "output_name": "output"
+        }
+      },
+      "inputs": [
+        {
+          "description": "runtime parameter for tool Cutadapt",
+          "name": "paired_end"
+        },
+        {
+          "description": "runtime parameter for tool Cutadapt",
+          "name": "input"
+        }
+      ],
+      "label": null,
+      "name": "Cutadapt",
+      "outputs": [
+        {
+          "name": "report",
+          "type": "txt"
+        },
+        {
+          "name": "output",
+          "type": "input"
+        },
+        {
+          "name": "paired_output",
+          "type": "input"
+        },
+        {
+          "name": "rest_output",
+          "type": "input"
+        },
+        {
+          "name": "wild_output",
+          "type": "input"
+        },
+        {
+          "name": "too_short_output",
+          "type": "input"
+        },
+        {
+          "name": "too_long_output",
+          "type": "input"
+        },
+        {
+          "name": "untrimmed_output",
+          "type": "input"
+        },
+        {
+          "name": "untrimmed_paired_output",
+          "type": "input"
+        },
+        {
+          "name": "info_file",
+          "type": "input"
+        }
+      ],
+      "position": {
+        "left": 947.4375,
+        "top": 1203.5
+      },
+      "post_job_actions": {
+        "HideDatasetActioninfo_file": {
+          "action_arguments": {},
+          "action_type": "HideDatasetAction",
+          "output_name": "info_file"
+        },
+        "HideDatasetActionoutput": {
+          "action_arguments": {},
+          "action_type": "HideDatasetAction",
+          "output_name": "output"
+        },
+        "HideDatasetActionpaired_output": {
+          "action_arguments": {},
+          "action_type": "HideDatasetAction",
+          "output_name": "paired_output"
+        },
+        "HideDatasetActionreport": {
+          "action_arguments": {},
+          "action_type": "HideDatasetAction",
+          "output_name": "report"
+        },
+        "HideDatasetActionrest_output": {
+          "action_arguments": {},
+          "action_type": "HideDatasetAction",
+          "output_name": "rest_output"
+        },
+        "HideDatasetActiontoo_long_output": {
+          "action_arguments": {},
+          "action_type": "HideDatasetAction",
+          "output_name": "too_long_output"
+        },
+        "HideDatasetActiontoo_short_output": {
+          "action_arguments": {},
+          "action_type": "HideDatasetAction",
+          "output_name": "too_short_output"
+        },
+        "HideDatasetActionuntrimmed_output": {
+          "action_arguments": {},
+          "action_type": "HideDatasetAction",
+          "output_name": "untrimmed_output"
+        },
+        "HideDatasetActionuntrimmed_paired_output": {
+          "action_arguments": {},
+          "action_type": "HideDatasetAction",
+          "output_name": "untrimmed_paired_output"
+        },
+        "HideDatasetActionwild_output": {
+          "action_arguments": {},
+          "action_type": "HideDatasetAction",
+          "output_name": "wild_output"
+        }
+      },
+      "tool_id": "toolshed.g2.bx.psu.edu/repos/lparsons/cutadapt/cutadapt/1.6",
+      "tool_shed_repository": {
+        "changeset_revision": "01d94df2e32a",
+        "name": "cutadapt",
+        "owner": "lparsons",
+        "tool_shed": "toolshed.g2.bx.psu.edu"
+      },
+      "tool_state": "{\"count\": \"\\\"1\\\"\", \"error_rate\": \"\\\"0.1\\\"\", \"match_read_wildcards\": \"\\\"false\\\"\", \"paired_end\": \"{\\\"__current_case__\\\": 0, \\\"input2\\\": {\\\"__class__\\\": \\\"RuntimeValue\\\"}, \\\"paired_end_boolean\\\": \\\"true\\\"}\", \"__page__\": null, \"output_params\": \"{\\\"__current_case__\\\": 0, \\\"output_type\\\": \\\"default\\\"}\", \"__rerun_remap_job_id__\": null, \"overlap\": \"\\\"5\\\"\", \"front_adapters\": \"[{\\\"__index__\\\": 0, \\\"front_adapter_source\\\": {\\\"__current_case__\\\": 0, \\\"front_adapter\\\": \\\"CTTCCGATCTACAAGTT\\\", \\\"front_adapter_name\\\": \\\"\\\", \\\"front_adapter_source_list\\\": \\\"user\\\"}}, {\\\"__index__\\\": 1, \\\"front_adapter_source\\\": {\\\"__current_case__\\\": 0, \\\"front_adapter\\\": \\\"CTTCCGATCTTGGTCCT\\\", \\\"front_adapter_name\\\": \\\"\\\", \\\"front_adapter_source_list\\\": \\\"user\\\"}}]\", \"input\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\", \"no_indels\": \"\\\"false\\\"\", \"anywhere_adapters\": \"[]\", \"adapters\": \"[{\\\"__index__\\\": 0, \\\"adapter_source\\\": {\\\"__current_case__\\\": 0, \\\"adapter\\\": \\\"AACTTGTAGATCGGA\\\", \\\"adapter_name\\\": \\\"\\\", \\\"adapter_source_list\\\": \\\"user\\\"}}, {\\\"__index__\\\": 1, \\\"adapter_source\\\": {\\\"__current_case__\\\": 0, \\\"adapter\\\": \\\"AGGACCAAGATCGGA\\\", \\\"adapter_name\\\": \\\"\\\", \\\"adapter_source_list\\\": \\\"user\\\"}}]\", \"read_modification_params\": \"{\\\"__current_case__\\\": 0, \\\"read_modification\\\": \\\"none\\\"}\", \"output_filtering_options\": \"{\\\"__current_case__\\\": 1, \\\"discard\\\": \\\"false\\\", \\\"discard_untrimmed\\\": \\\"false\\\", \\\"mask_adapter\\\": \\\"false\\\", \\\"max\\\": \\\"0\\\", \\\"min\\\": \\\"10\\\", \\\"no_trim\\\": \\\"false\\\", \\\"output_filtering\\\": \\\"filter\\\"}\"}",
+      "tool_version": "1.6",
+      "type": "tool",
+      "uuid": "b72bd8da-b2c9-49fb-a263-567afb5b876e",
+      "workflow_outputs": []
+    },
+    "12": {
+      "annotation": "",
+      "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/umi_tools_extract/umi_tools_extract/0.5.3.2",
+      "errors": null,
+      "id": 12,
+      "input_connections": {
+        "input_type|input_read1": {
+          "id": 10,
+          "output_name": "output"
+        },
+        "input_type|input_read2": {
+          "id": 10,
+          "output_name": "paired_output"
+        }
+      },
+      "inputs": [
+        {
+          "description": "runtime parameter for tool UMI-tools extract",
+          "name": "input_type"
+        },
+        {
+          "description": "runtime parameter for tool UMI-tools extract",
+          "name": "input_type"
+        }
+      ],
+      "label": null,
+      "name": "UMI-tools extract",
+      "outputs": [
+        {
+          "name": "out",
+          "type": "input"
+        },
+        {
+          "name": "out1",
+          "type": "input"
+        },
+        {
+          "name": "out2",
+          "type": "input"
+        },
+        {
+          "name": "out_log",
+          "type": "txt"
+        }
+      ],
+      "position": {
+        "left": 1214.4375,
+        "top": 419.5
+      },
+      "post_job_actions": {
+        "HideDatasetActionout": {
+          "action_arguments": {},
+          "action_type": "HideDatasetAction",
+          "output_name": "out"
+        },
+        "HideDatasetActionout1": {
+          "action_arguments": {},
+          "action_type": "HideDatasetAction",
+          "output_name": "out1"
+        },
+        "HideDatasetActionout2": {
+          "action_arguments": {},
+          "action_type": "HideDatasetAction",
+          "output_name": "out2"
+        },
+        "HideDatasetActionout_log": {
+          "action_arguments": {},
+          "action_type": "HideDatasetAction",
+          "output_name": "out_log"
+        }
+      },
+      "tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/umi_tools_extract/umi_tools_extract/0.5.3.2",
+      "tool_shed_repository": {
+        "changeset_revision": "828dba98cdb4",
+        "name": "umi_tools_extract",
+        "owner": "iuc",
+        "tool_shed": "toolshed.g2.bx.psu.edu"
+      },
+      "tool_state": "{\"__page__\": null, \"extract_method\": \"\\\"string\\\"\", \"input_type\": \"{\\\"__current_case__\\\": 1, \\\"barcode\\\": {\\\"__current_case__\\\": 0, \\\"barcode_select\\\": \\\"first_read_only\\\"}, \\\"input_read1\\\": {\\\"__class__\\\": \\\"RuntimeValue\\\"}, \\\"input_read2\\\": {\\\"__class__\\\": \\\"RuntimeValue\\\"}, \\\"type\\\": \\\"paired\\\"}\", \"__rerun_remap_job_id__\": null, \"bc_pattern\": \"\\\"NNNNN\\\"\", \"print_log\": \"\\\"true\\\"\", \"prime3\": \"\\\"true\\\"\", \"quality\": \"{\\\"__current_case__\\\": 0, \\\"quality_selector\\\": \\\"false\\\"}\", \"barcodes\": \"{\\\"__current_case__\\\": 0, \\\"use_barcodes\\\": \\\"no\\\"}\"}",
+      "tool_version": "0.5.3.2",
+      "type": "tool",
+      "uuid": "9f1ac00b-1c4b-4f2a-b7b6-3ef0bfa6b38c",
+      "workflow_outputs": []
+    },
+    "13": {
+      "annotation": "",
+      "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/umi_tools_extract/umi_tools_extract/0.5.3.2",
+      "errors": null,
+      "id": 13,
+      "input_connections": {
+        "input_type|input_read1": {
+          "id": 11,
+          "output_name": "output"
+        },
+        "input_type|input_read2": {
+          "id": 11,
+          "output_name": "paired_output"
+        }
+      },
+      "inputs": [
+        {
+          "description": "runtime parameter for tool UMI-tools extract",
+          "name": "input_type"
+        },
+        {
+          "description": "runtime parameter for tool UMI-tools extract",
+          "name": "input_type"
+        }
+      ],
+      "label": null,
+      "name": "UMI-tools extract",
+      "outputs": [
+        {
+          "name": "out",
+          "type": "input"
+        },
+        {
+          "name": "out1",
+          "type": "input"
+        },
+        {
+          "name": "out2",
+          "type": "input"
+        },
+        {
+          "name": "out_log",
+          "type": "txt"
+        }
+      ],
+      "position": {
+        "left": 1241.4375,
+        "top": 1202.5
+      },
+      "post_job_actions": {
+        "HideDatasetActionout": {
+          "action_arguments": {},
+          "action_type": "HideDatasetAction",
+          "output_name": "out"
+        },
+        "HideDatasetActionout1": {
+          "action_arguments": {},
+          "action_type": "HideDatasetAction",
+          "output_name": "out1"
+        },
+        "HideDatasetActionout2": {
+          "action_arguments": {},
+          "action_type": "HideDatasetAction",
+          "output_name": "out2"
+        },
+        "HideDatasetActionout_log": {
+          "action_arguments": {},
+          "action_type": "HideDatasetAction",
+          "output_name": "out_log"
+        }
+      },
+      "tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/umi_tools_extract/umi_tools_extract/0.5.3.2",
+      "tool_shed_repository": {
+        "changeset_revision": "828dba98cdb4",
+        "name": "umi_tools_extract",
+        "owner": "iuc",
+        "tool_shed": "toolshed.g2.bx.psu.edu"
+      },
+      "tool_state": "{\"__page__\": null, \"extract_method\": \"\\\"string\\\"\", \"input_type\": \"{\\\"__current_case__\\\": 1, \\\"barcode\\\": {\\\"__current_case__\\\": 0, \\\"barcode_select\\\": \\\"first_read_only\\\"}, \\\"input_read1\\\": {\\\"__class__\\\": \\\"RuntimeValue\\\"}, \\\"input_read2\\\": {\\\"__class__\\\": \\\"RuntimeValue\\\"}, \\\"type\\\": \\\"paired\\\"}\", \"__rerun_remap_job_id__\": null, \"bc_pattern\": \"\\\"NNNNN\\\"\", \"print_log\": \"\\\"true\\\"\", \"prime3\": \"\\\"true\\\"\", \"quality\": \"{\\\"__current_case__\\\": 0, \\\"quality_selector\\\": \\\"false\\\"}\", \"barcodes\": \"{\\\"__current_case__\\\": 0, \\\"use_barcodes\\\": \\\"no\\\"}\"}",
+      "tool_version": "0.5.3.2",
+      "type": "tool",
+      "uuid": "e5040195-08ec-45d3-8910-53f2b72a5b2b",
+      "workflow_outputs": []
+    },
+    "14": {
+      "annotation": "",
+      "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/rgrnastar/rna_star/2.5.2b-2",
+      "errors": null,
+      "id": 14,
+      "input_connections": {
+        "singlePaired|input1": {
+          "id": 12,
+          "output_name": "out1"
+        },
+        "singlePaired|input2": {
+          "id": 12,
+          "output_name": "out2"
+        }
+      },
+      "inputs": [
+        {
+          "description": "runtime parameter for tool RNA STAR",
+          "name": "singlePaired"
+        },
+        {
+          "description": "runtime parameter for tool RNA STAR",
+          "name": "singlePaired"
+        }
+      ],
+      "label": null,
+      "name": "RNA STAR",
+      "outputs": [
+        {
+          "name": "output_log",
+          "type": "txt"
+        },
+        {
+          "name": "chimeric_junctions",
+          "type": "interval"
+        },
+        {
+          "name": "chimeric_reads",
+          "type": "bam"
+        },
+        {
+          "name": "splice_junctions",
+          "type": "interval"
+        },
+        {
+          "name": "mapped_reads",
+          "type": "bam"
+        },
+        {
+          "name": "reads_per_gene",
+          "type": "tabular"
+        }
+      ],
+      "position": {
+        "left": 1916.921875,
+        "top": 588.515625
+      },
+      "post_job_actions": {
+        "HideDatasetActionchimeric_junctions": {
+          "action_arguments": {},
+          "action_type": "HideDatasetAction",
+          "output_name": "chimeric_junctions"
+        },
+        "HideDatasetActionchimeric_reads": {
+          "action_arguments": {},
+          "action_type": "HideDatasetAction",
+          "output_name": "chimeric_reads"
+        },
+        "HideDatasetActionmapped_reads": {
+          "action_arguments": {},
+          "action_type": "HideDatasetAction",
+          "output_name": "mapped_reads"
+        },
+        "HideDatasetActionoutput_log": {
+          "action_arguments": {},
+          "action_type": "HideDatasetAction",
+          "output_name": "output_log"
+        },
+        "HideDatasetActionreads_per_gene": {
+          "action_arguments": {},
+          "action_type": "HideDatasetAction",
+          "output_name": "reads_per_gene"
+        },
+        "HideDatasetActionsplice_junctions": {
+          "action_arguments": {},
+          "action_type": "HideDatasetAction",
+          "output_name": "splice_junctions"
+        }
+      },
+      "tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/rgrnastar/rna_star/2.5.2b-2",
+      "tool_shed_repository": {
+        "changeset_revision": "2055c2667eb3",
+        "name": "rgrnastar",
+        "owner": "iuc",
+        "tool_shed": "toolshed.g2.bx.psu.edu"
+      },
+      "tool_state": "{\"__page__\": null, \"singlePaired\": \"{\\\"__current_case__\\\": 1, \\\"input1\\\": {\\\"__class__\\\": \\\"RuntimeValue\\\"}, \\\"input2\\\": {\\\"__class__\\\": \\\"RuntimeValue\\\"}, \\\"sPaired\\\": \\\"paired\\\"}\", \"output_params\": \"{\\\"__current_case__\\\": 0, \\\"outFilterIntronMotifs\\\": \\\"None\\\", \\\"outSAMattributes\\\": \\\"All\\\", \\\"outSAMstrandField\\\": \\\"intronMotif\\\", \\\"output_params2\\\": {\\\"__current_case__\\\": 0, \\\"outFilterMatchNmin\\\": \\\"0\\\", \\\"outFilterMatchNminOverLread\\\": \\\"0.66\\\", \\\"outFilterMismatchNmax\\\": \\\"10\\\", \\\"outFilterMismatchNoverLmax\\\": \\\"0.3\\\", \\\"outFilterMismatchNoverReadLmax\\\": \\\"1.0\\\", \\\"outFilterMultimapNmax\\\": \\\"10\\\", \\\"outFilterMultimapScoreRange\\\": \\\"1\\\", \\\"outFilterScoreMin\\\": \\\"0\\\", \\\"outFilterScoreMinOverLread\\\": \\\"0.66\\\", \\\"outFilterType\\\": \\\"false\\\", \\\"outSAMmapqUnique\\\": \\\"255\\\", \\\"outSAMprimaryFlag\\\": \\\"false\\\", \\\"outSAMunmapped\\\": \\\"false\\\", \\\"output_select2\\\": \\\"yes\\\"}, \\\"output_select\\\": \\\"yes\\\"}\", \"__rerun_remap_job_id__\": null, \"params\": \"{\\\"__current_case__\\\": 2, \\\"align\\\": {\\\"alignEndsType\\\": \\\"true\\\", \\\"alignIntronMax\\\": \\\"0\\\", \\\"alignIntronMin\\\": \\\"21\\\", \\\"alignMatesGapMax\\\": \\\"0\\\", \\\"alignSJDBoverhangMin\\\": \\\"3\\\", \\\"alignSJoverhangMin\\\": \\\"5\\\", \\\"alignSplicedMateMapLmin\\\": \\\"0\\\", \\\"alignSplicedMateMapLminOverLmate\\\": \\\"0.66\\\", \\\"alignTranscriptsPerReadNmax\\\": \\\"10000\\\", \\\"alignTranscriptsPerWindowNmax\\\": \\\"100\\\", \\\"alignWindowsPerReadNmax\\\": \\\"10000\\\"}, \\\"chim\\\": {\\\"__current_case__\\\": 1, \\\"chim_select\\\": \\\"no\\\"}, \\\"limits\\\": {\\\"limitBAMsortRAM\\\": \\\"0\\\", \\\"limitOutSJcollapsed\\\": \\\"1000000\\\", \\\"limitOutSJoneRead\\\": \\\"1000\\\", \\\"limitSjdbInsertNsj\\\": \\\"1000000\\\"}, \\\"seed\\\": {\\\"seedMultimapNmax\\\": \\\"10000\\\", \\\"seedNoneLociPerWindow\\\": \\\"10\\\", \\\"seedPerReadNmax\\\": \\\"1000\\\", \\\"seedPerWindowNmax\\\": \\\"50\\\", \\\"seedSearchLmax\\\": \\\"0\\\", \\\"seedSearchStartLmax\\\": \\\"50\\\", \\\"seedSearchStartLmaxOverLread\\\": \\\"1.0\\\"}, \\\"settingsType\\\": \\\"full\\\", \\\"twopass\\\": {\\\"twopass1readsN\\\": \\\"-1\\\", \\\"twopassMode\\\": \\\"false\\\"}}\", \"refGenomeSource\": \"{\\\"GTFconditional\\\": {\\\"GTFselect\\\": \\\"with-gtf\\\", \\\"__current_case__\\\": 0, \\\"genomeDir\\\": \\\"hg38\\\"}, \\\"__current_case__\\\": 0, \\\"geneSource\\\": \\\"indexed\\\"}\", \"quantMode\": \"\\\"false\\\"\"}",
+      "tool_version": "2.5.2b-2",
+      "type": "tool",
+      "uuid": "41e5fce4-f49d-4bae-b0ef-2a76782ac7b7",
+      "workflow_outputs": []
+    },
+    "15": {
+      "annotation": "",
+      "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/rgrnastar/rna_star/2.5.2b-2",
+      "errors": null,
+      "id": 15,
+      "input_connections": {
+        "singlePaired|input1": {
+          "id": 13,
+          "output_name": "out1"
+        },
+        "singlePaired|input2": {
+          "id": 13,
+          "output_name": "out2"
+        }
+      },
+      "inputs": [
+        {
+          "description": "runtime parameter for tool RNA STAR",
+          "name": "singlePaired"
+        },
+        {
+          "description": "runtime parameter for tool RNA STAR",
+          "name": "singlePaired"
+        }
+      ],
+      "label": null,
+      "name": "RNA STAR",
+      "outputs": [
+        {
+          "name": "output_log",
+          "type": "txt"
+        },
+        {
+          "name": "chimeric_junctions",
+          "type": "interval"
+        },
+        {
+          "name": "chimeric_reads",
+          "type": "bam"
+        },
+        {
+          "name": "splice_junctions",
+          "type": "interval"
+        },
+        {
+          "name": "mapped_reads",
+          "type": "bam"
+        },
+        {
+          "name": "reads_per_gene",
+          "type": "tabular"
+        }
+      ],
+      "position": {
+        "left": 1760.921875,
+        "top": 1418.5
+      },
+      "post_job_actions": {
+        "HideDatasetActionchimeric_junctions": {
+          "action_arguments": {},
+          "action_type": "HideDatasetAction",
+          "output_name": "chimeric_junctions"
+        },
+        "HideDatasetActionchimeric_reads": {
+          "action_arguments": {},
+          "action_type": "HideDatasetAction",
+          "output_name": "chimeric_reads"
+        },
+        "HideDatasetActionmapped_reads": {
+          "action_arguments": {},
+          "action_type": "HideDatasetAction",
+          "output_name": "mapped_reads"
+        },
+        "HideDatasetActionoutput_log": {
+          "action_arguments": {},
+          "action_type": "HideDatasetAction",
+          "output_name": "output_log"
+        },
+        "HideDatasetActionreads_per_gene": {
+          "action_arguments": {},
+          "action_type": "HideDatasetAction",
+          "output_name": "reads_per_gene"
+        },
+        "HideDatasetActionsplice_junctions": {
+          "action_arguments": {},
+          "action_type": "HideDatasetAction",
+          "output_name": "splice_junctions"
+        }
+      },
+      "tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/rgrnastar/rna_star/2.5.2b-2",
+      "tool_shed_repository": {
+        "changeset_revision": "2055c2667eb3",
+        "name": "rgrnastar",
+        "owner": "iuc",
+        "tool_shed": "toolshed.g2.bx.psu.edu"
+      },
+      "tool_state": "{\"__page__\": null, \"singlePaired\": \"{\\\"__current_case__\\\": 1, \\\"input1\\\": {\\\"__class__\\\": \\\"RuntimeValue\\\"}, \\\"input2\\\": {\\\"__class__\\\": \\\"RuntimeValue\\\"}, \\\"sPaired\\\": \\\"paired\\\"}\", \"output_params\": \"{\\\"__current_case__\\\": 0, \\\"outFilterIntronMotifs\\\": \\\"None\\\", \\\"outSAMattributes\\\": \\\"All\\\", \\\"outSAMstrandField\\\": \\\"intronMotif\\\", \\\"output_params2\\\": {\\\"__current_case__\\\": 0, \\\"outFilterMatchNmin\\\": \\\"0\\\", \\\"outFilterMatchNminOverLread\\\": \\\"0.66\\\", \\\"outFilterMismatchNmax\\\": \\\"10\\\", \\\"outFilterMismatchNoverLmax\\\": \\\"0.3\\\", \\\"outFilterMismatchNoverReadLmax\\\": \\\"1.0\\\", \\\"outFilterMultimapNmax\\\": \\\"10\\\", \\\"outFilterMultimapScoreRange\\\": \\\"1\\\", \\\"outFilterScoreMin\\\": \\\"0\\\", \\\"outFilterScoreMinOverLread\\\": \\\"0.66\\\", \\\"outFilterType\\\": \\\"false\\\", \\\"outSAMmapqUnique\\\": \\\"255\\\", \\\"outSAMprimaryFlag\\\": \\\"false\\\", \\\"outSAMunmapped\\\": \\\"false\\\", \\\"output_select2\\\": \\\"yes\\\"}, \\\"output_select\\\": \\\"yes\\\"}\", \"__rerun_remap_job_id__\": null, \"params\": \"{\\\"__current_case__\\\": 2, \\\"align\\\": {\\\"alignEndsType\\\": \\\"true\\\", \\\"alignIntronMax\\\": \\\"0\\\", \\\"alignIntronMin\\\": \\\"21\\\", \\\"alignMatesGapMax\\\": \\\"0\\\", \\\"alignSJDBoverhangMin\\\": \\\"3\\\", \\\"alignSJoverhangMin\\\": \\\"5\\\", \\\"alignSplicedMateMapLmin\\\": \\\"0\\\", \\\"alignSplicedMateMapLminOverLmate\\\": \\\"0.66\\\", \\\"alignTranscriptsPerReadNmax\\\": \\\"10000\\\", \\\"alignTranscriptsPerWindowNmax\\\": \\\"100\\\", \\\"alignWindowsPerReadNmax\\\": \\\"10000\\\"}, \\\"chim\\\": {\\\"__current_case__\\\": 1, \\\"chim_select\\\": \\\"no\\\"}, \\\"limits\\\": {\\\"limitBAMsortRAM\\\": \\\"0\\\", \\\"limitOutSJcollapsed\\\": \\\"1000000\\\", \\\"limitOutSJoneRead\\\": \\\"1000\\\", \\\"limitSjdbInsertNsj\\\": \\\"1000000\\\"}, \\\"seed\\\": {\\\"seedMultimapNmax\\\": \\\"10000\\\", \\\"seedNoneLociPerWindow\\\": \\\"10\\\", \\\"seedPerReadNmax\\\": \\\"1000\\\", \\\"seedPerWindowNmax\\\": \\\"50\\\", \\\"seedSearchLmax\\\": \\\"0\\\", \\\"seedSearchStartLmax\\\": \\\"50\\\", \\\"seedSearchStartLmaxOverLread\\\": \\\"1.0\\\"}, \\\"settingsType\\\": \\\"full\\\", \\\"twopass\\\": {\\\"twopass1readsN\\\": \\\"-1\\\", \\\"twopassMode\\\": \\\"false\\\"}}\", \"refGenomeSource\": \"{\\\"GTFconditional\\\": {\\\"GTFselect\\\": \\\"with-gtf\\\", \\\"__current_case__\\\": 0, \\\"genomeDir\\\": \\\"hg38\\\"}, \\\"__current_case__\\\": 0, \\\"geneSource\\\": \\\"indexed\\\"}\", \"quantMode\": \"\\\"false\\\"\"}",
+      "tool_version": "2.5.2b-2",
+      "type": "tool",
+      "uuid": "e4ebcf65-a6f3-44e9-b9be-297255954a28",
+      "workflow_outputs": []
+    },
+    "16": {
+      "annotation": "",
+      "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/umi_tools_dedup/umi_tools_dedup/0.5.3.0",
+      "errors": null,
+      "id": 16,
+      "input_connections": {
+        "input": {
+          "id": 14,
+          "output_name": "mapped_reads"
+        }
+      },
+      "inputs": [
+        {
+          "description": "runtime parameter for tool UMI-tools deduplicate",
+          "name": "gene_transcript_map"
+        },
+        {
+          "description": "runtime parameter for tool UMI-tools deduplicate",
+          "name": "input"
+        }
+      ],
+      "label": null,
+      "name": "UMI-tools deduplicate",
+      "outputs": [
+        {
+          "name": "output",
+          "type": "bam"
+        }
+      ],
+      "position": {
+        "left": 2236.015625,
+        "top": 790.46875
+      },
+      "post_job_actions": {
+        "HideDatasetActionoutput": {
+          "action_arguments": {},
+          "action_type": "HideDatasetAction",
+          "output_name": "output"
+        }
+      },
+      "tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/umi_tools_dedup/umi_tools_dedup/0.5.3.0",
+      "tool_shed_repository": {
+        "changeset_revision": "e9256e2e22e0",
+        "name": "umi_tools_dedup",
+        "owner": "iuc",
+        "tool_shed": "toolshed.g2.bx.psu.edu"
+      },
+      "tool_state": "{\"subset\": \"\\\"1.0\\\"\", \"__page__\": null, \"extract_umi_method\": \"\\\"read_id\\\"\", \"read_length\": \"\\\"false\\\"\", \"chrom\": \"\\\"false\\\"\", \"gene_tag\": \"\\\"\\\"\", \"edit_distance_threshold\": \"\\\"1\\\"\", \"per_contig\": \"\\\"false\\\"\", \"per_gene\": \"\\\"false\\\"\", \"paired\": \"\\\"true\\\"\", \"__rerun_remap_job_id__\": null, \"gene_transcript_map\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\", \"spliced_is_unique\": \"\\\"false\\\"\", \"soft_clip_threshold\": \"\\\"4\\\"\", \"input\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\", \"whole_contig\": \"\\\"false\\\"\", \"method\": \"\\\"adjacency\\\"\", \"umi_separator\": \"\\\"_\\\"\", \"umi_tag\": \"\\\"\\\"\"}",
+      "tool_version": "0.5.3.0",
+      "type": "tool",
+      "uuid": "44909d26-6d13-496d-ab5e-8ac270ba7142",
+      "workflow_outputs": []
+    },
+    "17": {
+      "annotation": "",
+      "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/umi_tools_dedup/umi_tools_dedup/0.5.3.0",
+      "errors": null,
+      "id": 17,
+      "input_connections": {
+        "input": {
+          "id": 15,
+          "output_name": "mapped_reads"
+        }
+      },
+      "inputs": [
+        {
+          "description": "runtime parameter for tool UMI-tools deduplicate",
+          "name": "gene_transcript_map"
+        },
+        {
+          "description": "runtime parameter for tool UMI-tools deduplicate",
+          "name": "input"
+        }
+      ],
+      "label": null,
+      "name": "UMI-tools deduplicate",
+      "outputs": [
+        {
+          "name": "output",
+          "type": "bam"
+        }
+      ],
+      "position": {
+        "left": 2132.171875,
+        "top": 1557.6875
+      },
+      "post_job_actions": {
+        "HideDatasetActionoutput": {
+          "action_arguments": {},
+          "action_type": "HideDatasetAction",
+          "output_name": "output"
+        }
+      },
+      "tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/umi_tools_dedup/umi_tools_dedup/0.5.3.0",
+      "tool_shed_repository": {
+        "changeset_revision": "e9256e2e22e0",
+        "name": "umi_tools_dedup",
+        "owner": "iuc",
+        "tool_shed": "toolshed.g2.bx.psu.edu"
+      },
+      "tool_state": "{\"subset\": \"\\\"1.0\\\"\", \"__page__\": null, \"extract_umi_method\": \"\\\"read_id\\\"\", \"read_length\": \"\\\"false\\\"\", \"chrom\": \"\\\"false\\\"\", \"gene_tag\": \"\\\"\\\"\", \"edit_distance_threshold\": \"\\\"1\\\"\", \"per_contig\": \"\\\"false\\\"\", \"per_gene\": \"\\\"false\\\"\", \"paired\": \"\\\"true\\\"\", \"__rerun_remap_job_id__\": null, \"gene_transcript_map\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\", \"spliced_is_unique\": \"\\\"false\\\"\", \"soft_clip_threshold\": \"\\\"4\\\"\", \"input\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\", \"whole_contig\": \"\\\"false\\\"\", \"method\": \"\\\"adjacency\\\"\", \"umi_separator\": \"\\\"_\\\"\", \"umi_tag\": \"\\\"\\\"\"}",
+      "tool_version": "0.5.3.0",
+      "type": "tool",
+      "uuid": "49786cc4-e78a-4488-9946-507ed9740bb8",
+      "workflow_outputs": []
+    },
+    "18": {
+      "annotation": "",
+      "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/bctools_extract_alignment_ends/bctools_extract_alignment_ends/0.2.2",
+      "errors": null,
+      "id": 18,
+      "input_connections": {
+        "alignments": {
+          "id": 16,
+          "output_name": "output"
+        }
+      },
+      "inputs": [
+        {
+          "description": "runtime parameter for tool Extract alignment ends",
+          "name": "alignments"
+        }
+      ],
+      "label": null,
+      "name": "Extract alignment ends",
+      "outputs": [
+        {
+          "name": "alignment_ends",
+          "type": "bed"
+        }
+      ],
+      "position": {
+        "left": 2312.140625,
+        "top": 459.9375
+      },
+      "post_job_actions": {
+        "HideDatasetActionalignment_ends": {
+          "action_arguments": {},
+          "action_type": "HideDatasetAction",
+          "output_name": "alignment_ends"
+        }
+      },
+      "tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/bctools_extract_alignment_ends/bctools_extract_alignment_ends/0.2.2",
+      "tool_shed_repository": {
+        "changeset_revision": "8076141a76a7",
+        "name": "bctools_extract_alignment_ends",
+        "owner": "iuc",
+        "tool_shed": "toolshed.g2.bx.psu.edu"
+      },
+      "tool_state": "{\"__page__\": null, \"__rerun_remap_job_id__\": null, \"alignments\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\"}",
+      "tool_version": "0.2.2",
+      "type": "tool",
+      "uuid": "20010654-0f50-482b-a9f9-7e7f8919bf32",
+      "workflow_outputs": []
+    },
+    "19": {
+      "annotation": "",
+      "content_id": "toolshed.g2.bx.psu.edu/repos/devteam/fastqc/fastqc/0.71",
+      "errors": null,
+      "id": 19,
+      "input_connections": {
+        "input_file": {
+          "id": 16,
+          "output_name": "output"
+        }
+      },
+      "inputs": [
+        {
+          "description": "runtime parameter for tool FastQC",
+          "name": "contaminants"
+        },
+        {
+          "description": "runtime parameter for tool FastQC",
+          "name": "limits"
+        },
+        {
+          "description": "runtime parameter for tool FastQC",
+          "name": "input_file"
+        }
+      ],
+      "label": null,
+      "name": "FastQC",
+      "outputs": [
+        {
+          "name": "html_file",
+          "type": "html"
+        },
+        {
+          "name": "text_file",
+          "type": "txt"
+        }
+      ],
+      "position": {
+        "left": 2764.9375,
+        "top": 899
+      },
+      "post_job_actions": {
+        "HideDatasetActiontext_file": {
+          "action_arguments": {},
+          "action_type": "HideDatasetAction",
+          "output_name": "text_file"
+        }
+      },
+      "tool_id": "toolshed.g2.bx.psu.edu/repos/devteam/fastqc/fastqc/0.71",
+      "tool_shed_repository": {
+        "changeset_revision": "ff9530579d1f",
+        "name": "fastqc",
+        "owner": "devteam",
+        "tool_shed": "toolshed.g2.bx.psu.edu"
+      },
+      "tool_state": "{\"__page__\": null, \"contaminants\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\", \"__rerun_remap_job_id__\": null, \"limits\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\", \"input_file\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\"}",
+      "tool_version": "0.71",
+      "type": "tool",
+      "uuid": "d24623ab-91a1-46fd-993f-f3fa0fba3470",
+      "workflow_outputs": [
+        {
+          "label": null,
+          "output_name": "html_file",
+          "uuid": "40dd1734-fe88-4754-be95-fce11fc1a242"
+        }
+      ]
+    },
+    "2": {
+      "annotation": "",
+      "content_id": null,
+      "errors": null,
+      "id": 2,
+      "input_connections": {},
+      "inputs": [],
+      "label": "Genome Chromosome Sizes",
+      "name": "Input dataset",
+      "outputs": [],
+      "position": {
+        "left": 3458.921875,
+        "top": 838.53125
+      },
+      "tool_id": null,
+      "tool_state": "{}",
+      "tool_version": null,
+      "type": "data_input",
+      "uuid": "ec701e9f-810c-4f9e-98a5-073cd9408dc1",
+      "workflow_outputs": [
+        {
+          "label": null,
+          "output_name": "output",
+          "uuid": "0cc59b7e-0dda-4d98-8123-a9b211cdc658"
+        }
+      ]
+    },
+    "20": {
+      "annotation": "",
+      "content_id": "__MERGE_COLLECTION__",
+      "errors": null,
+      "id": 20,
+      "input_connections": {
+        "inputs_0|input": {
+          "id": 16,
+          "output_name": "output"
+        },
+        "inputs_1|input": {
+          "id": 17,
+          "output_name": "output"
+        }
+      },
+      "inputs": [],
+      "label": null,
+      "name": "Merge Collections",
+      "outputs": [
+        {
+          "name": "output",
+          "type": "input"
+        }
+      ],
+      "position": {
+        "left": 2376.34375,
+        "top": 1212.609375
+      },
+      "post_job_actions": {
+        "HideDatasetActionoutput": {
+          "action_arguments": {},
+          "action_type": "HideDatasetAction",
+          "output_name": "output"
+        }
+      },
+      "tool_id": "__MERGE_COLLECTION__",
+      "tool_state": "{\"inputs\": \"[{\\\"__index__\\\": 0, \\\"input\\\": {\\\"__class__\\\": \\\"RuntimeValue\\\"}}, {\\\"__index__\\\": 1, \\\"input\\\": {\\\"__class__\\\": \\\"RuntimeValue\\\"}}]\", \"__rerun_remap_job_id__\": null, \"advanced\": \"{\\\"conflict\\\": {\\\"__current_case__\\\": 3, \\\"duplicate_options\\\": \\\"keep_first\\\"}}\", \"__page__\": null}",
+      "tool_version": "1.0.0",
+      "type": "tool",
+      "uuid": "0a011f4f-2014-4e2e-8f15-46bc6aa823a0",
+      "workflow_outputs": []
+    },
+    "21": {
+      "annotation": "",
+      "content_id": "toolshed.g2.bx.psu.edu/repos/devteam/fastqc/fastqc/0.67",
+      "errors": null,
+      "id": 21,
+      "input_connections": {
+        "input_file": {
+          "id": 17,
+          "output_name": "output"
+        }
+      },
+      "inputs": [
+        {
+          "description": "runtime parameter for tool FastQC",
+          "name": "contaminants"
+        },
+        {
+          "description": "runtime parameter for tool FastQC",
+          "name": "limits"
+        },
+        {
+          "description": "runtime parameter for tool FastQC",
+          "name": "input_file"
+        }
+      ],
+      "label": null,
+      "name": "FastQC",
+      "outputs": [
+        {
+          "name": "html_file",
+          "type": "html"
+        },
+        {
+          "name": "text_file",
+          "type": "txt"
+        }
+      ],
+      "position": {
+        "left": 2585.984375,
+        "top": 1850.453125
+      },
+      "post_job_actions": {
+        "HideDatasetActiontext_file": {
+          "action_arguments": {},
+          "action_type": "HideDatasetAction",
+          "output_name": "text_file"
+        }
+      },
+      "tool_id": "toolshed.g2.bx.psu.edu/repos/devteam/fastqc/fastqc/0.67",
+      "tool_shed_repository": {
+        "changeset_revision": "3a458e268066",
+        "name": "fastqc",
+        "owner": "devteam",
+        "tool_shed": "toolshed.g2.bx.psu.edu"
+      },
+      "tool_state": "{\"__page__\": null, \"contaminants\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\", \"__rerun_remap_job_id__\": null, \"limits\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\", \"input_file\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\"}",
+      "tool_version": "0.67",
+      "type": "tool",
+      "uuid": "45253c70-37a4-4f55-a449-f170407f2ed4",
+      "workflow_outputs": [
+        {
+          "label": null,
+          "output_name": "html_file",
+          "uuid": "bc201824-7d20-4c9c-aaab-611237f1d68f"
+        }
+      ]
+    },
+    "22": {
+      "annotation": "",
+      "content_id": "toolshed.g2.bx.psu.edu/repos/rnateam/peakachu/peakachu/0.1.0.2",
+      "errors": null,
+      "id": 22,
+      "input_connections": {
+        "controlLibs": {
+          "id": 16,
+          "output_name": "output"
+        },
+        "experimentLibs": {
+          "id": 17,
+          "output_name": "output"
+        }
+      },
+      "inputs": [
+        {
+          "description": "runtime parameter for tool PEAKachu",
+          "name": "controlLibs"
+        },
+        {
+          "description": "runtime parameter for tool PEAKachu",
+          "name": "experimentLibs"
+        }
+      ],
+      "label": null,
+      "name": "PEAKachu",
+      "outputs": [
+        {
+          "name": "peak_tables",
+          "type": "tabular"
+        },
+        {
+          "name": "peak_annotations",
+          "type": "gff"
+        },
+        {
+          "name": "MA_plot",
+          "type": "png"
+        }
+      ],
+      "position": {
+        "left": 3310.875,
+        "top": 1205.359375
+      },
+      "post_job_actions": {},
+      "tool_id": "toolshed.g2.bx.psu.edu/repos/rnateam/peakachu/peakachu/0.1.0.2",
+      "tool_shed_repository": {
+        "changeset_revision": "886f5adba83d",
+        "name": "peakachu",
+        "owner": "rnateam",
+        "tool_shed": "toolshed.g2.bx.psu.edu"
+      },
+      "tool_state": "{\"padj_threshold\": \"\\\"0.05\\\"\", \"paired_end\": \"\\\"true\\\"\", \"sub_features\": \"\\\"\\\"\", \"features\": \"\\\"\\\"\", \"__page__\": null, \"mad_multiplier\": \"\\\"0.0\\\"\", \"fc_cutoff\": \"\\\"2.0\\\"\", \"controlLibs\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\", \"max_insert_size\": \"\\\"200\\\"\", \"pairwise_replicates\": \"\\\"false\\\"\", \"experimentLibs\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\", \"__rerun_remap_job_id__\": null, \"mode\": \"{\\\"__current_case__\\\": 0, \\\"min_block_overlap\\\": \\\"0.5\\\", \\\"min_cluster_expr_frac\\\": \\\"0.01\\\", \\\"min_max_block_expr\\\": \\\"0.1\\\", \\\"mode_selector\\\": \\\"adaptive\\\", \\\"norm_method\\\": {\\\"__current_case__\\\": 0, \\\"norm_method_selector\\\": \\\"deseq\\\"}}\"}",
+      "tool_version": "0.1.0.2",
+      "type": "tool",
+      "uuid": "a3532c26-f5dc-4b4b-8af2-35084e8c34cb",
+      "workflow_outputs": [
+        {
+          "label": null,
+          "output_name": "peak_tables",
+          "uuid": "7c7ac458-a885-4d56-9919-4e4be2e9ed24"
+        },
+        {
+          "label": null,
+          "output_name": "peak_annotations",
+          "uuid": "d26c67e0-a493-4045-a21e-6af8ec2547e5"
+        },
+        {
+          "label": null,
+          "output_name": "MA_plot",
+          "uuid": "4658c80f-2c75-4768-b4a2-4caa04d8422a"
+        }
+      ]
+    },
+    "23": {
+      "annotation": "",
+      "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/bctools_extract_alignment_ends/bctools_extract_alignment_ends/0.2.2",
+      "errors": null,
+      "id": 23,
+      "input_connections": {
+        "alignments": {
+          "id": 17,
+          "output_name": "output"
+        }
+      },
+      "inputs": [
+        {
+          "description": "runtime parameter for tool Extract alignment ends",
+          "name": "alignments"
+        }
+      ],
+      "label": null,
+      "name": "Extract alignment ends",
+      "outputs": [
+        {
+          "name": "alignment_ends",
+          "type": "bed"
+        }
+      ],
+      "position": {
+        "left": 3185.984375,
+        "top": 1929.953125
+      },
+      "post_job_actions": {
+        "HideDatasetActionalignment_ends": {
+          "action_arguments": {},
+          "action_type": "HideDatasetAction",
+          "output_name": "alignment_ends"
+        }
+      },
+      "tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/bctools_extract_alignment_ends/bctools_extract_alignment_ends/0.2.2",
+      "tool_shed_repository": {
+        "changeset_revision": "8076141a76a7",
+        "name": "bctools_extract_alignment_ends",
+        "owner": "iuc",
+        "tool_shed": "toolshed.g2.bx.psu.edu"
+      },
+      "tool_state": "{\"__page__\": null, \"__rerun_remap_job_id__\": null, \"alignments\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\"}",
+      "tool_version": "0.2.2",
+      "type": "tool",
+      "uuid": "c9b71593-6fcd-4dc9-90e0-f5b391aea332",
+      "workflow_outputs": []
+    },
+    "24": {
+      "annotation": "",
+      "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/bedtools/bedtools_sortbed/2.27.0.0",
+      "errors": null,
+      "id": 24,
+      "input_connections": {
+        "input": {
+          "id": 18,
+          "output_name": "alignment_ends"
+        }
+      },
+      "inputs": [
+        {
+          "description": "runtime parameter for tool SortBED",
+          "name": "input"
+        }
+      ],
+      "label": null,
+      "name": "SortBED",
+      "outputs": [
+        {
+          "name": "output",
+          "type": "input"
+        }
+      ],
+      "position": {
+        "left": 2553.65625,
+        "top": 457.125
+      },
+      "post_job_actions": {
+        "HideDatasetActionoutput": {
+          "action_arguments": {},
+          "action_type": "HideDatasetAction",
+          "output_name": "output"
+        }
+      },
+      "tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/bedtools/bedtools_sortbed/2.27.0.0",
+      "tool_shed_repository": {
+        "changeset_revision": "e19bebe96cd2",
+        "name": "bedtools",
+        "owner": "iuc",
+        "tool_shed": "toolshed.g2.bx.psu.edu"
+      },
+      "tool_state": "{\"input\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\", \"__rerun_remap_job_id__\": null, \"option\": \"\\\"\\\"\", \"__page__\": null}",
+      "tool_version": "2.27.0.0",
+      "type": "tool",
+      "uuid": "d7fa6a5d-b2cf-4e5a-9d26-7fd830e8b493",
+      "workflow_outputs": []
+    },
+    "25": {
+      "annotation": "",
+      "content_id": "__SORTLIST__",
+      "errors": null,
+      "id": 25,
+      "input_connections": {
+        "input": {
+          "id": 20,
+          "output_name": "output"
+        }
+      },
+      "inputs": [
+        {
+          "description": "runtime parameter for tool Sort Collection",
+          "name": "input"
+        }
+      ],
+      "label": null,
+      "name": "Sort Collection",
+      "outputs": [
+        {
+          "name": "output",
+          "type": "input"
+        }
+      ],
+      "position": {
+        "left": 2697.34375,
+        "top": 1287.609375
+      },
+      "post_job_actions": {
+        "HideDatasetActionoutput": {
+          "action_arguments": {},
+          "action_type": "HideDatasetAction",
+          "output_name": "output"
+        }
+      },
+      "tool_id": "__SORTLIST__",
+      "tool_state": "{\"input\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\", \"sort_type\": \"{\\\"__current_case__\\\": 1, \\\"sort_type\\\": \\\"alpha\\\"}\", \"__rerun_remap_job_id__\": null, \"__page__\": null}",
+      "tool_version": "1.0.0",
+      "type": "tool",
+      "uuid": "8079eb59-d1dc-40fb-9ab2-901d9d080c67",
+      "workflow_outputs": []
+    },
+    "26": {
+      "annotation": "",
+      "content_id": "toolshed.g2.bx.psu.edu/repos/bgruening/text_processing/tp_awk_tool/1.1.1",
+      "errors": null,
+      "id": 26,
+      "input_connections": {
+        "infile": {
+          "id": 22,
+          "output_name": "peak_tables"
+        }
+      },
+      "inputs": [
+        {
+          "description": "runtime parameter for tool Text reformatting",
+          "name": "infile"
+        }
+      ],
+      "label": null,
+      "name": "Text reformatting",
+      "outputs": [
+        {
+          "name": "outfile",
+          "type": "input"
+        }
+      ],
+      "position": {
+        "left": 3538.5,
+        "top": 1211.984375
+      },
+      "post_job_actions": {
+        "ChangeDatatypeActionoutfile": {
+          "action_arguments": {
+            "newtype": "bed"
+          },
+          "action_type": "ChangeDatatypeAction",
+          "output_name": "outfile"
+        },
+        "HideDatasetActionoutfile": {
+          "action_arguments": {},
+          "action_type": "HideDatasetAction",
+          "output_name": "outfile"
+        }
+      },
+      "tool_id": "toolshed.g2.bx.psu.edu/repos/bgruening/text_processing/tp_awk_tool/1.1.1",
+      "tool_shed_repository": {
+        "changeset_revision": "a6f147a050a2",
+        "name": "text_processing",
+        "owner": "bgruening",
+        "tool_shed": "toolshed.g2.bx.psu.edu"
+      },
+      "tool_state": "{\"__page__\": null, \"__rerun_remap_job_id__\": null, \"code\": \"\\\"NR>1{\\\\nif ($3 < $4) {\\\\n   print $1,$3,$4,\\\\\\\"clip_peak_\\\\\\\"NR-1,$9,$5;\\\\n}\\\\nelse {\\\\n   print $1,$4,$3,\\\\\\\"clip_peak_\\\\\\\"NR-1,$9,$5;\\\\n}\\\\n}\\\"\", \"infile\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\"}",
+      "tool_version": "1.1.1",
+      "type": "tool",
+      "uuid": "fcc68faf-228f-4226-bbf5-ff5048df555e",
+      "workflow_outputs": []
+    },
+    "27": {
+      "annotation": "",
+      "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/bedtools/bedtools_sortbed/2.27.0.0",
+      "errors": null,
+      "id": 27,
+      "input_connections": {
+        "input": {
+          "id": 23,
+          "output_name": "alignment_ends"
+        }
+      },
+      "inputs": [
+        {
+          "description": "runtime parameter for tool SortBED",
+          "name": "input"
+        }
+      ],
+      "label": null,
+      "name": "SortBED",
+      "outputs": [
+        {
+          "name": "output",
+          "type": "input"
+        }
+      ],
+      "position": {
+        "left": 3481.6875,
+        "top": 1902.296875
+      },
+      "post_job_actions": {
+        "HideDatasetActionoutput": {
+          "action_arguments": {},
+          "action_type": "HideDatasetAction",
+          "output_name": "output"
+        }
+      },
+      "tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/bedtools/bedtools_sortbed/2.27.0.0",
+      "tool_shed_repository": {
+        "changeset_revision": "e19bebe96cd2",
+        "name": "bedtools",
+        "owner": "iuc",
+        "tool_shed": "toolshed.g2.bx.psu.edu"
+      },
+      "tool_state": "{\"input\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\", \"__rerun_remap_job_id__\": null, \"option\": \"\\\"\\\"\", \"__page__\": null}",
+      "tool_version": "2.27.0.0",
+      "type": "tool",
+      "uuid": "ca43b913-4fb5-4fc9-a9d5-100a2493121b",
+      "workflow_outputs": []
+    },
+    "28": {
+      "annotation": "",
+      "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/bedtools/bedtools_genomecoveragebed_bedgraph/2.19.0",
+      "errors": null,
+      "id": 28,
+      "input_connections": {
+        "input": {
+          "id": 24,
+          "output_name": "output"
+        }
+      },
+      "inputs": [
+        {
+          "description": "runtime parameter for tool Create a BedGraph of genome coverage",
+          "name": "input"
+        }
+      ],
+      "label": null,
+      "name": "Create a BedGraph of genome coverage",
+      "outputs": [
+        {
+          "name": "output",
+          "type": "bedgraph"
+        }
+      ],
+      "position": {
+        "left": 2755.171875,
+        "top": 446.015625
+      },
+      "post_job_actions": {
+        "HideDatasetActionoutput": {
+          "action_arguments": {},
+          "action_type": "HideDatasetAction",
+          "output_name": "output"
+        }
+      },
+      "tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/bedtools/bedtools_genomecoveragebed_bedgraph/2.19.0",
+      "tool_shed_repository": {
+        "changeset_revision": "b8348686a0b9",
+        "name": "bedtools",
+        "owner": "iuc",
+        "tool_shed": "toolshed.g2.bx.psu.edu"
+      },
+      "tool_state": "{\"zero_regions\": \"\\\"false\\\"\", \"__page__\": null, \"scale\": \"\\\"\\\"\", \"__rerun_remap_job_id__\": null, \"split\": \"\\\"false\\\"\", \"input\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\", \"strand\": \"\\\"\\\"\"}",
+      "tool_version": "2.19.0",
+      "type": "tool",
+      "uuid": "35c6aeff-1a74-4dcb-a47d-ec9577e1cd55",
+      "workflow_outputs": []
+    },
+    "29": {
+      "annotation": "",
+      "content_id": "toolshed.g2.bx.psu.edu/repos/bgruening/deeptools_multi_bam_summary/deeptools_multi_bam_summary/2.5.7.0",
+      "errors": null,
+      "id": 29,
+      "input_connections": {
+        "multibam_conditional|bamfiles": {
+          "id": 25,
+          "output_name": "output"
+        }
+      },
+      "inputs": [
+        {
+          "description": "runtime parameter for tool multiBamSummary",
+          "name": "multibam_conditional"
+        }
+      ],
+      "label": null,
+      "name": "multiBamSummary",
+      "outputs": [
+        {
+          "name": "outFile",
+          "type": "deeptools_coverage_matrix"
+        },
+        {
+          "name": "outFileRawCounts",
+          "type": "tabular"
+        }
+      ],
+      "position": {
+        "left": 2794.46875,
+        "top": 1637.984375
+      },
+      "post_job_actions": {
+        "HideDatasetActionoutFile": {
+          "action_arguments": {},
+          "action_type": "HideDatasetAction",
+          "output_name": "outFile"
+        },
+        "HideDatasetActionoutFileRawCounts": {
+          "action_arguments": {},
+          "action_type": "HideDatasetAction",
+          "output_name": "outFileRawCounts"
+        }
+      },
+      "tool_id": "toolshed.g2.bx.psu.edu/repos/bgruening/deeptools_multi_bam_summary/deeptools_multi_bam_summary/2.5.7.0",
+      "tool_shed_repository": {
+        "changeset_revision": "a2c5c5f87dd4",
+        "name": "deeptools_multi_bam_summary",
+        "owner": "bgruening",
+        "tool_shed": "toolshed.g2.bx.psu.edu"
+      },
+      "tool_state": "{\"__page__\": null, \"region\": \"\\\"\\\"\", \"mode\": \"{\\\"__current_case__\\\": 0, \\\"binSize\\\": \\\"1000\\\", \\\"distanceBetweenBins\\\": \\\"0\\\", \\\"modeOpt\\\": \\\"bins\\\"}\", \"multibam_conditional\": \"{\\\"__current_case__\\\": 0, \\\"bamfiles\\\": {\\\"__class__\\\": \\\"RuntimeValue\\\"}, \\\"orderMatters\\\": \\\"No\\\"}\", \"advancedOpt\": \"{\\\"__current_case__\\\": 0, \\\"showAdvancedOpt\\\": \\\"no\\\"}\", \"__rerun_remap_job_id__\": null, \"outRawCounts\": \"\\\"false\\\"\"}",
+      "tool_version": "2.5.7.0",
+      "type": "tool",
+      "uuid": "7a11d286-15b8-48ac-877e-8b1ffc91646d",
+      "workflow_outputs": []
+    },
+    "3": {
+      "annotation": "",
+      "content_id": null,
+      "errors": null,
+      "id": 3,
+      "input_connections": {},
+      "inputs": [],
+      "label": "Annotation Reference File for RCAS",
+      "name": "Input dataset",
+      "outputs": [],
+      "position": {
+        "left": 3737.015625,
+        "top": 322.9375
+      },
+      "tool_id": null,
+      "tool_state": "{}",
+      "tool_version": null,
+      "type": "data_input",
+      "uuid": "61afe886-f6eb-4ed7-b964-63959c132be0",
+      "workflow_outputs": [
+        {
+          "label": null,
+          "output_name": "output",
+          "uuid": "3d02905f-3c8b-4c38-a5d7-e6df07a0b0e6"
+        }
+      ]
+    },
+    "30": {
+      "annotation": "",
+      "content_id": "toolshed.g2.bx.psu.edu/repos/bgruening/deeptools_plot_fingerprint/deeptools_plot_fingerprint/2.5.7.0",
+      "errors": null,
+      "id": 30,
+      "input_connections": {
+        "multibam_conditional|bamfiles": {
+          "id": 25,
+          "output_name": "output"
+        }
+      },
+      "inputs": [
+        {
+          "description": "runtime parameter for tool plotFingerprint",
+          "name": "multibam_conditional"
+        },
+        {
+          "description": "runtime parameter for tool plotFingerprint",
+          "name": "advancedOpt"
+        }
+      ],
+      "label": null,
+      "name": "plotFingerprint",
+      "outputs": [
+        {
+          "name": "outFileName",
+          "type": "png"
+        },
+        {
+          "name": "outFileRawCounts",
+          "type": "tabular"
+        },
+        {
+          "name": "outFileQualityMetrics",
+          "type": "tabular"
+        }
+      ],
+      "position": {
+        "left": 3021.96875,
+        "top": 1371.9375
+      },
+      "post_job_actions": {
+        "HideDatasetActionoutFileQualityMetrics": {
+          "action_arguments": {},
+          "action_type": "HideDatasetAction",
+          "output_name": "outFileQualityMetrics"
+        },
+        "HideDatasetActionoutFileRawCounts": {
+          "action_arguments": {},
+          "action_type": "HideDatasetAction",
+          "output_name": "outFileRawCounts"
+        }
+      },
+      "tool_id": "toolshed.g2.bx.psu.edu/repos/bgruening/deeptools_plot_fingerprint/deeptools_plot_fingerprint/2.5.7.0",
+      "tool_shed_repository": {
+        "changeset_revision": "ba5ce5ec93aa",
+        "name": "deeptools_plot_fingerprint",
+        "owner": "bgruening",
+        "tool_shed": "toolshed.g2.bx.psu.edu"
+      },
+      "tool_state": "{\"__page__\": null, \"__rerun_remap_job_id__\": null, \"multibam_conditional\": \"{\\\"__current_case__\\\": 0, \\\"bamfiles\\\": {\\\"__class__\\\": \\\"RuntimeValue\\\"}, \\\"orderMatters\\\": \\\"No\\\"}\", \"output\": \"{\\\"__current_case__\\\": 0, \\\"showOutputSettings\\\": \\\"no\\\"}\", \"advancedOpt\": \"{\\\"__current_case__\\\": 1, \\\"binSize\\\": \\\"100\\\", \\\"blackListFileName\\\": {\\\"__class__\\\": \\\"RuntimeValue\\\"}, \\\"centerReads\\\": \\\"false\\\", \\\"doExtendCustom\\\": {\\\"__current_case__\\\": 0, \\\"doExtend\\\": \\\"no\\\"}, \\\"ignoreDuplicates\\\": \\\"false\\\", \\\"maxFragmentLength\\\": \\\"0\\\", \\\"minFragmentLength\\\": \\\"0\\\", \\\"minMappingQuality\\\": \\\"1\\\", \\\"numberOfSamples\\\": \\\"100000\\\", \\\"plotTitle\\\": \\\"\\\", \\\"samFlagExclude\\\": \\\"\\\", \\\"samFlagInclude\\\": \\\"\\\", \\\"showAdvancedOpt\\\": \\\"yes\\\", \\\"skipZeros\\\": \\\"false\\\"}\", \"region\": \"\\\"\\\"\"}",
+      "tool_version": "2.5.7.0",
+      "type": "tool",
+      "uuid": "b56ca1bf-65bd-4c3f-87af-3865ca422cec",
+      "workflow_outputs": [
+        {
+          "label": null,
+          "output_name": "outFileName",
+          "uuid": "136a872a-d662-4908-995e-73cf91995c80"
+        }
+      ]
+    },
+    "31": {
+      "annotation": "",
+      "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/bedtools/bedtools_slopbed/2.27.0.0",
+      "errors": null,
+      "id": 31,
+      "input_connections": {
+        "genome_file_opts|genome": {
+          "id": 2,
+          "output_name": "output"
+        },
+        "inputA": {
+          "id": 26,
+          "output_name": "outfile"
+        }
+      },
+      "inputs": [
+        {
+          "description": "runtime parameter for tool SlopBed",
+          "name": "genome_file_opts"
+        },
+        {
+          "description": "runtime parameter for tool SlopBed",
+          "name": "inputA"
+        }
+      ],
+      "label": null,
+      "name": "SlopBed",
+      "outputs": [
+        {
+          "name": "output",
+          "type": "bed"
+        }
+      ],
+      "position": {
+        "left": 3677.921875,
+        "top": 1045.53125
+      },
+      "post_job_actions": {
+        "ChangeDatatypeActionoutput": {
+          "action_arguments": {
+            "newtype": "bed"
+          },
+          "action_type": "ChangeDatatypeAction",
+          "output_name": "output"
+        },
+        "HideDatasetActionoutput": {
+          "action_arguments": {},
+          "action_type": "HideDatasetAction",
+          "output_name": "output"
+        }
+      },
+      "tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/bedtools/bedtools_slopbed/2.27.0.0",
+      "tool_shed_repository": {
+        "changeset_revision": "e19bebe96cd2",
+        "name": "bedtools",
+        "owner": "iuc",
+        "tool_shed": "toolshed.g2.bx.psu.edu"
+      },
+      "tool_state": "{\"__page__\": null, \"addition\": \"{\\\"__current_case__\\\": 0, \\\"addition_select\\\": \\\"b\\\", \\\"b\\\": \\\"20\\\"}\", \"__rerun_remap_job_id__\": null, \"genome_file_opts\": \"{\\\"__current_case__\\\": 1, \\\"genome\\\": {\\\"__class__\\\": \\\"RuntimeValue\\\"}, \\\"genome_file_opts_selector\\\": \\\"hist\\\"}\", \"pct\": \"\\\"false\\\"\", \"header\": \"\\\"false\\\"\", \"inputA\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\", \"strand\": \"\\\"false\\\"\"}",
+      "tool_version": "2.27.0.0",
+      "type": "tool",
+      "uuid": "809f8eb8-cf0e-4c2c-90c1-b6d47dfa33e2",
+      "workflow_outputs": []
+    },
+    "32": {
+      "annotation": "",
+      "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/bedtools/bedtools_genomecoveragebed_bedgraph/2.19.0",
+      "errors": null,
+      "id": 32,
+      "input_connections": {
+        "input": {
+          "id": 27,
+          "output_name": "output"
+        }
+      },
+      "inputs": [
+        {
+          "description": "runtime parameter for tool Create a BedGraph of genome coverage",
+          "name": "input"
+        }
+      ],
+      "label": null,
+      "name": "Create a BedGraph of genome coverage",
+      "outputs": [
+        {
+          "name": "output",
+          "type": "bedgraph"
+        }
+      ],
+      "position": {
+        "left": 3760,
+        "top": 1881.4375
+      },
+      "post_job_actions": {
+        "HideDatasetActionoutput": {
+          "action_arguments": {},
+          "action_type": "HideDatasetAction",
+          "output_name": "output"
+        }
+      },
+      "tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/bedtools/bedtools_genomecoveragebed_bedgraph/2.19.0",
+      "tool_shed_repository": {
+        "changeset_revision": "b8348686a0b9",
+        "name": "bedtools",
+        "owner": "iuc",
+        "tool_shed": "toolshed.g2.bx.psu.edu"
+      },
+      "tool_state": "{\"zero_regions\": \"\\\"false\\\"\", \"__page__\": null, \"scale\": \"\\\"\\\"\", \"__rerun_remap_job_id__\": null, \"split\": \"\\\"false\\\"\", \"input\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\", \"strand\": \"\\\"\\\"\"}",
+      "tool_version": "2.19.0",
+      "type": "tool",
+      "uuid": "f9928bb4-737a-4fe0-b4b1-6a5f7c305aac",
+      "workflow_outputs": []
+    },
+    "33": {
+      "annotation": "",
+      "content_id": "wig_to_bigWig",
+      "errors": null,
+      "id": 33,
+      "input_connections": {
+        "input1": {
+          "id": 28,
+          "output_name": "output"
+        }
+      },
+      "inputs": [
+        {
+          "description": "runtime parameter for tool Wig/BedGraph-to-bigWig",
+          "name": "input1"
+        }
+      ],
+      "label": null,
+      "name": "Wig/BedGraph-to-bigWig",
+      "outputs": [
+        {
+          "name": "out_file1",
+          "type": "bigwig"
+        }
+      ],
+      "position": {
+        "left": 3051.3125,
+        "top": 466.859375
+      },
+      "post_job_actions": {
+        "HideDatasetActionout_file1": {
+          "action_arguments": {},
+          "action_type": "HideDatasetAction",
+          "output_name": "out_file1"
+        }
+      },
+      "tool_id": "wig_to_bigWig",
+      "tool_state": "{\"__page__\": null, \"__rerun_remap_job_id__\": null, \"input1\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\", \"settings\": \"{\\\"__current_case__\\\": 0, \\\"settingsType\\\": \\\"preset\\\"}\"}",
+      "tool_version": "1.1.1",
+      "type": "tool",
+      "uuid": "b3c594b9-b83e-4990-a4d4-2f1bbc2ddbec",
+      "workflow_outputs": []
+    },
+    "34": {
+      "annotation": "",
+      "content_id": "toolshed.g2.bx.psu.edu/repos/bgruening/deeptools_plot_correlation/deeptools_plot_correlation/2.5.7.0",
+      "errors": null,
+      "id": 34,
+      "input_connections": {
+        "corData": {
+          "id": 29,
+          "output_name": "outFile"
+        }
+      },
+      "inputs": [
+        {
+          "description": "runtime parameter for tool plotCorrelation",
+          "name": "corData"
+        }
+      ],
+      "label": null,
+      "name": "plotCorrelation",
+      "outputs": [
+        {
+          "name": "outFileName",
+          "type": "png"
+        },
+        {
+          "name": "matrix",
+          "type": "tabular"
+        }
+      ],
+      "position": {
+        "left": 3114.96875,
+        "top": 1641.9375
+      },
+      "post_job_actions": {
+        "HideDatasetActionmatrix": {
+          "action_arguments": {},
+          "action_type": "HideDatasetAction",
+          "output_name": "matrix"
+        }
+      },
+      "tool_id": "toolshed.g2.bx.psu.edu/repos/bgruening/deeptools_plot_correlation/deeptools_plot_correlation/2.5.7.0",
+      "tool_shed_repository": {
+        "changeset_revision": "a165d1e95d7d",
+        "name": "deeptools_plot_correlation",
+        "owner": "bgruening",
+        "tool_shed": "toolshed.g2.bx.psu.edu"
+      },
+      "tool_state": "{\"__page__\": null, \"removeOutliers\": \"\\\"false\\\"\", \"outFileFormat\": \"\\\"png\\\"\", \"__rerun_remap_job_id__\": null, \"corMethod\": \"\\\"spearman\\\"\", \"skipZeros\": \"\\\"true\\\"\", \"plotting_type\": \"{\\\"__current_case__\\\": 0, \\\"colorMap\\\": [\\\"RdYlBu\\\"], \\\"plotHeight\\\": \\\"9.5\\\", \\\"plotNumbers\\\": \\\"false\\\", \\\"plotTitle\\\": \\\"\\\", \\\"plotWidth\\\": \\\"11.0\\\", \\\"whatToPlot\\\": \\\"heatmap\\\", \\\"zMax\\\": \\\"\\\", \\\"zMin\\\": \\\"\\\"}\", \"corData\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\", \"outFileCorMatrix\": \"\\\"false\\\"\"}",
+      "tool_version": "2.5.7.0",
+      "type": "tool",
+      "uuid": "89870514-b435-4c27-84b7-f62cca48cb74",
+      "workflow_outputs": [
+        {
+          "label": null,
+          "output_name": "outFileName",
+          "uuid": "7ca293a1-c55d-4778-92ae-50b0fdfc4d5f"
+        }
+      ]
+    },
+    "35": {
+      "annotation": "",
+      "content_id": "toolshed.g2.bx.psu.edu/repos/bgruening/text_processing/tp_awk_tool/1.1.1",
+      "errors": null,
+      "id": 35,
+      "input_connections": {
+        "infile": {
+          "id": 31,
+          "output_name": "output"
+        }
+      },
+      "inputs": [
+        {
+          "description": "runtime parameter for tool Text reformatting",
+          "name": "infile"
+        }
+      ],
+      "label": null,
+      "name": "Text reformatting",
+      "outputs": [
+        {
+          "name": "outfile",
+          "type": "input"
+        }
+      ],
+      "position": {
+        "left": 3742.4375,
+        "top": 206.53125
+      },
+      "post_job_actions": {
+        "ChangeDatatypeActionoutfile": {
+          "action_arguments": {
+            "newtype": "bed"
+          },
+          "action_type": "ChangeDatatypeAction",
+          "output_name": "outfile"
+        },
+        "HideDatasetActionoutfile": {
+          "action_arguments": {},
+          "action_type": "HideDatasetAction",
+          "output_name": "outfile"
+        }
+      },
+      "tool_id": "toolshed.g2.bx.psu.edu/repos/bgruening/text_processing/tp_awk_tool/1.1.1",
+      "tool_shed_repository": {
+        "changeset_revision": "a6f147a050a2",
+        "name": "text_processing",
+        "owner": "bgruening",
+        "tool_shed": "toolshed.g2.bx.psu.edu"
+      },
+      "tool_state": "{\"__page__\": null, \"__rerun_remap_job_id__\": null, \"code\": \"\\\"{print $0}\\\"\", \"infile\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\"}",
+      "tool_version": "1.1.1",
+      "type": "tool",
+      "uuid": "d3001faf-3df4-4ba8-bb65-874cd8c82038",
+      "workflow_outputs": []
+    },
+    "36": {
+      "annotation": "",
+      "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/extract_genomic_dna/Extract genomic DNA 1/3.0.0",
+      "errors": null,
+      "id": 36,
+      "input_connections": {
+        "input": {
+          "id": 31,
+          "output_name": "output"
+        }
+      },
+      "inputs": [
+        {
+          "description": "runtime parameter for tool Extract Genomic DNA",
+          "name": "input"
+        }
+      ],
+      "label": null,
+      "name": "Extract Genomic DNA",
+      "outputs": [
+        {
+          "name": "output",
+          "type": "gff"
+        }
+      ],
+      "position": {
+        "left": 3924.4375,
+        "top": 1043.53125
+      },
+      "post_job_actions": {
+        "ChangeDatatypeActionoutput": {
+          "action_arguments": {
+            "newtype": "fasta"
+          },
+          "action_type": "ChangeDatatypeAction",
+          "output_name": "output"
+        },
+        "HideDatasetActionoutput": {
+          "action_arguments": {},
+          "action_type": "HideDatasetAction",
+          "output_name": "output"
+        }
+      },
+      "tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/extract_genomic_dna/Extract genomic DNA 1/3.0.0",
+      "tool_shed_repository": {
+        "changeset_revision": "8dd8e89c0603",
+        "name": "extract_genomic_dna",
+        "owner": "iuc",
+        "tool_shed": "toolshed.g2.bx.psu.edu"
+      },
+      "tool_state": "{\"__page__\": null, \"interpret_features\": \"\\\"yes\\\"\", \"output_format\": \"\\\"fasta\\\"\", \"reference_genome_cond\": \"{\\\"__current_case__\\\": 0, \\\"reference_genome\\\": \\\"hg38\\\", \\\"reference_genome_source\\\": \\\"cached\\\"}\", \"input\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\", \"__rerun_remap_job_id__\": null}",
+      "tool_version": "3.0.0",
+      "type": "tool",
+      "uuid": "fe61aa32-4ada-47bb-9595-0745f4da75de",
+      "workflow_outputs": []
+    },
+    "37": {
+      "annotation": "",
+      "content_id": "wig_to_bigWig",
+      "errors": null,
+      "id": 37,
+      "input_connections": {
+        "input1": {
+          "id": 32,
+          "output_name": "output"
+        }
+      },
+      "inputs": [
+        {
+          "description": "runtime parameter for tool Wig/BedGraph-to-bigWig",
+          "name": "input1"
+        }
+      ],
+      "label": null,
+      "name": "Wig/BedGraph-to-bigWig",
+      "outputs": [
+        {
+          "name": "out_file1",
+          "type": "bigwig"
+        }
+      ],
+      "position": {
+        "left": 4063.515625,
+        "top": 1901.453125
+      },
+      "post_job_actions": {
+        "HideDatasetActionout_file1": {
+          "action_arguments": {},
+          "action_type": "HideDatasetAction",
+          "output_name": "out_file1"
+        }
+      },
+      "tool_id": "wig_to_bigWig",
+      "tool_state": "{\"__page__\": null, \"__rerun_remap_job_id__\": null, \"input1\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\", \"settings\": \"{\\\"__current_case__\\\": 0, \\\"settingsType\\\": \\\"preset\\\"}\"}",
+      "tool_version": "1.1.1",
+      "type": "tool",
+      "uuid": "155b7227-de37-466b-8265-8ad016ab4b60",
+      "workflow_outputs": []
+    },
+    "38": {
+      "annotation": "",
+      "content_id": "toolshed.g2.bx.psu.edu/repos/rnateam/rcas/rcas/1.5.4",
+      "errors": null,
+      "id": 38,
+      "input_connections": {
+        "analysis_type|single_bed_file": {
+          "id": 35,
+          "output_name": "outfile"
+        },
+        "input_gtf_file": {
+          "id": 3,
+          "output_name": "output"
+        }
+      },
+      "inputs": [
+        {
+          "description": "runtime parameter for tool RCAS",
+          "name": "analysis_type"
+        },
+        {
+          "description": "runtime parameter for tool RCAS",
+          "name": "input_gtf_file"
+        }
+      ],
+      "label": null,
+      "name": "RCAS",
+      "outputs": [
+        {
+          "name": "report",
+          "type": "html"
+        },
+        {
+          "name": "summarizeQueryRegions",
+          "type": "tsv"
+        },
+        {
+          "name": "query_gene_types",
+          "type": "tsv"
+        },
+        {
+          "name": "transcriptBoundaryCoverage.fiveprime",
+          "type": "tsv"
+        },
+        {
+          "name": "transcriptBoundaryCoverage.threeprime",
+          "type": "tsv"
+        },
+        {
+          "name": "exonIntronBoundaryCoverage.fiveprime",
+          "type": "tsv"
+        },
+        {
+          "name": "exonIntronBoundaryCoverage.threeprime",
+          "type": "tsv"
+        },
+        {
+          "name": "coverageprofilelist",
+          "type": "tsv"
+        },
+        {
+          "name": "getTargetedGenesTable",
+          "type": "tsv"
+        },
+        {
+          "name": "goCC",
+          "type": "tsv"
+        },
+        {
+          "name": "goBP",
+          "type": "tsv"
+        },
+        {
+          "name": "goMF",
+          "type": "tsv"
+        },
+        {
+          "name": "GSEA",
+          "type": "tsv"
+        },
+        {
+          "name": "multi_report",
+          "type": "html"
+        }
+      ],
+      "position": {
+        "left": 3972.03125,
+        "top": 200
+      },
+      "post_job_actions": {
+        "HideDatasetActionGSEA": {
+          "action_arguments": {},
+          "action_type": "HideDatasetAction",
+          "output_name": "GSEA"
+        },
+        "HideDatasetActioncoverageprofilelist": {
+          "action_arguments": {},
+          "action_type": "HideDatasetAction",
+          "output_name": "coverageprofilelist"
+        },
+        "HideDatasetActionexonIntronBoundaryCoverage.fiveprime": {
+          "action_arguments": {},
+          "action_type": "HideDatasetAction",
+          "output_name": "exonIntronBoundaryCoverage.fiveprime"
+        },
+        "HideDatasetActionexonIntronBoundaryCoverage.threeprime": {
+          "action_arguments": {},
+          "action_type": "HideDatasetAction",
+          "output_name": "exonIntronBoundaryCoverage.threeprime"
+        },
+        "HideDatasetActiongetTargetedGenesTable": {
+          "action_arguments": {},
+          "action_type": "HideDatasetAction",
+          "output_name": "getTargetedGenesTable"
+        },
+        "HideDatasetActiongoBP": {
+          "action_arguments": {},
+          "action_type": "HideDatasetAction",
+          "output_name": "goBP"
+        },
+        "HideDatasetActiongoCC": {
+          "action_arguments": {},
+          "action_type": "HideDatasetAction",
+          "output_name": "goCC"
+        },
+        "HideDatasetActiongoMF": {
+          "action_arguments": {},
+          "action_type": "HideDatasetAction",
+          "output_name": "goMF"
+        },
+        "HideDatasetActionmulti_report": {
+          "action_arguments": {},
+          "action_type": "HideDatasetAction",
+          "output_name": "multi_report"
+        },
+        "HideDatasetActionquery_gene_types": {
+          "action_arguments": {},
+          "action_type": "HideDatasetAction",
+          "output_name": "query_gene_types"
+        },
+        "HideDatasetActionsummarizeQueryRegions": {
+          "action_arguments": {},
+          "action_type": "HideDatasetAction",
+          "output_name": "summarizeQueryRegions"
+        },
+        "HideDatasetActiontranscriptBoundaryCoverage.fiveprime": {
+          "action_arguments": {},
+          "action_type": "HideDatasetAction",
+          "output_name": "transcriptBoundaryCoverage.fiveprime"
+        },
+        "HideDatasetActiontranscriptBoundaryCoverage.threeprime": {
+          "action_arguments": {},
+          "action_type": "HideDatasetAction",
+          "output_name": "transcriptBoundaryCoverage.threeprime"
+        }
+      },
+      "tool_id": "toolshed.g2.bx.psu.edu/repos/rnateam/rcas/rcas/1.5.4",
+      "tool_shed_repository": {
+        "changeset_revision": "7c7a2a381dfe",
+        "name": "rcas",
+        "owner": "rnateam",
+        "tool_shed": "toolshed.g2.bx.psu.edu"
+      },
+      "tool_state": "{\"__page__\": null, \"run_annot\": \"\\\"true\\\"\", \"__rerun_remap_job_id__\": null, \"input_gtf_file\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\", \"run_motif\": \"\\\"false\\\"\", \"genome_version\": \"\\\"hg38\\\"\", \"analysis_type\": \"{\\\"__current_case__\\\": 0, \\\"analysis_type_selector\\\": \\\"single_set_analysis\\\", \\\"downsampling\\\": \\\"0\\\", \\\"gsea_set\\\": {\\\"__current_case__\\\": 0, \\\"run_gsea\\\": \\\"false\\\"}, \\\"output_raw_tables\\\": \\\"true\\\", \\\"run_go\\\": \\\"true\\\", \\\"single_bed_file\\\": {\\\"__class__\\\": \\\"RuntimeValue\\\"}}\"}",
+      "tool_version": "1.5.4",
+      "type": "tool",
+      "uuid": "70579628-4754-48f2-b85d-2f4969e226de",
+      "workflow_outputs": [
+        {
+          "label": null,
+          "output_name": "report",
+          "uuid": "52630a89-59cf-4d0d-b9b0-ee901433a3fc"
+        }
+      ]
+    },
+    "39": {
+      "annotation": "",
+      "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/meme_chip/meme_chip/4.11.2",
+      "errors": null,
+      "id": 39,
+      "input_connections": {
+        "input": {
+          "id": 36,
+          "output_name": "output"
+        }
+      },
+      "inputs": [
+        {
+          "description": "runtime parameter for tool MEME-ChIP",
+          "name": "control"
+        },
+        {
+          "description": "runtime parameter for tool MEME-ChIP",
+          "name": "input"
+        }
+      ],
+      "label": null,
+      "name": "MEME-ChIP",
+      "outputs": [
+        {
+          "name": "output",
+          "type": "html"
+        }
+      ],
+      "position": {
+        "left": 4176.921875,
+        "top": 1035.984375
+      },
+      "post_job_actions": {},
+      "tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/meme_chip/meme_chip/4.11.2",
+      "tool_shed_repository": {
+        "changeset_revision": "6095db402811",
+        "name": "meme_chip",
+        "owner": "iuc",
+        "tool_shed": "toolshed.g2.bx.psu.edu"
+      },
+      "tool_state": "{\"control\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\", \"__page__\": null, \"sequence_alphabet\": \"\\\"-dna\\\"\", \"__rerun_remap_job_id__\": null, \"non_commercial_use\": \"\\\"true\\\"\", \"input\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\", \"options_type_cond\": \"{\\\"__current_case__\\\": 1, \\\"background_model_order\\\": \\\"1\\\", \\\"ccut\\\": \\\"0\\\", \\\"dreme_e\\\": \\\"0.05\\\", \\\"dreme_m\\\": \\\"5\\\", \\\"filter_thresh\\\": \\\"0.05\\\", \\\"group_threash\\\": \\\"0.05\\\", \\\"group_weak\\\": \\\"0.0\\\", \\\"meme_maxsites\\\": \\\"0\\\", \\\"meme_maxw\\\": \\\"20\\\", \\\"meme_minsites\\\": \\\"0\\\", \\\"meme_minw\\\": \\\"5\\\", \\\"meme_mod\\\": \\\"zoops\\\", \\\"meme_nmotifs\\\": \\\"20\\\", \\\"meme_pal\\\": \\\"false\\\", \\\"nmeme\\\": \\\"100\\\", \\\"old_clustering\\\": \\\"false\\\", \\\"options_type\\\": \\\"advanced\\\", \\\"search_given_strand\\\": \\\"true\\\", \\\"subsampling_cond\\\": {\\\"__current_case__\\\": 0, \\\"seed\\\": \\\"123\\\", \\\"subsampling\\\": \\\"yes\\\"}}\"}",
+      "tool_version": "4.11.2",
+      "type": "tool",
+      "uuid": "be9c97a4-9ba8-478d-858f-f98e36695343",
+      "workflow_outputs": [
+        {
+          "label": null,
+          "output_name": "output",
+          "uuid": "40ccb74c-6f03-41c4-a93b-26bc548b08e1"
+        }
+      ]
+    },
+    "4": {
+      "annotation": "",
+      "content_id": "__UNZIP_COLLECTION__",
+      "errors": null,
+      "id": 4,
+      "input_connections": {
+        "input": {
+          "id": 0,
+          "output_name": "output"
+        }
+      },
+      "inputs": [
+        {
+          "description": "runtime parameter for tool Unzip Collection",
+          "name": "input"
+        }
+      ],
+      "label": null,
+      "name": "Unzip Collection",
+      "outputs": [
+        {
+          "name": "forward",
+          "type": "data"
+        },
+        {
+          "name": "reverse",
+          "type": "data"
+        }
+      ],
+      "position": {
+        "left": 513.5625,
+        "top": 412.625
+      },
+      "post_job_actions": {
+        "ChangeDatatypeActionforward": {
+          "action_arguments": {
+            "newtype": "fastqsanger"
+          },
+          "action_type": "ChangeDatatypeAction",
+          "output_name": "forward"
+        },
+        "ChangeDatatypeActionreverse": {
+          "action_arguments": {
+            "newtype": "fastqsanger"
+          },
+          "action_type": "ChangeDatatypeAction",
+          "output_name": "reverse"
+        },
+        "HideDatasetActionforward": {
+          "action_arguments": {},
+          "action_type": "HideDatasetAction",
+          "output_name": "forward"
+        },
+        "HideDatasetActionreverse": {
+          "action_arguments": {},
+          "action_type": "HideDatasetAction",
+          "output_name": "reverse"
+        }
+      },
+      "tool_id": "__UNZIP_COLLECTION__",
+      "tool_state": "{\"input\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\", \"__rerun_remap_job_id__\": null, \"__page__\": null}",
+      "tool_version": "1.0.0",
+      "type": "tool",
+      "uuid": "69da121d-9386-4502-aebb-85bd4ea76c2e",
+      "workflow_outputs": []
+    },
+    "5": {
+      "annotation": "",
+      "content_id": "toolshed.g2.bx.psu.edu/repos/devteam/fastqc/fastqc/0.71",
+      "errors": null,
+      "id": 5,
+      "input_connections": {
+        "input_file": {
+          "id": 0,
+          "output_name": "output"
+        }
+      },
+      "inputs": [
+        {
+          "description": "runtime parameter for tool FastQC",
+          "name": "contaminants"
+        },
+        {
+          "description": "runtime parameter for tool FastQC",
+          "name": "limits"
+        },
+        {
+          "description": "runtime parameter for tool FastQC",
+          "name": "input_file"
+        }
+      ],
+      "label": null,
+      "name": "FastQC",
+      "outputs": [
+        {
+          "name": "html_file",
+          "type": "html"
+        },
+        {
+          "name": "text_file",
+          "type": "txt"
+        }
+      ],
+      "position": {
+        "left": 296.96875,
+        "top": 648.9375
+      },
+      "post_job_actions": {
+        "HideDatasetActiontext_file": {
+          "action_arguments": {},
+          "action_type": "HideDatasetAction",
+          "output_name": "text_file"
+        }
+      },
+      "tool_id": "toolshed.g2.bx.psu.edu/repos/devteam/fastqc/fastqc/0.71",
+      "tool_shed_repository": {
+        "changeset_revision": "ff9530579d1f",
+        "name": "fastqc",
+        "owner": "devteam",
+        "tool_shed": "toolshed.g2.bx.psu.edu"
+      },
+      "tool_state": "{\"__page__\": null, \"contaminants\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\", \"__rerun_remap_job_id__\": null, \"limits\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\", \"input_file\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\"}",
+      "tool_version": "0.71",
+      "type": "tool",
+      "uuid": "160075d4-e7d5-45a6-a29c-4ab604b8b1e0",
+      "workflow_outputs": [
+        {
+          "label": null,
+          "output_name": "html_file",
+          "uuid": "28b01599-4f4d-4ed9-ba14-ab897d181c40"
+        }
+      ]
+    },
+    "6": {
+      "annotation": "",
+      "content_id": "__UNZIP_COLLECTION__",
+      "errors": null,
+      "id": 6,
+      "input_connections": {
+        "input": {
+          "id": 1,
+          "output_name": "output"
+        }
+      },
+      "inputs": [
+        {
+          "description": "runtime parameter for tool Unzip Collection",
+          "name": "input"
+        }
+      ],
+      "label": null,
+      "name": "Unzip Collection",
+      "outputs": [
+        {
+          "name": "forward",
+          "type": "data"
+        },
+        {
+          "name": "reverse",
+          "type": "data"
+        }
+      ],
+      "position": {
+        "left": 471.078125,
+        "top": 1193.75
+      },
+      "post_job_actions": {
+        "ChangeDatatypeActionforward": {
+          "action_arguments": {
+            "newtype": "fastq"
+          },
+          "action_type": "ChangeDatatypeAction",
+          "output_name": "forward"
+        },
+        "ChangeDatatypeActionreverse": {
+          "action_arguments": {
+            "newtype": "fastq"
+          },
+          "action_type": "ChangeDatatypeAction",
+          "output_name": "reverse"
+        },
+        "HideDatasetActionforward": {
+          "action_arguments": {},
+          "action_type": "HideDatasetAction",
+          "output_name": "forward"
+        },
+        "HideDatasetActionreverse": {
+          "action_arguments": {},
+          "action_type": "HideDatasetAction",
+          "output_name": "reverse"
+        }
+      },
+      "tool_id": "__UNZIP_COLLECTION__",
+      "tool_state": "{\"input\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\", \"__rerun_remap_job_id__\": null, \"__page__\": null}",
+      "tool_version": "1.0.0",
+      "type": "tool",
+      "uuid": "61b987e1-abcb-4660-8881-6c8de1c76334",
+      "workflow_outputs": []
+    },
+    "7": {
+      "annotation": "",
+      "content_id": "toolshed.g2.bx.psu.edu/repos/devteam/fastqc/fastqc/0.71",
+      "errors": null,
+      "id": 7,
+      "input_connections": {
+        "input_file": {
+          "id": 1,
+          "output_name": "output"
+        }
+      },
+      "inputs": [
+        {
+          "description": "runtime parameter for tool FastQC",
+          "name": "contaminants"
+        },
+        {
+          "description": "runtime parameter for tool FastQC",
+          "name": "limits"
+        },
+        {
+          "description": "runtime parameter for tool FastQC",
+          "name": "input_file"
+        }
+      ],
+      "label": null,
+      "name": "FastQC",
+      "outputs": [
+        {
+          "name": "html_file",
+          "type": "html"
+        },
+        {
+          "name": "text_file",
+          "type": "txt"
+        }
+      ],
+      "position": {
+        "left": 260,
+        "top": 1405.984375
+      },
+      "post_job_actions": {
+        "HideDatasetActiontext_file": {
+          "action_arguments": {},
+          "action_type": "HideDatasetAction",
+          "output_name": "text_file"
+        }
+      },
+      "tool_id": "toolshed.g2.bx.psu.edu/repos/devteam/fastqc/fastqc/0.71",
+      "tool_shed_repository": {
+        "changeset_revision": "ff9530579d1f",
+        "name": "fastqc",
+        "owner": "devteam",
+        "tool_shed": "toolshed.g2.bx.psu.edu"
+      },
+      "tool_state": "{\"__page__\": null, \"contaminants\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\", \"__rerun_remap_job_id__\": null, \"limits\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\", \"input_file\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\"}",
+      "tool_version": "0.71",
+      "type": "tool",
+      "uuid": "b91bbfc0-45ec-4798-9fba-50fc99861989",
+      "workflow_outputs": [
+        {
+          "label": null,
+          "output_name": "html_file",
+          "uuid": "eb520228-351d-480e-bac2-964967f6aac1"
+        }
+      ]
+    },
+    "8": {
+      "annotation": "",
+      "content_id": "toolshed.g2.bx.psu.edu/repos/lparsons/cutadapt/cutadapt/1.6",
+      "errors": null,
+      "id": 8,
+      "input_connections": {
+        "input": {
+          "id": 4,
+          "output_name": "forward"
+        },
+        "paired_end|input2": {
+          "id": 4,
+          "output_name": "reverse"
+        }
+      },
+      "inputs": [
+        {
+          "description": "runtime parameter for tool Cutadapt",
+          "name": "paired_end"
+        },
+        {
+          "description": "runtime parameter for tool Cutadapt",
+          "name": "input"
+        }
+      ],
+      "label": null,
+      "name": "Cutadapt",
+      "outputs": [
+        {
+          "name": "report",
+          "type": "txt"
+        },
+        {
+          "name": "output",
+          "type": "input"
+        },
+        {
+          "name": "paired_output",
+          "type": "input"
+        },
+        {
+          "name": "rest_output",
+          "type": "input"
+        },
+        {
+          "name": "wild_output",
+          "type": "input"
+        },
+        {
+          "name": "too_short_output",
+          "type": "input"
+        },
+        {
+          "name": "too_long_output",
+          "type": "input"
+        },
+        {
+          "name": "untrimmed_output",
+          "type": "input"
+        },
+        {
+          "name": "untrimmed_paired_output",
+          "type": "input"
+        },
+        {
+          "name": "info_file",
+          "type": "input"
+        }
+      ],
+      "position": {
+        "left": 727.4375,
+        "top": 416.5
+      },
+      "post_job_actions": {
+        "HideDatasetActioninfo_file": {
+          "action_arguments": {},
+          "action_type": "HideDatasetAction",
+          "output_name": "info_file"
+        },
+        "HideDatasetActionoutput": {
+          "action_arguments": {},
+          "action_type": "HideDatasetAction",
+          "output_name": "output"
+        },
+        "HideDatasetActionpaired_output": {
+          "action_arguments": {},
+          "action_type": "HideDatasetAction",
+          "output_name": "paired_output"
+        },
+        "HideDatasetActionreport": {
+          "action_arguments": {},
+          "action_type": "HideDatasetAction",
+          "output_name": "report"
+        },
+        "HideDatasetActionrest_output": {
+          "action_arguments": {},
+          "action_type": "HideDatasetAction",
+          "output_name": "rest_output"
+        },
+        "HideDatasetActiontoo_long_output": {
+          "action_arguments": {},
+          "action_type": "HideDatasetAction",
+          "output_name": "too_long_output"
+        },
+        "HideDatasetActiontoo_short_output": {
+          "action_arguments": {},
+          "action_type": "HideDatasetAction",
+          "output_name": "too_short_output"
+        },
+        "HideDatasetActionuntrimmed_output": {
+          "action_arguments": {},
+          "action_type": "HideDatasetAction",
+          "output_name": "untrimmed_output"
+        },
+        "HideDatasetActionuntrimmed_paired_output": {
+          "action_arguments": {},
+          "action_type": "HideDatasetAction",
+          "output_name": "untrimmed_paired_output"
+        },
+        "HideDatasetActionwild_output": {
+          "action_arguments": {},
+          "action_type": "HideDatasetAction",
+          "output_name": "wild_output"
+        }
+      },
+      "tool_id": "toolshed.g2.bx.psu.edu/repos/lparsons/cutadapt/cutadapt/1.6",
+      "tool_shed_repository": {
+        "changeset_revision": "01d94df2e32a",
+        "name": "cutadapt",
+        "owner": "lparsons",
+        "tool_shed": "toolshed.g2.bx.psu.edu"
+      },
+      "tool_state": "{\"count\": \"\\\"1\\\"\", \"error_rate\": \"\\\"0.1\\\"\", \"match_read_wildcards\": \"\\\"false\\\"\", \"paired_end\": \"{\\\"__current_case__\\\": 0, \\\"input2\\\": {\\\"__class__\\\": \\\"RuntimeValue\\\"}, \\\"paired_end_boolean\\\": \\\"true\\\"}\", \"__page__\": null, \"output_params\": \"{\\\"__current_case__\\\": 0, \\\"output_type\\\": \\\"default\\\"}\", \"__rerun_remap_job_id__\": null, \"overlap\": \"\\\"5\\\"\", \"front_adapters\": \"[{\\\"__index__\\\": 0, \\\"front_adapter_source\\\": {\\\"__current_case__\\\": 0, \\\"front_adapter\\\": \\\"CTTCCGATCTACAAGTT\\\", \\\"front_adapter_name\\\": \\\"\\\", \\\"front_adapter_source_list\\\": \\\"user\\\"}}, {\\\"__index__\\\": 1, \\\"front_adapter_source\\\": {\\\"__current_case__\\\": 0, \\\"front_adapter\\\": \\\"CTTCCGATCTTGGTCCT\\\", \\\"front_adapter_name\\\": \\\"\\\", \\\"front_adapter_source_list\\\": \\\"user\\\"}}]\", \"input\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\", \"no_indels\": \"\\\"false\\\"\", \"anywhere_adapters\": \"[]\", \"adapters\": \"[{\\\"__index__\\\": 0, \\\"adapter_source\\\": {\\\"__current_case__\\\": 0, \\\"adapter\\\": \\\"AACTTGTAGATCGGA\\\", \\\"adapter_name\\\": \\\"\\\", \\\"adapter_source_list\\\": \\\"user\\\"}}, {\\\"__index__\\\": 1, \\\"adapter_source\\\": {\\\"__current_case__\\\": 0, \\\"adapter\\\": \\\"AGGACCAAGATCGGA\\\", \\\"adapter_name\\\": \\\"\\\", \\\"adapter_source_list\\\": \\\"user\\\"}}]\", \"read_modification_params\": \"{\\\"__current_case__\\\": 1, \\\"cut\\\": \\\"-5\\\", \\\"length_tag\\\": \\\"\\\", \\\"prefix\\\": \\\"\\\", \\\"quality_cutoff\\\": \\\"0\\\", \\\"read_modification\\\": \\\"modify\\\", \\\"strip_suffix\\\": \\\"\\\", \\\"suffix\\\": \\\"\\\", \\\"zero_cap\\\": \\\"false\\\"}\", \"output_filtering_options\": \"{\\\"__current_case__\\\": 1, \\\"discard\\\": \\\"false\\\", \\\"discard_untrimmed\\\": \\\"false\\\", \\\"mask_adapter\\\": \\\"false\\\", \\\"max\\\": \\\"0\\\", \\\"min\\\": \\\"10\\\", \\\"no_trim\\\": \\\"false\\\", \\\"output_filtering\\\": \\\"filter\\\"}\"}",
+      "tool_version": "1.6",
+      "type": "tool",
+      "uuid": "051e5c15-50ee-4dea-8ca6-1e237dba4e6a",
+      "workflow_outputs": []
+    },
+    "9": {
+      "annotation": "",
+      "content_id": "toolshed.g2.bx.psu.edu/repos/lparsons/cutadapt/cutadapt/1.6",
+      "errors": null,
+      "id": 9,
+      "input_connections": {
+        "input": {
+          "id": 6,
+          "output_name": "forward"
+        },
+        "paired_end|input2": {
+          "id": 6,
+          "output_name": "reverse"
+        }
+      },
+      "inputs": [
+        {
+          "description": "runtime parameter for tool Cutadapt",
+          "name": "paired_end"
+        },
+        {
+          "description": "runtime parameter for tool Cutadapt",
+          "name": "input"
+        }
+      ],
+      "label": null,
+      "name": "Cutadapt",
+      "outputs": [
+        {
+          "name": "report",
+          "type": "txt"
+        },
+        {
+          "name": "output",
+          "type": "input"
+        },
+        {
+          "name": "paired_output",
+          "type": "input"
+        },
+        {
+          "name": "rest_output",
+          "type": "input"
+        },
+        {
+          "name": "wild_output",
+          "type": "input"
+        },
+        {
+          "name": "too_short_output",
+          "type": "input"
+        },
+        {
+          "name": "too_long_output",
+          "type": "input"
+        },
+        {
+          "name": "untrimmed_output",
+          "type": "input"
+        },
+        {
+          "name": "untrimmed_paired_output",
+          "type": "input"
+        },
+        {
+          "name": "info_file",
+          "type": "input"
+        }
+      ],
+      "position": {
+        "left": 709.4375,
+        "top": 1197.5
+      },
+      "post_job_actions": {
+        "HideDatasetActioninfo_file": {
+          "action_arguments": {},
+          "action_type": "HideDatasetAction",
+          "output_name": "info_file"
+        },
+        "HideDatasetActionoutput": {
+          "action_arguments": {},
+          "action_type": "HideDatasetAction",
+          "output_name": "output"
+        },
+        "HideDatasetActionpaired_output": {
+          "action_arguments": {},
+          "action_type": "HideDatasetAction",
+          "output_name": "paired_output"
+        },
+        "HideDatasetActionreport": {
+          "action_arguments": {},
+          "action_type": "HideDatasetAction",
+          "output_name": "report"
+        },
+        "HideDatasetActionrest_output": {
+          "action_arguments": {},
+          "action_type": "HideDatasetAction",
+          "output_name": "rest_output"
+        },
+        "HideDatasetActiontoo_long_output": {
+          "action_arguments": {},
+          "action_type": "HideDatasetAction",
+          "output_name": "too_long_output"
+        },
+        "HideDatasetActiontoo_short_output": {
+          "action_arguments": {},
+          "action_type": "HideDatasetAction",
+          "output_name": "too_short_output"
+        },
+        "HideDatasetActionuntrimmed_output": {
+          "action_arguments": {},
+          "action_type": "HideDatasetAction",
+          "output_name": "untrimmed_output"
+        },
+        "HideDatasetActionuntrimmed_paired_output": {
+          "action_arguments": {},
+          "action_type": "HideDatasetAction",
+          "output_name": "untrimmed_paired_output"
+        },
+        "HideDatasetActionwild_output": {
+          "action_arguments": {},
+          "action_type": "HideDatasetAction",
+          "output_name": "wild_output"
+        }
+      },
+      "tool_id": "toolshed.g2.bx.psu.edu/repos/lparsons/cutadapt/cutadapt/1.6",
+      "tool_shed_repository": {
+        "changeset_revision": "01d94df2e32a",
+        "name": "cutadapt",
+        "owner": "lparsons",
+        "tool_shed": "toolshed.g2.bx.psu.edu"
+      },
+      "tool_state": "{\"count\": \"\\\"1\\\"\", \"error_rate\": \"\\\"0.1\\\"\", \"match_read_wildcards\": \"\\\"false\\\"\", \"paired_end\": \"{\\\"__current_case__\\\": 0, \\\"input2\\\": {\\\"__class__\\\": \\\"RuntimeValue\\\"}, \\\"paired_end_boolean\\\": \\\"true\\\"}\", \"__page__\": null, \"output_params\": \"{\\\"__current_case__\\\": 0, \\\"output_type\\\": \\\"default\\\"}\", \"__rerun_remap_job_id__\": null, \"overlap\": \"\\\"5\\\"\", \"front_adapters\": \"[{\\\"__index__\\\": 0, \\\"front_adapter_source\\\": {\\\"__current_case__\\\": 0, \\\"front_adapter\\\": \\\"CTTCCGATCTACAAGTT\\\", \\\"front_adapter_name\\\": \\\"\\\", \\\"front_adapter_source_list\\\": \\\"user\\\"}}, {\\\"__index__\\\": 1, \\\"front_adapter_source\\\": {\\\"__current_case__\\\": 0, \\\"front_adapter\\\": \\\"CTTCCGATCTTGGTCCT\\\", \\\"front_adapter_name\\\": \\\"\\\", \\\"front_adapter_source_list\\\": \\\"user\\\"}}]\", \"input\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\", \"no_indels\": \"\\\"false\\\"\", \"anywhere_adapters\": \"[]\", \"adapters\": \"[{\\\"__index__\\\": 0, \\\"adapter_source\\\": {\\\"__current_case__\\\": 0, \\\"adapter\\\": \\\"AACTTGTAGATCGGA\\\", \\\"adapter_name\\\": \\\"\\\", \\\"adapter_source_list\\\": \\\"user\\\"}}, {\\\"__index__\\\": 1, \\\"adapter_source\\\": {\\\"__current_case__\\\": 0, \\\"adapter\\\": \\\"AGGACCAAGATCGGA\\\", \\\"adapter_name\\\": \\\"\\\", \\\"adapter_source_list\\\": \\\"user\\\"}}]\", \"read_modification_params\": \"{\\\"__current_case__\\\": 1, \\\"cut\\\": \\\"-5\\\", \\\"length_tag\\\": \\\"\\\", \\\"prefix\\\": \\\"\\\", \\\"quality_cutoff\\\": \\\"0\\\", \\\"read_modification\\\": \\\"modify\\\", \\\"strip_suffix\\\": \\\"\\\", \\\"suffix\\\": \\\"\\\", \\\"zero_cap\\\": \\\"false\\\"}\", \"output_filtering_options\": \"{\\\"__current_case__\\\": 1, \\\"discard\\\": \\\"false\\\", \\\"discard_untrimmed\\\": \\\"false\\\", \\\"mask_adapter\\\": \\\"false\\\", \\\"max\\\": \\\"0\\\", \\\"min\\\": \\\"10\\\", \\\"no_trim\\\": \\\"false\\\", \\\"output_filtering\\\": \\\"filter\\\"}\"}",
+      "tool_version": "1.6",
+      "type": "tool",
+      "uuid": "f1af723e-4c41-4cc2-8baf-080650f758e7",
+      "workflow_outputs": []
+    }
+  },
+  "tags": [],
+  "uuid": "5c350c2e-f8d1-433f-8627-e68608f226d3",
+  "version": 24
+}

--- a/topics/transcriptomics/tutorials/de-novo/workflows/transcriptomics-denovo-workflow.ga
+++ b/topics/transcriptomics/tutorials/de-novo/workflows/transcriptomics-denovo-workflow.ga
@@ -1,1 +1,2232 @@
-{"uuid": "dc8abeee-46fa-4965-9a58-396b3ac0c310", "tags": [], "format-version": "0.1", "name": "transcriptomics-denovo-workflow", "steps": {"0": {"tool_id": null, "tool_version": null, "outputs": [], "workflow_outputs": [], "input_connections": {}, "tool_state": "{\"name\": \"G1E_rep1_forward_read\"}", "id": 0, "uuid": "cbc6590c-d6de-4abf-b53f-6c83b4ab4120", "errors": null, "name": "Input dataset", "label": null, "inputs": [{"name": "G1E_rep1_forward_read", "description": ""}], "position": {"top": 10, "left": 10}, "annotation": "", "content_id": null, "type": "data_input"}, "1": {"tool_id": null, "tool_version": null, "outputs": [], "workflow_outputs": [], "input_connections": {}, "tool_state": "{\"name\": \"G1E_rep1_reverse_read\"}", "id": 1, "uuid": "c2ba4aba-060a-40ba-88d6-e6fef8a1f2eb", "errors": null, "name": "Input dataset", "label": null, "inputs": [{"name": "G1E_rep1_reverse_read", "description": ""}], "position": {"top": 130, "left": 10}, "annotation": "", "content_id": null, "type": "data_input"}, "2": {"tool_id": null, "tool_version": null, "outputs": [], "workflow_outputs": [], "input_connections": {}, "tool_state": "{\"name\": \"G1E_rep2_forward_read\"}", "id": 2, "uuid": "c24cf053-248c-4922-874e-240f187853ca", "errors": null, "name": "Input dataset", "label": null, "inputs": [{"name": "G1E_rep2_forward_read", "description": ""}], "position": {"top": 250, "left": 10}, "annotation": "", "content_id": null, "type": "data_input"}, "3": {"tool_id": null, "tool_version": null, "outputs": [], "workflow_outputs": [], "input_connections": {}, "tool_state": "{\"name\": \"G1E_rep2_reverse_read\"}", "id": 3, "uuid": "4d89fd77-a8ae-41c8-8dfe-e9446fdeaddb", "errors": null, "name": "Input dataset", "label": null, "inputs": [{"name": "G1E_rep2_reverse_read", "description": ""}], "position": {"top": 370, "left": 10}, "annotation": "", "content_id": null, "type": "data_input"}, "4": {"tool_id": null, "tool_version": null, "outputs": [], "workflow_outputs": [], "input_connections": {}, "tool_state": "{\"name\": \"Megakaryocyte_rep1_forward_read\"}", "id": 4, "uuid": "41e16899-910c-4750-84cf-4bddc17437c2", "errors": null, "name": "Input dataset", "label": null, "inputs": [{"name": "Megakaryocyte_rep1_forward_read", "description": ""}], "position": {"top": 490, "left": 10}, "annotation": "", "content_id": null, "type": "data_input"}, "5": {"tool_id": null, "tool_version": null, "outputs": [], "workflow_outputs": [], "input_connections": {}, "tool_state": "{\"name\": \"Megakaryocyte_rep1_reverse_read\"}", "id": 5, "uuid": "e7b2ddb1-99fc-4898-9c10-e5ac8fa9fd3a", "errors": null, "name": "Input dataset", "label": null, "inputs": [{"name": "Megakaryocyte_rep1_reverse_read", "description": ""}], "position": {"top": 610, "left": 10}, "annotation": "", "content_id": null, "type": "data_input"}, "6": {"tool_id": null, "tool_version": null, "outputs": [], "workflow_outputs": [], "input_connections": {}, "tool_state": "{\"name\": \"Megakaryocyte_rep2_forward_read\"}", "id": 6, "uuid": "8eff105a-d216-4399-bac1-a67d3f09514f", "errors": null, "name": "Input dataset", "label": null, "inputs": [{"name": "Megakaryocyte_rep2_forward_read", "description": ""}], "position": {"top": 730, "left": 10}, "annotation": "", "content_id": null, "type": "data_input"}, "7": {"tool_id": null, "tool_version": null, "outputs": [], "workflow_outputs": [], "input_connections": {}, "tool_state": "{\"name\": \"Megakaryocyte_rep2_reverse_read\"}", "id": 7, "uuid": "f22827e1-68d3-4ae0-9d4a-67bca6a8b288", "errors": null, "name": "Input dataset", "label": null, "inputs": [{"name": "Megakaryocyte_rep2_reverse_read", "description": ""}], "position": {"top": 850, "left": 10}, "annotation": "", "content_id": null, "type": "data_input"}, "8": {"tool_id": null, "tool_version": null, "outputs": [], "workflow_outputs": [], "input_connections": {}, "tool_state": "{\"name\": \"RefSeq_reference_GTF\"}", "id": 8, "uuid": "758d9ac9-4e4a-45fa-a5ad-2fb4f5f7f87d", "errors": null, "name": "Input dataset", "label": null, "inputs": [{"name": "RefSeq_reference_GTF", "description": ""}], "position": {"top": 970, "left": 10}, "annotation": "", "content_id": null, "type": "data_input"}, "9": {"tool_id": "toolshed.g2.bx.psu.edu/repos/devteam/fastqc/fastqc/0.72", "tool_version": "0.72", "outputs": [{"type": "html", "name": "html_file"}, {"type": "txt", "name": "text_file"}], "workflow_outputs": [], "input_connections": {"input_file": {"output_name": "output", "id": 0}}, "tool_state": "{\"__page__\": null, \"limits\": \"null\", \"input_file\": \"null\", \"__rerun_remap_job_id__\": null, \"__workflow_invocation_uuid__\": \"\\\"fde8952eb77711e8a468005056ba55fb\\\"\", \"contaminants\": \"null\", \"chromInfo\": \"\\\"/cvmfs/data.galaxyproject.org/managed/len/ucsc/?.len\\\"\"}", "id": 9, "tool_shed_repository": {"owner": "devteam", "changeset_revision": "c15237684a01", "name": "fastqc", "tool_shed": "toolshed.g2.bx.psu.edu"}, "uuid": "32c35846-2972-4d71-8af6-03350acd490a", "errors": null, "name": "FastQC", "post_job_actions": {}, "label": null, "inputs": [], "position": {"top": 10, "left": 230}, "annotation": "", "content_id": "toolshed.g2.bx.psu.edu/repos/devteam/fastqc/fastqc/0.72", "type": "tool"}, "10": {"tool_id": "toolshed.g2.bx.psu.edu/repos/devteam/fastqc/fastqc/0.72", "tool_version": "0.72", "outputs": [{"type": "html", "name": "html_file"}, {"type": "txt", "name": "text_file"}], "workflow_outputs": [], "input_connections": {"input_file": {"output_name": "output", "id": 1}}, "tool_state": "{\"__page__\": null, \"limits\": \"null\", \"input_file\": \"null\", \"__rerun_remap_job_id__\": null, \"__workflow_invocation_uuid__\": \"\\\"fde8952eb77711e8a468005056ba55fb\\\"\", \"contaminants\": \"null\", \"chromInfo\": \"\\\"/cvmfs/data.galaxyproject.org/managed/len/ucsc/?.len\\\"\"}", "id": 10, "tool_shed_repository": {"owner": "devteam", "changeset_revision": "c15237684a01", "name": "fastqc", "tool_shed": "toolshed.g2.bx.psu.edu"}, "uuid": "a4db4907-e8e9-4534-a37c-7c1d6c34de20", "errors": null, "name": "FastQC", "post_job_actions": {}, "label": null, "inputs": [], "position": {"top": 130, "left": 230}, "annotation": "", "content_id": "toolshed.g2.bx.psu.edu/repos/devteam/fastqc/fastqc/0.72", "type": "tool"}, "11": {"tool_id": "toolshed.g2.bx.psu.edu/repos/pjbriggs/trimmomatic/trimmomatic/0.36.5", "tool_version": "0.36.5", "outputs": [{"type": "input", "name": "fastq_out_paired"}, {"type": "input", "name": "fastq_out_unpaired"}, {"type": "input", "name": "fastq_out_r1_paired"}, {"type": "input", "name": "fastq_out_r2_paired"}, {"type": "input", "name": "fastq_out_r1_unpaired"}, {"type": "input", "name": "fastq_out_r2_unpaired"}, {"type": "input", "name": "fastq_out"}], "workflow_outputs": [], "input_connections": {"readtype|fastq_r2_in": {"output_name": "output", "id": 1}, "readtype|fastq_r1_in": {"output_name": "output", "id": 0}}, "tool_state": "{\"operations\": \"[{\\\"__index__\\\": 0, \\\"operation\\\": {\\\"window_size\\\": \\\"4\\\", \\\"name\\\": \\\"SLIDINGWINDOW\\\", \\\"__current_case__\\\": 0, \\\"required_quality\\\": \\\"20\\\"}}]\", \"__page__\": null, \"__rerun_remap_job_id__\": null, \"readtype\": \"{\\\"single_or_paired\\\": \\\"pair_of_files\\\", \\\"fastq_r1_in\\\": null, \\\"__current_case__\\\": 1, \\\"fastq_r2_in\\\": null}\", \"illuminaclip\": \"{\\\"do_illuminaclip\\\": \\\"false\\\", \\\"__current_case__\\\": 1}\", \"__workflow_invocation_uuid__\": \"\\\"fde8952eb77711e8a468005056ba55fb\\\"\", \"chromInfo\": \"\\\"/cvmfs/data.galaxyproject.org/managed/len/ucsc/?.len\\\"\"}", "id": 11, "tool_shed_repository": {"owner": "pjbriggs", "changeset_revision": "dfa082f84068", "name": "trimmomatic", "tool_shed": "toolshed.g2.bx.psu.edu"}, "uuid": "d7a54fe5-9cd2-4209-9a02-b7d2d636b337", "errors": null, "name": "Trimmomatic", "post_job_actions": {}, "label": null, "inputs": [], "position": {"top": 250, "left": 230}, "annotation": "", "content_id": "toolshed.g2.bx.psu.edu/repos/pjbriggs/trimmomatic/trimmomatic/0.36.5", "type": "tool"}, "12": {"tool_id": "toolshed.g2.bx.psu.edu/repos/devteam/fastqc/fastqc/0.72", "tool_version": "0.72", "outputs": [{"type": "html", "name": "html_file"}, {"type": "txt", "name": "text_file"}], "workflow_outputs": [], "input_connections": {"input_file": {"output_name": "output", "id": 2}}, "tool_state": "{\"__page__\": null, \"limits\": \"null\", \"input_file\": \"null\", \"__rerun_remap_job_id__\": null, \"__workflow_invocation_uuid__\": \"\\\"fde8952eb77711e8a468005056ba55fb\\\"\", \"contaminants\": \"null\", \"chromInfo\": \"\\\"/cvmfs/data.galaxyproject.org/managed/len/ucsc/?.len\\\"\"}", "id": 12, "tool_shed_repository": {"owner": "devteam", "changeset_revision": "c15237684a01", "name": "fastqc", "tool_shed": "toolshed.g2.bx.psu.edu"}, "uuid": "c96f55e9-c898-4e79-abe2-0795b54d3a05", "errors": null, "name": "FastQC", "post_job_actions": {}, "label": null, "inputs": [], "position": {"top": 370, "left": 230}, "annotation": "", "content_id": "toolshed.g2.bx.psu.edu/repos/devteam/fastqc/fastqc/0.72", "type": "tool"}, "13": {"tool_id": "toolshed.g2.bx.psu.edu/repos/devteam/fastqc/fastqc/0.72", "tool_version": "0.72", "outputs": [{"type": "html", "name": "html_file"}, {"type": "txt", "name": "text_file"}], "workflow_outputs": [], "input_connections": {"input_file": {"output_name": "output", "id": 3}}, "tool_state": "{\"__page__\": null, \"limits\": \"null\", \"input_file\": \"null\", \"__rerun_remap_job_id__\": null, \"__workflow_invocation_uuid__\": \"\\\"fde8952eb77711e8a468005056ba55fb\\\"\", \"contaminants\": \"null\", \"chromInfo\": \"\\\"/cvmfs/data.galaxyproject.org/managed/len/ucsc/?.len\\\"\"}", "id": 13, "tool_shed_repository": {"owner": "devteam", "changeset_revision": "c15237684a01", "name": "fastqc", "tool_shed": "toolshed.g2.bx.psu.edu"}, "uuid": "d30af66b-0ab0-4bb9-8009-ce96a6c16993", "errors": null, "name": "FastQC", "post_job_actions": {}, "label": null, "inputs": [], "position": {"top": 490, "left": 230}, "annotation": "", "content_id": "toolshed.g2.bx.psu.edu/repos/devteam/fastqc/fastqc/0.72", "type": "tool"}, "14": {"tool_id": "toolshed.g2.bx.psu.edu/repos/pjbriggs/trimmomatic/trimmomatic/0.36.5", "tool_version": "0.36.5", "outputs": [{"type": "input", "name": "fastq_out_paired"}, {"type": "input", "name": "fastq_out_unpaired"}, {"type": "input", "name": "fastq_out_r1_paired"}, {"type": "input", "name": "fastq_out_r2_paired"}, {"type": "input", "name": "fastq_out_r1_unpaired"}, {"type": "input", "name": "fastq_out_r2_unpaired"}, {"type": "input", "name": "fastq_out"}], "workflow_outputs": [], "input_connections": {"readtype|fastq_r2_in": {"output_name": "output", "id": 3}, "readtype|fastq_r1_in": {"output_name": "output", "id": 2}}, "tool_state": "{\"operations\": \"[{\\\"__index__\\\": 0, \\\"operation\\\": {\\\"window_size\\\": \\\"4\\\", \\\"name\\\": \\\"SLIDINGWINDOW\\\", \\\"__current_case__\\\": 0, \\\"required_quality\\\": \\\"20\\\"}}]\", \"__page__\": null, \"__rerun_remap_job_id__\": null, \"readtype\": \"{\\\"single_or_paired\\\": \\\"pair_of_files\\\", \\\"fastq_r1_in\\\": null, \\\"__current_case__\\\": 1, \\\"fastq_r2_in\\\": null}\", \"illuminaclip\": \"{\\\"do_illuminaclip\\\": \\\"false\\\", \\\"__current_case__\\\": 1}\", \"__workflow_invocation_uuid__\": \"\\\"fde8952eb77711e8a468005056ba55fb\\\"\", \"chromInfo\": \"\\\"/cvmfs/data.galaxyproject.org/managed/len/ucsc/?.len\\\"\"}", "id": 14, "tool_shed_repository": {"owner": "pjbriggs", "changeset_revision": "dfa082f84068", "name": "trimmomatic", "tool_shed": "toolshed.g2.bx.psu.edu"}, "uuid": "3d3cfa70-c027-40aa-b01c-52c36035fe92", "errors": null, "name": "Trimmomatic", "post_job_actions": {}, "label": null, "inputs": [], "position": {"top": 610, "left": 230}, "annotation": "", "content_id": "toolshed.g2.bx.psu.edu/repos/pjbriggs/trimmomatic/trimmomatic/0.36.5", "type": "tool"}, "15": {"tool_id": "toolshed.g2.bx.psu.edu/repos/devteam/fastqc/fastqc/0.72", "tool_version": "0.72", "outputs": [{"type": "html", "name": "html_file"}, {"type": "txt", "name": "text_file"}], "workflow_outputs": [], "input_connections": {"input_file": {"output_name": "output", "id": 4}}, "tool_state": "{\"__page__\": null, \"limits\": \"null\", \"input_file\": \"null\", \"__rerun_remap_job_id__\": null, \"__workflow_invocation_uuid__\": \"\\\"fde8952eb77711e8a468005056ba55fb\\\"\", \"contaminants\": \"null\", \"chromInfo\": \"\\\"/cvmfs/data.galaxyproject.org/managed/len/ucsc/?.len\\\"\"}", "id": 15, "tool_shed_repository": {"owner": "devteam", "changeset_revision": "c15237684a01", "name": "fastqc", "tool_shed": "toolshed.g2.bx.psu.edu"}, "uuid": "a6295400-a0ee-4790-9294-44e39e5df96c", "errors": null, "name": "FastQC", "post_job_actions": {}, "label": null, "inputs": [], "position": {"top": 730, "left": 230}, "annotation": "", "content_id": "toolshed.g2.bx.psu.edu/repos/devteam/fastqc/fastqc/0.72", "type": "tool"}, "16": {"tool_id": "toolshed.g2.bx.psu.edu/repos/devteam/fastqc/fastqc/0.72", "tool_version": "0.72", "outputs": [{"type": "html", "name": "html_file"}, {"type": "txt", "name": "text_file"}], "workflow_outputs": [], "input_connections": {"input_file": {"output_name": "output", "id": 5}}, "tool_state": "{\"__page__\": null, \"limits\": \"null\", \"input_file\": \"null\", \"__rerun_remap_job_id__\": null, \"__workflow_invocation_uuid__\": \"\\\"fde8952eb77711e8a468005056ba55fb\\\"\", \"contaminants\": \"null\", \"chromInfo\": \"\\\"/cvmfs/data.galaxyproject.org/managed/len/ucsc/?.len\\\"\"}", "id": 16, "tool_shed_repository": {"owner": "devteam", "changeset_revision": "c15237684a01", "name": "fastqc", "tool_shed": "toolshed.g2.bx.psu.edu"}, "uuid": "d7866331-a1c1-4c4b-8f6b-f7feb78fa78c", "errors": null, "name": "FastQC", "post_job_actions": {}, "label": null, "inputs": [], "position": {"top": 850, "left": 230}, "annotation": "", "content_id": "toolshed.g2.bx.psu.edu/repos/devteam/fastqc/fastqc/0.72", "type": "tool"}, "17": {"tool_id": "toolshed.g2.bx.psu.edu/repos/pjbriggs/trimmomatic/trimmomatic/0.36.5", "tool_version": "0.36.5", "outputs": [{"type": "input", "name": "fastq_out_paired"}, {"type": "input", "name": "fastq_out_unpaired"}, {"type": "input", "name": "fastq_out_r1_paired"}, {"type": "input", "name": "fastq_out_r2_paired"}, {"type": "input", "name": "fastq_out_r1_unpaired"}, {"type": "input", "name": "fastq_out_r2_unpaired"}, {"type": "input", "name": "fastq_out"}], "workflow_outputs": [], "input_connections": {"readtype|fastq_r2_in": {"output_name": "output", "id": 5}, "readtype|fastq_r1_in": {"output_name": "output", "id": 4}}, "tool_state": "{\"operations\": \"[{\\\"__index__\\\": 0, \\\"operation\\\": {\\\"window_size\\\": \\\"4\\\", \\\"name\\\": \\\"SLIDINGWINDOW\\\", \\\"__current_case__\\\": 0, \\\"required_quality\\\": \\\"20\\\"}}]\", \"__page__\": null, \"__rerun_remap_job_id__\": null, \"readtype\": \"{\\\"single_or_paired\\\": \\\"pair_of_files\\\", \\\"fastq_r1_in\\\": null, \\\"__current_case__\\\": 1, \\\"fastq_r2_in\\\": null}\", \"illuminaclip\": \"{\\\"do_illuminaclip\\\": \\\"false\\\", \\\"__current_case__\\\": 1}\", \"__workflow_invocation_uuid__\": \"\\\"fde8952eb77711e8a468005056ba55fb\\\"\", \"chromInfo\": \"\\\"/cvmfs/data.galaxyproject.org/managed/len/ucsc/?.len\\\"\"}", "id": 17, "tool_shed_repository": {"owner": "pjbriggs", "changeset_revision": "dfa082f84068", "name": "trimmomatic", "tool_shed": "toolshed.g2.bx.psu.edu"}, "uuid": "c7ff55a4-e3df-4fde-93a3-ab0e175d5d6e", "errors": null, "name": "Trimmomatic", "post_job_actions": {}, "label": null, "inputs": [], "position": {"top": 970, "left": 230}, "annotation": "", "content_id": "toolshed.g2.bx.psu.edu/repos/pjbriggs/trimmomatic/trimmomatic/0.36.5", "type": "tool"}, "18": {"tool_id": "toolshed.g2.bx.psu.edu/repos/devteam/fastqc/fastqc/0.72", "tool_version": "0.72", "outputs": [{"type": "html", "name": "html_file"}, {"type": "txt", "name": "text_file"}], "workflow_outputs": [], "input_connections": {"input_file": {"output_name": "output", "id": 6}}, "tool_state": "{\"__page__\": null, \"limits\": \"null\", \"input_file\": \"null\", \"__rerun_remap_job_id__\": null, \"__workflow_invocation_uuid__\": \"\\\"fde8952eb77711e8a468005056ba55fb\\\"\", \"contaminants\": \"null\", \"chromInfo\": \"\\\"/cvmfs/data.galaxyproject.org/managed/len/ucsc/?.len\\\"\"}", "id": 18, "tool_shed_repository": {"owner": "devteam", "changeset_revision": "c15237684a01", "name": "fastqc", "tool_shed": "toolshed.g2.bx.psu.edu"}, "uuid": "e56ae1f1-b6ee-4f0a-873b-fae2c345c216", "errors": null, "name": "FastQC", "post_job_actions": {}, "label": null, "inputs": [], "position": {"top": 1090, "left": 230}, "annotation": "", "content_id": "toolshed.g2.bx.psu.edu/repos/devteam/fastqc/fastqc/0.72", "type": "tool"}, "19": {"tool_id": "toolshed.g2.bx.psu.edu/repos/devteam/fastqc/fastqc/0.72", "tool_version": "0.72", "outputs": [{"type": "html", "name": "html_file"}, {"type": "txt", "name": "text_file"}], "workflow_outputs": [], "input_connections": {"input_file": {"output_name": "output", "id": 7}}, "tool_state": "{\"__page__\": null, \"limits\": \"null\", \"input_file\": \"null\", \"__rerun_remap_job_id__\": null, \"__workflow_invocation_uuid__\": \"\\\"fde8952eb77711e8a468005056ba55fb\\\"\", \"contaminants\": \"null\", \"chromInfo\": \"\\\"/cvmfs/data.galaxyproject.org/managed/len/ucsc/?.len\\\"\"}", "id": 19, "tool_shed_repository": {"owner": "devteam", "changeset_revision": "c15237684a01", "name": "fastqc", "tool_shed": "toolshed.g2.bx.psu.edu"}, "uuid": "d1068d72-f84b-431c-9137-38eb42606147", "errors": null, "name": "FastQC", "post_job_actions": {}, "label": null, "inputs": [], "position": {"top": 1210, "left": 230}, "annotation": "", "content_id": "toolshed.g2.bx.psu.edu/repos/devteam/fastqc/fastqc/0.72", "type": "tool"}, "20": {"tool_id": "toolshed.g2.bx.psu.edu/repos/pjbriggs/trimmomatic/trimmomatic/0.36.5", "tool_version": "0.36.5", "outputs": [{"type": "input", "name": "fastq_out_paired"}, {"type": "input", "name": "fastq_out_unpaired"}, {"type": "input", "name": "fastq_out_r1_paired"}, {"type": "input", "name": "fastq_out_r2_paired"}, {"type": "input", "name": "fastq_out_r1_unpaired"}, {"type": "input", "name": "fastq_out_r2_unpaired"}, {"type": "input", "name": "fastq_out"}], "workflow_outputs": [], "input_connections": {"readtype|fastq_r2_in": {"output_name": "output", "id": 7}, "readtype|fastq_r1_in": {"output_name": "output", "id": 6}}, "tool_state": "{\"operations\": \"[{\\\"__index__\\\": 0, \\\"operation\\\": {\\\"window_size\\\": \\\"4\\\", \\\"name\\\": \\\"SLIDINGWINDOW\\\", \\\"__current_case__\\\": 0, \\\"required_quality\\\": \\\"20\\\"}}]\", \"__page__\": null, \"__rerun_remap_job_id__\": null, \"readtype\": \"{\\\"single_or_paired\\\": \\\"pair_of_files\\\", \\\"fastq_r1_in\\\": null, \\\"__current_case__\\\": 1, \\\"fastq_r2_in\\\": null}\", \"illuminaclip\": \"{\\\"do_illuminaclip\\\": \\\"false\\\", \\\"__current_case__\\\": 1}\", \"__workflow_invocation_uuid__\": \"\\\"fde8952eb77711e8a468005056ba55fb\\\"\", \"chromInfo\": \"\\\"/cvmfs/data.galaxyproject.org/managed/len/ucsc/?.len\\\"\"}", "id": 20, "tool_shed_repository": {"owner": "pjbriggs", "changeset_revision": "dfa082f84068", "name": "trimmomatic", "tool_shed": "toolshed.g2.bx.psu.edu"}, "uuid": "81433b00-0996-44b0-ae73-db880a8c68c0", "errors": null, "name": "Trimmomatic", "post_job_actions": {}, "label": null, "inputs": [], "position": {"top": 1330, "left": 230}, "annotation": "", "content_id": "toolshed.g2.bx.psu.edu/repos/pjbriggs/trimmomatic/trimmomatic/0.36.5", "type": "tool"}, "21": {"tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/hisat2/hisat2/2.1.0", "tool_version": "2.1.0", "outputs": [{"type": "bam", "name": "output_alignments"}, {"type": "fastqsanger", "name": "output_unaligned_reads_l"}, {"type": "fastqsanger", "name": "output_aligned_reads_l"}, {"type": "fastqsanger", "name": "output_unaligned_reads_r"}, {"type": "fastqsanger", "name": "output_aligned_reads_r"}, {"type": "txt", "name": "summary_file"}], "workflow_outputs": [], "input_connections": {"library|input_2": {"output_name": "fastq_out_r2_paired", "id": 11}, "library|input_1": {"output_name": "fastq_out_r1_paired", "id": 11}}, "tool_state": "{\"adv\": \"{\\\"alignment_options\\\": {\\\"__current_case__\\\": 0, \\\"alignment_options_selector\\\": \\\"defaults\\\"}, \\\"output_options\\\": {\\\"output_options_selector\\\": \\\"defaults\\\", \\\"__current_case__\\\": 0}, \\\"other_options\\\": {\\\"other_options_selector\\\": \\\"defaults\\\", \\\"__current_case__\\\": 0}, \\\"scoring_options\\\": {\\\"scoring_options_selector\\\": \\\"defaults\\\", \\\"__current_case__\\\": 0}, \\\"spliced_options\\\": {\\\"coefficient\\\": \\\"0.0\\\", \\\"canonical_penalty\\\": \\\"0\\\", \\\"no_spliced_alignment_options\\\": {\\\"no_spliced_alignment\\\": \\\"\\\", \\\"__current_case__\\\": 1}, \\\"nc_function_type\\\": \\\"C\\\", \\\"constant_term\\\": \\\"0.0\\\", \\\"nc_coefficient\\\": \\\"1.0\\\", \\\"noncanonical_penalty\\\": \\\"3\\\", \\\"known_splice_gtf\\\": null, \\\"nc_constant_term\\\": \\\"-8.0\\\", \\\"min_intron\\\": \\\"20\\\", \\\"function_type\\\": \\\"C\\\", \\\"__current_case__\\\": 1, \\\"notmplen\\\": \\\"false\\\", \\\"tma\\\": \\\"--dta\\\", \\\"max_intron\\\": \\\"500000\\\", \\\"spliced_options_selector\\\": \\\"advanced\\\"}, \\\"reporting_options\\\": {\\\"reporting_options_selector\\\": \\\"defaults\\\", \\\"__current_case__\\\": 0}, \\\"input_options\\\": {\\\"input_options_selector\\\": \\\"defaults\\\", \\\"__current_case__\\\": 0}}\", \"__page__\": null, \"sum\": \"{\\\"new_summary\\\": \\\"false\\\", \\\"summary_file\\\": \\\"false\\\"}\", \"library\": \"{\\\"rna_strandness\\\": \\\"FR\\\", \\\"input_2\\\": null, \\\"__current_case__\\\": 1, \\\"input_1\\\": null, \\\"type\\\": \\\"paired\\\", \\\"paired_options\\\": {\\\"paired_options_selector\\\": \\\"defaults\\\", \\\"__current_case__\\\": 0}}\", \"reference_genome\": \"{\\\"source\\\": \\\"indexed\\\", \\\"__current_case__\\\": 0, \\\"index\\\": \\\"mm10\\\"}\", \"__workflow_invocation_uuid__\": \"\\\"fde8952eb77711e8a468005056ba55fb\\\"\", \"chromInfo\": \"\\\"/cvmfs/data.galaxyproject.org/managed/len/ucsc/?.len\\\"\", \"__rerun_remap_job_id__\": null}", "id": 21, "tool_shed_repository": {"owner": "iuc", "changeset_revision": "6ab42baa56e9", "name": "hisat2", "tool_shed": "toolshed.g2.bx.psu.edu"}, "uuid": "817cc498-44f1-4813-92f0-3b88fed3451f", "errors": null, "name": "HISAT2", "post_job_actions": {}, "label": null, "inputs": [], "position": {"top": 10, "left": 450}, "annotation": "", "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/hisat2/hisat2/2.1.0", "type": "tool"}, "22": {"tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/hisat2/hisat2/2.1.0", "tool_version": "2.1.0", "outputs": [{"type": "bam", "name": "output_alignments"}, {"type": "fastqsanger", "name": "output_unaligned_reads_l"}, {"type": "fastqsanger", "name": "output_aligned_reads_l"}, {"type": "fastqsanger", "name": "output_unaligned_reads_r"}, {"type": "fastqsanger", "name": "output_aligned_reads_r"}, {"type": "txt", "name": "summary_file"}], "workflow_outputs": [], "input_connections": {"library|input_2": {"output_name": "fastq_out_r2_paired", "id": 14}, "library|input_1": {"output_name": "fastq_out_r1_paired", "id": 14}}, "tool_state": "{\"adv\": \"{\\\"alignment_options\\\": {\\\"__current_case__\\\": 0, \\\"alignment_options_selector\\\": \\\"defaults\\\"}, \\\"output_options\\\": {\\\"output_options_selector\\\": \\\"defaults\\\", \\\"__current_case__\\\": 0}, \\\"other_options\\\": {\\\"other_options_selector\\\": \\\"defaults\\\", \\\"__current_case__\\\": 0}, \\\"scoring_options\\\": {\\\"scoring_options_selector\\\": \\\"defaults\\\", \\\"__current_case__\\\": 0}, \\\"spliced_options\\\": {\\\"coefficient\\\": \\\"0.0\\\", \\\"canonical_penalty\\\": \\\"0\\\", \\\"no_spliced_alignment_options\\\": {\\\"no_spliced_alignment\\\": \\\"\\\", \\\"__current_case__\\\": 1}, \\\"nc_function_type\\\": \\\"C\\\", \\\"constant_term\\\": \\\"0.0\\\", \\\"nc_coefficient\\\": \\\"1.0\\\", \\\"noncanonical_penalty\\\": \\\"3\\\", \\\"known_splice_gtf\\\": null, \\\"nc_constant_term\\\": \\\"-8.0\\\", \\\"min_intron\\\": \\\"20\\\", \\\"function_type\\\": \\\"C\\\", \\\"__current_case__\\\": 1, \\\"notmplen\\\": \\\"false\\\", \\\"tma\\\": \\\"--dta\\\", \\\"max_intron\\\": \\\"500000\\\", \\\"spliced_options_selector\\\": \\\"advanced\\\"}, \\\"reporting_options\\\": {\\\"reporting_options_selector\\\": \\\"defaults\\\", \\\"__current_case__\\\": 0}, \\\"input_options\\\": {\\\"input_options_selector\\\": \\\"defaults\\\", \\\"__current_case__\\\": 0}}\", \"__page__\": null, \"sum\": \"{\\\"new_summary\\\": \\\"false\\\", \\\"summary_file\\\": \\\"false\\\"}\", \"library\": \"{\\\"rna_strandness\\\": \\\"FR\\\", \\\"input_2\\\": null, \\\"__current_case__\\\": 1, \\\"input_1\\\": null, \\\"type\\\": \\\"paired\\\", \\\"paired_options\\\": {\\\"paired_options_selector\\\": \\\"defaults\\\", \\\"__current_case__\\\": 0}}\", \"reference_genome\": \"{\\\"source\\\": \\\"indexed\\\", \\\"__current_case__\\\": 0, \\\"index\\\": \\\"mm10\\\"}\", \"__workflow_invocation_uuid__\": \"\\\"fde8952eb77711e8a468005056ba55fb\\\"\", \"chromInfo\": \"\\\"/cvmfs/data.galaxyproject.org/managed/len/ucsc/?.len\\\"\", \"__rerun_remap_job_id__\": null}", "id": 22, "tool_shed_repository": {"owner": "iuc", "changeset_revision": "6ab42baa56e9", "name": "hisat2", "tool_shed": "toolshed.g2.bx.psu.edu"}, "uuid": "1e92db79-135e-4a5e-9d3f-ea0d7f5045da", "errors": null, "name": "HISAT2", "post_job_actions": {}, "label": null, "inputs": [], "position": {"top": 130, "left": 450}, "annotation": "", "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/hisat2/hisat2/2.1.0", "type": "tool"}, "23": {"tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/hisat2/hisat2/2.1.0", "tool_version": "2.1.0", "outputs": [{"type": "bam", "name": "output_alignments"}, {"type": "fastqsanger", "name": "output_unaligned_reads_l"}, {"type": "fastqsanger", "name": "output_aligned_reads_l"}, {"type": "fastqsanger", "name": "output_unaligned_reads_r"}, {"type": "fastqsanger", "name": "output_aligned_reads_r"}, {"type": "txt", "name": "summary_file"}], "workflow_outputs": [], "input_connections": {"library|input_2": {"output_name": "fastq_out_r2_paired", "id": 17}, "library|input_1": {"output_name": "fastq_out_r1_paired", "id": 17}}, "tool_state": "{\"adv\": \"{\\\"alignment_options\\\": {\\\"__current_case__\\\": 0, \\\"alignment_options_selector\\\": \\\"defaults\\\"}, \\\"output_options\\\": {\\\"output_options_selector\\\": \\\"defaults\\\", \\\"__current_case__\\\": 0}, \\\"other_options\\\": {\\\"other_options_selector\\\": \\\"defaults\\\", \\\"__current_case__\\\": 0}, \\\"scoring_options\\\": {\\\"scoring_options_selector\\\": \\\"defaults\\\", \\\"__current_case__\\\": 0}, \\\"spliced_options\\\": {\\\"coefficient\\\": \\\"0.0\\\", \\\"canonical_penalty\\\": \\\"0\\\", \\\"no_spliced_alignment_options\\\": {\\\"no_spliced_alignment\\\": \\\"\\\", \\\"__current_case__\\\": 1}, \\\"nc_function_type\\\": \\\"C\\\", \\\"constant_term\\\": \\\"0.0\\\", \\\"nc_coefficient\\\": \\\"1.0\\\", \\\"noncanonical_penalty\\\": \\\"3\\\", \\\"known_splice_gtf\\\": null, \\\"nc_constant_term\\\": \\\"-8.0\\\", \\\"min_intron\\\": \\\"20\\\", \\\"function_type\\\": \\\"C\\\", \\\"__current_case__\\\": 1, \\\"notmplen\\\": \\\"false\\\", \\\"tma\\\": \\\"--dta\\\", \\\"max_intron\\\": \\\"500000\\\", \\\"spliced_options_selector\\\": \\\"advanced\\\"}, \\\"reporting_options\\\": {\\\"reporting_options_selector\\\": \\\"defaults\\\", \\\"__current_case__\\\": 0}, \\\"input_options\\\": {\\\"input_options_selector\\\": \\\"defaults\\\", \\\"__current_case__\\\": 0}}\", \"__page__\": null, \"sum\": \"{\\\"new_summary\\\": \\\"false\\\", \\\"summary_file\\\": \\\"false\\\"}\", \"library\": \"{\\\"rna_strandness\\\": \\\"FR\\\", \\\"input_2\\\": null, \\\"__current_case__\\\": 1, \\\"input_1\\\": null, \\\"type\\\": \\\"paired\\\", \\\"paired_options\\\": {\\\"paired_options_selector\\\": \\\"defaults\\\", \\\"__current_case__\\\": 0}}\", \"reference_genome\": \"{\\\"source\\\": \\\"indexed\\\", \\\"__current_case__\\\": 0, \\\"index\\\": \\\"mm10\\\"}\", \"__workflow_invocation_uuid__\": \"\\\"fde8952eb77711e8a468005056ba55fb\\\"\", \"chromInfo\": \"\\\"/cvmfs/data.galaxyproject.org/managed/len/ucsc/?.len\\\"\", \"__rerun_remap_job_id__\": null}", "id": 23, "tool_shed_repository": {"owner": "iuc", "changeset_revision": "6ab42baa56e9", "name": "hisat2", "tool_shed": "toolshed.g2.bx.psu.edu"}, "uuid": "c488973c-6fe1-4f11-9268-1f108e3e1aae", "errors": null, "name": "HISAT2", "post_job_actions": {}, "label": null, "inputs": [], "position": {"top": 250, "left": 450}, "annotation": "", "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/hisat2/hisat2/2.1.0", "type": "tool"}, "24": {"tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/hisat2/hisat2/2.1.0", "tool_version": "2.1.0", "outputs": [{"type": "bam", "name": "output_alignments"}, {"type": "fastqsanger", "name": "output_unaligned_reads_l"}, {"type": "fastqsanger", "name": "output_aligned_reads_l"}, {"type": "fastqsanger", "name": "output_unaligned_reads_r"}, {"type": "fastqsanger", "name": "output_aligned_reads_r"}, {"type": "txt", "name": "summary_file"}], "workflow_outputs": [], "input_connections": {"library|input_2": {"output_name": "fastq_out_r2_paired", "id": 20}, "library|input_1": {"output_name": "fastq_out_r1_paired", "id": 20}}, "tool_state": "{\"adv\": \"{\\\"alignment_options\\\": {\\\"__current_case__\\\": 0, \\\"alignment_options_selector\\\": \\\"defaults\\\"}, \\\"output_options\\\": {\\\"output_options_selector\\\": \\\"defaults\\\", \\\"__current_case__\\\": 0}, \\\"other_options\\\": {\\\"other_options_selector\\\": \\\"defaults\\\", \\\"__current_case__\\\": 0}, \\\"scoring_options\\\": {\\\"scoring_options_selector\\\": \\\"defaults\\\", \\\"__current_case__\\\": 0}, \\\"spliced_options\\\": {\\\"coefficient\\\": \\\"0.0\\\", \\\"canonical_penalty\\\": \\\"0\\\", \\\"no_spliced_alignment_options\\\": {\\\"no_spliced_alignment\\\": \\\"\\\", \\\"__current_case__\\\": 1}, \\\"nc_function_type\\\": \\\"C\\\", \\\"constant_term\\\": \\\"0.0\\\", \\\"nc_coefficient\\\": \\\"1.0\\\", \\\"noncanonical_penalty\\\": \\\"3\\\", \\\"known_splice_gtf\\\": null, \\\"nc_constant_term\\\": \\\"-8.0\\\", \\\"min_intron\\\": \\\"20\\\", \\\"function_type\\\": \\\"C\\\", \\\"__current_case__\\\": 1, \\\"notmplen\\\": \\\"false\\\", \\\"tma\\\": \\\"--dta\\\", \\\"max_intron\\\": \\\"500000\\\", \\\"spliced_options_selector\\\": \\\"advanced\\\"}, \\\"reporting_options\\\": {\\\"reporting_options_selector\\\": \\\"defaults\\\", \\\"__current_case__\\\": 0}, \\\"input_options\\\": {\\\"input_options_selector\\\": \\\"defaults\\\", \\\"__current_case__\\\": 0}}\", \"__page__\": null, \"sum\": \"{\\\"new_summary\\\": \\\"false\\\", \\\"summary_file\\\": \\\"false\\\"}\", \"library\": \"{\\\"rna_strandness\\\": \\\"FR\\\", \\\"input_2\\\": null, \\\"__current_case__\\\": 1, \\\"input_1\\\": null, \\\"type\\\": \\\"paired\\\", \\\"paired_options\\\": {\\\"paired_options_selector\\\": \\\"defaults\\\", \\\"__current_case__\\\": 0}}\", \"reference_genome\": \"{\\\"source\\\": \\\"indexed\\\", \\\"__current_case__\\\": 0, \\\"index\\\": \\\"mm10\\\"}\", \"__workflow_invocation_uuid__\": \"\\\"fde8952eb77711e8a468005056ba55fb\\\"\", \"chromInfo\": \"\\\"/cvmfs/data.galaxyproject.org/managed/len/ucsc/?.len\\\"\", \"__rerun_remap_job_id__\": null}", "id": 24, "tool_shed_repository": {"owner": "iuc", "changeset_revision": "6ab42baa56e9", "name": "hisat2", "tool_shed": "toolshed.g2.bx.psu.edu"}, "uuid": "614c1c41-fcd0-447e-8514-c0876641809d", "errors": null, "name": "HISAT2", "post_job_actions": {}, "label": null, "inputs": [], "position": {"top": 370, "left": 450}, "annotation": "", "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/hisat2/hisat2/2.1.0", "type": "tool"}, "25": {"tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/stringtie/stringtie/1.3.3.2", "tool_version": "1.3.3.2", "outputs": [{"type": "gtf", "name": "output_gtf"}, {"type": "gtf", "name": "gene_abundance_estimation"}, {"type": "gtf", "name": "coverage"}, {"type": "tabular", "name": "exon_expression"}, {"type": "tabular", "name": "intron_expression"}, {"type": "tabular", "name": "transcript_expression"}, {"type": "tabular", "name": "exon_transcript_mapping"}, {"type": "tabular", "name": "intron_transcript_mapping"}, {"type": "tabular", "name": "gene_counts"}, {"type": "tabular", "name": "transcript_counts"}, {"type": "tabular", "name": "legend"}], "workflow_outputs": [], "input_connections": {"input_bam": {"output_name": "output_alignments", "id": 21}}, "tool_state": "{\"adv\": \"{\\\"min_bundle_cov\\\": \\\"2\\\", \\\"min_tlen\\\": \\\"200\\\", \\\"bdist\\\": \\\"50\\\", \\\"multi_mapping\\\": \\\"false\\\", \\\"abundance_estimation\\\": \\\"false\\\", \\\"fraction\\\": \\\"0.15\\\", \\\"disable_trimming\\\": \\\"false\\\", \\\"omit_sequences\\\": \\\"\\\", \\\"name_prefix\\\": \\\"\\\", \\\"min_anchor_len\\\": \\\"10\\\", \\\"bundle_fraction\\\": \\\"0.95\\\", \\\"min_anchor_cov\\\": \\\"1\\\"}\", \"__page__\": null, \"chromInfo\": \"\\\"/cvmfs/data.galaxyproject.org/managed/len/ucsc/mm10.len\\\"\", \"__rerun_remap_job_id__\": null, \"__workflow_invocation_uuid__\": \"\\\"fde8952eb77711e8a468005056ba55fb\\\"\", \"rna_strandness\": \"\\\"--fr\\\"\", \"input_bam\": \"null\", \"guide\": \"{\\\"use_guide\\\": \\\"no\\\", \\\"__current_case__\\\": 0}\"}", "id": 25, "tool_shed_repository": {"owner": "iuc", "changeset_revision": "eafd5dc95228", "name": "stringtie", "tool_shed": "toolshed.g2.bx.psu.edu"}, "uuid": "5fbbf39b-c5da-435e-a7cf-4d0d3ed9e05e", "errors": null, "name": "StringTie", "post_job_actions": {}, "label": null, "inputs": [], "position": {"top": 10, "left": 670}, "annotation": "", "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/stringtie/stringtie/1.3.3.2", "type": "tool"}, "26": {"tool_id": "toolshed.g2.bx.psu.edu/repos/bgruening/deeptools_bam_coverage/deeptools_bam_coverage/3.0.2.0", "tool_version": "3.0.2.0", "outputs": [{"type": "bigwig", "name": "outFileName"}], "workflow_outputs": [], "input_connections": {"bamInput": {"output_name": "output_alignments", "id": 21}}, "tool_state": "{\"__page__\": null, \"outFileFormat\": \"\\\"bigwig\\\"\", \"region\": \"\\\"\\\"\", \"bamInput\": \"null\", \"binSize\": \"\\\"1\\\"\", \"scaling\": \"{\\\"effectiveGenomeSize\\\": {\\\"effectiveGenomeSize_opt\\\": \\\"2304947926\\\", \\\"__current_case__\\\": 6}, \\\"type\\\": \\\"1x\\\", \\\"__current_case__\\\": 4}\", \"advancedOpt\": \"{\\\"ignoreDuplicates\\\": \\\"false\\\", \\\"centerReads\\\": \\\"false\\\", \\\"ignoreForNormalization\\\": \\\"\\\", \\\"minFragmentLength\\\": \\\"0\\\", \\\"minMappingQuality\\\": \\\"1\\\", \\\"MNase\\\": \\\"false\\\", \\\"samFlagInclude\\\": \\\"\\\", \\\"filterRNAstrand\\\": \\\"forward\\\", \\\"Offset\\\": \\\"\\\", \\\"smoothLength\\\": \\\"\\\", \\\"showAdvancedOpt\\\": \\\"yes\\\", \\\"__current_case__\\\": 1, \\\"samFlagExclude\\\": \\\"\\\", \\\"doExtendCustom\\\": {\\\"__current_case__\\\": 0, \\\"doExtend\\\": \\\"no\\\"}, \\\"skipNAs\\\": \\\"false\\\", \\\"scaleFactor\\\": \\\"1.0\\\", \\\"blackListFileName\\\": null, \\\"maxFragmentLength\\\": \\\"0\\\"}\", \"chromInfo\": \"\\\"/cvmfs/data.galaxyproject.org/managed/len/ucsc/mm10.len\\\"\", \"__rerun_remap_job_id__\": null}", "id": 26, "tool_shed_repository": {"owner": "bgruening", "changeset_revision": "3033c3fba046", "name": "deeptools_bam_coverage", "tool_shed": "toolshed.g2.bx.psu.edu"}, "uuid": "d61115e2-0a95-4b80-93bb-a14183d0e219", "errors": null, "name": "bamCoverage", "post_job_actions": {}, "label": null, "inputs": [], "position": {"top": 490, "left": 670}, "annotation": "", "content_id": "toolshed.g2.bx.psu.edu/repos/bgruening/deeptools_bam_coverage/deeptools_bam_coverage/3.0.2.0", "type": "tool"}, "27": {"tool_id": "toolshed.g2.bx.psu.edu/repos/bgruening/deeptools_bam_coverage/deeptools_bam_coverage/3.0.2.0", "tool_version": "3.0.2.0", "outputs": [{"type": "bigwig", "name": "outFileName"}], "workflow_outputs": [], "input_connections": {"bamInput": {"output_name": "output_alignments", "id": 21}}, "tool_state": "{\"__page__\": null, \"outFileFormat\": \"\\\"bigwig\\\"\", \"region\": \"\\\"\\\"\", \"bamInput\": \"null\", \"binSize\": \"\\\"1\\\"\", \"scaling\": \"{\\\"effectiveGenomeSize\\\": {\\\"effectiveGenomeSize_opt\\\": \\\"2304947926\\\", \\\"__current_case__\\\": 6}, \\\"type\\\": \\\"1x\\\", \\\"__current_case__\\\": 4}\", \"advancedOpt\": \"{\\\"ignoreDuplicates\\\": \\\"false\\\", \\\"centerReads\\\": \\\"false\\\", \\\"ignoreForNormalization\\\": \\\"\\\", \\\"minFragmentLength\\\": \\\"0\\\", \\\"minMappingQuality\\\": \\\"1\\\", \\\"MNase\\\": \\\"false\\\", \\\"samFlagInclude\\\": \\\"\\\", \\\"filterRNAstrand\\\": \\\"reverse\\\", \\\"Offset\\\": \\\"\\\", \\\"smoothLength\\\": \\\"\\\", \\\"showAdvancedOpt\\\": \\\"yes\\\", \\\"__current_case__\\\": 1, \\\"samFlagExclude\\\": \\\"\\\", \\\"doExtendCustom\\\": {\\\"__current_case__\\\": 0, \\\"doExtend\\\": \\\"no\\\"}, \\\"skipNAs\\\": \\\"false\\\", \\\"scaleFactor\\\": \\\"1.0\\\", \\\"blackListFileName\\\": null, \\\"maxFragmentLength\\\": \\\"0\\\"}\", \"chromInfo\": \"\\\"/cvmfs/data.galaxyproject.org/managed/len/ucsc/mm10.len\\\"\", \"__rerun_remap_job_id__\": null}", "id": 27, "tool_shed_repository": {"owner": "bgruening", "changeset_revision": "3033c3fba046", "name": "deeptools_bam_coverage", "tool_shed": "toolshed.g2.bx.psu.edu"}, "uuid": "72051e92-7fc3-447f-b289-e9d7e7043397", "errors": null, "name": "bamCoverage", "post_job_actions": {}, "label": null, "inputs": [], "position": {"top": 970, "left": 670}, "annotation": "", "content_id": "toolshed.g2.bx.psu.edu/repos/bgruening/deeptools_bam_coverage/deeptools_bam_coverage/3.0.2.0", "type": "tool"}, "28": {"tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/stringtie/stringtie/1.3.3.2", "tool_version": "1.3.3.2", "outputs": [{"type": "gtf", "name": "output_gtf"}, {"type": "gtf", "name": "gene_abundance_estimation"}, {"type": "gtf", "name": "coverage"}, {"type": "tabular", "name": "exon_expression"}, {"type": "tabular", "name": "intron_expression"}, {"type": "tabular", "name": "transcript_expression"}, {"type": "tabular", "name": "exon_transcript_mapping"}, {"type": "tabular", "name": "intron_transcript_mapping"}, {"type": "tabular", "name": "gene_counts"}, {"type": "tabular", "name": "transcript_counts"}, {"type": "tabular", "name": "legend"}], "workflow_outputs": [], "input_connections": {"input_bam": {"output_name": "output_alignments", "id": 22}}, "tool_state": "{\"adv\": \"{\\\"min_bundle_cov\\\": \\\"2\\\", \\\"min_tlen\\\": \\\"200\\\", \\\"bdist\\\": \\\"50\\\", \\\"multi_mapping\\\": \\\"false\\\", \\\"abundance_estimation\\\": \\\"false\\\", \\\"fraction\\\": \\\"0.15\\\", \\\"disable_trimming\\\": \\\"false\\\", \\\"omit_sequences\\\": \\\"\\\", \\\"name_prefix\\\": \\\"\\\", \\\"min_anchor_len\\\": \\\"10\\\", \\\"bundle_fraction\\\": \\\"0.95\\\", \\\"min_anchor_cov\\\": \\\"1\\\"}\", \"__page__\": null, \"chromInfo\": \"\\\"/cvmfs/data.galaxyproject.org/managed/len/ucsc/mm10.len\\\"\", \"__rerun_remap_job_id__\": null, \"__workflow_invocation_uuid__\": \"\\\"fde8952eb77711e8a468005056ba55fb\\\"\", \"rna_strandness\": \"\\\"--fr\\\"\", \"input_bam\": \"null\", \"guide\": \"{\\\"use_guide\\\": \\\"no\\\", \\\"__current_case__\\\": 0}\"}", "id": 28, "tool_shed_repository": {"owner": "iuc", "changeset_revision": "eafd5dc95228", "name": "stringtie", "tool_shed": "toolshed.g2.bx.psu.edu"}, "uuid": "c96d2ba9-5fb2-444f-afa1-8311a54460c0", "errors": null, "name": "StringTie", "post_job_actions": {}, "label": null, "inputs": [], "position": {"top": 130, "left": 670}, "annotation": "", "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/stringtie/stringtie/1.3.3.2", "type": "tool"}, "29": {"tool_id": "toolshed.g2.bx.psu.edu/repos/bgruening/deeptools_bam_coverage/deeptools_bam_coverage/3.0.2.0", "tool_version": "3.0.2.0", "outputs": [{"type": "bigwig", "name": "outFileName"}], "workflow_outputs": [], "input_connections": {"bamInput": {"output_name": "output_alignments", "id": 22}}, "tool_state": "{\"__page__\": null, \"outFileFormat\": \"\\\"bigwig\\\"\", \"region\": \"\\\"\\\"\", \"bamInput\": \"null\", \"binSize\": \"\\\"1\\\"\", \"scaling\": \"{\\\"effectiveGenomeSize\\\": {\\\"effectiveGenomeSize_opt\\\": \\\"2304947926\\\", \\\"__current_case__\\\": 6}, \\\"type\\\": \\\"1x\\\", \\\"__current_case__\\\": 4}\", \"advancedOpt\": \"{\\\"ignoreDuplicates\\\": \\\"false\\\", \\\"centerReads\\\": \\\"false\\\", \\\"ignoreForNormalization\\\": \\\"\\\", \\\"minFragmentLength\\\": \\\"0\\\", \\\"minMappingQuality\\\": \\\"1\\\", \\\"MNase\\\": \\\"false\\\", \\\"samFlagInclude\\\": \\\"\\\", \\\"filterRNAstrand\\\": \\\"forward\\\", \\\"Offset\\\": \\\"\\\", \\\"smoothLength\\\": \\\"\\\", \\\"showAdvancedOpt\\\": \\\"yes\\\", \\\"__current_case__\\\": 1, \\\"samFlagExclude\\\": \\\"\\\", \\\"doExtendCustom\\\": {\\\"__current_case__\\\": 0, \\\"doExtend\\\": \\\"no\\\"}, \\\"skipNAs\\\": \\\"false\\\", \\\"scaleFactor\\\": \\\"1.0\\\", \\\"blackListFileName\\\": null, \\\"maxFragmentLength\\\": \\\"0\\\"}\", \"chromInfo\": \"\\\"/cvmfs/data.galaxyproject.org/managed/len/ucsc/mm10.len\\\"\", \"__rerun_remap_job_id__\": null}", "id": 29, "tool_shed_repository": {"owner": "bgruening", "changeset_revision": "3033c3fba046", "name": "deeptools_bam_coverage", "tool_shed": "toolshed.g2.bx.psu.edu"}, "uuid": "e2b0c494-a05a-4fd7-9d32-97f466fe3bcf", "errors": null, "name": "bamCoverage", "post_job_actions": {}, "label": null, "inputs": [], "position": {"top": 610, "left": 670}, "annotation": "", "content_id": "toolshed.g2.bx.psu.edu/repos/bgruening/deeptools_bam_coverage/deeptools_bam_coverage/3.0.2.0", "type": "tool"}, "30": {"tool_id": "toolshed.g2.bx.psu.edu/repos/bgruening/deeptools_bam_coverage/deeptools_bam_coverage/3.0.2.0", "tool_version": "3.0.2.0", "outputs": [{"type": "bigwig", "name": "outFileName"}], "workflow_outputs": [], "input_connections": {"bamInput": {"output_name": "output_alignments", "id": 22}}, "tool_state": "{\"__page__\": null, \"outFileFormat\": \"\\\"bigwig\\\"\", \"region\": \"\\\"\\\"\", \"bamInput\": \"null\", \"binSize\": \"\\\"1\\\"\", \"scaling\": \"{\\\"effectiveGenomeSize\\\": {\\\"effectiveGenomeSize_opt\\\": \\\"2304947926\\\", \\\"__current_case__\\\": 6}, \\\"type\\\": \\\"1x\\\", \\\"__current_case__\\\": 4}\", \"advancedOpt\": \"{\\\"ignoreDuplicates\\\": \\\"false\\\", \\\"centerReads\\\": \\\"false\\\", \\\"ignoreForNormalization\\\": \\\"\\\", \\\"minFragmentLength\\\": \\\"0\\\", \\\"minMappingQuality\\\": \\\"1\\\", \\\"MNase\\\": \\\"false\\\", \\\"samFlagInclude\\\": \\\"\\\", \\\"filterRNAstrand\\\": \\\"reverse\\\", \\\"Offset\\\": \\\"\\\", \\\"smoothLength\\\": \\\"\\\", \\\"showAdvancedOpt\\\": \\\"yes\\\", \\\"__current_case__\\\": 1, \\\"samFlagExclude\\\": \\\"\\\", \\\"doExtendCustom\\\": {\\\"__current_case__\\\": 0, \\\"doExtend\\\": \\\"no\\\"}, \\\"skipNAs\\\": \\\"false\\\", \\\"scaleFactor\\\": \\\"1.0\\\", \\\"blackListFileName\\\": null, \\\"maxFragmentLength\\\": \\\"0\\\"}\", \"chromInfo\": \"\\\"/cvmfs/data.galaxyproject.org/managed/len/ucsc/mm10.len\\\"\", \"__rerun_remap_job_id__\": null}", "id": 30, "tool_shed_repository": {"owner": "bgruening", "changeset_revision": "3033c3fba046", "name": "deeptools_bam_coverage", "tool_shed": "toolshed.g2.bx.psu.edu"}, "uuid": "b4c95c39-273b-4138-bbad-8e46a3adfaae", "errors": null, "name": "bamCoverage", "post_job_actions": {}, "label": null, "inputs": [], "position": {"top": 1090, "left": 670}, "annotation": "", "content_id": "toolshed.g2.bx.psu.edu/repos/bgruening/deeptools_bam_coverage/deeptools_bam_coverage/3.0.2.0", "type": "tool"}, "31": {"tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/stringtie/stringtie/1.3.3.2", "tool_version": "1.3.3.2", "outputs": [{"type": "gtf", "name": "output_gtf"}, {"type": "gtf", "name": "gene_abundance_estimation"}, {"type": "gtf", "name": "coverage"}, {"type": "tabular", "name": "exon_expression"}, {"type": "tabular", "name": "intron_expression"}, {"type": "tabular", "name": "transcript_expression"}, {"type": "tabular", "name": "exon_transcript_mapping"}, {"type": "tabular", "name": "intron_transcript_mapping"}, {"type": "tabular", "name": "gene_counts"}, {"type": "tabular", "name": "transcript_counts"}, {"type": "tabular", "name": "legend"}], "workflow_outputs": [], "input_connections": {"input_bam": {"output_name": "output_alignments", "id": 23}}, "tool_state": "{\"adv\": \"{\\\"min_bundle_cov\\\": \\\"2\\\", \\\"min_tlen\\\": \\\"200\\\", \\\"bdist\\\": \\\"50\\\", \\\"multi_mapping\\\": \\\"false\\\", \\\"abundance_estimation\\\": \\\"false\\\", \\\"fraction\\\": \\\"0.15\\\", \\\"disable_trimming\\\": \\\"false\\\", \\\"omit_sequences\\\": \\\"\\\", \\\"name_prefix\\\": \\\"\\\", \\\"min_anchor_len\\\": \\\"10\\\", \\\"bundle_fraction\\\": \\\"0.95\\\", \\\"min_anchor_cov\\\": \\\"1\\\"}\", \"__page__\": null, \"chromInfo\": \"\\\"/cvmfs/data.galaxyproject.org/managed/len/ucsc/mm10.len\\\"\", \"__rerun_remap_job_id__\": null, \"__workflow_invocation_uuid__\": \"\\\"fde8952eb77711e8a468005056ba55fb\\\"\", \"rna_strandness\": \"\\\"--fr\\\"\", \"input_bam\": \"null\", \"guide\": \"{\\\"use_guide\\\": \\\"no\\\", \\\"__current_case__\\\": 0}\"}", "id": 31, "tool_shed_repository": {"owner": "iuc", "changeset_revision": "eafd5dc95228", "name": "stringtie", "tool_shed": "toolshed.g2.bx.psu.edu"}, "uuid": "4c15f586-8fe3-4dca-94fe-2ca0205ec76e", "errors": null, "name": "StringTie", "post_job_actions": {}, "label": null, "inputs": [], "position": {"top": 250, "left": 670}, "annotation": "", "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/stringtie/stringtie/1.3.3.2", "type": "tool"}, "32": {"tool_id": "toolshed.g2.bx.psu.edu/repos/bgruening/deeptools_bam_coverage/deeptools_bam_coverage/3.0.2.0", "tool_version": "3.0.2.0", "outputs": [{"type": "bigwig", "name": "outFileName"}], "workflow_outputs": [], "input_connections": {"bamInput": {"output_name": "output_alignments", "id": 23}}, "tool_state": "{\"__page__\": null, \"outFileFormat\": \"\\\"bigwig\\\"\", \"region\": \"\\\"\\\"\", \"bamInput\": \"null\", \"binSize\": \"\\\"1\\\"\", \"scaling\": \"{\\\"effectiveGenomeSize\\\": {\\\"effectiveGenomeSize_opt\\\": \\\"2304947926\\\", \\\"__current_case__\\\": 6}, \\\"type\\\": \\\"1x\\\", \\\"__current_case__\\\": 4}\", \"advancedOpt\": \"{\\\"ignoreDuplicates\\\": \\\"false\\\", \\\"centerReads\\\": \\\"false\\\", \\\"ignoreForNormalization\\\": \\\"\\\", \\\"minFragmentLength\\\": \\\"0\\\", \\\"minMappingQuality\\\": \\\"1\\\", \\\"MNase\\\": \\\"false\\\", \\\"samFlagInclude\\\": \\\"\\\", \\\"filterRNAstrand\\\": \\\"forward\\\", \\\"Offset\\\": \\\"\\\", \\\"smoothLength\\\": \\\"\\\", \\\"showAdvancedOpt\\\": \\\"yes\\\", \\\"__current_case__\\\": 1, \\\"samFlagExclude\\\": \\\"\\\", \\\"doExtendCustom\\\": {\\\"__current_case__\\\": 0, \\\"doExtend\\\": \\\"no\\\"}, \\\"skipNAs\\\": \\\"false\\\", \\\"scaleFactor\\\": \\\"1.0\\\", \\\"blackListFileName\\\": null, \\\"maxFragmentLength\\\": \\\"0\\\"}\", \"chromInfo\": \"\\\"/cvmfs/data.galaxyproject.org/managed/len/ucsc/mm10.len\\\"\", \"__rerun_remap_job_id__\": null}", "id": 32, "tool_shed_repository": {"owner": "bgruening", "changeset_revision": "3033c3fba046", "name": "deeptools_bam_coverage", "tool_shed": "toolshed.g2.bx.psu.edu"}, "uuid": "9a7a8ac0-a980-4b19-91d8-a775af979957", "errors": null, "name": "bamCoverage", "post_job_actions": {}, "label": null, "inputs": [], "position": {"top": 730, "left": 670}, "annotation": "", "content_id": "toolshed.g2.bx.psu.edu/repos/bgruening/deeptools_bam_coverage/deeptools_bam_coverage/3.0.2.0", "type": "tool"}, "33": {"tool_id": "toolshed.g2.bx.psu.edu/repos/bgruening/deeptools_bam_coverage/deeptools_bam_coverage/3.0.2.0", "tool_version": "3.0.2.0", "outputs": [{"type": "bigwig", "name": "outFileName"}], "workflow_outputs": [], "input_connections": {"bamInput": {"output_name": "output_alignments", "id": 23}}, "tool_state": "{\"__page__\": null, \"outFileFormat\": \"\\\"bigwig\\\"\", \"region\": \"\\\"\\\"\", \"bamInput\": \"null\", \"binSize\": \"\\\"1\\\"\", \"scaling\": \"{\\\"effectiveGenomeSize\\\": {\\\"effectiveGenomeSize_opt\\\": \\\"2304947926\\\", \\\"__current_case__\\\": 6}, \\\"type\\\": \\\"1x\\\", \\\"__current_case__\\\": 4}\", \"advancedOpt\": \"{\\\"ignoreDuplicates\\\": \\\"false\\\", \\\"centerReads\\\": \\\"false\\\", \\\"ignoreForNormalization\\\": \\\"\\\", \\\"minFragmentLength\\\": \\\"0\\\", \\\"minMappingQuality\\\": \\\"1\\\", \\\"MNase\\\": \\\"false\\\", \\\"samFlagInclude\\\": \\\"\\\", \\\"filterRNAstrand\\\": \\\"reverse\\\", \\\"Offset\\\": \\\"\\\", \\\"smoothLength\\\": \\\"\\\", \\\"showAdvancedOpt\\\": \\\"yes\\\", \\\"__current_case__\\\": 1, \\\"samFlagExclude\\\": \\\"\\\", \\\"doExtendCustom\\\": {\\\"__current_case__\\\": 0, \\\"doExtend\\\": \\\"no\\\"}, \\\"skipNAs\\\": \\\"false\\\", \\\"scaleFactor\\\": \\\"1.0\\\", \\\"blackListFileName\\\": null, \\\"maxFragmentLength\\\": \\\"0\\\"}\", \"chromInfo\": \"\\\"/cvmfs/data.galaxyproject.org/managed/len/ucsc/mm10.len\\\"\", \"__rerun_remap_job_id__\": null}", "id": 33, "tool_shed_repository": {"owner": "bgruening", "changeset_revision": "3033c3fba046", "name": "deeptools_bam_coverage", "tool_shed": "toolshed.g2.bx.psu.edu"}, "uuid": "cac5762b-01b2-492e-ab4a-ed6ca63b65de", "errors": null, "name": "bamCoverage", "post_job_actions": {}, "label": null, "inputs": [], "position": {"top": 1210, "left": 670}, "annotation": "", "content_id": "toolshed.g2.bx.psu.edu/repos/bgruening/deeptools_bam_coverage/deeptools_bam_coverage/3.0.2.0", "type": "tool"}, "34": {"tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/stringtie/stringtie/1.3.3.2", "tool_version": "1.3.3.2", "outputs": [{"type": "gtf", "name": "output_gtf"}, {"type": "gtf", "name": "gene_abundance_estimation"}, {"type": "gtf", "name": "coverage"}, {"type": "tabular", "name": "exon_expression"}, {"type": "tabular", "name": "intron_expression"}, {"type": "tabular", "name": "transcript_expression"}, {"type": "tabular", "name": "exon_transcript_mapping"}, {"type": "tabular", "name": "intron_transcript_mapping"}, {"type": "tabular", "name": "gene_counts"}, {"type": "tabular", "name": "transcript_counts"}, {"type": "tabular", "name": "legend"}], "workflow_outputs": [], "input_connections": {"input_bam": {"output_name": "output_alignments", "id": 24}}, "tool_state": "{\"adv\": \"{\\\"min_bundle_cov\\\": \\\"2\\\", \\\"min_tlen\\\": \\\"200\\\", \\\"bdist\\\": \\\"50\\\", \\\"multi_mapping\\\": \\\"false\\\", \\\"abundance_estimation\\\": \\\"false\\\", \\\"fraction\\\": \\\"0.15\\\", \\\"disable_trimming\\\": \\\"false\\\", \\\"omit_sequences\\\": \\\"\\\", \\\"name_prefix\\\": \\\"\\\", \\\"min_anchor_len\\\": \\\"10\\\", \\\"bundle_fraction\\\": \\\"0.95\\\", \\\"min_anchor_cov\\\": \\\"1\\\"}\", \"__page__\": null, \"chromInfo\": \"\\\"/cvmfs/data.galaxyproject.org/managed/len/ucsc/mm10.len\\\"\", \"__rerun_remap_job_id__\": null, \"__workflow_invocation_uuid__\": \"\\\"fde8952eb77711e8a468005056ba55fb\\\"\", \"rna_strandness\": \"\\\"--fr\\\"\", \"input_bam\": \"null\", \"guide\": \"{\\\"use_guide\\\": \\\"no\\\", \\\"__current_case__\\\": 0}\"}", "id": 34, "tool_shed_repository": {"owner": "iuc", "changeset_revision": "eafd5dc95228", "name": "stringtie", "tool_shed": "toolshed.g2.bx.psu.edu"}, "uuid": "1538c29a-305e-454e-801c-e4501fb326b1", "errors": null, "name": "StringTie", "post_job_actions": {}, "label": null, "inputs": [], "position": {"top": 370, "left": 670}, "annotation": "", "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/stringtie/stringtie/1.3.3.2", "type": "tool"}, "35": {"tool_id": "toolshed.g2.bx.psu.edu/repos/bgruening/deeptools_bam_coverage/deeptools_bam_coverage/3.0.2.0", "tool_version": "3.0.2.0", "outputs": [{"type": "bigwig", "name": "outFileName"}], "workflow_outputs": [], "input_connections": {"bamInput": {"output_name": "output_alignments", "id": 24}}, "tool_state": "{\"__page__\": null, \"outFileFormat\": \"\\\"bigwig\\\"\", \"region\": \"\\\"\\\"\", \"bamInput\": \"null\", \"binSize\": \"\\\"1\\\"\", \"scaling\": \"{\\\"effectiveGenomeSize\\\": {\\\"effectiveGenomeSize_opt\\\": \\\"2304947926\\\", \\\"__current_case__\\\": 6}, \\\"type\\\": \\\"1x\\\", \\\"__current_case__\\\": 4}\", \"advancedOpt\": \"{\\\"ignoreDuplicates\\\": \\\"false\\\", \\\"centerReads\\\": \\\"false\\\", \\\"ignoreForNormalization\\\": \\\"\\\", \\\"minFragmentLength\\\": \\\"0\\\", \\\"minMappingQuality\\\": \\\"1\\\", \\\"MNase\\\": \\\"false\\\", \\\"samFlagInclude\\\": \\\"\\\", \\\"filterRNAstrand\\\": \\\"forward\\\", \\\"Offset\\\": \\\"\\\", \\\"smoothLength\\\": \\\"\\\", \\\"showAdvancedOpt\\\": \\\"yes\\\", \\\"__current_case__\\\": 1, \\\"samFlagExclude\\\": \\\"\\\", \\\"doExtendCustom\\\": {\\\"__current_case__\\\": 0, \\\"doExtend\\\": \\\"no\\\"}, \\\"skipNAs\\\": \\\"false\\\", \\\"scaleFactor\\\": \\\"1.0\\\", \\\"blackListFileName\\\": null, \\\"maxFragmentLength\\\": \\\"0\\\"}\", \"chromInfo\": \"\\\"/cvmfs/data.galaxyproject.org/managed/len/ucsc/mm10.len\\\"\", \"__rerun_remap_job_id__\": null}", "id": 35, "tool_shed_repository": {"owner": "bgruening", "changeset_revision": "3033c3fba046", "name": "deeptools_bam_coverage", "tool_shed": "toolshed.g2.bx.psu.edu"}, "uuid": "63c35755-3978-4c47-9063-bd06737ccafc", "errors": null, "name": "bamCoverage", "post_job_actions": {}, "label": null, "inputs": [], "position": {"top": 850, "left": 670}, "annotation": "", "content_id": "toolshed.g2.bx.psu.edu/repos/bgruening/deeptools_bam_coverage/deeptools_bam_coverage/3.0.2.0", "type": "tool"}, "36": {"tool_id": "toolshed.g2.bx.psu.edu/repos/bgruening/deeptools_bam_coverage/deeptools_bam_coverage/3.0.2.0", "tool_version": "3.0.2.0", "outputs": [{"type": "bigwig", "name": "outFileName"}], "workflow_outputs": [], "input_connections": {"bamInput": {"output_name": "output_alignments", "id": 24}}, "tool_state": "{\"__page__\": null, \"outFileFormat\": \"\\\"bigwig\\\"\", \"region\": \"\\\"\\\"\", \"bamInput\": \"null\", \"binSize\": \"\\\"1\\\"\", \"scaling\": \"{\\\"effectiveGenomeSize\\\": {\\\"effectiveGenomeSize_opt\\\": \\\"2304947926\\\", \\\"__current_case__\\\": 6}, \\\"type\\\": \\\"1x\\\", \\\"__current_case__\\\": 4}\", \"advancedOpt\": \"{\\\"ignoreDuplicates\\\": \\\"false\\\", \\\"centerReads\\\": \\\"false\\\", \\\"ignoreForNormalization\\\": \\\"\\\", \\\"minFragmentLength\\\": \\\"0\\\", \\\"minMappingQuality\\\": \\\"1\\\", \\\"MNase\\\": \\\"false\\\", \\\"samFlagInclude\\\": \\\"\\\", \\\"filterRNAstrand\\\": \\\"reverse\\\", \\\"Offset\\\": \\\"\\\", \\\"smoothLength\\\": \\\"\\\", \\\"showAdvancedOpt\\\": \\\"yes\\\", \\\"__current_case__\\\": 1, \\\"samFlagExclude\\\": \\\"\\\", \\\"doExtendCustom\\\": {\\\"__current_case__\\\": 0, \\\"doExtend\\\": \\\"no\\\"}, \\\"skipNAs\\\": \\\"false\\\", \\\"scaleFactor\\\": \\\"1.0\\\", \\\"blackListFileName\\\": null, \\\"maxFragmentLength\\\": \\\"0\\\"}\", \"chromInfo\": \"\\\"/cvmfs/data.galaxyproject.org/managed/len/ucsc/mm10.len\\\"\", \"__rerun_remap_job_id__\": null}", "id": 36, "tool_shed_repository": {"owner": "bgruening", "changeset_revision": "3033c3fba046", "name": "deeptools_bam_coverage", "tool_shed": "toolshed.g2.bx.psu.edu"}, "uuid": "dbe2b8a3-bc6a-461c-8ca3-06b3966edbdd", "errors": null, "name": "bamCoverage", "post_job_actions": {}, "label": null, "inputs": [], "position": {"top": 1330, "left": 670}, "annotation": "", "content_id": "toolshed.g2.bx.psu.edu/repos/bgruening/deeptools_bam_coverage/deeptools_bam_coverage/3.0.2.0", "type": "tool"}, "37": {"tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/stringtie/stringtie_merge/1.3.3", "tool_version": "1.3.3", "outputs": [{"type": "gtf", "name": "out_gtf"}], "workflow_outputs": [], "input_connections": {"input_gtf": [{"output_name": "output_gtf", "id": 31}, {"output_name": "output_gtf", "id": 34}, {"output_name": "output_gtf", "id": 25}, {"output_name": "output_gtf", "id": 28}], "guide_gff": {"output_name": "output", "id": 8}}, "tool_state": "{\"keep_introns\": \"\\\"false\\\"\", \"min_fpkm\": \"\\\"1.0\\\"\", \"__page__\": null, \"__rerun_remap_job_id__\": null, \"min_len\": \"\\\"50\\\"\", \"__workflow_invocation_uuid__\": \"\\\"fde8952eb77711e8a468005056ba55fb\\\"\", \"guide_gff\": \"null\", \"min_cov\": \"\\\"0\\\"\", \"min_iso\": \"\\\"0.01\\\"\", \"min_tpm\": \"\\\"1.0\\\"\", \"chromInfo\": \"\\\"/cvmfs/data.galaxyproject.org/managed/len/ucsc/mm10.len\\\"\", \"input_gtf\": \"null\", \"gap_len\": \"\\\"250\\\"\"}", "id": 37, "tool_shed_repository": {"owner": "iuc", "changeset_revision": "eafd5dc95228", "name": "stringtie", "tool_shed": "toolshed.g2.bx.psu.edu"}, "uuid": "47307af1-9fd1-4936-a01e-ca9d660173e7", "errors": null, "name": "StringTie merge", "post_job_actions": {}, "label": null, "inputs": [], "position": {"top": 10, "left": 890}, "annotation": "", "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/stringtie/stringtie_merge/1.3.3", "type": "tool"}, "38": {"tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/gffcompare/gffcompare/0.9.8", "tool_version": "0.9.8", "outputs": [{"type": "txt", "name": "transcripts_stats"}, {"type": "tabular", "name": "transcripts_loci"}, {"type": "tabular", "name": "transcripts_tracking"}, {"type": "gtf", "name": "transcripts_combined"}, {"type": "gtf", "name": "transcripts_annotated"}], "workflow_outputs": [], "input_connections": {"inputs": {"output_name": "out_gtf", "id": 37}, "annotation|reference_annotation": {"output_name": "output", "id": 8}}, "tool_state": "{\"seq_data\": \"{\\\"use_seq_data\\\": \\\"Yes\\\", \\\"seq_source\\\": {\\\"index_source\\\": \\\"cached\\\", \\\"index\\\": \\\"mm10\\\", \\\"__current_case__\\\": 0}, \\\"__current_case__\\\": 1}\", \"inputs\": \"null\", \"max_dist_group\": \"\\\"100\\\"\", \"__page__\": null, \"max_dist_exon\": \"\\\"100\\\"\", \"__rerun_remap_job_id__\": null, \"__workflow_invocation_uuid__\": \"\\\"fde8952eb77711e8a468005056ba55fb\\\"\", \"chromInfo\": \"\\\"/cvmfs/data.galaxyproject.org/managed/len/ucsc/mm10.len\\\"\", \"discard_single_exon\": \"\\\"\\\"\", \"discard_intron_redundant_transfrags\": \"\\\"false\\\"\", \"annotation\": \"{\\\"reference_annotation\\\": null, \\\"use_ref_annotation\\\": \\\"Yes\\\", \\\"ignore_nonoverlapping_reference\\\": \\\"false\\\", \\\"__current_case__\\\": 0, \\\"ignore_nonoverlapping_transfrags\\\": \\\"false\\\"}\"}", "id": 38, "tool_shed_repository": {"owner": "iuc", "changeset_revision": "3c97c841a443", "name": "gffcompare", "tool_shed": "toolshed.g2.bx.psu.edu"}, "uuid": "6292c087-6c93-435e-ab1f-348ce4bff2bb", "errors": null, "name": "GffCompare", "post_job_actions": {}, "label": null, "inputs": [], "position": {"top": 10, "left": 1110}, "annotation": "", "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/gffcompare/gffcompare/0.9.8", "type": "tool"}, "39": {"tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/featurecounts/featurecounts/1.6.0.6", "tool_version": "1.6.0.6", "outputs": [{"type": "tabular", "name": "output_medium"}, {"type": "tabular", "name": "output_short"}, {"type": "tabular", "name": "output_full"}, {"type": "tabular", "name": "output_summary"}, {"type": "tabular", "name": "output_feature_lengths"}, {"type": "tabular", "name": "output_jcounts"}], "workflow_outputs": [], "input_connections": {"alignment": {"output_name": "output_alignments", "id": 21}, "anno|reference_gene_sets": {"output_name": "transcripts_annotated", "id": 38}}, "tool_state": "{\"pe_parameters\": \"{\\\"only_both_ends\\\": \\\"false\\\", \\\"exclude_chimerics\\\": \\\"true\\\", \\\"fragment_counting_enabled\\\": {\\\"fragment_counting\\\": \\\"\\\", \\\"__current_case__\\\": 1}}\", \"format\": \"\\\"tabdel_short\\\"\", \"__page__\": null, \"__rerun_remap_job_id__\": null, \"strand_specificity\": \"\\\"1\\\"\", \"include_feature_length_file\": \"\\\"false\\\"\", \"__workflow_invocation_uuid__\": \"\\\"fde8952eb77711e8a468005056ba55fb\\\"\", \"anno\": \"{\\\"anno_select\\\": \\\"history\\\", \\\"reference_gene_sets\\\": null, \\\"__current_case__\\\": 2}\", \"chromInfo\": \"\\\"/cvmfs/data.galaxyproject.org/managed/len/ucsc/mm10.len\\\"\", \"extended_parameters\": \"{\\\"gff_feature_attribute\\\": \\\"transcript_id\\\", \\\"exon_exon_junction_read_counting_enabled\\\": {\\\"__current_case__\\\": 1, \\\"count_exon_exon_junction_reads\\\": \\\"false\\\"}, \\\"read_extension_3p\\\": \\\"0\\\", \\\"frac_overlap_feature\\\": \\\"0\\\", \\\"min_overlap\\\": \\\"1\\\", \\\"read_extension_5p\\\": \\\"0\\\", \\\"contribute_to_multiple_features\\\": \\\"false\\\", \\\"frac_overlap\\\": \\\"0\\\", \\\"primary\\\": \\\"false\\\", \\\"count_split_alignments_only\\\": \\\"false\\\", \\\"by_read_group\\\": \\\"false\\\", \\\"ignore_dup\\\": \\\"false\\\", \\\"mapping_quality\\\": \\\"12\\\", \\\"summarization_level\\\": \\\"false\\\", \\\"largest_overlap\\\": \\\"false\\\", \\\"read_reduction\\\": \\\"\\\", \\\"multimapping_enabled\\\": {\\\"multimapping_counts\\\": \\\"\\\", \\\"__current_case__\\\": 1}, \\\"long_reads\\\": \\\"false\\\", \\\"gff_feature_type\\\": \\\"exon\\\"}\", \"alignment\": \"null\"}", "id": 39, "tool_shed_repository": {"owner": "iuc", "changeset_revision": "92808b865dfb", "name": "featurecounts", "tool_shed": "toolshed.g2.bx.psu.edu"}, "uuid": "fc054e7c-a603-4aa6-b3cf-d2e1cd4d7be9", "errors": null, "name": "featureCounts", "post_job_actions": {}, "label": null, "inputs": [], "position": {"top": 10, "left": 1330}, "annotation": "", "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/featurecounts/featurecounts/1.6.0.6", "type": "tool"}, "40": {"tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/featurecounts/featurecounts/1.6.0.6", "tool_version": "1.6.0.6", "outputs": [{"type": "tabular", "name": "output_medium"}, {"type": "tabular", "name": "output_short"}, {"type": "tabular", "name": "output_full"}, {"type": "tabular", "name": "output_summary"}, {"type": "tabular", "name": "output_feature_lengths"}, {"type": "tabular", "name": "output_jcounts"}], "workflow_outputs": [], "input_connections": {"alignment": {"output_name": "output_alignments", "id": 22}, "anno|reference_gene_sets": {"output_name": "transcripts_annotated", "id": 38}}, "tool_state": "{\"pe_parameters\": \"{\\\"only_both_ends\\\": \\\"false\\\", \\\"exclude_chimerics\\\": \\\"true\\\", \\\"fragment_counting_enabled\\\": {\\\"fragment_counting\\\": \\\"\\\", \\\"__current_case__\\\": 1}}\", \"format\": \"\\\"tabdel_short\\\"\", \"__page__\": null, \"__rerun_remap_job_id__\": null, \"strand_specificity\": \"\\\"1\\\"\", \"include_feature_length_file\": \"\\\"false\\\"\", \"__workflow_invocation_uuid__\": \"\\\"fde8952eb77711e8a468005056ba55fb\\\"\", \"anno\": \"{\\\"anno_select\\\": \\\"history\\\", \\\"reference_gene_sets\\\": null, \\\"__current_case__\\\": 2}\", \"chromInfo\": \"\\\"/cvmfs/data.galaxyproject.org/managed/len/ucsc/mm10.len\\\"\", \"extended_parameters\": \"{\\\"gff_feature_attribute\\\": \\\"transcript_id\\\", \\\"exon_exon_junction_read_counting_enabled\\\": {\\\"__current_case__\\\": 1, \\\"count_exon_exon_junction_reads\\\": \\\"false\\\"}, \\\"read_extension_3p\\\": \\\"0\\\", \\\"frac_overlap_feature\\\": \\\"0\\\", \\\"min_overlap\\\": \\\"1\\\", \\\"read_extension_5p\\\": \\\"0\\\", \\\"contribute_to_multiple_features\\\": \\\"false\\\", \\\"frac_overlap\\\": \\\"0\\\", \\\"primary\\\": \\\"false\\\", \\\"count_split_alignments_only\\\": \\\"false\\\", \\\"by_read_group\\\": \\\"false\\\", \\\"ignore_dup\\\": \\\"false\\\", \\\"mapping_quality\\\": \\\"12\\\", \\\"summarization_level\\\": \\\"false\\\", \\\"largest_overlap\\\": \\\"false\\\", \\\"read_reduction\\\": \\\"\\\", \\\"multimapping_enabled\\\": {\\\"multimapping_counts\\\": \\\"\\\", \\\"__current_case__\\\": 1}, \\\"long_reads\\\": \\\"false\\\", \\\"gff_feature_type\\\": \\\"exon\\\"}\", \"alignment\": \"null\"}", "id": 40, "tool_shed_repository": {"owner": "iuc", "changeset_revision": "92808b865dfb", "name": "featurecounts", "tool_shed": "toolshed.g2.bx.psu.edu"}, "uuid": "a29ab182-8103-425e-86e8-d71a08277f7c", "errors": null, "name": "featureCounts", "post_job_actions": {}, "label": null, "inputs": [], "position": {"top": 130, "left": 1330}, "annotation": "", "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/featurecounts/featurecounts/1.6.0.6", "type": "tool"}, "41": {"tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/featurecounts/featurecounts/1.6.0.6", "tool_version": "1.6.0.6", "outputs": [{"type": "tabular", "name": "output_medium"}, {"type": "tabular", "name": "output_short"}, {"type": "tabular", "name": "output_full"}, {"type": "tabular", "name": "output_summary"}, {"type": "tabular", "name": "output_feature_lengths"}, {"type": "tabular", "name": "output_jcounts"}], "workflow_outputs": [], "input_connections": {"alignment": {"output_name": "output_alignments", "id": 23}, "anno|reference_gene_sets": {"output_name": "transcripts_annotated", "id": 38}}, "tool_state": "{\"pe_parameters\": \"{\\\"only_both_ends\\\": \\\"false\\\", \\\"exclude_chimerics\\\": \\\"true\\\", \\\"fragment_counting_enabled\\\": {\\\"fragment_counting\\\": \\\"\\\", \\\"__current_case__\\\": 1}}\", \"format\": \"\\\"tabdel_short\\\"\", \"__page__\": null, \"__rerun_remap_job_id__\": null, \"strand_specificity\": \"\\\"1\\\"\", \"include_feature_length_file\": \"\\\"false\\\"\", \"__workflow_invocation_uuid__\": \"\\\"fde8952eb77711e8a468005056ba55fb\\\"\", \"anno\": \"{\\\"anno_select\\\": \\\"history\\\", \\\"reference_gene_sets\\\": null, \\\"__current_case__\\\": 2}\", \"chromInfo\": \"\\\"/cvmfs/data.galaxyproject.org/managed/len/ucsc/mm10.len\\\"\", \"extended_parameters\": \"{\\\"gff_feature_attribute\\\": \\\"transcript_id\\\", \\\"exon_exon_junction_read_counting_enabled\\\": {\\\"__current_case__\\\": 1, \\\"count_exon_exon_junction_reads\\\": \\\"false\\\"}, \\\"read_extension_3p\\\": \\\"0\\\", \\\"frac_overlap_feature\\\": \\\"0\\\", \\\"min_overlap\\\": \\\"1\\\", \\\"read_extension_5p\\\": \\\"0\\\", \\\"contribute_to_multiple_features\\\": \\\"false\\\", \\\"frac_overlap\\\": \\\"0\\\", \\\"primary\\\": \\\"false\\\", \\\"count_split_alignments_only\\\": \\\"false\\\", \\\"by_read_group\\\": \\\"false\\\", \\\"ignore_dup\\\": \\\"false\\\", \\\"mapping_quality\\\": \\\"12\\\", \\\"summarization_level\\\": \\\"false\\\", \\\"largest_overlap\\\": \\\"false\\\", \\\"read_reduction\\\": \\\"\\\", \\\"multimapping_enabled\\\": {\\\"multimapping_counts\\\": \\\"\\\", \\\"__current_case__\\\": 1}, \\\"long_reads\\\": \\\"false\\\", \\\"gff_feature_type\\\": \\\"exon\\\"}\", \"alignment\": \"null\"}", "id": 41, "tool_shed_repository": {"owner": "iuc", "changeset_revision": "92808b865dfb", "name": "featurecounts", "tool_shed": "toolshed.g2.bx.psu.edu"}, "uuid": "8b73ac2b-9e21-4cd3-bff2-ce0215d3a213", "errors": null, "name": "featureCounts", "post_job_actions": {}, "label": null, "inputs": [], "position": {"top": 250, "left": 1330}, "annotation": "", "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/featurecounts/featurecounts/1.6.0.6", "type": "tool"}, "42": {"tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/featurecounts/featurecounts/1.6.0.6", "tool_version": "1.6.0.6", "outputs": [{"type": "tabular", "name": "output_medium"}, {"type": "tabular", "name": "output_short"}, {"type": "tabular", "name": "output_full"}, {"type": "tabular", "name": "output_summary"}, {"type": "tabular", "name": "output_feature_lengths"}, {"type": "tabular", "name": "output_jcounts"}], "workflow_outputs": [], "input_connections": {"alignment": {"output_name": "output_alignments", "id": 24}, "anno|reference_gene_sets": {"output_name": "transcripts_annotated", "id": 38}}, "tool_state": "{\"pe_parameters\": \"{\\\"only_both_ends\\\": \\\"false\\\", \\\"exclude_chimerics\\\": \\\"true\\\", \\\"fragment_counting_enabled\\\": {\\\"fragment_counting\\\": \\\"\\\", \\\"__current_case__\\\": 1}}\", \"format\": \"\\\"tabdel_short\\\"\", \"__page__\": null, \"__rerun_remap_job_id__\": null, \"strand_specificity\": \"\\\"1\\\"\", \"include_feature_length_file\": \"\\\"false\\\"\", \"__workflow_invocation_uuid__\": \"\\\"fde8952eb77711e8a468005056ba55fb\\\"\", \"anno\": \"{\\\"anno_select\\\": \\\"history\\\", \\\"reference_gene_sets\\\": null, \\\"__current_case__\\\": 2}\", \"chromInfo\": \"\\\"/cvmfs/data.galaxyproject.org/managed/len/ucsc/mm10.len\\\"\", \"extended_parameters\": \"{\\\"gff_feature_attribute\\\": \\\"transcript_id\\\", \\\"exon_exon_junction_read_counting_enabled\\\": {\\\"__current_case__\\\": 1, \\\"count_exon_exon_junction_reads\\\": \\\"false\\\"}, \\\"read_extension_3p\\\": \\\"0\\\", \\\"frac_overlap_feature\\\": \\\"0\\\", \\\"min_overlap\\\": \\\"1\\\", \\\"read_extension_5p\\\": \\\"0\\\", \\\"contribute_to_multiple_features\\\": \\\"false\\\", \\\"frac_overlap\\\": \\\"0\\\", \\\"primary\\\": \\\"false\\\", \\\"count_split_alignments_only\\\": \\\"false\\\", \\\"by_read_group\\\": \\\"false\\\", \\\"ignore_dup\\\": \\\"false\\\", \\\"mapping_quality\\\": \\\"12\\\", \\\"summarization_level\\\": \\\"false\\\", \\\"largest_overlap\\\": \\\"false\\\", \\\"read_reduction\\\": \\\"\\\", \\\"multimapping_enabled\\\": {\\\"multimapping_counts\\\": \\\"\\\", \\\"__current_case__\\\": 1}, \\\"long_reads\\\": \\\"false\\\", \\\"gff_feature_type\\\": \\\"exon\\\"}\", \"alignment\": \"null\"}", "id": 42, "tool_shed_repository": {"owner": "iuc", "changeset_revision": "92808b865dfb", "name": "featurecounts", "tool_shed": "toolshed.g2.bx.psu.edu"}, "uuid": "02a66170-4c0c-4c1e-8073-ec626190390e", "errors": null, "name": "featureCounts", "post_job_actions": {}, "label": null, "inputs": [], "position": {"top": 370, "left": 1330}, "annotation": "", "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/featurecounts/featurecounts/1.6.0.6", "type": "tool"}, "43": {"tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/deseq2/deseq2/2.11.40.2", "tool_version": "2.11.40.2", "outputs": [{"type": "input", "name": "split_output"}, {"type": "tabular", "name": "deseq_out"}, {"type": "pdf", "name": "plots"}, {"type": "tabular", "name": "counts_out"}], "workflow_outputs": [], "input_connections": {"rep_factorName_0|rep_factorLevel_0|countsFile": [{"output_name": "output_short", "id": 39}, {"output_name": "output_short", "id": 40}], "rep_factorName_0|rep_factorLevel_1|countsFile": [{"output_name": "output_short", "id": 41}, {"output_name": "output_short", "id": 42}]}, "tool_state": "{\"fit_type\": \"\\\"1\\\"\", \"__page__\": null, \"tximport\": \"{\\\"tximport_selector\\\": \\\"count\\\", \\\"__current_case__\\\": 1}\", \"outlier_replace_off\": \"\\\"false\\\"\", \"__rerun_remap_job_id__\": null, \"auto_mean_filter_off\": \"\\\"false\\\"\", \"header\": \"\\\"true\\\"\", \"rep_factorName\": \"[{\\\"__index__\\\": 0, \\\"factorName\\\": \\\"FactorName\\\", \\\"rep_factorLevel\\\": [{\\\"__index__\\\": 0, \\\"factorLevel\\\": \\\"GIE\\\", \\\"countsFile\\\": null}, {\\\"__index__\\\": 1, \\\"factorLevel\\\": \\\"Mega\\\", \\\"countsFile\\\": null}]}]\", \"normCounts\": \"\\\"true\\\"\", \"__workflow_invocation_uuid__\": \"\\\"fde8952eb77711e8a468005056ba55fb\\\"\", \"many_contrasts\": \"\\\"false\\\"\", \"pdf\": \"\\\"true\\\"\", \"chromInfo\": \"\\\"/cvmfs/data.galaxyproject.org/managed/len/ucsc/mm10.len\\\"\", \"outlier_filter_off\": \"\\\"false\\\"\"}", "id": 43, "tool_shed_repository": {"owner": "iuc", "changeset_revision": "9a616afdbda5", "name": "deseq2", "tool_shed": "toolshed.g2.bx.psu.edu"}, "uuid": "73d67b36-4316-446b-85f6-5b1e2b64f684", "errors": null, "name": "DESeq2", "post_job_actions": {}, "label": null, "inputs": [], "position": {"top": 10, "left": 1550}, "annotation": "", "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/deseq2/deseq2/2.11.40.2", "type": "tool"}, "44": {"tool_id": "Filter1", "tool_version": "1.1.0", "outputs": [{"type": "input", "name": "out_file1"}], "workflow_outputs": [], "input_connections": {"input": {"output_name": "deseq_out", "id": 43}}, "tool_state": "{\"__page__\": null, \"__rerun_remap_job_id__\": null, \"cond\": \"\\\"c7<0.05\\\"\", \"input\": \"null\", \"header_lines\": \"\\\"0\\\"\", \"chromInfo\": \"\\\"/cvmfs/data.galaxyproject.org/managed/len/ucsc/mm10.len\\\"\"}", "id": 44, "uuid": "3581c4be-1732-47fc-ad14-73f5e3a42b23", "errors": null, "name": "Filter", "post_job_actions": {}, "label": null, "inputs": [], "position": {"top": 10, "left": 1770}, "annotation": "", "content_id": "Filter1", "type": "tool"}, "45": {"tool_id": "Filter1", "tool_version": "1.1.0", "outputs": [{"type": "input", "name": "out_file1"}], "workflow_outputs": [], "input_connections": {"input": {"output_name": "out_file1", "id": 44}}, "tool_state": "{\"__page__\": null, \"__rerun_remap_job_id__\": null, \"cond\": \"\\\"c3>0\\\"\", \"input\": \"null\", \"header_lines\": \"\\\"0\\\"\", \"chromInfo\": \"\\\"/cvmfs/data.galaxyproject.org/managed/len/ucsc/mm10.len\\\"\"}", "id": 45, "uuid": "c9d279df-d6bb-4b48-a743-250e9fb30548", "errors": null, "name": "Filter", "post_job_actions": {}, "label": null, "inputs": [], "position": {"top": 10, "left": 1990}, "annotation": "", "content_id": "Filter1", "type": "tool"}, "46": {"tool_id": "Filter1", "tool_version": "1.1.0", "outputs": [{"type": "input", "name": "out_file1"}], "workflow_outputs": [], "input_connections": {"input": {"output_name": "out_file1", "id": 44}}, "tool_state": "{\"__page__\": null, \"__rerun_remap_job_id__\": null, \"cond\": \"\\\"c3<0\\\"\", \"input\": \"null\", \"header_lines\": \"\\\"0\\\"\", \"chromInfo\": \"\\\"/cvmfs/data.galaxyproject.org/managed/len/ucsc/mm10.len\\\"\"}", "id": 46, "uuid": "aa0f881b-5524-4a0c-9cc5-c8fdfe2e3b89", "errors": null, "name": "Filter", "post_job_actions": {}, "label": null, "inputs": [], "position": {"top": 130, "left": 1990}, "annotation": "", "content_id": "Filter1", "type": "tool"}}, "annotation": "", "a_galaxy_workflow": "true"}
+{
+  "a_galaxy_workflow": "true",
+  "annotation": "",
+  "format-version": "0.1",
+  "name": "transcriptomics-denovo-workflow",
+  "steps": {
+    "0": {
+      "annotation": "",
+      "content_id": null,
+      "errors": null,
+      "id": 0,
+      "input_connections": {},
+      "inputs": [
+        {
+          "description": "",
+          "name": "G1E_rep1_forward_read"
+        }
+      ],
+      "label": null,
+      "name": "Input dataset",
+      "outputs": [],
+      "position": {
+        "left": 10,
+        "top": 10
+      },
+      "tool_id": null,
+      "tool_state": "{\"name\": \"G1E_rep1_forward_read\"}",
+      "tool_version": null,
+      "type": "data_input",
+      "uuid": "cbc6590c-d6de-4abf-b53f-6c83b4ab4120",
+      "workflow_outputs": []
+    },
+    "1": {
+      "annotation": "",
+      "content_id": null,
+      "errors": null,
+      "id": 1,
+      "input_connections": {},
+      "inputs": [
+        {
+          "description": "",
+          "name": "G1E_rep1_reverse_read"
+        }
+      ],
+      "label": null,
+      "name": "Input dataset",
+      "outputs": [],
+      "position": {
+        "left": 10,
+        "top": 130
+      },
+      "tool_id": null,
+      "tool_state": "{\"name\": \"G1E_rep1_reverse_read\"}",
+      "tool_version": null,
+      "type": "data_input",
+      "uuid": "c2ba4aba-060a-40ba-88d6-e6fef8a1f2eb",
+      "workflow_outputs": []
+    },
+    "10": {
+      "annotation": "",
+      "content_id": "toolshed.g2.bx.psu.edu/repos/devteam/fastqc/fastqc/0.72",
+      "errors": null,
+      "id": 10,
+      "input_connections": {
+        "input_file": {
+          "id": 1,
+          "output_name": "output"
+        }
+      },
+      "inputs": [],
+      "label": null,
+      "name": "FastQC",
+      "outputs": [
+        {
+          "name": "html_file",
+          "type": "html"
+        },
+        {
+          "name": "text_file",
+          "type": "txt"
+        }
+      ],
+      "position": {
+        "left": 230,
+        "top": 130
+      },
+      "post_job_actions": {},
+      "tool_id": "toolshed.g2.bx.psu.edu/repos/devteam/fastqc/fastqc/0.72",
+      "tool_shed_repository": {
+        "changeset_revision": "c15237684a01",
+        "name": "fastqc",
+        "owner": "devteam",
+        "tool_shed": "toolshed.g2.bx.psu.edu"
+      },
+      "tool_state": "{\"__page__\": null, \"limits\": \"null\", \"input_file\": \"null\", \"__rerun_remap_job_id__\": null, \"__workflow_invocation_uuid__\": \"\\\"fde8952eb77711e8a468005056ba55fb\\\"\", \"contaminants\": \"null\", \"chromInfo\": \"\\\"/cvmfs/data.galaxyproject.org/managed/len/ucsc/?.len\\\"\"}",
+      "tool_version": "0.72",
+      "type": "tool",
+      "uuid": "a4db4907-e8e9-4534-a37c-7c1d6c34de20",
+      "workflow_outputs": []
+    },
+    "11": {
+      "annotation": "",
+      "content_id": "toolshed.g2.bx.psu.edu/repos/pjbriggs/trimmomatic/trimmomatic/0.36.5",
+      "errors": null,
+      "id": 11,
+      "input_connections": {
+        "readtype|fastq_r1_in": {
+          "id": 0,
+          "output_name": "output"
+        },
+        "readtype|fastq_r2_in": {
+          "id": 1,
+          "output_name": "output"
+        }
+      },
+      "inputs": [],
+      "label": null,
+      "name": "Trimmomatic",
+      "outputs": [
+        {
+          "name": "fastq_out_paired",
+          "type": "input"
+        },
+        {
+          "name": "fastq_out_unpaired",
+          "type": "input"
+        },
+        {
+          "name": "fastq_out_r1_paired",
+          "type": "input"
+        },
+        {
+          "name": "fastq_out_r2_paired",
+          "type": "input"
+        },
+        {
+          "name": "fastq_out_r1_unpaired",
+          "type": "input"
+        },
+        {
+          "name": "fastq_out_r2_unpaired",
+          "type": "input"
+        },
+        {
+          "name": "fastq_out",
+          "type": "input"
+        }
+      ],
+      "position": {
+        "left": 230,
+        "top": 250
+      },
+      "post_job_actions": {},
+      "tool_id": "toolshed.g2.bx.psu.edu/repos/pjbriggs/trimmomatic/trimmomatic/0.36.5",
+      "tool_shed_repository": {
+        "changeset_revision": "dfa082f84068",
+        "name": "trimmomatic",
+        "owner": "pjbriggs",
+        "tool_shed": "toolshed.g2.bx.psu.edu"
+      },
+      "tool_state": "{\"operations\": \"[{\\\"__index__\\\": 0, \\\"operation\\\": {\\\"window_size\\\": \\\"4\\\", \\\"name\\\": \\\"SLIDINGWINDOW\\\", \\\"__current_case__\\\": 0, \\\"required_quality\\\": \\\"20\\\"}}]\", \"__page__\": null, \"__rerun_remap_job_id__\": null, \"readtype\": \"{\\\"single_or_paired\\\": \\\"pair_of_files\\\", \\\"fastq_r1_in\\\": null, \\\"__current_case__\\\": 1, \\\"fastq_r2_in\\\": null}\", \"illuminaclip\": \"{\\\"do_illuminaclip\\\": \\\"false\\\", \\\"__current_case__\\\": 1}\", \"__workflow_invocation_uuid__\": \"\\\"fde8952eb77711e8a468005056ba55fb\\\"\", \"chromInfo\": \"\\\"/cvmfs/data.galaxyproject.org/managed/len/ucsc/?.len\\\"\"}",
+      "tool_version": "0.36.5",
+      "type": "tool",
+      "uuid": "d7a54fe5-9cd2-4209-9a02-b7d2d636b337",
+      "workflow_outputs": []
+    },
+    "12": {
+      "annotation": "",
+      "content_id": "toolshed.g2.bx.psu.edu/repos/devteam/fastqc/fastqc/0.72",
+      "errors": null,
+      "id": 12,
+      "input_connections": {
+        "input_file": {
+          "id": 2,
+          "output_name": "output"
+        }
+      },
+      "inputs": [],
+      "label": null,
+      "name": "FastQC",
+      "outputs": [
+        {
+          "name": "html_file",
+          "type": "html"
+        },
+        {
+          "name": "text_file",
+          "type": "txt"
+        }
+      ],
+      "position": {
+        "left": 230,
+        "top": 370
+      },
+      "post_job_actions": {},
+      "tool_id": "toolshed.g2.bx.psu.edu/repos/devteam/fastqc/fastqc/0.72",
+      "tool_shed_repository": {
+        "changeset_revision": "c15237684a01",
+        "name": "fastqc",
+        "owner": "devteam",
+        "tool_shed": "toolshed.g2.bx.psu.edu"
+      },
+      "tool_state": "{\"__page__\": null, \"limits\": \"null\", \"input_file\": \"null\", \"__rerun_remap_job_id__\": null, \"__workflow_invocation_uuid__\": \"\\\"fde8952eb77711e8a468005056ba55fb\\\"\", \"contaminants\": \"null\", \"chromInfo\": \"\\\"/cvmfs/data.galaxyproject.org/managed/len/ucsc/?.len\\\"\"}",
+      "tool_version": "0.72",
+      "type": "tool",
+      "uuid": "c96f55e9-c898-4e79-abe2-0795b54d3a05",
+      "workflow_outputs": []
+    },
+    "13": {
+      "annotation": "",
+      "content_id": "toolshed.g2.bx.psu.edu/repos/devteam/fastqc/fastqc/0.72",
+      "errors": null,
+      "id": 13,
+      "input_connections": {
+        "input_file": {
+          "id": 3,
+          "output_name": "output"
+        }
+      },
+      "inputs": [],
+      "label": null,
+      "name": "FastQC",
+      "outputs": [
+        {
+          "name": "html_file",
+          "type": "html"
+        },
+        {
+          "name": "text_file",
+          "type": "txt"
+        }
+      ],
+      "position": {
+        "left": 230,
+        "top": 490
+      },
+      "post_job_actions": {},
+      "tool_id": "toolshed.g2.bx.psu.edu/repos/devteam/fastqc/fastqc/0.72",
+      "tool_shed_repository": {
+        "changeset_revision": "c15237684a01",
+        "name": "fastqc",
+        "owner": "devteam",
+        "tool_shed": "toolshed.g2.bx.psu.edu"
+      },
+      "tool_state": "{\"__page__\": null, \"limits\": \"null\", \"input_file\": \"null\", \"__rerun_remap_job_id__\": null, \"__workflow_invocation_uuid__\": \"\\\"fde8952eb77711e8a468005056ba55fb\\\"\", \"contaminants\": \"null\", \"chromInfo\": \"\\\"/cvmfs/data.galaxyproject.org/managed/len/ucsc/?.len\\\"\"}",
+      "tool_version": "0.72",
+      "type": "tool",
+      "uuid": "d30af66b-0ab0-4bb9-8009-ce96a6c16993",
+      "workflow_outputs": []
+    },
+    "14": {
+      "annotation": "",
+      "content_id": "toolshed.g2.bx.psu.edu/repos/pjbriggs/trimmomatic/trimmomatic/0.36.5",
+      "errors": null,
+      "id": 14,
+      "input_connections": {
+        "readtype|fastq_r1_in": {
+          "id": 2,
+          "output_name": "output"
+        },
+        "readtype|fastq_r2_in": {
+          "id": 3,
+          "output_name": "output"
+        }
+      },
+      "inputs": [],
+      "label": null,
+      "name": "Trimmomatic",
+      "outputs": [
+        {
+          "name": "fastq_out_paired",
+          "type": "input"
+        },
+        {
+          "name": "fastq_out_unpaired",
+          "type": "input"
+        },
+        {
+          "name": "fastq_out_r1_paired",
+          "type": "input"
+        },
+        {
+          "name": "fastq_out_r2_paired",
+          "type": "input"
+        },
+        {
+          "name": "fastq_out_r1_unpaired",
+          "type": "input"
+        },
+        {
+          "name": "fastq_out_r2_unpaired",
+          "type": "input"
+        },
+        {
+          "name": "fastq_out",
+          "type": "input"
+        }
+      ],
+      "position": {
+        "left": 230,
+        "top": 610
+      },
+      "post_job_actions": {},
+      "tool_id": "toolshed.g2.bx.psu.edu/repos/pjbriggs/trimmomatic/trimmomatic/0.36.5",
+      "tool_shed_repository": {
+        "changeset_revision": "dfa082f84068",
+        "name": "trimmomatic",
+        "owner": "pjbriggs",
+        "tool_shed": "toolshed.g2.bx.psu.edu"
+      },
+      "tool_state": "{\"operations\": \"[{\\\"__index__\\\": 0, \\\"operation\\\": {\\\"window_size\\\": \\\"4\\\", \\\"name\\\": \\\"SLIDINGWINDOW\\\", \\\"__current_case__\\\": 0, \\\"required_quality\\\": \\\"20\\\"}}]\", \"__page__\": null, \"__rerun_remap_job_id__\": null, \"readtype\": \"{\\\"single_or_paired\\\": \\\"pair_of_files\\\", \\\"fastq_r1_in\\\": null, \\\"__current_case__\\\": 1, \\\"fastq_r2_in\\\": null}\", \"illuminaclip\": \"{\\\"do_illuminaclip\\\": \\\"false\\\", \\\"__current_case__\\\": 1}\", \"__workflow_invocation_uuid__\": \"\\\"fde8952eb77711e8a468005056ba55fb\\\"\", \"chromInfo\": \"\\\"/cvmfs/data.galaxyproject.org/managed/len/ucsc/?.len\\\"\"}",
+      "tool_version": "0.36.5",
+      "type": "tool",
+      "uuid": "3d3cfa70-c027-40aa-b01c-52c36035fe92",
+      "workflow_outputs": []
+    },
+    "15": {
+      "annotation": "",
+      "content_id": "toolshed.g2.bx.psu.edu/repos/devteam/fastqc/fastqc/0.72",
+      "errors": null,
+      "id": 15,
+      "input_connections": {
+        "input_file": {
+          "id": 4,
+          "output_name": "output"
+        }
+      },
+      "inputs": [],
+      "label": null,
+      "name": "FastQC",
+      "outputs": [
+        {
+          "name": "html_file",
+          "type": "html"
+        },
+        {
+          "name": "text_file",
+          "type": "txt"
+        }
+      ],
+      "position": {
+        "left": 230,
+        "top": 730
+      },
+      "post_job_actions": {},
+      "tool_id": "toolshed.g2.bx.psu.edu/repos/devteam/fastqc/fastqc/0.72",
+      "tool_shed_repository": {
+        "changeset_revision": "c15237684a01",
+        "name": "fastqc",
+        "owner": "devteam",
+        "tool_shed": "toolshed.g2.bx.psu.edu"
+      },
+      "tool_state": "{\"__page__\": null, \"limits\": \"null\", \"input_file\": \"null\", \"__rerun_remap_job_id__\": null, \"__workflow_invocation_uuid__\": \"\\\"fde8952eb77711e8a468005056ba55fb\\\"\", \"contaminants\": \"null\", \"chromInfo\": \"\\\"/cvmfs/data.galaxyproject.org/managed/len/ucsc/?.len\\\"\"}",
+      "tool_version": "0.72",
+      "type": "tool",
+      "uuid": "a6295400-a0ee-4790-9294-44e39e5df96c",
+      "workflow_outputs": []
+    },
+    "16": {
+      "annotation": "",
+      "content_id": "toolshed.g2.bx.psu.edu/repos/devteam/fastqc/fastqc/0.72",
+      "errors": null,
+      "id": 16,
+      "input_connections": {
+        "input_file": {
+          "id": 5,
+          "output_name": "output"
+        }
+      },
+      "inputs": [],
+      "label": null,
+      "name": "FastQC",
+      "outputs": [
+        {
+          "name": "html_file",
+          "type": "html"
+        },
+        {
+          "name": "text_file",
+          "type": "txt"
+        }
+      ],
+      "position": {
+        "left": 230,
+        "top": 850
+      },
+      "post_job_actions": {},
+      "tool_id": "toolshed.g2.bx.psu.edu/repos/devteam/fastqc/fastqc/0.72",
+      "tool_shed_repository": {
+        "changeset_revision": "c15237684a01",
+        "name": "fastqc",
+        "owner": "devteam",
+        "tool_shed": "toolshed.g2.bx.psu.edu"
+      },
+      "tool_state": "{\"__page__\": null, \"limits\": \"null\", \"input_file\": \"null\", \"__rerun_remap_job_id__\": null, \"__workflow_invocation_uuid__\": \"\\\"fde8952eb77711e8a468005056ba55fb\\\"\", \"contaminants\": \"null\", \"chromInfo\": \"\\\"/cvmfs/data.galaxyproject.org/managed/len/ucsc/?.len\\\"\"}",
+      "tool_version": "0.72",
+      "type": "tool",
+      "uuid": "d7866331-a1c1-4c4b-8f6b-f7feb78fa78c",
+      "workflow_outputs": []
+    },
+    "17": {
+      "annotation": "",
+      "content_id": "toolshed.g2.bx.psu.edu/repos/pjbriggs/trimmomatic/trimmomatic/0.36.5",
+      "errors": null,
+      "id": 17,
+      "input_connections": {
+        "readtype|fastq_r1_in": {
+          "id": 4,
+          "output_name": "output"
+        },
+        "readtype|fastq_r2_in": {
+          "id": 5,
+          "output_name": "output"
+        }
+      },
+      "inputs": [],
+      "label": null,
+      "name": "Trimmomatic",
+      "outputs": [
+        {
+          "name": "fastq_out_paired",
+          "type": "input"
+        },
+        {
+          "name": "fastq_out_unpaired",
+          "type": "input"
+        },
+        {
+          "name": "fastq_out_r1_paired",
+          "type": "input"
+        },
+        {
+          "name": "fastq_out_r2_paired",
+          "type": "input"
+        },
+        {
+          "name": "fastq_out_r1_unpaired",
+          "type": "input"
+        },
+        {
+          "name": "fastq_out_r2_unpaired",
+          "type": "input"
+        },
+        {
+          "name": "fastq_out",
+          "type": "input"
+        }
+      ],
+      "position": {
+        "left": 230,
+        "top": 970
+      },
+      "post_job_actions": {},
+      "tool_id": "toolshed.g2.bx.psu.edu/repos/pjbriggs/trimmomatic/trimmomatic/0.36.5",
+      "tool_shed_repository": {
+        "changeset_revision": "dfa082f84068",
+        "name": "trimmomatic",
+        "owner": "pjbriggs",
+        "tool_shed": "toolshed.g2.bx.psu.edu"
+      },
+      "tool_state": "{\"operations\": \"[{\\\"__index__\\\": 0, \\\"operation\\\": {\\\"window_size\\\": \\\"4\\\", \\\"name\\\": \\\"SLIDINGWINDOW\\\", \\\"__current_case__\\\": 0, \\\"required_quality\\\": \\\"20\\\"}}]\", \"__page__\": null, \"__rerun_remap_job_id__\": null, \"readtype\": \"{\\\"single_or_paired\\\": \\\"pair_of_files\\\", \\\"fastq_r1_in\\\": null, \\\"__current_case__\\\": 1, \\\"fastq_r2_in\\\": null}\", \"illuminaclip\": \"{\\\"do_illuminaclip\\\": \\\"false\\\", \\\"__current_case__\\\": 1}\", \"__workflow_invocation_uuid__\": \"\\\"fde8952eb77711e8a468005056ba55fb\\\"\", \"chromInfo\": \"\\\"/cvmfs/data.galaxyproject.org/managed/len/ucsc/?.len\\\"\"}",
+      "tool_version": "0.36.5",
+      "type": "tool",
+      "uuid": "c7ff55a4-e3df-4fde-93a3-ab0e175d5d6e",
+      "workflow_outputs": []
+    },
+    "18": {
+      "annotation": "",
+      "content_id": "toolshed.g2.bx.psu.edu/repos/devteam/fastqc/fastqc/0.72",
+      "errors": null,
+      "id": 18,
+      "input_connections": {
+        "input_file": {
+          "id": 6,
+          "output_name": "output"
+        }
+      },
+      "inputs": [],
+      "label": null,
+      "name": "FastQC",
+      "outputs": [
+        {
+          "name": "html_file",
+          "type": "html"
+        },
+        {
+          "name": "text_file",
+          "type": "txt"
+        }
+      ],
+      "position": {
+        "left": 230,
+        "top": 1090
+      },
+      "post_job_actions": {},
+      "tool_id": "toolshed.g2.bx.psu.edu/repos/devteam/fastqc/fastqc/0.72",
+      "tool_shed_repository": {
+        "changeset_revision": "c15237684a01",
+        "name": "fastqc",
+        "owner": "devteam",
+        "tool_shed": "toolshed.g2.bx.psu.edu"
+      },
+      "tool_state": "{\"__page__\": null, \"limits\": \"null\", \"input_file\": \"null\", \"__rerun_remap_job_id__\": null, \"__workflow_invocation_uuid__\": \"\\\"fde8952eb77711e8a468005056ba55fb\\\"\", \"contaminants\": \"null\", \"chromInfo\": \"\\\"/cvmfs/data.galaxyproject.org/managed/len/ucsc/?.len\\\"\"}",
+      "tool_version": "0.72",
+      "type": "tool",
+      "uuid": "e56ae1f1-b6ee-4f0a-873b-fae2c345c216",
+      "workflow_outputs": []
+    },
+    "19": {
+      "annotation": "",
+      "content_id": "toolshed.g2.bx.psu.edu/repos/devteam/fastqc/fastqc/0.72",
+      "errors": null,
+      "id": 19,
+      "input_connections": {
+        "input_file": {
+          "id": 7,
+          "output_name": "output"
+        }
+      },
+      "inputs": [],
+      "label": null,
+      "name": "FastQC",
+      "outputs": [
+        {
+          "name": "html_file",
+          "type": "html"
+        },
+        {
+          "name": "text_file",
+          "type": "txt"
+        }
+      ],
+      "position": {
+        "left": 230,
+        "top": 1210
+      },
+      "post_job_actions": {},
+      "tool_id": "toolshed.g2.bx.psu.edu/repos/devteam/fastqc/fastqc/0.72",
+      "tool_shed_repository": {
+        "changeset_revision": "c15237684a01",
+        "name": "fastqc",
+        "owner": "devteam",
+        "tool_shed": "toolshed.g2.bx.psu.edu"
+      },
+      "tool_state": "{\"__page__\": null, \"limits\": \"null\", \"input_file\": \"null\", \"__rerun_remap_job_id__\": null, \"__workflow_invocation_uuid__\": \"\\\"fde8952eb77711e8a468005056ba55fb\\\"\", \"contaminants\": \"null\", \"chromInfo\": \"\\\"/cvmfs/data.galaxyproject.org/managed/len/ucsc/?.len\\\"\"}",
+      "tool_version": "0.72",
+      "type": "tool",
+      "uuid": "d1068d72-f84b-431c-9137-38eb42606147",
+      "workflow_outputs": []
+    },
+    "2": {
+      "annotation": "",
+      "content_id": null,
+      "errors": null,
+      "id": 2,
+      "input_connections": {},
+      "inputs": [
+        {
+          "description": "",
+          "name": "G1E_rep2_forward_read"
+        }
+      ],
+      "label": null,
+      "name": "Input dataset",
+      "outputs": [],
+      "position": {
+        "left": 10,
+        "top": 250
+      },
+      "tool_id": null,
+      "tool_state": "{\"name\": \"G1E_rep2_forward_read\"}",
+      "tool_version": null,
+      "type": "data_input",
+      "uuid": "c24cf053-248c-4922-874e-240f187853ca",
+      "workflow_outputs": []
+    },
+    "20": {
+      "annotation": "",
+      "content_id": "toolshed.g2.bx.psu.edu/repos/pjbriggs/trimmomatic/trimmomatic/0.36.5",
+      "errors": null,
+      "id": 20,
+      "input_connections": {
+        "readtype|fastq_r1_in": {
+          "id": 6,
+          "output_name": "output"
+        },
+        "readtype|fastq_r2_in": {
+          "id": 7,
+          "output_name": "output"
+        }
+      },
+      "inputs": [],
+      "label": null,
+      "name": "Trimmomatic",
+      "outputs": [
+        {
+          "name": "fastq_out_paired",
+          "type": "input"
+        },
+        {
+          "name": "fastq_out_unpaired",
+          "type": "input"
+        },
+        {
+          "name": "fastq_out_r1_paired",
+          "type": "input"
+        },
+        {
+          "name": "fastq_out_r2_paired",
+          "type": "input"
+        },
+        {
+          "name": "fastq_out_r1_unpaired",
+          "type": "input"
+        },
+        {
+          "name": "fastq_out_r2_unpaired",
+          "type": "input"
+        },
+        {
+          "name": "fastq_out",
+          "type": "input"
+        }
+      ],
+      "position": {
+        "left": 230,
+        "top": 1330
+      },
+      "post_job_actions": {},
+      "tool_id": "toolshed.g2.bx.psu.edu/repos/pjbriggs/trimmomatic/trimmomatic/0.36.5",
+      "tool_shed_repository": {
+        "changeset_revision": "dfa082f84068",
+        "name": "trimmomatic",
+        "owner": "pjbriggs",
+        "tool_shed": "toolshed.g2.bx.psu.edu"
+      },
+      "tool_state": "{\"operations\": \"[{\\\"__index__\\\": 0, \\\"operation\\\": {\\\"window_size\\\": \\\"4\\\", \\\"name\\\": \\\"SLIDINGWINDOW\\\", \\\"__current_case__\\\": 0, \\\"required_quality\\\": \\\"20\\\"}}]\", \"__page__\": null, \"__rerun_remap_job_id__\": null, \"readtype\": \"{\\\"single_or_paired\\\": \\\"pair_of_files\\\", \\\"fastq_r1_in\\\": null, \\\"__current_case__\\\": 1, \\\"fastq_r2_in\\\": null}\", \"illuminaclip\": \"{\\\"do_illuminaclip\\\": \\\"false\\\", \\\"__current_case__\\\": 1}\", \"__workflow_invocation_uuid__\": \"\\\"fde8952eb77711e8a468005056ba55fb\\\"\", \"chromInfo\": \"\\\"/cvmfs/data.galaxyproject.org/managed/len/ucsc/?.len\\\"\"}",
+      "tool_version": "0.36.5",
+      "type": "tool",
+      "uuid": "81433b00-0996-44b0-ae73-db880a8c68c0",
+      "workflow_outputs": []
+    },
+    "21": {
+      "annotation": "",
+      "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/hisat2/hisat2/2.1.0",
+      "errors": null,
+      "id": 21,
+      "input_connections": {
+        "library|input_1": {
+          "id": 11,
+          "output_name": "fastq_out_r1_paired"
+        },
+        "library|input_2": {
+          "id": 11,
+          "output_name": "fastq_out_r2_paired"
+        }
+      },
+      "inputs": [],
+      "label": null,
+      "name": "HISAT2",
+      "outputs": [
+        {
+          "name": "output_alignments",
+          "type": "bam"
+        },
+        {
+          "name": "output_unaligned_reads_l",
+          "type": "fastqsanger"
+        },
+        {
+          "name": "output_aligned_reads_l",
+          "type": "fastqsanger"
+        },
+        {
+          "name": "output_unaligned_reads_r",
+          "type": "fastqsanger"
+        },
+        {
+          "name": "output_aligned_reads_r",
+          "type": "fastqsanger"
+        },
+        {
+          "name": "summary_file",
+          "type": "txt"
+        }
+      ],
+      "position": {
+        "left": 450,
+        "top": 10
+      },
+      "post_job_actions": {},
+      "tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/hisat2/hisat2/2.1.0",
+      "tool_shed_repository": {
+        "changeset_revision": "6ab42baa56e9",
+        "name": "hisat2",
+        "owner": "iuc",
+        "tool_shed": "toolshed.g2.bx.psu.edu"
+      },
+      "tool_state": "{\"adv\": \"{\\\"alignment_options\\\": {\\\"__current_case__\\\": 0, \\\"alignment_options_selector\\\": \\\"defaults\\\"}, \\\"output_options\\\": {\\\"output_options_selector\\\": \\\"defaults\\\", \\\"__current_case__\\\": 0}, \\\"other_options\\\": {\\\"other_options_selector\\\": \\\"defaults\\\", \\\"__current_case__\\\": 0}, \\\"scoring_options\\\": {\\\"scoring_options_selector\\\": \\\"defaults\\\", \\\"__current_case__\\\": 0}, \\\"spliced_options\\\": {\\\"coefficient\\\": \\\"0.0\\\", \\\"canonical_penalty\\\": \\\"0\\\", \\\"no_spliced_alignment_options\\\": {\\\"no_spliced_alignment\\\": \\\"\\\", \\\"__current_case__\\\": 1}, \\\"nc_function_type\\\": \\\"C\\\", \\\"constant_term\\\": \\\"0.0\\\", \\\"nc_coefficient\\\": \\\"1.0\\\", \\\"noncanonical_penalty\\\": \\\"3\\\", \\\"known_splice_gtf\\\": null, \\\"nc_constant_term\\\": \\\"-8.0\\\", \\\"min_intron\\\": \\\"20\\\", \\\"function_type\\\": \\\"C\\\", \\\"__current_case__\\\": 1, \\\"notmplen\\\": \\\"false\\\", \\\"tma\\\": \\\"--dta\\\", \\\"max_intron\\\": \\\"500000\\\", \\\"spliced_options_selector\\\": \\\"advanced\\\"}, \\\"reporting_options\\\": {\\\"reporting_options_selector\\\": \\\"defaults\\\", \\\"__current_case__\\\": 0}, \\\"input_options\\\": {\\\"input_options_selector\\\": \\\"defaults\\\", \\\"__current_case__\\\": 0}}\", \"__page__\": null, \"sum\": \"{\\\"new_summary\\\": \\\"false\\\", \\\"summary_file\\\": \\\"false\\\"}\", \"library\": \"{\\\"rna_strandness\\\": \\\"FR\\\", \\\"input_2\\\": null, \\\"__current_case__\\\": 1, \\\"input_1\\\": null, \\\"type\\\": \\\"paired\\\", \\\"paired_options\\\": {\\\"paired_options_selector\\\": \\\"defaults\\\", \\\"__current_case__\\\": 0}}\", \"reference_genome\": \"{\\\"source\\\": \\\"indexed\\\", \\\"__current_case__\\\": 0, \\\"index\\\": \\\"mm10\\\"}\", \"__workflow_invocation_uuid__\": \"\\\"fde8952eb77711e8a468005056ba55fb\\\"\", \"chromInfo\": \"\\\"/cvmfs/data.galaxyproject.org/managed/len/ucsc/?.len\\\"\", \"__rerun_remap_job_id__\": null}",
+      "tool_version": "2.1.0",
+      "type": "tool",
+      "uuid": "817cc498-44f1-4813-92f0-3b88fed3451f",
+      "workflow_outputs": []
+    },
+    "22": {
+      "annotation": "",
+      "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/hisat2/hisat2/2.1.0",
+      "errors": null,
+      "id": 22,
+      "input_connections": {
+        "library|input_1": {
+          "id": 14,
+          "output_name": "fastq_out_r1_paired"
+        },
+        "library|input_2": {
+          "id": 14,
+          "output_name": "fastq_out_r2_paired"
+        }
+      },
+      "inputs": [],
+      "label": null,
+      "name": "HISAT2",
+      "outputs": [
+        {
+          "name": "output_alignments",
+          "type": "bam"
+        },
+        {
+          "name": "output_unaligned_reads_l",
+          "type": "fastqsanger"
+        },
+        {
+          "name": "output_aligned_reads_l",
+          "type": "fastqsanger"
+        },
+        {
+          "name": "output_unaligned_reads_r",
+          "type": "fastqsanger"
+        },
+        {
+          "name": "output_aligned_reads_r",
+          "type": "fastqsanger"
+        },
+        {
+          "name": "summary_file",
+          "type": "txt"
+        }
+      ],
+      "position": {
+        "left": 450,
+        "top": 130
+      },
+      "post_job_actions": {},
+      "tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/hisat2/hisat2/2.1.0",
+      "tool_shed_repository": {
+        "changeset_revision": "6ab42baa56e9",
+        "name": "hisat2",
+        "owner": "iuc",
+        "tool_shed": "toolshed.g2.bx.psu.edu"
+      },
+      "tool_state": "{\"adv\": \"{\\\"alignment_options\\\": {\\\"__current_case__\\\": 0, \\\"alignment_options_selector\\\": \\\"defaults\\\"}, \\\"output_options\\\": {\\\"output_options_selector\\\": \\\"defaults\\\", \\\"__current_case__\\\": 0}, \\\"other_options\\\": {\\\"other_options_selector\\\": \\\"defaults\\\", \\\"__current_case__\\\": 0}, \\\"scoring_options\\\": {\\\"scoring_options_selector\\\": \\\"defaults\\\", \\\"__current_case__\\\": 0}, \\\"spliced_options\\\": {\\\"coefficient\\\": \\\"0.0\\\", \\\"canonical_penalty\\\": \\\"0\\\", \\\"no_spliced_alignment_options\\\": {\\\"no_spliced_alignment\\\": \\\"\\\", \\\"__current_case__\\\": 1}, \\\"nc_function_type\\\": \\\"C\\\", \\\"constant_term\\\": \\\"0.0\\\", \\\"nc_coefficient\\\": \\\"1.0\\\", \\\"noncanonical_penalty\\\": \\\"3\\\", \\\"known_splice_gtf\\\": null, \\\"nc_constant_term\\\": \\\"-8.0\\\", \\\"min_intron\\\": \\\"20\\\", \\\"function_type\\\": \\\"C\\\", \\\"__current_case__\\\": 1, \\\"notmplen\\\": \\\"false\\\", \\\"tma\\\": \\\"--dta\\\", \\\"max_intron\\\": \\\"500000\\\", \\\"spliced_options_selector\\\": \\\"advanced\\\"}, \\\"reporting_options\\\": {\\\"reporting_options_selector\\\": \\\"defaults\\\", \\\"__current_case__\\\": 0}, \\\"input_options\\\": {\\\"input_options_selector\\\": \\\"defaults\\\", \\\"__current_case__\\\": 0}}\", \"__page__\": null, \"sum\": \"{\\\"new_summary\\\": \\\"false\\\", \\\"summary_file\\\": \\\"false\\\"}\", \"library\": \"{\\\"rna_strandness\\\": \\\"FR\\\", \\\"input_2\\\": null, \\\"__current_case__\\\": 1, \\\"input_1\\\": null, \\\"type\\\": \\\"paired\\\", \\\"paired_options\\\": {\\\"paired_options_selector\\\": \\\"defaults\\\", \\\"__current_case__\\\": 0}}\", \"reference_genome\": \"{\\\"source\\\": \\\"indexed\\\", \\\"__current_case__\\\": 0, \\\"index\\\": \\\"mm10\\\"}\", \"__workflow_invocation_uuid__\": \"\\\"fde8952eb77711e8a468005056ba55fb\\\"\", \"chromInfo\": \"\\\"/cvmfs/data.galaxyproject.org/managed/len/ucsc/?.len\\\"\", \"__rerun_remap_job_id__\": null}",
+      "tool_version": "2.1.0",
+      "type": "tool",
+      "uuid": "1e92db79-135e-4a5e-9d3f-ea0d7f5045da",
+      "workflow_outputs": []
+    },
+    "23": {
+      "annotation": "",
+      "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/hisat2/hisat2/2.1.0",
+      "errors": null,
+      "id": 23,
+      "input_connections": {
+        "library|input_1": {
+          "id": 17,
+          "output_name": "fastq_out_r1_paired"
+        },
+        "library|input_2": {
+          "id": 17,
+          "output_name": "fastq_out_r2_paired"
+        }
+      },
+      "inputs": [],
+      "label": null,
+      "name": "HISAT2",
+      "outputs": [
+        {
+          "name": "output_alignments",
+          "type": "bam"
+        },
+        {
+          "name": "output_unaligned_reads_l",
+          "type": "fastqsanger"
+        },
+        {
+          "name": "output_aligned_reads_l",
+          "type": "fastqsanger"
+        },
+        {
+          "name": "output_unaligned_reads_r",
+          "type": "fastqsanger"
+        },
+        {
+          "name": "output_aligned_reads_r",
+          "type": "fastqsanger"
+        },
+        {
+          "name": "summary_file",
+          "type": "txt"
+        }
+      ],
+      "position": {
+        "left": 450,
+        "top": 250
+      },
+      "post_job_actions": {},
+      "tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/hisat2/hisat2/2.1.0",
+      "tool_shed_repository": {
+        "changeset_revision": "6ab42baa56e9",
+        "name": "hisat2",
+        "owner": "iuc",
+        "tool_shed": "toolshed.g2.bx.psu.edu"
+      },
+      "tool_state": "{\"adv\": \"{\\\"alignment_options\\\": {\\\"__current_case__\\\": 0, \\\"alignment_options_selector\\\": \\\"defaults\\\"}, \\\"output_options\\\": {\\\"output_options_selector\\\": \\\"defaults\\\", \\\"__current_case__\\\": 0}, \\\"other_options\\\": {\\\"other_options_selector\\\": \\\"defaults\\\", \\\"__current_case__\\\": 0}, \\\"scoring_options\\\": {\\\"scoring_options_selector\\\": \\\"defaults\\\", \\\"__current_case__\\\": 0}, \\\"spliced_options\\\": {\\\"coefficient\\\": \\\"0.0\\\", \\\"canonical_penalty\\\": \\\"0\\\", \\\"no_spliced_alignment_options\\\": {\\\"no_spliced_alignment\\\": \\\"\\\", \\\"__current_case__\\\": 1}, \\\"nc_function_type\\\": \\\"C\\\", \\\"constant_term\\\": \\\"0.0\\\", \\\"nc_coefficient\\\": \\\"1.0\\\", \\\"noncanonical_penalty\\\": \\\"3\\\", \\\"known_splice_gtf\\\": null, \\\"nc_constant_term\\\": \\\"-8.0\\\", \\\"min_intron\\\": \\\"20\\\", \\\"function_type\\\": \\\"C\\\", \\\"__current_case__\\\": 1, \\\"notmplen\\\": \\\"false\\\", \\\"tma\\\": \\\"--dta\\\", \\\"max_intron\\\": \\\"500000\\\", \\\"spliced_options_selector\\\": \\\"advanced\\\"}, \\\"reporting_options\\\": {\\\"reporting_options_selector\\\": \\\"defaults\\\", \\\"__current_case__\\\": 0}, \\\"input_options\\\": {\\\"input_options_selector\\\": \\\"defaults\\\", \\\"__current_case__\\\": 0}}\", \"__page__\": null, \"sum\": \"{\\\"new_summary\\\": \\\"false\\\", \\\"summary_file\\\": \\\"false\\\"}\", \"library\": \"{\\\"rna_strandness\\\": \\\"FR\\\", \\\"input_2\\\": null, \\\"__current_case__\\\": 1, \\\"input_1\\\": null, \\\"type\\\": \\\"paired\\\", \\\"paired_options\\\": {\\\"paired_options_selector\\\": \\\"defaults\\\", \\\"__current_case__\\\": 0}}\", \"reference_genome\": \"{\\\"source\\\": \\\"indexed\\\", \\\"__current_case__\\\": 0, \\\"index\\\": \\\"mm10\\\"}\", \"__workflow_invocation_uuid__\": \"\\\"fde8952eb77711e8a468005056ba55fb\\\"\", \"chromInfo\": \"\\\"/cvmfs/data.galaxyproject.org/managed/len/ucsc/?.len\\\"\", \"__rerun_remap_job_id__\": null}",
+      "tool_version": "2.1.0",
+      "type": "tool",
+      "uuid": "c488973c-6fe1-4f11-9268-1f108e3e1aae",
+      "workflow_outputs": []
+    },
+    "24": {
+      "annotation": "",
+      "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/hisat2/hisat2/2.1.0",
+      "errors": null,
+      "id": 24,
+      "input_connections": {
+        "library|input_1": {
+          "id": 20,
+          "output_name": "fastq_out_r1_paired"
+        },
+        "library|input_2": {
+          "id": 20,
+          "output_name": "fastq_out_r2_paired"
+        }
+      },
+      "inputs": [],
+      "label": null,
+      "name": "HISAT2",
+      "outputs": [
+        {
+          "name": "output_alignments",
+          "type": "bam"
+        },
+        {
+          "name": "output_unaligned_reads_l",
+          "type": "fastqsanger"
+        },
+        {
+          "name": "output_aligned_reads_l",
+          "type": "fastqsanger"
+        },
+        {
+          "name": "output_unaligned_reads_r",
+          "type": "fastqsanger"
+        },
+        {
+          "name": "output_aligned_reads_r",
+          "type": "fastqsanger"
+        },
+        {
+          "name": "summary_file",
+          "type": "txt"
+        }
+      ],
+      "position": {
+        "left": 450,
+        "top": 370
+      },
+      "post_job_actions": {},
+      "tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/hisat2/hisat2/2.1.0",
+      "tool_shed_repository": {
+        "changeset_revision": "6ab42baa56e9",
+        "name": "hisat2",
+        "owner": "iuc",
+        "tool_shed": "toolshed.g2.bx.psu.edu"
+      },
+      "tool_state": "{\"adv\": \"{\\\"alignment_options\\\": {\\\"__current_case__\\\": 0, \\\"alignment_options_selector\\\": \\\"defaults\\\"}, \\\"output_options\\\": {\\\"output_options_selector\\\": \\\"defaults\\\", \\\"__current_case__\\\": 0}, \\\"other_options\\\": {\\\"other_options_selector\\\": \\\"defaults\\\", \\\"__current_case__\\\": 0}, \\\"scoring_options\\\": {\\\"scoring_options_selector\\\": \\\"defaults\\\", \\\"__current_case__\\\": 0}, \\\"spliced_options\\\": {\\\"coefficient\\\": \\\"0.0\\\", \\\"canonical_penalty\\\": \\\"0\\\", \\\"no_spliced_alignment_options\\\": {\\\"no_spliced_alignment\\\": \\\"\\\", \\\"__current_case__\\\": 1}, \\\"nc_function_type\\\": \\\"C\\\", \\\"constant_term\\\": \\\"0.0\\\", \\\"nc_coefficient\\\": \\\"1.0\\\", \\\"noncanonical_penalty\\\": \\\"3\\\", \\\"known_splice_gtf\\\": null, \\\"nc_constant_term\\\": \\\"-8.0\\\", \\\"min_intron\\\": \\\"20\\\", \\\"function_type\\\": \\\"C\\\", \\\"__current_case__\\\": 1, \\\"notmplen\\\": \\\"false\\\", \\\"tma\\\": \\\"--dta\\\", \\\"max_intron\\\": \\\"500000\\\", \\\"spliced_options_selector\\\": \\\"advanced\\\"}, \\\"reporting_options\\\": {\\\"reporting_options_selector\\\": \\\"defaults\\\", \\\"__current_case__\\\": 0}, \\\"input_options\\\": {\\\"input_options_selector\\\": \\\"defaults\\\", \\\"__current_case__\\\": 0}}\", \"__page__\": null, \"sum\": \"{\\\"new_summary\\\": \\\"false\\\", \\\"summary_file\\\": \\\"false\\\"}\", \"library\": \"{\\\"rna_strandness\\\": \\\"FR\\\", \\\"input_2\\\": null, \\\"__current_case__\\\": 1, \\\"input_1\\\": null, \\\"type\\\": \\\"paired\\\", \\\"paired_options\\\": {\\\"paired_options_selector\\\": \\\"defaults\\\", \\\"__current_case__\\\": 0}}\", \"reference_genome\": \"{\\\"source\\\": \\\"indexed\\\", \\\"__current_case__\\\": 0, \\\"index\\\": \\\"mm10\\\"}\", \"__workflow_invocation_uuid__\": \"\\\"fde8952eb77711e8a468005056ba55fb\\\"\", \"chromInfo\": \"\\\"/cvmfs/data.galaxyproject.org/managed/len/ucsc/?.len\\\"\", \"__rerun_remap_job_id__\": null}",
+      "tool_version": "2.1.0",
+      "type": "tool",
+      "uuid": "614c1c41-fcd0-447e-8514-c0876641809d",
+      "workflow_outputs": []
+    },
+    "25": {
+      "annotation": "",
+      "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/stringtie/stringtie/1.3.3.2",
+      "errors": null,
+      "id": 25,
+      "input_connections": {
+        "input_bam": {
+          "id": 21,
+          "output_name": "output_alignments"
+        }
+      },
+      "inputs": [],
+      "label": null,
+      "name": "StringTie",
+      "outputs": [
+        {
+          "name": "output_gtf",
+          "type": "gtf"
+        },
+        {
+          "name": "gene_abundance_estimation",
+          "type": "gtf"
+        },
+        {
+          "name": "coverage",
+          "type": "gtf"
+        },
+        {
+          "name": "exon_expression",
+          "type": "tabular"
+        },
+        {
+          "name": "intron_expression",
+          "type": "tabular"
+        },
+        {
+          "name": "transcript_expression",
+          "type": "tabular"
+        },
+        {
+          "name": "exon_transcript_mapping",
+          "type": "tabular"
+        },
+        {
+          "name": "intron_transcript_mapping",
+          "type": "tabular"
+        },
+        {
+          "name": "gene_counts",
+          "type": "tabular"
+        },
+        {
+          "name": "transcript_counts",
+          "type": "tabular"
+        },
+        {
+          "name": "legend",
+          "type": "tabular"
+        }
+      ],
+      "position": {
+        "left": 670,
+        "top": 10
+      },
+      "post_job_actions": {},
+      "tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/stringtie/stringtie/1.3.3.2",
+      "tool_shed_repository": {
+        "changeset_revision": "eafd5dc95228",
+        "name": "stringtie",
+        "owner": "iuc",
+        "tool_shed": "toolshed.g2.bx.psu.edu"
+      },
+      "tool_state": "{\"adv\": \"{\\\"min_bundle_cov\\\": \\\"2\\\", \\\"min_tlen\\\": \\\"200\\\", \\\"bdist\\\": \\\"50\\\", \\\"multi_mapping\\\": \\\"false\\\", \\\"abundance_estimation\\\": \\\"false\\\", \\\"fraction\\\": \\\"0.15\\\", \\\"disable_trimming\\\": \\\"false\\\", \\\"omit_sequences\\\": \\\"\\\", \\\"name_prefix\\\": \\\"\\\", \\\"min_anchor_len\\\": \\\"10\\\", \\\"bundle_fraction\\\": \\\"0.95\\\", \\\"min_anchor_cov\\\": \\\"1\\\"}\", \"__page__\": null, \"chromInfo\": \"\\\"/cvmfs/data.galaxyproject.org/managed/len/ucsc/mm10.len\\\"\", \"__rerun_remap_job_id__\": null, \"__workflow_invocation_uuid__\": \"\\\"fde8952eb77711e8a468005056ba55fb\\\"\", \"rna_strandness\": \"\\\"--fr\\\"\", \"input_bam\": \"null\", \"guide\": \"{\\\"use_guide\\\": \\\"no\\\", \\\"__current_case__\\\": 0}\"}",
+      "tool_version": "1.3.3.2",
+      "type": "tool",
+      "uuid": "5fbbf39b-c5da-435e-a7cf-4d0d3ed9e05e",
+      "workflow_outputs": []
+    },
+    "26": {
+      "annotation": "",
+      "content_id": "toolshed.g2.bx.psu.edu/repos/bgruening/deeptools_bam_coverage/deeptools_bam_coverage/3.0.2.0",
+      "errors": null,
+      "id": 26,
+      "input_connections": {
+        "bamInput": {
+          "id": 21,
+          "output_name": "output_alignments"
+        }
+      },
+      "inputs": [],
+      "label": null,
+      "name": "bamCoverage",
+      "outputs": [
+        {
+          "name": "outFileName",
+          "type": "bigwig"
+        }
+      ],
+      "position": {
+        "left": 670,
+        "top": 490
+      },
+      "post_job_actions": {},
+      "tool_id": "toolshed.g2.bx.psu.edu/repos/bgruening/deeptools_bam_coverage/deeptools_bam_coverage/3.0.2.0",
+      "tool_shed_repository": {
+        "changeset_revision": "3033c3fba046",
+        "name": "deeptools_bam_coverage",
+        "owner": "bgruening",
+        "tool_shed": "toolshed.g2.bx.psu.edu"
+      },
+      "tool_state": "{\"__page__\": null, \"outFileFormat\": \"\\\"bigwig\\\"\", \"region\": \"\\\"\\\"\", \"bamInput\": \"null\", \"binSize\": \"\\\"1\\\"\", \"scaling\": \"{\\\"effectiveGenomeSize\\\": {\\\"effectiveGenomeSize_opt\\\": \\\"2304947926\\\", \\\"__current_case__\\\": 6}, \\\"type\\\": \\\"1x\\\", \\\"__current_case__\\\": 4}\", \"advancedOpt\": \"{\\\"ignoreDuplicates\\\": \\\"false\\\", \\\"centerReads\\\": \\\"false\\\", \\\"ignoreForNormalization\\\": \\\"\\\", \\\"minFragmentLength\\\": \\\"0\\\", \\\"minMappingQuality\\\": \\\"1\\\", \\\"MNase\\\": \\\"false\\\", \\\"samFlagInclude\\\": \\\"\\\", \\\"filterRNAstrand\\\": \\\"forward\\\", \\\"Offset\\\": \\\"\\\", \\\"smoothLength\\\": \\\"\\\", \\\"showAdvancedOpt\\\": \\\"yes\\\", \\\"__current_case__\\\": 1, \\\"samFlagExclude\\\": \\\"\\\", \\\"doExtendCustom\\\": {\\\"__current_case__\\\": 0, \\\"doExtend\\\": \\\"no\\\"}, \\\"skipNAs\\\": \\\"false\\\", \\\"scaleFactor\\\": \\\"1.0\\\", \\\"blackListFileName\\\": null, \\\"maxFragmentLength\\\": \\\"0\\\"}\", \"chromInfo\": \"\\\"/cvmfs/data.galaxyproject.org/managed/len/ucsc/mm10.len\\\"\", \"__rerun_remap_job_id__\": null}",
+      "tool_version": "3.0.2.0",
+      "type": "tool",
+      "uuid": "d61115e2-0a95-4b80-93bb-a14183d0e219",
+      "workflow_outputs": []
+    },
+    "27": {
+      "annotation": "",
+      "content_id": "toolshed.g2.bx.psu.edu/repos/bgruening/deeptools_bam_coverage/deeptools_bam_coverage/3.0.2.0",
+      "errors": null,
+      "id": 27,
+      "input_connections": {
+        "bamInput": {
+          "id": 21,
+          "output_name": "output_alignments"
+        }
+      },
+      "inputs": [],
+      "label": null,
+      "name": "bamCoverage",
+      "outputs": [
+        {
+          "name": "outFileName",
+          "type": "bigwig"
+        }
+      ],
+      "position": {
+        "left": 670,
+        "top": 970
+      },
+      "post_job_actions": {},
+      "tool_id": "toolshed.g2.bx.psu.edu/repos/bgruening/deeptools_bam_coverage/deeptools_bam_coverage/3.0.2.0",
+      "tool_shed_repository": {
+        "changeset_revision": "3033c3fba046",
+        "name": "deeptools_bam_coverage",
+        "owner": "bgruening",
+        "tool_shed": "toolshed.g2.bx.psu.edu"
+      },
+      "tool_state": "{\"__page__\": null, \"outFileFormat\": \"\\\"bigwig\\\"\", \"region\": \"\\\"\\\"\", \"bamInput\": \"null\", \"binSize\": \"\\\"1\\\"\", \"scaling\": \"{\\\"effectiveGenomeSize\\\": {\\\"effectiveGenomeSize_opt\\\": \\\"2304947926\\\", \\\"__current_case__\\\": 6}, \\\"type\\\": \\\"1x\\\", \\\"__current_case__\\\": 4}\", \"advancedOpt\": \"{\\\"ignoreDuplicates\\\": \\\"false\\\", \\\"centerReads\\\": \\\"false\\\", \\\"ignoreForNormalization\\\": \\\"\\\", \\\"minFragmentLength\\\": \\\"0\\\", \\\"minMappingQuality\\\": \\\"1\\\", \\\"MNase\\\": \\\"false\\\", \\\"samFlagInclude\\\": \\\"\\\", \\\"filterRNAstrand\\\": \\\"reverse\\\", \\\"Offset\\\": \\\"\\\", \\\"smoothLength\\\": \\\"\\\", \\\"showAdvancedOpt\\\": \\\"yes\\\", \\\"__current_case__\\\": 1, \\\"samFlagExclude\\\": \\\"\\\", \\\"doExtendCustom\\\": {\\\"__current_case__\\\": 0, \\\"doExtend\\\": \\\"no\\\"}, \\\"skipNAs\\\": \\\"false\\\", \\\"scaleFactor\\\": \\\"1.0\\\", \\\"blackListFileName\\\": null, \\\"maxFragmentLength\\\": \\\"0\\\"}\", \"chromInfo\": \"\\\"/cvmfs/data.galaxyproject.org/managed/len/ucsc/mm10.len\\\"\", \"__rerun_remap_job_id__\": null}",
+      "tool_version": "3.0.2.0",
+      "type": "tool",
+      "uuid": "72051e92-7fc3-447f-b289-e9d7e7043397",
+      "workflow_outputs": []
+    },
+    "28": {
+      "annotation": "",
+      "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/stringtie/stringtie/1.3.3.2",
+      "errors": null,
+      "id": 28,
+      "input_connections": {
+        "input_bam": {
+          "id": 22,
+          "output_name": "output_alignments"
+        }
+      },
+      "inputs": [],
+      "label": null,
+      "name": "StringTie",
+      "outputs": [
+        {
+          "name": "output_gtf",
+          "type": "gtf"
+        },
+        {
+          "name": "gene_abundance_estimation",
+          "type": "gtf"
+        },
+        {
+          "name": "coverage",
+          "type": "gtf"
+        },
+        {
+          "name": "exon_expression",
+          "type": "tabular"
+        },
+        {
+          "name": "intron_expression",
+          "type": "tabular"
+        },
+        {
+          "name": "transcript_expression",
+          "type": "tabular"
+        },
+        {
+          "name": "exon_transcript_mapping",
+          "type": "tabular"
+        },
+        {
+          "name": "intron_transcript_mapping",
+          "type": "tabular"
+        },
+        {
+          "name": "gene_counts",
+          "type": "tabular"
+        },
+        {
+          "name": "transcript_counts",
+          "type": "tabular"
+        },
+        {
+          "name": "legend",
+          "type": "tabular"
+        }
+      ],
+      "position": {
+        "left": 670,
+        "top": 130
+      },
+      "post_job_actions": {},
+      "tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/stringtie/stringtie/1.3.3.2",
+      "tool_shed_repository": {
+        "changeset_revision": "eafd5dc95228",
+        "name": "stringtie",
+        "owner": "iuc",
+        "tool_shed": "toolshed.g2.bx.psu.edu"
+      },
+      "tool_state": "{\"adv\": \"{\\\"min_bundle_cov\\\": \\\"2\\\", \\\"min_tlen\\\": \\\"200\\\", \\\"bdist\\\": \\\"50\\\", \\\"multi_mapping\\\": \\\"false\\\", \\\"abundance_estimation\\\": \\\"false\\\", \\\"fraction\\\": \\\"0.15\\\", \\\"disable_trimming\\\": \\\"false\\\", \\\"omit_sequences\\\": \\\"\\\", \\\"name_prefix\\\": \\\"\\\", \\\"min_anchor_len\\\": \\\"10\\\", \\\"bundle_fraction\\\": \\\"0.95\\\", \\\"min_anchor_cov\\\": \\\"1\\\"}\", \"__page__\": null, \"chromInfo\": \"\\\"/cvmfs/data.galaxyproject.org/managed/len/ucsc/mm10.len\\\"\", \"__rerun_remap_job_id__\": null, \"__workflow_invocation_uuid__\": \"\\\"fde8952eb77711e8a468005056ba55fb\\\"\", \"rna_strandness\": \"\\\"--fr\\\"\", \"input_bam\": \"null\", \"guide\": \"{\\\"use_guide\\\": \\\"no\\\", \\\"__current_case__\\\": 0}\"}",
+      "tool_version": "1.3.3.2",
+      "type": "tool",
+      "uuid": "c96d2ba9-5fb2-444f-afa1-8311a54460c0",
+      "workflow_outputs": []
+    },
+    "29": {
+      "annotation": "",
+      "content_id": "toolshed.g2.bx.psu.edu/repos/bgruening/deeptools_bam_coverage/deeptools_bam_coverage/3.0.2.0",
+      "errors": null,
+      "id": 29,
+      "input_connections": {
+        "bamInput": {
+          "id": 22,
+          "output_name": "output_alignments"
+        }
+      },
+      "inputs": [],
+      "label": null,
+      "name": "bamCoverage",
+      "outputs": [
+        {
+          "name": "outFileName",
+          "type": "bigwig"
+        }
+      ],
+      "position": {
+        "left": 670,
+        "top": 610
+      },
+      "post_job_actions": {},
+      "tool_id": "toolshed.g2.bx.psu.edu/repos/bgruening/deeptools_bam_coverage/deeptools_bam_coverage/3.0.2.0",
+      "tool_shed_repository": {
+        "changeset_revision": "3033c3fba046",
+        "name": "deeptools_bam_coverage",
+        "owner": "bgruening",
+        "tool_shed": "toolshed.g2.bx.psu.edu"
+      },
+      "tool_state": "{\"__page__\": null, \"outFileFormat\": \"\\\"bigwig\\\"\", \"region\": \"\\\"\\\"\", \"bamInput\": \"null\", \"binSize\": \"\\\"1\\\"\", \"scaling\": \"{\\\"effectiveGenomeSize\\\": {\\\"effectiveGenomeSize_opt\\\": \\\"2304947926\\\", \\\"__current_case__\\\": 6}, \\\"type\\\": \\\"1x\\\", \\\"__current_case__\\\": 4}\", \"advancedOpt\": \"{\\\"ignoreDuplicates\\\": \\\"false\\\", \\\"centerReads\\\": \\\"false\\\", \\\"ignoreForNormalization\\\": \\\"\\\", \\\"minFragmentLength\\\": \\\"0\\\", \\\"minMappingQuality\\\": \\\"1\\\", \\\"MNase\\\": \\\"false\\\", \\\"samFlagInclude\\\": \\\"\\\", \\\"filterRNAstrand\\\": \\\"forward\\\", \\\"Offset\\\": \\\"\\\", \\\"smoothLength\\\": \\\"\\\", \\\"showAdvancedOpt\\\": \\\"yes\\\", \\\"__current_case__\\\": 1, \\\"samFlagExclude\\\": \\\"\\\", \\\"doExtendCustom\\\": {\\\"__current_case__\\\": 0, \\\"doExtend\\\": \\\"no\\\"}, \\\"skipNAs\\\": \\\"false\\\", \\\"scaleFactor\\\": \\\"1.0\\\", \\\"blackListFileName\\\": null, \\\"maxFragmentLength\\\": \\\"0\\\"}\", \"chromInfo\": \"\\\"/cvmfs/data.galaxyproject.org/managed/len/ucsc/mm10.len\\\"\", \"__rerun_remap_job_id__\": null}",
+      "tool_version": "3.0.2.0",
+      "type": "tool",
+      "uuid": "e2b0c494-a05a-4fd7-9d32-97f466fe3bcf",
+      "workflow_outputs": []
+    },
+    "3": {
+      "annotation": "",
+      "content_id": null,
+      "errors": null,
+      "id": 3,
+      "input_connections": {},
+      "inputs": [
+        {
+          "description": "",
+          "name": "G1E_rep2_reverse_read"
+        }
+      ],
+      "label": null,
+      "name": "Input dataset",
+      "outputs": [],
+      "position": {
+        "left": 10,
+        "top": 370
+      },
+      "tool_id": null,
+      "tool_state": "{\"name\": \"G1E_rep2_reverse_read\"}",
+      "tool_version": null,
+      "type": "data_input",
+      "uuid": "4d89fd77-a8ae-41c8-8dfe-e9446fdeaddb",
+      "workflow_outputs": []
+    },
+    "30": {
+      "annotation": "",
+      "content_id": "toolshed.g2.bx.psu.edu/repos/bgruening/deeptools_bam_coverage/deeptools_bam_coverage/3.0.2.0",
+      "errors": null,
+      "id": 30,
+      "input_connections": {
+        "bamInput": {
+          "id": 22,
+          "output_name": "output_alignments"
+        }
+      },
+      "inputs": [],
+      "label": null,
+      "name": "bamCoverage",
+      "outputs": [
+        {
+          "name": "outFileName",
+          "type": "bigwig"
+        }
+      ],
+      "position": {
+        "left": 670,
+        "top": 1090
+      },
+      "post_job_actions": {},
+      "tool_id": "toolshed.g2.bx.psu.edu/repos/bgruening/deeptools_bam_coverage/deeptools_bam_coverage/3.0.2.0",
+      "tool_shed_repository": {
+        "changeset_revision": "3033c3fba046",
+        "name": "deeptools_bam_coverage",
+        "owner": "bgruening",
+        "tool_shed": "toolshed.g2.bx.psu.edu"
+      },
+      "tool_state": "{\"__page__\": null, \"outFileFormat\": \"\\\"bigwig\\\"\", \"region\": \"\\\"\\\"\", \"bamInput\": \"null\", \"binSize\": \"\\\"1\\\"\", \"scaling\": \"{\\\"effectiveGenomeSize\\\": {\\\"effectiveGenomeSize_opt\\\": \\\"2304947926\\\", \\\"__current_case__\\\": 6}, \\\"type\\\": \\\"1x\\\", \\\"__current_case__\\\": 4}\", \"advancedOpt\": \"{\\\"ignoreDuplicates\\\": \\\"false\\\", \\\"centerReads\\\": \\\"false\\\", \\\"ignoreForNormalization\\\": \\\"\\\", \\\"minFragmentLength\\\": \\\"0\\\", \\\"minMappingQuality\\\": \\\"1\\\", \\\"MNase\\\": \\\"false\\\", \\\"samFlagInclude\\\": \\\"\\\", \\\"filterRNAstrand\\\": \\\"reverse\\\", \\\"Offset\\\": \\\"\\\", \\\"smoothLength\\\": \\\"\\\", \\\"showAdvancedOpt\\\": \\\"yes\\\", \\\"__current_case__\\\": 1, \\\"samFlagExclude\\\": \\\"\\\", \\\"doExtendCustom\\\": {\\\"__current_case__\\\": 0, \\\"doExtend\\\": \\\"no\\\"}, \\\"skipNAs\\\": \\\"false\\\", \\\"scaleFactor\\\": \\\"1.0\\\", \\\"blackListFileName\\\": null, \\\"maxFragmentLength\\\": \\\"0\\\"}\", \"chromInfo\": \"\\\"/cvmfs/data.galaxyproject.org/managed/len/ucsc/mm10.len\\\"\", \"__rerun_remap_job_id__\": null}",
+      "tool_version": "3.0.2.0",
+      "type": "tool",
+      "uuid": "b4c95c39-273b-4138-bbad-8e46a3adfaae",
+      "workflow_outputs": []
+    },
+    "31": {
+      "annotation": "",
+      "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/stringtie/stringtie/1.3.3.2",
+      "errors": null,
+      "id": 31,
+      "input_connections": {
+        "input_bam": {
+          "id": 23,
+          "output_name": "output_alignments"
+        }
+      },
+      "inputs": [],
+      "label": null,
+      "name": "StringTie",
+      "outputs": [
+        {
+          "name": "output_gtf",
+          "type": "gtf"
+        },
+        {
+          "name": "gene_abundance_estimation",
+          "type": "gtf"
+        },
+        {
+          "name": "coverage",
+          "type": "gtf"
+        },
+        {
+          "name": "exon_expression",
+          "type": "tabular"
+        },
+        {
+          "name": "intron_expression",
+          "type": "tabular"
+        },
+        {
+          "name": "transcript_expression",
+          "type": "tabular"
+        },
+        {
+          "name": "exon_transcript_mapping",
+          "type": "tabular"
+        },
+        {
+          "name": "intron_transcript_mapping",
+          "type": "tabular"
+        },
+        {
+          "name": "gene_counts",
+          "type": "tabular"
+        },
+        {
+          "name": "transcript_counts",
+          "type": "tabular"
+        },
+        {
+          "name": "legend",
+          "type": "tabular"
+        }
+      ],
+      "position": {
+        "left": 670,
+        "top": 250
+      },
+      "post_job_actions": {},
+      "tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/stringtie/stringtie/1.3.3.2",
+      "tool_shed_repository": {
+        "changeset_revision": "eafd5dc95228",
+        "name": "stringtie",
+        "owner": "iuc",
+        "tool_shed": "toolshed.g2.bx.psu.edu"
+      },
+      "tool_state": "{\"adv\": \"{\\\"min_bundle_cov\\\": \\\"2\\\", \\\"min_tlen\\\": \\\"200\\\", \\\"bdist\\\": \\\"50\\\", \\\"multi_mapping\\\": \\\"false\\\", \\\"abundance_estimation\\\": \\\"false\\\", \\\"fraction\\\": \\\"0.15\\\", \\\"disable_trimming\\\": \\\"false\\\", \\\"omit_sequences\\\": \\\"\\\", \\\"name_prefix\\\": \\\"\\\", \\\"min_anchor_len\\\": \\\"10\\\", \\\"bundle_fraction\\\": \\\"0.95\\\", \\\"min_anchor_cov\\\": \\\"1\\\"}\", \"__page__\": null, \"chromInfo\": \"\\\"/cvmfs/data.galaxyproject.org/managed/len/ucsc/mm10.len\\\"\", \"__rerun_remap_job_id__\": null, \"__workflow_invocation_uuid__\": \"\\\"fde8952eb77711e8a468005056ba55fb\\\"\", \"rna_strandness\": \"\\\"--fr\\\"\", \"input_bam\": \"null\", \"guide\": \"{\\\"use_guide\\\": \\\"no\\\", \\\"__current_case__\\\": 0}\"}",
+      "tool_version": "1.3.3.2",
+      "type": "tool",
+      "uuid": "4c15f586-8fe3-4dca-94fe-2ca0205ec76e",
+      "workflow_outputs": []
+    },
+    "32": {
+      "annotation": "",
+      "content_id": "toolshed.g2.bx.psu.edu/repos/bgruening/deeptools_bam_coverage/deeptools_bam_coverage/3.0.2.0",
+      "errors": null,
+      "id": 32,
+      "input_connections": {
+        "bamInput": {
+          "id": 23,
+          "output_name": "output_alignments"
+        }
+      },
+      "inputs": [],
+      "label": null,
+      "name": "bamCoverage",
+      "outputs": [
+        {
+          "name": "outFileName",
+          "type": "bigwig"
+        }
+      ],
+      "position": {
+        "left": 670,
+        "top": 730
+      },
+      "post_job_actions": {},
+      "tool_id": "toolshed.g2.bx.psu.edu/repos/bgruening/deeptools_bam_coverage/deeptools_bam_coverage/3.0.2.0",
+      "tool_shed_repository": {
+        "changeset_revision": "3033c3fba046",
+        "name": "deeptools_bam_coverage",
+        "owner": "bgruening",
+        "tool_shed": "toolshed.g2.bx.psu.edu"
+      },
+      "tool_state": "{\"__page__\": null, \"outFileFormat\": \"\\\"bigwig\\\"\", \"region\": \"\\\"\\\"\", \"bamInput\": \"null\", \"binSize\": \"\\\"1\\\"\", \"scaling\": \"{\\\"effectiveGenomeSize\\\": {\\\"effectiveGenomeSize_opt\\\": \\\"2304947926\\\", \\\"__current_case__\\\": 6}, \\\"type\\\": \\\"1x\\\", \\\"__current_case__\\\": 4}\", \"advancedOpt\": \"{\\\"ignoreDuplicates\\\": \\\"false\\\", \\\"centerReads\\\": \\\"false\\\", \\\"ignoreForNormalization\\\": \\\"\\\", \\\"minFragmentLength\\\": \\\"0\\\", \\\"minMappingQuality\\\": \\\"1\\\", \\\"MNase\\\": \\\"false\\\", \\\"samFlagInclude\\\": \\\"\\\", \\\"filterRNAstrand\\\": \\\"forward\\\", \\\"Offset\\\": \\\"\\\", \\\"smoothLength\\\": \\\"\\\", \\\"showAdvancedOpt\\\": \\\"yes\\\", \\\"__current_case__\\\": 1, \\\"samFlagExclude\\\": \\\"\\\", \\\"doExtendCustom\\\": {\\\"__current_case__\\\": 0, \\\"doExtend\\\": \\\"no\\\"}, \\\"skipNAs\\\": \\\"false\\\", \\\"scaleFactor\\\": \\\"1.0\\\", \\\"blackListFileName\\\": null, \\\"maxFragmentLength\\\": \\\"0\\\"}\", \"chromInfo\": \"\\\"/cvmfs/data.galaxyproject.org/managed/len/ucsc/mm10.len\\\"\", \"__rerun_remap_job_id__\": null}",
+      "tool_version": "3.0.2.0",
+      "type": "tool",
+      "uuid": "9a7a8ac0-a980-4b19-91d8-a775af979957",
+      "workflow_outputs": []
+    },
+    "33": {
+      "annotation": "",
+      "content_id": "toolshed.g2.bx.psu.edu/repos/bgruening/deeptools_bam_coverage/deeptools_bam_coverage/3.0.2.0",
+      "errors": null,
+      "id": 33,
+      "input_connections": {
+        "bamInput": {
+          "id": 23,
+          "output_name": "output_alignments"
+        }
+      },
+      "inputs": [],
+      "label": null,
+      "name": "bamCoverage",
+      "outputs": [
+        {
+          "name": "outFileName",
+          "type": "bigwig"
+        }
+      ],
+      "position": {
+        "left": 670,
+        "top": 1210
+      },
+      "post_job_actions": {},
+      "tool_id": "toolshed.g2.bx.psu.edu/repos/bgruening/deeptools_bam_coverage/deeptools_bam_coverage/3.0.2.0",
+      "tool_shed_repository": {
+        "changeset_revision": "3033c3fba046",
+        "name": "deeptools_bam_coverage",
+        "owner": "bgruening",
+        "tool_shed": "toolshed.g2.bx.psu.edu"
+      },
+      "tool_state": "{\"__page__\": null, \"outFileFormat\": \"\\\"bigwig\\\"\", \"region\": \"\\\"\\\"\", \"bamInput\": \"null\", \"binSize\": \"\\\"1\\\"\", \"scaling\": \"{\\\"effectiveGenomeSize\\\": {\\\"effectiveGenomeSize_opt\\\": \\\"2304947926\\\", \\\"__current_case__\\\": 6}, \\\"type\\\": \\\"1x\\\", \\\"__current_case__\\\": 4}\", \"advancedOpt\": \"{\\\"ignoreDuplicates\\\": \\\"false\\\", \\\"centerReads\\\": \\\"false\\\", \\\"ignoreForNormalization\\\": \\\"\\\", \\\"minFragmentLength\\\": \\\"0\\\", \\\"minMappingQuality\\\": \\\"1\\\", \\\"MNase\\\": \\\"false\\\", \\\"samFlagInclude\\\": \\\"\\\", \\\"filterRNAstrand\\\": \\\"reverse\\\", \\\"Offset\\\": \\\"\\\", \\\"smoothLength\\\": \\\"\\\", \\\"showAdvancedOpt\\\": \\\"yes\\\", \\\"__current_case__\\\": 1, \\\"samFlagExclude\\\": \\\"\\\", \\\"doExtendCustom\\\": {\\\"__current_case__\\\": 0, \\\"doExtend\\\": \\\"no\\\"}, \\\"skipNAs\\\": \\\"false\\\", \\\"scaleFactor\\\": \\\"1.0\\\", \\\"blackListFileName\\\": null, \\\"maxFragmentLength\\\": \\\"0\\\"}\", \"chromInfo\": \"\\\"/cvmfs/data.galaxyproject.org/managed/len/ucsc/mm10.len\\\"\", \"__rerun_remap_job_id__\": null}",
+      "tool_version": "3.0.2.0",
+      "type": "tool",
+      "uuid": "cac5762b-01b2-492e-ab4a-ed6ca63b65de",
+      "workflow_outputs": []
+    },
+    "34": {
+      "annotation": "",
+      "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/stringtie/stringtie/1.3.3.2",
+      "errors": null,
+      "id": 34,
+      "input_connections": {
+        "input_bam": {
+          "id": 24,
+          "output_name": "output_alignments"
+        }
+      },
+      "inputs": [],
+      "label": null,
+      "name": "StringTie",
+      "outputs": [
+        {
+          "name": "output_gtf",
+          "type": "gtf"
+        },
+        {
+          "name": "gene_abundance_estimation",
+          "type": "gtf"
+        },
+        {
+          "name": "coverage",
+          "type": "gtf"
+        },
+        {
+          "name": "exon_expression",
+          "type": "tabular"
+        },
+        {
+          "name": "intron_expression",
+          "type": "tabular"
+        },
+        {
+          "name": "transcript_expression",
+          "type": "tabular"
+        },
+        {
+          "name": "exon_transcript_mapping",
+          "type": "tabular"
+        },
+        {
+          "name": "intron_transcript_mapping",
+          "type": "tabular"
+        },
+        {
+          "name": "gene_counts",
+          "type": "tabular"
+        },
+        {
+          "name": "transcript_counts",
+          "type": "tabular"
+        },
+        {
+          "name": "legend",
+          "type": "tabular"
+        }
+      ],
+      "position": {
+        "left": 670,
+        "top": 370
+      },
+      "post_job_actions": {},
+      "tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/stringtie/stringtie/1.3.3.2",
+      "tool_shed_repository": {
+        "changeset_revision": "eafd5dc95228",
+        "name": "stringtie",
+        "owner": "iuc",
+        "tool_shed": "toolshed.g2.bx.psu.edu"
+      },
+      "tool_state": "{\"adv\": \"{\\\"min_bundle_cov\\\": \\\"2\\\", \\\"min_tlen\\\": \\\"200\\\", \\\"bdist\\\": \\\"50\\\", \\\"multi_mapping\\\": \\\"false\\\", \\\"abundance_estimation\\\": \\\"false\\\", \\\"fraction\\\": \\\"0.15\\\", \\\"disable_trimming\\\": \\\"false\\\", \\\"omit_sequences\\\": \\\"\\\", \\\"name_prefix\\\": \\\"\\\", \\\"min_anchor_len\\\": \\\"10\\\", \\\"bundle_fraction\\\": \\\"0.95\\\", \\\"min_anchor_cov\\\": \\\"1\\\"}\", \"__page__\": null, \"chromInfo\": \"\\\"/cvmfs/data.galaxyproject.org/managed/len/ucsc/mm10.len\\\"\", \"__rerun_remap_job_id__\": null, \"__workflow_invocation_uuid__\": \"\\\"fde8952eb77711e8a468005056ba55fb\\\"\", \"rna_strandness\": \"\\\"--fr\\\"\", \"input_bam\": \"null\", \"guide\": \"{\\\"use_guide\\\": \\\"no\\\", \\\"__current_case__\\\": 0}\"}",
+      "tool_version": "1.3.3.2",
+      "type": "tool",
+      "uuid": "1538c29a-305e-454e-801c-e4501fb326b1",
+      "workflow_outputs": []
+    },
+    "35": {
+      "annotation": "",
+      "content_id": "toolshed.g2.bx.psu.edu/repos/bgruening/deeptools_bam_coverage/deeptools_bam_coverage/3.0.2.0",
+      "errors": null,
+      "id": 35,
+      "input_connections": {
+        "bamInput": {
+          "id": 24,
+          "output_name": "output_alignments"
+        }
+      },
+      "inputs": [],
+      "label": null,
+      "name": "bamCoverage",
+      "outputs": [
+        {
+          "name": "outFileName",
+          "type": "bigwig"
+        }
+      ],
+      "position": {
+        "left": 670,
+        "top": 850
+      },
+      "post_job_actions": {},
+      "tool_id": "toolshed.g2.bx.psu.edu/repos/bgruening/deeptools_bam_coverage/deeptools_bam_coverage/3.0.2.0",
+      "tool_shed_repository": {
+        "changeset_revision": "3033c3fba046",
+        "name": "deeptools_bam_coverage",
+        "owner": "bgruening",
+        "tool_shed": "toolshed.g2.bx.psu.edu"
+      },
+      "tool_state": "{\"__page__\": null, \"outFileFormat\": \"\\\"bigwig\\\"\", \"region\": \"\\\"\\\"\", \"bamInput\": \"null\", \"binSize\": \"\\\"1\\\"\", \"scaling\": \"{\\\"effectiveGenomeSize\\\": {\\\"effectiveGenomeSize_opt\\\": \\\"2304947926\\\", \\\"__current_case__\\\": 6}, \\\"type\\\": \\\"1x\\\", \\\"__current_case__\\\": 4}\", \"advancedOpt\": \"{\\\"ignoreDuplicates\\\": \\\"false\\\", \\\"centerReads\\\": \\\"false\\\", \\\"ignoreForNormalization\\\": \\\"\\\", \\\"minFragmentLength\\\": \\\"0\\\", \\\"minMappingQuality\\\": \\\"1\\\", \\\"MNase\\\": \\\"false\\\", \\\"samFlagInclude\\\": \\\"\\\", \\\"filterRNAstrand\\\": \\\"forward\\\", \\\"Offset\\\": \\\"\\\", \\\"smoothLength\\\": \\\"\\\", \\\"showAdvancedOpt\\\": \\\"yes\\\", \\\"__current_case__\\\": 1, \\\"samFlagExclude\\\": \\\"\\\", \\\"doExtendCustom\\\": {\\\"__current_case__\\\": 0, \\\"doExtend\\\": \\\"no\\\"}, \\\"skipNAs\\\": \\\"false\\\", \\\"scaleFactor\\\": \\\"1.0\\\", \\\"blackListFileName\\\": null, \\\"maxFragmentLength\\\": \\\"0\\\"}\", \"chromInfo\": \"\\\"/cvmfs/data.galaxyproject.org/managed/len/ucsc/mm10.len\\\"\", \"__rerun_remap_job_id__\": null}",
+      "tool_version": "3.0.2.0",
+      "type": "tool",
+      "uuid": "63c35755-3978-4c47-9063-bd06737ccafc",
+      "workflow_outputs": []
+    },
+    "36": {
+      "annotation": "",
+      "content_id": "toolshed.g2.bx.psu.edu/repos/bgruening/deeptools_bam_coverage/deeptools_bam_coverage/3.0.2.0",
+      "errors": null,
+      "id": 36,
+      "input_connections": {
+        "bamInput": {
+          "id": 24,
+          "output_name": "output_alignments"
+        }
+      },
+      "inputs": [],
+      "label": null,
+      "name": "bamCoverage",
+      "outputs": [
+        {
+          "name": "outFileName",
+          "type": "bigwig"
+        }
+      ],
+      "position": {
+        "left": 670,
+        "top": 1330
+      },
+      "post_job_actions": {},
+      "tool_id": "toolshed.g2.bx.psu.edu/repos/bgruening/deeptools_bam_coverage/deeptools_bam_coverage/3.0.2.0",
+      "tool_shed_repository": {
+        "changeset_revision": "3033c3fba046",
+        "name": "deeptools_bam_coverage",
+        "owner": "bgruening",
+        "tool_shed": "toolshed.g2.bx.psu.edu"
+      },
+      "tool_state": "{\"__page__\": null, \"outFileFormat\": \"\\\"bigwig\\\"\", \"region\": \"\\\"\\\"\", \"bamInput\": \"null\", \"binSize\": \"\\\"1\\\"\", \"scaling\": \"{\\\"effectiveGenomeSize\\\": {\\\"effectiveGenomeSize_opt\\\": \\\"2304947926\\\", \\\"__current_case__\\\": 6}, \\\"type\\\": \\\"1x\\\", \\\"__current_case__\\\": 4}\", \"advancedOpt\": \"{\\\"ignoreDuplicates\\\": \\\"false\\\", \\\"centerReads\\\": \\\"false\\\", \\\"ignoreForNormalization\\\": \\\"\\\", \\\"minFragmentLength\\\": \\\"0\\\", \\\"minMappingQuality\\\": \\\"1\\\", \\\"MNase\\\": \\\"false\\\", \\\"samFlagInclude\\\": \\\"\\\", \\\"filterRNAstrand\\\": \\\"reverse\\\", \\\"Offset\\\": \\\"\\\", \\\"smoothLength\\\": \\\"\\\", \\\"showAdvancedOpt\\\": \\\"yes\\\", \\\"__current_case__\\\": 1, \\\"samFlagExclude\\\": \\\"\\\", \\\"doExtendCustom\\\": {\\\"__current_case__\\\": 0, \\\"doExtend\\\": \\\"no\\\"}, \\\"skipNAs\\\": \\\"false\\\", \\\"scaleFactor\\\": \\\"1.0\\\", \\\"blackListFileName\\\": null, \\\"maxFragmentLength\\\": \\\"0\\\"}\", \"chromInfo\": \"\\\"/cvmfs/data.galaxyproject.org/managed/len/ucsc/mm10.len\\\"\", \"__rerun_remap_job_id__\": null}",
+      "tool_version": "3.0.2.0",
+      "type": "tool",
+      "uuid": "dbe2b8a3-bc6a-461c-8ca3-06b3966edbdd",
+      "workflow_outputs": []
+    },
+    "37": {
+      "annotation": "",
+      "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/stringtie/stringtie_merge/1.3.3",
+      "errors": null,
+      "id": 37,
+      "input_connections": {
+        "guide_gff": {
+          "id": 8,
+          "output_name": "output"
+        },
+        "input_gtf": [
+          {
+            "id": 31,
+            "output_name": "output_gtf"
+          },
+          {
+            "id": 34,
+            "output_name": "output_gtf"
+          },
+          {
+            "id": 25,
+            "output_name": "output_gtf"
+          },
+          {
+            "id": 28,
+            "output_name": "output_gtf"
+          }
+        ]
+      },
+      "inputs": [],
+      "label": null,
+      "name": "StringTie merge",
+      "outputs": [
+        {
+          "name": "out_gtf",
+          "type": "gtf"
+        }
+      ],
+      "position": {
+        "left": 890,
+        "top": 10
+      },
+      "post_job_actions": {},
+      "tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/stringtie/stringtie_merge/1.3.3",
+      "tool_shed_repository": {
+        "changeset_revision": "eafd5dc95228",
+        "name": "stringtie",
+        "owner": "iuc",
+        "tool_shed": "toolshed.g2.bx.psu.edu"
+      },
+      "tool_state": "{\"keep_introns\": \"\\\"false\\\"\", \"min_fpkm\": \"\\\"1.0\\\"\", \"__page__\": null, \"__rerun_remap_job_id__\": null, \"min_len\": \"\\\"50\\\"\", \"__workflow_invocation_uuid__\": \"\\\"fde8952eb77711e8a468005056ba55fb\\\"\", \"guide_gff\": \"null\", \"min_cov\": \"\\\"0\\\"\", \"min_iso\": \"\\\"0.01\\\"\", \"min_tpm\": \"\\\"1.0\\\"\", \"chromInfo\": \"\\\"/cvmfs/data.galaxyproject.org/managed/len/ucsc/mm10.len\\\"\", \"input_gtf\": \"null\", \"gap_len\": \"\\\"250\\\"\"}",
+      "tool_version": "1.3.3",
+      "type": "tool",
+      "uuid": "47307af1-9fd1-4936-a01e-ca9d660173e7",
+      "workflow_outputs": []
+    },
+    "38": {
+      "annotation": "",
+      "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/gffcompare/gffcompare/0.9.8",
+      "errors": null,
+      "id": 38,
+      "input_connections": {
+        "annotation|reference_annotation": {
+          "id": 8,
+          "output_name": "output"
+        },
+        "inputs": {
+          "id": 37,
+          "output_name": "out_gtf"
+        }
+      },
+      "inputs": [],
+      "label": null,
+      "name": "GffCompare",
+      "outputs": [
+        {
+          "name": "transcripts_stats",
+          "type": "txt"
+        },
+        {
+          "name": "transcripts_loci",
+          "type": "tabular"
+        },
+        {
+          "name": "transcripts_tracking",
+          "type": "tabular"
+        },
+        {
+          "name": "transcripts_combined",
+          "type": "gtf"
+        },
+        {
+          "name": "transcripts_annotated",
+          "type": "gtf"
+        }
+      ],
+      "position": {
+        "left": 1110,
+        "top": 10
+      },
+      "post_job_actions": {},
+      "tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/gffcompare/gffcompare/0.9.8",
+      "tool_shed_repository": {
+        "changeset_revision": "3c97c841a443",
+        "name": "gffcompare",
+        "owner": "iuc",
+        "tool_shed": "toolshed.g2.bx.psu.edu"
+      },
+      "tool_state": "{\"seq_data\": \"{\\\"use_seq_data\\\": \\\"Yes\\\", \\\"seq_source\\\": {\\\"index_source\\\": \\\"cached\\\", \\\"index\\\": \\\"mm10\\\", \\\"__current_case__\\\": 0}, \\\"__current_case__\\\": 1}\", \"inputs\": \"null\", \"max_dist_group\": \"\\\"100\\\"\", \"__page__\": null, \"max_dist_exon\": \"\\\"100\\\"\", \"__rerun_remap_job_id__\": null, \"__workflow_invocation_uuid__\": \"\\\"fde8952eb77711e8a468005056ba55fb\\\"\", \"chromInfo\": \"\\\"/cvmfs/data.galaxyproject.org/managed/len/ucsc/mm10.len\\\"\", \"discard_single_exon\": \"\\\"\\\"\", \"discard_intron_redundant_transfrags\": \"\\\"false\\\"\", \"annotation\": \"{\\\"reference_annotation\\\": null, \\\"use_ref_annotation\\\": \\\"Yes\\\", \\\"ignore_nonoverlapping_reference\\\": \\\"false\\\", \\\"__current_case__\\\": 0, \\\"ignore_nonoverlapping_transfrags\\\": \\\"false\\\"}\"}",
+      "tool_version": "0.9.8",
+      "type": "tool",
+      "uuid": "6292c087-6c93-435e-ab1f-348ce4bff2bb",
+      "workflow_outputs": []
+    },
+    "39": {
+      "annotation": "",
+      "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/featurecounts/featurecounts/1.6.0.6",
+      "errors": null,
+      "id": 39,
+      "input_connections": {
+        "alignment": {
+          "id": 21,
+          "output_name": "output_alignments"
+        },
+        "anno|reference_gene_sets": {
+          "id": 38,
+          "output_name": "transcripts_annotated"
+        }
+      },
+      "inputs": [],
+      "label": null,
+      "name": "featureCounts",
+      "outputs": [
+        {
+          "name": "output_medium",
+          "type": "tabular"
+        },
+        {
+          "name": "output_short",
+          "type": "tabular"
+        },
+        {
+          "name": "output_full",
+          "type": "tabular"
+        },
+        {
+          "name": "output_summary",
+          "type": "tabular"
+        },
+        {
+          "name": "output_feature_lengths",
+          "type": "tabular"
+        },
+        {
+          "name": "output_jcounts",
+          "type": "tabular"
+        }
+      ],
+      "position": {
+        "left": 1330,
+        "top": 10
+      },
+      "post_job_actions": {},
+      "tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/featurecounts/featurecounts/1.6.0.6",
+      "tool_shed_repository": {
+        "changeset_revision": "92808b865dfb",
+        "name": "featurecounts",
+        "owner": "iuc",
+        "tool_shed": "toolshed.g2.bx.psu.edu"
+      },
+      "tool_state": "{\"pe_parameters\": \"{\\\"only_both_ends\\\": \\\"false\\\", \\\"exclude_chimerics\\\": \\\"true\\\", \\\"fragment_counting_enabled\\\": {\\\"fragment_counting\\\": \\\"\\\", \\\"__current_case__\\\": 1}}\", \"format\": \"\\\"tabdel_short\\\"\", \"__page__\": null, \"__rerun_remap_job_id__\": null, \"strand_specificity\": \"\\\"1\\\"\", \"include_feature_length_file\": \"\\\"false\\\"\", \"__workflow_invocation_uuid__\": \"\\\"fde8952eb77711e8a468005056ba55fb\\\"\", \"anno\": \"{\\\"anno_select\\\": \\\"history\\\", \\\"reference_gene_sets\\\": null, \\\"__current_case__\\\": 2}\", \"chromInfo\": \"\\\"/cvmfs/data.galaxyproject.org/managed/len/ucsc/mm10.len\\\"\", \"extended_parameters\": \"{\\\"gff_feature_attribute\\\": \\\"transcript_id\\\", \\\"exon_exon_junction_read_counting_enabled\\\": {\\\"__current_case__\\\": 1, \\\"count_exon_exon_junction_reads\\\": \\\"false\\\"}, \\\"read_extension_3p\\\": \\\"0\\\", \\\"frac_overlap_feature\\\": \\\"0\\\", \\\"min_overlap\\\": \\\"1\\\", \\\"read_extension_5p\\\": \\\"0\\\", \\\"contribute_to_multiple_features\\\": \\\"false\\\", \\\"frac_overlap\\\": \\\"0\\\", \\\"primary\\\": \\\"false\\\", \\\"count_split_alignments_only\\\": \\\"false\\\", \\\"by_read_group\\\": \\\"false\\\", \\\"ignore_dup\\\": \\\"false\\\", \\\"mapping_quality\\\": \\\"12\\\", \\\"summarization_level\\\": \\\"false\\\", \\\"largest_overlap\\\": \\\"false\\\", \\\"read_reduction\\\": \\\"\\\", \\\"multimapping_enabled\\\": {\\\"multimapping_counts\\\": \\\"\\\", \\\"__current_case__\\\": 1}, \\\"long_reads\\\": \\\"false\\\", \\\"gff_feature_type\\\": \\\"exon\\\"}\", \"alignment\": \"null\"}",
+      "tool_version": "1.6.0.6",
+      "type": "tool",
+      "uuid": "fc054e7c-a603-4aa6-b3cf-d2e1cd4d7be9",
+      "workflow_outputs": []
+    },
+    "4": {
+      "annotation": "",
+      "content_id": null,
+      "errors": null,
+      "id": 4,
+      "input_connections": {},
+      "inputs": [
+        {
+          "description": "",
+          "name": "Megakaryocyte_rep1_forward_read"
+        }
+      ],
+      "label": null,
+      "name": "Input dataset",
+      "outputs": [],
+      "position": {
+        "left": 10,
+        "top": 490
+      },
+      "tool_id": null,
+      "tool_state": "{\"name\": \"Megakaryocyte_rep1_forward_read\"}",
+      "tool_version": null,
+      "type": "data_input",
+      "uuid": "41e16899-910c-4750-84cf-4bddc17437c2",
+      "workflow_outputs": []
+    },
+    "40": {
+      "annotation": "",
+      "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/featurecounts/featurecounts/1.6.0.6",
+      "errors": null,
+      "id": 40,
+      "input_connections": {
+        "alignment": {
+          "id": 22,
+          "output_name": "output_alignments"
+        },
+        "anno|reference_gene_sets": {
+          "id": 38,
+          "output_name": "transcripts_annotated"
+        }
+      },
+      "inputs": [],
+      "label": null,
+      "name": "featureCounts",
+      "outputs": [
+        {
+          "name": "output_medium",
+          "type": "tabular"
+        },
+        {
+          "name": "output_short",
+          "type": "tabular"
+        },
+        {
+          "name": "output_full",
+          "type": "tabular"
+        },
+        {
+          "name": "output_summary",
+          "type": "tabular"
+        },
+        {
+          "name": "output_feature_lengths",
+          "type": "tabular"
+        },
+        {
+          "name": "output_jcounts",
+          "type": "tabular"
+        }
+      ],
+      "position": {
+        "left": 1330,
+        "top": 130
+      },
+      "post_job_actions": {},
+      "tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/featurecounts/featurecounts/1.6.0.6",
+      "tool_shed_repository": {
+        "changeset_revision": "92808b865dfb",
+        "name": "featurecounts",
+        "owner": "iuc",
+        "tool_shed": "toolshed.g2.bx.psu.edu"
+      },
+      "tool_state": "{\"pe_parameters\": \"{\\\"only_both_ends\\\": \\\"false\\\", \\\"exclude_chimerics\\\": \\\"true\\\", \\\"fragment_counting_enabled\\\": {\\\"fragment_counting\\\": \\\"\\\", \\\"__current_case__\\\": 1}}\", \"format\": \"\\\"tabdel_short\\\"\", \"__page__\": null, \"__rerun_remap_job_id__\": null, \"strand_specificity\": \"\\\"1\\\"\", \"include_feature_length_file\": \"\\\"false\\\"\", \"__workflow_invocation_uuid__\": \"\\\"fde8952eb77711e8a468005056ba55fb\\\"\", \"anno\": \"{\\\"anno_select\\\": \\\"history\\\", \\\"reference_gene_sets\\\": null, \\\"__current_case__\\\": 2}\", \"chromInfo\": \"\\\"/cvmfs/data.galaxyproject.org/managed/len/ucsc/mm10.len\\\"\", \"extended_parameters\": \"{\\\"gff_feature_attribute\\\": \\\"transcript_id\\\", \\\"exon_exon_junction_read_counting_enabled\\\": {\\\"__current_case__\\\": 1, \\\"count_exon_exon_junction_reads\\\": \\\"false\\\"}, \\\"read_extension_3p\\\": \\\"0\\\", \\\"frac_overlap_feature\\\": \\\"0\\\", \\\"min_overlap\\\": \\\"1\\\", \\\"read_extension_5p\\\": \\\"0\\\", \\\"contribute_to_multiple_features\\\": \\\"false\\\", \\\"frac_overlap\\\": \\\"0\\\", \\\"primary\\\": \\\"false\\\", \\\"count_split_alignments_only\\\": \\\"false\\\", \\\"by_read_group\\\": \\\"false\\\", \\\"ignore_dup\\\": \\\"false\\\", \\\"mapping_quality\\\": \\\"12\\\", \\\"summarization_level\\\": \\\"false\\\", \\\"largest_overlap\\\": \\\"false\\\", \\\"read_reduction\\\": \\\"\\\", \\\"multimapping_enabled\\\": {\\\"multimapping_counts\\\": \\\"\\\", \\\"__current_case__\\\": 1}, \\\"long_reads\\\": \\\"false\\\", \\\"gff_feature_type\\\": \\\"exon\\\"}\", \"alignment\": \"null\"}",
+      "tool_version": "1.6.0.6",
+      "type": "tool",
+      "uuid": "a29ab182-8103-425e-86e8-d71a08277f7c",
+      "workflow_outputs": []
+    },
+    "41": {
+      "annotation": "",
+      "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/featurecounts/featurecounts/1.6.0.6",
+      "errors": null,
+      "id": 41,
+      "input_connections": {
+        "alignment": {
+          "id": 23,
+          "output_name": "output_alignments"
+        },
+        "anno|reference_gene_sets": {
+          "id": 38,
+          "output_name": "transcripts_annotated"
+        }
+      },
+      "inputs": [],
+      "label": null,
+      "name": "featureCounts",
+      "outputs": [
+        {
+          "name": "output_medium",
+          "type": "tabular"
+        },
+        {
+          "name": "output_short",
+          "type": "tabular"
+        },
+        {
+          "name": "output_full",
+          "type": "tabular"
+        },
+        {
+          "name": "output_summary",
+          "type": "tabular"
+        },
+        {
+          "name": "output_feature_lengths",
+          "type": "tabular"
+        },
+        {
+          "name": "output_jcounts",
+          "type": "tabular"
+        }
+      ],
+      "position": {
+        "left": 1330,
+        "top": 250
+      },
+      "post_job_actions": {},
+      "tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/featurecounts/featurecounts/1.6.0.6",
+      "tool_shed_repository": {
+        "changeset_revision": "92808b865dfb",
+        "name": "featurecounts",
+        "owner": "iuc",
+        "tool_shed": "toolshed.g2.bx.psu.edu"
+      },
+      "tool_state": "{\"pe_parameters\": \"{\\\"only_both_ends\\\": \\\"false\\\", \\\"exclude_chimerics\\\": \\\"true\\\", \\\"fragment_counting_enabled\\\": {\\\"fragment_counting\\\": \\\"\\\", \\\"__current_case__\\\": 1}}\", \"format\": \"\\\"tabdel_short\\\"\", \"__page__\": null, \"__rerun_remap_job_id__\": null, \"strand_specificity\": \"\\\"1\\\"\", \"include_feature_length_file\": \"\\\"false\\\"\", \"__workflow_invocation_uuid__\": \"\\\"fde8952eb77711e8a468005056ba55fb\\\"\", \"anno\": \"{\\\"anno_select\\\": \\\"history\\\", \\\"reference_gene_sets\\\": null, \\\"__current_case__\\\": 2}\", \"chromInfo\": \"\\\"/cvmfs/data.galaxyproject.org/managed/len/ucsc/mm10.len\\\"\", \"extended_parameters\": \"{\\\"gff_feature_attribute\\\": \\\"transcript_id\\\", \\\"exon_exon_junction_read_counting_enabled\\\": {\\\"__current_case__\\\": 1, \\\"count_exon_exon_junction_reads\\\": \\\"false\\\"}, \\\"read_extension_3p\\\": \\\"0\\\", \\\"frac_overlap_feature\\\": \\\"0\\\", \\\"min_overlap\\\": \\\"1\\\", \\\"read_extension_5p\\\": \\\"0\\\", \\\"contribute_to_multiple_features\\\": \\\"false\\\", \\\"frac_overlap\\\": \\\"0\\\", \\\"primary\\\": \\\"false\\\", \\\"count_split_alignments_only\\\": \\\"false\\\", \\\"by_read_group\\\": \\\"false\\\", \\\"ignore_dup\\\": \\\"false\\\", \\\"mapping_quality\\\": \\\"12\\\", \\\"summarization_level\\\": \\\"false\\\", \\\"largest_overlap\\\": \\\"false\\\", \\\"read_reduction\\\": \\\"\\\", \\\"multimapping_enabled\\\": {\\\"multimapping_counts\\\": \\\"\\\", \\\"__current_case__\\\": 1}, \\\"long_reads\\\": \\\"false\\\", \\\"gff_feature_type\\\": \\\"exon\\\"}\", \"alignment\": \"null\"}",
+      "tool_version": "1.6.0.6",
+      "type": "tool",
+      "uuid": "8b73ac2b-9e21-4cd3-bff2-ce0215d3a213",
+      "workflow_outputs": []
+    },
+    "42": {
+      "annotation": "",
+      "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/featurecounts/featurecounts/1.6.0.6",
+      "errors": null,
+      "id": 42,
+      "input_connections": {
+        "alignment": {
+          "id": 24,
+          "output_name": "output_alignments"
+        },
+        "anno|reference_gene_sets": {
+          "id": 38,
+          "output_name": "transcripts_annotated"
+        }
+      },
+      "inputs": [],
+      "label": null,
+      "name": "featureCounts",
+      "outputs": [
+        {
+          "name": "output_medium",
+          "type": "tabular"
+        },
+        {
+          "name": "output_short",
+          "type": "tabular"
+        },
+        {
+          "name": "output_full",
+          "type": "tabular"
+        },
+        {
+          "name": "output_summary",
+          "type": "tabular"
+        },
+        {
+          "name": "output_feature_lengths",
+          "type": "tabular"
+        },
+        {
+          "name": "output_jcounts",
+          "type": "tabular"
+        }
+      ],
+      "position": {
+        "left": 1330,
+        "top": 370
+      },
+      "post_job_actions": {},
+      "tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/featurecounts/featurecounts/1.6.0.6",
+      "tool_shed_repository": {
+        "changeset_revision": "92808b865dfb",
+        "name": "featurecounts",
+        "owner": "iuc",
+        "tool_shed": "toolshed.g2.bx.psu.edu"
+      },
+      "tool_state": "{\"pe_parameters\": \"{\\\"only_both_ends\\\": \\\"false\\\", \\\"exclude_chimerics\\\": \\\"true\\\", \\\"fragment_counting_enabled\\\": {\\\"fragment_counting\\\": \\\"\\\", \\\"__current_case__\\\": 1}}\", \"format\": \"\\\"tabdel_short\\\"\", \"__page__\": null, \"__rerun_remap_job_id__\": null, \"strand_specificity\": \"\\\"1\\\"\", \"include_feature_length_file\": \"\\\"false\\\"\", \"__workflow_invocation_uuid__\": \"\\\"fde8952eb77711e8a468005056ba55fb\\\"\", \"anno\": \"{\\\"anno_select\\\": \\\"history\\\", \\\"reference_gene_sets\\\": null, \\\"__current_case__\\\": 2}\", \"chromInfo\": \"\\\"/cvmfs/data.galaxyproject.org/managed/len/ucsc/mm10.len\\\"\", \"extended_parameters\": \"{\\\"gff_feature_attribute\\\": \\\"transcript_id\\\", \\\"exon_exon_junction_read_counting_enabled\\\": {\\\"__current_case__\\\": 1, \\\"count_exon_exon_junction_reads\\\": \\\"false\\\"}, \\\"read_extension_3p\\\": \\\"0\\\", \\\"frac_overlap_feature\\\": \\\"0\\\", \\\"min_overlap\\\": \\\"1\\\", \\\"read_extension_5p\\\": \\\"0\\\", \\\"contribute_to_multiple_features\\\": \\\"false\\\", \\\"frac_overlap\\\": \\\"0\\\", \\\"primary\\\": \\\"false\\\", \\\"count_split_alignments_only\\\": \\\"false\\\", \\\"by_read_group\\\": \\\"false\\\", \\\"ignore_dup\\\": \\\"false\\\", \\\"mapping_quality\\\": \\\"12\\\", \\\"summarization_level\\\": \\\"false\\\", \\\"largest_overlap\\\": \\\"false\\\", \\\"read_reduction\\\": \\\"\\\", \\\"multimapping_enabled\\\": {\\\"multimapping_counts\\\": \\\"\\\", \\\"__current_case__\\\": 1}, \\\"long_reads\\\": \\\"false\\\", \\\"gff_feature_type\\\": \\\"exon\\\"}\", \"alignment\": \"null\"}",
+      "tool_version": "1.6.0.6",
+      "type": "tool",
+      "uuid": "02a66170-4c0c-4c1e-8073-ec626190390e",
+      "workflow_outputs": []
+    },
+    "43": {
+      "annotation": "",
+      "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/deseq2/deseq2/2.11.40.2",
+      "errors": null,
+      "id": 43,
+      "input_connections": {
+        "rep_factorName_0|rep_factorLevel_0|countsFile": [
+          {
+            "id": 39,
+            "output_name": "output_short"
+          },
+          {
+            "id": 40,
+            "output_name": "output_short"
+          }
+        ],
+        "rep_factorName_0|rep_factorLevel_1|countsFile": [
+          {
+            "id": 41,
+            "output_name": "output_short"
+          },
+          {
+            "id": 42,
+            "output_name": "output_short"
+          }
+        ]
+      },
+      "inputs": [],
+      "label": null,
+      "name": "DESeq2",
+      "outputs": [
+        {
+          "name": "split_output",
+          "type": "input"
+        },
+        {
+          "name": "deseq_out",
+          "type": "tabular"
+        },
+        {
+          "name": "plots",
+          "type": "pdf"
+        },
+        {
+          "name": "counts_out",
+          "type": "tabular"
+        }
+      ],
+      "position": {
+        "left": 1550,
+        "top": 10
+      },
+      "post_job_actions": {},
+      "tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/deseq2/deseq2/2.11.40.2",
+      "tool_shed_repository": {
+        "changeset_revision": "9a616afdbda5",
+        "name": "deseq2",
+        "owner": "iuc",
+        "tool_shed": "toolshed.g2.bx.psu.edu"
+      },
+      "tool_state": "{\"fit_type\": \"\\\"1\\\"\", \"__page__\": null, \"tximport\": \"{\\\"tximport_selector\\\": \\\"count\\\", \\\"__current_case__\\\": 1}\", \"outlier_replace_off\": \"\\\"false\\\"\", \"__rerun_remap_job_id__\": null, \"auto_mean_filter_off\": \"\\\"false\\\"\", \"header\": \"\\\"true\\\"\", \"rep_factorName\": \"[{\\\"__index__\\\": 0, \\\"factorName\\\": \\\"FactorName\\\", \\\"rep_factorLevel\\\": [{\\\"__index__\\\": 0, \\\"factorLevel\\\": \\\"GIE\\\", \\\"countsFile\\\": null}, {\\\"__index__\\\": 1, \\\"factorLevel\\\": \\\"Mega\\\", \\\"countsFile\\\": null}]}]\", \"normCounts\": \"\\\"true\\\"\", \"__workflow_invocation_uuid__\": \"\\\"fde8952eb77711e8a468005056ba55fb\\\"\", \"many_contrasts\": \"\\\"false\\\"\", \"pdf\": \"\\\"true\\\"\", \"chromInfo\": \"\\\"/cvmfs/data.galaxyproject.org/managed/len/ucsc/mm10.len\\\"\", \"outlier_filter_off\": \"\\\"false\\\"\"}",
+      "tool_version": "2.11.40.2",
+      "type": "tool",
+      "uuid": "73d67b36-4316-446b-85f6-5b1e2b64f684",
+      "workflow_outputs": []
+    },
+    "44": {
+      "annotation": "",
+      "content_id": "Filter1",
+      "errors": null,
+      "id": 44,
+      "input_connections": {
+        "input": {
+          "id": 43,
+          "output_name": "deseq_out"
+        }
+      },
+      "inputs": [],
+      "label": null,
+      "name": "Filter",
+      "outputs": [
+        {
+          "name": "out_file1",
+          "type": "input"
+        }
+      ],
+      "position": {
+        "left": 1770,
+        "top": 10
+      },
+      "post_job_actions": {},
+      "tool_id": "Filter1",
+      "tool_state": "{\"__page__\": null, \"__rerun_remap_job_id__\": null, \"cond\": \"\\\"c7<0.05\\\"\", \"input\": \"null\", \"header_lines\": \"\\\"0\\\"\", \"chromInfo\": \"\\\"/cvmfs/data.galaxyproject.org/managed/len/ucsc/mm10.len\\\"\"}",
+      "tool_version": "1.1.0",
+      "type": "tool",
+      "uuid": "3581c4be-1732-47fc-ad14-73f5e3a42b23",
+      "workflow_outputs": []
+    },
+    "45": {
+      "annotation": "",
+      "content_id": "Filter1",
+      "errors": null,
+      "id": 45,
+      "input_connections": {
+        "input": {
+          "id": 44,
+          "output_name": "out_file1"
+        }
+      },
+      "inputs": [],
+      "label": null,
+      "name": "Filter",
+      "outputs": [
+        {
+          "name": "out_file1",
+          "type": "input"
+        }
+      ],
+      "position": {
+        "left": 1990,
+        "top": 10
+      },
+      "post_job_actions": {},
+      "tool_id": "Filter1",
+      "tool_state": "{\"__page__\": null, \"__rerun_remap_job_id__\": null, \"cond\": \"\\\"c3>0\\\"\", \"input\": \"null\", \"header_lines\": \"\\\"0\\\"\", \"chromInfo\": \"\\\"/cvmfs/data.galaxyproject.org/managed/len/ucsc/mm10.len\\\"\"}",
+      "tool_version": "1.1.0",
+      "type": "tool",
+      "uuid": "c9d279df-d6bb-4b48-a743-250e9fb30548",
+      "workflow_outputs": []
+    },
+    "46": {
+      "annotation": "",
+      "content_id": "Filter1",
+      "errors": null,
+      "id": 46,
+      "input_connections": {
+        "input": {
+          "id": 44,
+          "output_name": "out_file1"
+        }
+      },
+      "inputs": [],
+      "label": null,
+      "name": "Filter",
+      "outputs": [
+        {
+          "name": "out_file1",
+          "type": "input"
+        }
+      ],
+      "position": {
+        "left": 1990,
+        "top": 130
+      },
+      "post_job_actions": {},
+      "tool_id": "Filter1",
+      "tool_state": "{\"__page__\": null, \"__rerun_remap_job_id__\": null, \"cond\": \"\\\"c3<0\\\"\", \"input\": \"null\", \"header_lines\": \"\\\"0\\\"\", \"chromInfo\": \"\\\"/cvmfs/data.galaxyproject.org/managed/len/ucsc/mm10.len\\\"\"}",
+      "tool_version": "1.1.0",
+      "type": "tool",
+      "uuid": "aa0f881b-5524-4a0c-9cc5-c8fdfe2e3b89",
+      "workflow_outputs": []
+    },
+    "5": {
+      "annotation": "",
+      "content_id": null,
+      "errors": null,
+      "id": 5,
+      "input_connections": {},
+      "inputs": [
+        {
+          "description": "",
+          "name": "Megakaryocyte_rep1_reverse_read"
+        }
+      ],
+      "label": null,
+      "name": "Input dataset",
+      "outputs": [],
+      "position": {
+        "left": 10,
+        "top": 610
+      },
+      "tool_id": null,
+      "tool_state": "{\"name\": \"Megakaryocyte_rep1_reverse_read\"}",
+      "tool_version": null,
+      "type": "data_input",
+      "uuid": "e7b2ddb1-99fc-4898-9c10-e5ac8fa9fd3a",
+      "workflow_outputs": []
+    },
+    "6": {
+      "annotation": "",
+      "content_id": null,
+      "errors": null,
+      "id": 6,
+      "input_connections": {},
+      "inputs": [
+        {
+          "description": "",
+          "name": "Megakaryocyte_rep2_forward_read"
+        }
+      ],
+      "label": null,
+      "name": "Input dataset",
+      "outputs": [],
+      "position": {
+        "left": 10,
+        "top": 730
+      },
+      "tool_id": null,
+      "tool_state": "{\"name\": \"Megakaryocyte_rep2_forward_read\"}",
+      "tool_version": null,
+      "type": "data_input",
+      "uuid": "8eff105a-d216-4399-bac1-a67d3f09514f",
+      "workflow_outputs": []
+    },
+    "7": {
+      "annotation": "",
+      "content_id": null,
+      "errors": null,
+      "id": 7,
+      "input_connections": {},
+      "inputs": [
+        {
+          "description": "",
+          "name": "Megakaryocyte_rep2_reverse_read"
+        }
+      ],
+      "label": null,
+      "name": "Input dataset",
+      "outputs": [],
+      "position": {
+        "left": 10,
+        "top": 850
+      },
+      "tool_id": null,
+      "tool_state": "{\"name\": \"Megakaryocyte_rep2_reverse_read\"}",
+      "tool_version": null,
+      "type": "data_input",
+      "uuid": "f22827e1-68d3-4ae0-9d4a-67bca6a8b288",
+      "workflow_outputs": []
+    },
+    "8": {
+      "annotation": "",
+      "content_id": null,
+      "errors": null,
+      "id": 8,
+      "input_connections": {},
+      "inputs": [
+        {
+          "description": "",
+          "name": "RefSeq_reference_GTF"
+        }
+      ],
+      "label": null,
+      "name": "Input dataset",
+      "outputs": [],
+      "position": {
+        "left": 10,
+        "top": 970
+      },
+      "tool_id": null,
+      "tool_state": "{\"name\": \"RefSeq_reference_GTF\"}",
+      "tool_version": null,
+      "type": "data_input",
+      "uuid": "758d9ac9-4e4a-45fa-a5ad-2fb4f5f7f87d",
+      "workflow_outputs": []
+    },
+    "9": {
+      "annotation": "",
+      "content_id": "toolshed.g2.bx.psu.edu/repos/devteam/fastqc/fastqc/0.72",
+      "errors": null,
+      "id": 9,
+      "input_connections": {
+        "input_file": {
+          "id": 0,
+          "output_name": "output"
+        }
+      },
+      "inputs": [],
+      "label": null,
+      "name": "FastQC",
+      "outputs": [
+        {
+          "name": "html_file",
+          "type": "html"
+        },
+        {
+          "name": "text_file",
+          "type": "txt"
+        }
+      ],
+      "position": {
+        "left": 230,
+        "top": 10
+      },
+      "post_job_actions": {},
+      "tool_id": "toolshed.g2.bx.psu.edu/repos/devteam/fastqc/fastqc/0.72",
+      "tool_shed_repository": {
+        "changeset_revision": "c15237684a01",
+        "name": "fastqc",
+        "owner": "devteam",
+        "tool_shed": "toolshed.g2.bx.psu.edu"
+      },
+      "tool_state": "{\"__page__\": null, \"limits\": \"null\", \"input_file\": \"null\", \"__rerun_remap_job_id__\": null, \"__workflow_invocation_uuid__\": \"\\\"fde8952eb77711e8a468005056ba55fb\\\"\", \"contaminants\": \"null\", \"chromInfo\": \"\\\"/cvmfs/data.galaxyproject.org/managed/len/ucsc/?.len\\\"\"}",
+      "tool_version": "0.72",
+      "type": "tool",
+      "uuid": "32c35846-2972-4d71-8af6-03350acd490a",
+      "workflow_outputs": []
+    }
+  },
+  "tags": [],
+  "uuid": "dc8abeee-46fa-4965-9a58-396b3ac0c310"
+}

--- a/topics/transcriptomics/tutorials/goenrichment/workflows/goenrichment-workflow.ga
+++ b/topics/transcriptomics/tutorials/goenrichment/workflows/goenrichment-workflow.ga
@@ -1,1 +1,987 @@
-{"uuid": "9f788b06-3aab-425d-8a14-0eb903e17f3a", "tags": [], "format-version": "0.1", "name": "GO Enrichment Workflow", "version": 1, "steps": {"0": {"tool_id": null, "tool_version": null, "outputs": [], "workflow_outputs": [], "input_connections": {}, "tool_state": "{\"name\": \"GO annotations Drosophila melanogaster\"}", "id": 0, "uuid": "44a4f678-6028-45fb-b5fc-59e6d6d30360", "errors": null, "name": "Input dataset", "label": "GO annotations Drosophila melanogaster", "inputs": [{"name": "GO annotations Drosophila melanogaster", "description": ""}], "position": {"top": 200, "left": 200}, "annotation": "", "content_id": null, "type": "data_input"}, "1": {"tool_id": null, "tool_version": null, "outputs": [], "workflow_outputs": [], "input_connections": {}, "tool_state": "{\"name\": \"GO\"}", "id": 1, "uuid": "ae9b3261-ca22-4018-8774-169358633422", "errors": null, "name": "Input dataset", "label": "GO", "inputs": [{"name": "GO", "description": ""}], "position": {"top": 320, "left": 200}, "annotation": "", "content_id": null, "type": "data_input"}, "2": {"tool_id": null, "tool_version": null, "outputs": [], "workflow_outputs": [], "input_connections": {}, "tool_state": "{\"name\": \"trapnellPopulation.tab\"}", "id": 2, "uuid": "b9332a9d-0dee-4a27-826c-1213b93c9c20", "errors": null, "name": "Input dataset", "label": "trapnellPopulation.tab", "inputs": [{"name": "trapnellPopulation.tab", "description": ""}], "position": {"top": 440, "left": 200}, "annotation": "", "content_id": null, "type": "data_input"}, "3": {"tool_id": null, "tool_version": null, "outputs": [], "workflow_outputs": [], "input_connections": {}, "tool_state": "{\"name\": \"GO annotations Mus musculus\"}", "id": 3, "uuid": "623b33b8-5edb-4f85-b377-127d0659504e", "errors": null, "name": "Input dataset", "label": "GO annotations Mus musculus", "inputs": [{"name": "GO annotations Mus musculus", "description": ""}], "position": {"top": 560, "left": 200}, "annotation": "", "content_id": null, "type": "data_input"}, "4": {"tool_id": null, "tool_version": null, "outputs": [], "workflow_outputs": [], "input_connections": {}, "tool_state": "{\"name\": \"Mouse population\"}", "id": 4, "uuid": "ea004077-e2c7-4e92-a003-ec25f25df0a0", "errors": null, "name": "Input dataset", "label": "Mouse population", "inputs": [{"name": "Mouse population", "description": ""}], "position": {"top": 680, "left": 200}, "annotation": "", "content_id": null, "type": "data_input"}, "5": {"tool_id": null, "tool_version": null, "outputs": [], "workflow_outputs": [], "input_connections": {}, "tool_state": "{\"name\": \"Mouse diff\"}", "id": 5, "uuid": "af1838d3-3af6-4e52-aa38-6ba38eae2c58", "errors": null, "name": "Input dataset", "label": "Mouse diff", "inputs": [{"name": "Mouse diff", "description": ""}], "position": {"top": 800, "left": 200}, "annotation": "", "content_id": null, "type": "data_input"}, "6": {"tool_id": null, "tool_version": null, "outputs": [], "workflow_outputs": [], "input_connections": {}, "tool_state": "{\"name\": \"GO Slim\"}", "id": 6, "uuid": "bc59fd06-ef94-46ea-a20b-b884f3b9a1b2", "errors": null, "name": "Input dataset", "label": "GO Slim", "inputs": [{"name": "GO Slim", "description": ""}], "position": {"top": 920, "left": 200}, "annotation": "", "content_id": null, "type": "data_input"}, "7": {"tool_id": null, "tool_version": null, "outputs": [], "workflow_outputs": [], "input_connections": {}, "tool_state": "{\"name\": \"mouseUnderexpressed.txt\"}", "id": 7, "uuid": "3d85962e-96c5-4152-962d-0cbb1757e2ed", "errors": null, "name": "Input dataset", "label": "mouseUnderexpressed.txt", "inputs": [{"name": "mouseUnderexpressed.txt", "description": ""}], "position": {"top": 1040, "left": 200}, "annotation": "", "content_id": null, "type": "data_input"}, "8": {"tool_id": null, "tool_version": null, "outputs": [], "workflow_outputs": [], "input_connections": {}, "tool_state": "{\"name\": \"mouseOverexpressed.txt\"}", "id": 8, "uuid": "a81fec4d-a0b7-4e26-b1be-55ae410e5b58", "errors": null, "name": "Input dataset", "label": "mouseOverexpressed.txt", "inputs": [{"name": "mouseOverexpressed.txt", "description": ""}], "position": {"top": 1160, "left": 200}, "annotation": "", "content_id": null, "type": "data_input"}, "9": {"tool_id": "Filter1", "tool_version": "1.1.0", "outputs": [{"type": "input", "name": "out_file1"}], "workflow_outputs": [], "input_connections": {"input": {"output_name": "output", "id": 2}}, "tool_state": "{\"__page__\": null, \"__rerun_remap_job_id__\": null, \"cond\": \"\\\"c7 < 0.05\\\"\", \"input\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\", \"header_lines\": \"\\\"0\\\"\", \"chromInfo\": \"\\\"/opt/galaxy/tool-data/shared/ucsc/chrom/?.len\\\"\"}", "id": 9, "uuid": "4a267ae5-ab4a-42c2-8abb-217e3c4eaad8", "errors": null, "name": "Filter", "post_job_actions": {}, "label": null, "inputs": [{"name": "input", "description": "runtime parameter for tool Filter"}], "position": {"top": 200, "left": 420}, "annotation": "", "content_id": "Filter1", "type": "tool"}, "10": {"tool_id": "Filter1", "tool_version": "1.1.0", "outputs": [{"type": "input", "name": "out_file1"}], "workflow_outputs": [], "input_connections": {"input": {"output_name": "output", "id": 2}}, "tool_state": "{\"__page__\": null, \"__rerun_remap_job_id__\": null, \"cond\": \"\\\"c7 != \\\\\\\"NA\\\\\\\"\\\"\", \"input\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\", \"header_lines\": \"\\\"0\\\"\", \"chromInfo\": \"\\\"/opt/galaxy/tool-data/shared/ucsc/chrom/?.len\\\"\"}", "id": 10, "uuid": "4589bad5-abab-462c-9d4f-50dbcfed0a58", "errors": null, "name": "Filter", "post_job_actions": {}, "label": null, "inputs": [{"name": "input", "description": "runtime parameter for tool Filter"}], "position": {"top": 320, "left": 420}, "annotation": "", "content_id": "Filter1", "type": "tool"}, "11": {"tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/goenrichment/goenrichment/2.0.1", "tool_version": "2.0.1", "outputs": [{"type": "tabular", "name": "mf_result"}, {"type": "tabular", "name": "bp_result"}, {"type": "tabular", "name": "cc_result"}, {"type": "png", "name": "mf_graph"}, {"type": "png", "name": "bp_graph"}, {"type": "png", "name": "cc_graph"}], "workflow_outputs": [], "input_connections": {"go": {"output_name": "output", "id": 1}, "study": {"output_name": "output", "id": 5}, "annotation": {"output_name": "output", "id": 3}, "population": {"output_name": "output", "id": 4}}, "tool_state": "{\"cutoff\": \"\\\"0.01\\\"\", \"__page__\": null, \"graph\": \"\\\"png\\\"\", \"study\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\", \"relations\": \"\\\"false\\\"\", \"correction\": \"\\\"Benjamini-Hochberg\\\"\", \"go\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\", \"__rerun_remap_job_id__\": null, \"singletons\": \"\\\"true\\\"\", \"summarize\": \"\\\"false\\\"\", \"chromInfo\": \"\\\"/opt/galaxy/tool-data/shared/ucsc/chrom/?.len\\\"\", \"annotation\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\", \"population\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\"}", "id": 11, "tool_shed_repository": {"owner": "iuc", "changeset_revision": "5ace5c7d1a86", "name": "goenrichment", "tool_shed": "toolshed.g2.bx.psu.edu"}, "uuid": "543bc50d-14ee-49c2-ae6c-fd521cf80a5d", "errors": null, "name": "GOEnrichment", "post_job_actions": {}, "label": null, "inputs": [{"name": "study", "description": "runtime parameter for tool GOEnrichment"}, {"name": "go", "description": "runtime parameter for tool GOEnrichment"}, {"name": "population", "description": "runtime parameter for tool GOEnrichment"}, {"name": "annotation", "description": "runtime parameter for tool GOEnrichment"}], "position": {"top": 440, "left": 420}, "annotation": "", "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/goenrichment/goenrichment/2.0.1", "type": "tool"}, "12": {"tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/goenrichment/goenrichment/2.0.1", "tool_version": "2.0.1", "outputs": [{"type": "tabular", "name": "mf_result"}, {"type": "tabular", "name": "bp_result"}, {"type": "tabular", "name": "cc_result"}, {"type": "png", "name": "mf_graph"}, {"type": "png", "name": "bp_graph"}, {"type": "png", "name": "cc_graph"}], "workflow_outputs": [], "input_connections": {"go": {"output_name": "output", "id": 1}, "study": {"output_name": "output", "id": 5}, "annotation": {"output_name": "output", "id": 3}, "population": {"output_name": "output", "id": 4}}, "tool_state": "{\"cutoff\": \"\\\"0.01\\\"\", \"__page__\": null, \"graph\": \"\\\"png\\\"\", \"study\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\", \"relations\": \"\\\"false\\\"\", \"correction\": \"\\\"Benjamini-Hochberg\\\"\", \"go\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\", \"__rerun_remap_job_id__\": null, \"singletons\": \"\\\"true\\\"\", \"summarize\": \"\\\"true\\\"\", \"chromInfo\": \"\\\"/opt/galaxy/tool-data/shared/ucsc/chrom/?.len\\\"\", \"annotation\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\", \"population\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\"}", "id": 12, "tool_shed_repository": {"owner": "iuc", "changeset_revision": "5ace5c7d1a86", "name": "goenrichment", "tool_shed": "toolshed.g2.bx.psu.edu"}, "uuid": "902fb644-df7a-411e-89c7-4641ddc4c8a6", "errors": null, "name": "GOEnrichment", "post_job_actions": {}, "label": null, "inputs": [{"name": "study", "description": "runtime parameter for tool GOEnrichment"}, {"name": "go", "description": "runtime parameter for tool GOEnrichment"}, {"name": "population", "description": "runtime parameter for tool GOEnrichment"}, {"name": "annotation", "description": "runtime parameter for tool GOEnrichment"}], "position": {"top": 560, "left": 420}, "annotation": "", "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/goenrichment/goenrichment/2.0.1", "type": "tool"}, "13": {"tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/goslimmer/goslimmer/1.0.1", "tool_version": "1.0.1", "outputs": [{"type": "tabular", "name": "output"}], "workflow_outputs": [], "input_connections": {"go": {"output_name": "output", "id": 1}, "slim": {"output_name": "output", "id": 6}, "annotation": {"output_name": "output", "id": 3}}, "tool_state": "{\"__page__\": null, \"__rerun_remap_job_id__\": null, \"slim\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\", \"go\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\", \"chromInfo\": \"\\\"/opt/galaxy/tool-data/shared/ucsc/chrom/?.len\\\"\", \"annotation\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\"}", "id": 13, "tool_shed_repository": {"owner": "iuc", "changeset_revision": "294de027cb5d", "name": "goslimmer", "tool_shed": "toolshed.g2.bx.psu.edu"}, "uuid": "15095c54-b1e7-43f5-9700-fc7d53232d45", "errors": null, "name": "GOSlimmer", "post_job_actions": {}, "label": null, "inputs": [{"name": "go", "description": "runtime parameter for tool GOSlimmer"}, {"name": "slim", "description": "runtime parameter for tool GOSlimmer"}, {"name": "annotation", "description": "runtime parameter for tool GOSlimmer"}], "position": {"top": 680, "left": 420}, "annotation": "", "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/goslimmer/goslimmer/1.0.1", "type": "tool"}, "14": {"tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/goenrichment/goenrichment/2.0.1", "tool_version": "2.0.1", "outputs": [{"type": "tabular", "name": "mf_result"}, {"type": "tabular", "name": "bp_result"}, {"type": "tabular", "name": "cc_result"}, {"type": "png", "name": "mf_graph"}, {"type": "png", "name": "bp_graph"}, {"type": "png", "name": "cc_graph"}], "workflow_outputs": [], "input_connections": {"go": {"output_name": "output", "id": 1}, "study": {"output_name": "output", "id": 7}, "annotation": {"output_name": "output", "id": 3}, "population": {"output_name": "output", "id": 4}}, "tool_state": "{\"cutoff\": \"\\\"0.01\\\"\", \"__page__\": null, \"graph\": \"\\\"png\\\"\", \"study\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\", \"relations\": \"\\\"false\\\"\", \"correction\": \"\\\"Benjamini-Hochberg\\\"\", \"go\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\", \"__rerun_remap_job_id__\": null, \"singletons\": \"\\\"true\\\"\", \"summarize\": \"\\\"true\\\"\", \"chromInfo\": \"\\\"/opt/galaxy/tool-data/shared/ucsc/chrom/?.len\\\"\", \"annotation\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\", \"population\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\"}", "id": 14, "tool_shed_repository": {"owner": "iuc", "changeset_revision": "5ace5c7d1a86", "name": "goenrichment", "tool_shed": "toolshed.g2.bx.psu.edu"}, "uuid": "a18b5380-53e9-4565-8c8b-9c8494840726", "errors": null, "name": "GOEnrichment", "post_job_actions": {}, "label": null, "inputs": [{"name": "study", "description": "runtime parameter for tool GOEnrichment"}, {"name": "go", "description": "runtime parameter for tool GOEnrichment"}, {"name": "population", "description": "runtime parameter for tool GOEnrichment"}, {"name": "annotation", "description": "runtime parameter for tool GOEnrichment"}], "position": {"top": 920, "left": 420}, "annotation": "", "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/goenrichment/goenrichment/2.0.1", "type": "tool"}, "15": {"tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/goenrichment/goenrichment/2.0.1", "tool_version": "2.0.1", "outputs": [{"type": "tabular", "name": "mf_result"}, {"type": "tabular", "name": "bp_result"}, {"type": "tabular", "name": "cc_result"}, {"type": "png", "name": "mf_graph"}, {"type": "png", "name": "bp_graph"}, {"type": "png", "name": "cc_graph"}], "workflow_outputs": [], "input_connections": {"go": {"output_name": "output", "id": 1}, "study": {"output_name": "output", "id": 8}, "annotation": {"output_name": "output", "id": 3}, "population": {"output_name": "output", "id": 4}}, "tool_state": "{\"cutoff\": \"\\\"0.01\\\"\", \"__page__\": null, \"graph\": \"\\\"png\\\"\", \"study\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\", \"relations\": \"\\\"false\\\"\", \"correction\": \"\\\"Benjamini-Hochberg\\\"\", \"go\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\", \"__rerun_remap_job_id__\": null, \"singletons\": \"\\\"true\\\"\", \"summarize\": \"\\\"true\\\"\", \"chromInfo\": \"\\\"/opt/galaxy/tool-data/shared/ucsc/chrom/?.len\\\"\", \"annotation\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\", \"population\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\"}", "id": 15, "tool_shed_repository": {"owner": "iuc", "changeset_revision": "5ace5c7d1a86", "name": "goenrichment", "tool_shed": "toolshed.g2.bx.psu.edu"}, "uuid": "d21a0eb7-f0f2-49c3-9d08-eeb0a83ebc85", "errors": null, "name": "GOEnrichment", "post_job_actions": {}, "label": null, "inputs": [{"name": "study", "description": "runtime parameter for tool GOEnrichment"}, {"name": "go", "description": "runtime parameter for tool GOEnrichment"}, {"name": "population", "description": "runtime parameter for tool GOEnrichment"}, {"name": "annotation", "description": "runtime parameter for tool GOEnrichment"}], "position": {"top": 800, "left": 420}, "annotation": "", "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/goenrichment/goenrichment/2.0.1", "type": "tool"}, "16": {"tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/goenrichment/goenrichment/2.0.1", "tool_version": "2.0.1", "outputs": [{"type": "tabular", "name": "mf_result"}, {"type": "tabular", "name": "bp_result"}, {"type": "tabular", "name": "cc_result"}, {"type": "png", "name": "mf_graph"}, {"type": "png", "name": "bp_graph"}, {"type": "png", "name": "cc_graph"}], "workflow_outputs": [], "input_connections": {"go": {"output_name": "output", "id": 1}, "study": {"output_name": "out_file1", "id": 9}, "annotation": {"output_name": "output", "id": 0}, "population": {"output_name": "output", "id": 2}}, "tool_state": "{\"cutoff\": \"\\\"0.01\\\"\", \"__page__\": null, \"graph\": \"\\\"png\\\"\", \"study\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\", \"relations\": \"\\\"false\\\"\", \"correction\": \"\\\"Benjamini-Hochberg\\\"\", \"go\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\", \"__rerun_remap_job_id__\": null, \"singletons\": \"\\\"true\\\"\", \"summarize\": \"\\\"true\\\"\", \"chromInfo\": \"\\\"/opt/galaxy/tool-data/shared/ucsc/chrom/?.len\\\"\", \"annotation\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\", \"population\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\"}", "id": 16, "tool_shed_repository": {"owner": "iuc", "changeset_revision": "5ace5c7d1a86", "name": "goenrichment", "tool_shed": "toolshed.g2.bx.psu.edu"}, "uuid": "689b8724-53da-4d04-be51-d1fbffdd8a0c", "errors": null, "name": "GOEnrichment", "post_job_actions": {}, "label": null, "inputs": [{"name": "study", "description": "runtime parameter for tool GOEnrichment"}, {"name": "go", "description": "runtime parameter for tool GOEnrichment"}, {"name": "population", "description": "runtime parameter for tool GOEnrichment"}, {"name": "annotation", "description": "runtime parameter for tool GOEnrichment"}], "position": {"top": 200, "left": 640}, "annotation": "", "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/goenrichment/goenrichment/2.0.1", "type": "tool"}, "17": {"tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/goenrichment/goenrichment/2.0.1", "tool_version": "2.0.1", "outputs": [{"type": "tabular", "name": "mf_result"}, {"type": "tabular", "name": "bp_result"}, {"type": "tabular", "name": "cc_result"}, {"type": "png", "name": "mf_graph"}, {"type": "png", "name": "bp_graph"}, {"type": "png", "name": "cc_graph"}], "workflow_outputs": [], "input_connections": {"go": {"output_name": "output", "id": 1}, "study": {"output_name": "out_file1", "id": 9}, "annotation": {"output_name": "output", "id": 0}, "population": {"output_name": "out_file1", "id": 10}}, "tool_state": "{\"cutoff\": \"\\\"0.01\\\"\", \"__page__\": null, \"graph\": \"\\\"png\\\"\", \"study\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\", \"relations\": \"\\\"false\\\"\", \"correction\": \"\\\"Benjamini-Hochberg\\\"\", \"go\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\", \"__rerun_remap_job_id__\": null, \"singletons\": \"\\\"true\\\"\", \"summarize\": \"\\\"true\\\"\", \"chromInfo\": \"\\\"/opt/galaxy/tool-data/shared/ucsc/chrom/?.len\\\"\", \"annotation\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\", \"population\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\"}", "id": 17, "tool_shed_repository": {"owner": "iuc", "changeset_revision": "5ace5c7d1a86", "name": "goenrichment", "tool_shed": "toolshed.g2.bx.psu.edu"}, "uuid": "19212b8f-3f35-4277-9802-c6c9ea35f4b2", "errors": null, "name": "GOEnrichment", "post_job_actions": {}, "label": null, "inputs": [{"name": "study", "description": "runtime parameter for tool GOEnrichment"}, {"name": "go", "description": "runtime parameter for tool GOEnrichment"}, {"name": "population", "description": "runtime parameter for tool GOEnrichment"}, {"name": "annotation", "description": "runtime parameter for tool GOEnrichment"}], "position": {"top": 320, "left": 640}, "annotation": "", "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/goenrichment/goenrichment/2.0.1", "type": "tool"}, "18": {"tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/goenrichment/goenrichment/2.0.1", "tool_version": "2.0.1", "outputs": [{"type": "tabular", "name": "mf_result"}, {"type": "tabular", "name": "bp_result"}, {"type": "tabular", "name": "cc_result"}, {"type": "png", "name": "mf_graph"}, {"type": "png", "name": "bp_graph"}, {"type": "png", "name": "cc_graph"}], "workflow_outputs": [], "input_connections": {"go": {"output_name": "output", "id": 6}, "study": {"output_name": "output", "id": 5}, "annotation": {"output_name": "output", "id": 13}, "population": {"output_name": "output", "id": 4}}, "tool_state": "{\"cutoff\": \"\\\"0.01\\\"\", \"__page__\": null, \"graph\": \"\\\"png\\\"\", \"study\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\", \"relations\": \"\\\"false\\\"\", \"correction\": \"\\\"Benjamini-Hochberg\\\"\", \"go\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\", \"__rerun_remap_job_id__\": null, \"singletons\": \"\\\"true\\\"\", \"summarize\": \"\\\"true\\\"\", \"chromInfo\": \"\\\"/opt/galaxy/tool-data/shared/ucsc/chrom/?.len\\\"\", \"annotation\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\", \"population\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\"}", "id": 18, "tool_shed_repository": {"owner": "iuc", "changeset_revision": "5ace5c7d1a86", "name": "goenrichment", "tool_shed": "toolshed.g2.bx.psu.edu"}, "uuid": "6f8dc224-0781-4119-a4e5-96587d1a6622", "errors": null, "name": "GOEnrichment", "post_job_actions": {}, "label": null, "inputs": [{"name": "study", "description": "runtime parameter for tool GOEnrichment"}, {"name": "go", "description": "runtime parameter for tool GOEnrichment"}, {"name": "population", "description": "runtime parameter for tool GOEnrichment"}, {"name": "annotation", "description": "runtime parameter for tool GOEnrichment"}], "position": {"top": 440, "left": 640}, "annotation": "", "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/goenrichment/goenrichment/2.0.1", "type": "tool"}}, "annotation": "GO Enrichment Analysis Tutorial", "a_galaxy_workflow": "true"}
+{
+  "a_galaxy_workflow": "true",
+  "annotation": "GO Enrichment Analysis Tutorial",
+  "format-version": "0.1",
+  "name": "GO Enrichment Workflow",
+  "steps": {
+    "0": {
+      "annotation": "",
+      "content_id": null,
+      "errors": null,
+      "id": 0,
+      "input_connections": {},
+      "inputs": [
+        {
+          "description": "",
+          "name": "GO annotations Drosophila melanogaster"
+        }
+      ],
+      "label": "GO annotations Drosophila melanogaster",
+      "name": "Input dataset",
+      "outputs": [],
+      "position": {
+        "left": 200,
+        "top": 200
+      },
+      "tool_id": null,
+      "tool_state": "{\"name\": \"GO annotations Drosophila melanogaster\"}",
+      "tool_version": null,
+      "type": "data_input",
+      "uuid": "44a4f678-6028-45fb-b5fc-59e6d6d30360",
+      "workflow_outputs": []
+    },
+    "1": {
+      "annotation": "",
+      "content_id": null,
+      "errors": null,
+      "id": 1,
+      "input_connections": {},
+      "inputs": [
+        {
+          "description": "",
+          "name": "GO"
+        }
+      ],
+      "label": "GO",
+      "name": "Input dataset",
+      "outputs": [],
+      "position": {
+        "left": 200,
+        "top": 320
+      },
+      "tool_id": null,
+      "tool_state": "{\"name\": \"GO\"}",
+      "tool_version": null,
+      "type": "data_input",
+      "uuid": "ae9b3261-ca22-4018-8774-169358633422",
+      "workflow_outputs": []
+    },
+    "10": {
+      "annotation": "",
+      "content_id": "Filter1",
+      "errors": null,
+      "id": 10,
+      "input_connections": {
+        "input": {
+          "id": 2,
+          "output_name": "output"
+        }
+      },
+      "inputs": [
+        {
+          "description": "runtime parameter for tool Filter",
+          "name": "input"
+        }
+      ],
+      "label": null,
+      "name": "Filter",
+      "outputs": [
+        {
+          "name": "out_file1",
+          "type": "input"
+        }
+      ],
+      "position": {
+        "left": 420,
+        "top": 320
+      },
+      "post_job_actions": {},
+      "tool_id": "Filter1",
+      "tool_state": "{\"__page__\": null, \"__rerun_remap_job_id__\": null, \"cond\": \"\\\"c7 != \\\\\\\"NA\\\\\\\"\\\"\", \"input\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\", \"header_lines\": \"\\\"0\\\"\", \"chromInfo\": \"\\\"/opt/galaxy/tool-data/shared/ucsc/chrom/?.len\\\"\"}",
+      "tool_version": "1.1.0",
+      "type": "tool",
+      "uuid": "4589bad5-abab-462c-9d4f-50dbcfed0a58",
+      "workflow_outputs": []
+    },
+    "11": {
+      "annotation": "",
+      "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/goenrichment/goenrichment/2.0.1",
+      "errors": null,
+      "id": 11,
+      "input_connections": {
+        "annotation": {
+          "id": 3,
+          "output_name": "output"
+        },
+        "go": {
+          "id": 1,
+          "output_name": "output"
+        },
+        "population": {
+          "id": 4,
+          "output_name": "output"
+        },
+        "study": {
+          "id": 5,
+          "output_name": "output"
+        }
+      },
+      "inputs": [
+        {
+          "description": "runtime parameter for tool GOEnrichment",
+          "name": "study"
+        },
+        {
+          "description": "runtime parameter for tool GOEnrichment",
+          "name": "go"
+        },
+        {
+          "description": "runtime parameter for tool GOEnrichment",
+          "name": "population"
+        },
+        {
+          "description": "runtime parameter for tool GOEnrichment",
+          "name": "annotation"
+        }
+      ],
+      "label": null,
+      "name": "GOEnrichment",
+      "outputs": [
+        {
+          "name": "mf_result",
+          "type": "tabular"
+        },
+        {
+          "name": "bp_result",
+          "type": "tabular"
+        },
+        {
+          "name": "cc_result",
+          "type": "tabular"
+        },
+        {
+          "name": "mf_graph",
+          "type": "png"
+        },
+        {
+          "name": "bp_graph",
+          "type": "png"
+        },
+        {
+          "name": "cc_graph",
+          "type": "png"
+        }
+      ],
+      "position": {
+        "left": 420,
+        "top": 440
+      },
+      "post_job_actions": {},
+      "tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/goenrichment/goenrichment/2.0.1",
+      "tool_shed_repository": {
+        "changeset_revision": "5ace5c7d1a86",
+        "name": "goenrichment",
+        "owner": "iuc",
+        "tool_shed": "toolshed.g2.bx.psu.edu"
+      },
+      "tool_state": "{\"cutoff\": \"\\\"0.01\\\"\", \"__page__\": null, \"graph\": \"\\\"png\\\"\", \"study\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\", \"relations\": \"\\\"false\\\"\", \"correction\": \"\\\"Benjamini-Hochberg\\\"\", \"go\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\", \"__rerun_remap_job_id__\": null, \"singletons\": \"\\\"true\\\"\", \"summarize\": \"\\\"false\\\"\", \"chromInfo\": \"\\\"/opt/galaxy/tool-data/shared/ucsc/chrom/?.len\\\"\", \"annotation\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\", \"population\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\"}",
+      "tool_version": "2.0.1",
+      "type": "tool",
+      "uuid": "543bc50d-14ee-49c2-ae6c-fd521cf80a5d",
+      "workflow_outputs": []
+    },
+    "12": {
+      "annotation": "",
+      "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/goenrichment/goenrichment/2.0.1",
+      "errors": null,
+      "id": 12,
+      "input_connections": {
+        "annotation": {
+          "id": 3,
+          "output_name": "output"
+        },
+        "go": {
+          "id": 1,
+          "output_name": "output"
+        },
+        "population": {
+          "id": 4,
+          "output_name": "output"
+        },
+        "study": {
+          "id": 5,
+          "output_name": "output"
+        }
+      },
+      "inputs": [
+        {
+          "description": "runtime parameter for tool GOEnrichment",
+          "name": "study"
+        },
+        {
+          "description": "runtime parameter for tool GOEnrichment",
+          "name": "go"
+        },
+        {
+          "description": "runtime parameter for tool GOEnrichment",
+          "name": "population"
+        },
+        {
+          "description": "runtime parameter for tool GOEnrichment",
+          "name": "annotation"
+        }
+      ],
+      "label": null,
+      "name": "GOEnrichment",
+      "outputs": [
+        {
+          "name": "mf_result",
+          "type": "tabular"
+        },
+        {
+          "name": "bp_result",
+          "type": "tabular"
+        },
+        {
+          "name": "cc_result",
+          "type": "tabular"
+        },
+        {
+          "name": "mf_graph",
+          "type": "png"
+        },
+        {
+          "name": "bp_graph",
+          "type": "png"
+        },
+        {
+          "name": "cc_graph",
+          "type": "png"
+        }
+      ],
+      "position": {
+        "left": 420,
+        "top": 560
+      },
+      "post_job_actions": {},
+      "tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/goenrichment/goenrichment/2.0.1",
+      "tool_shed_repository": {
+        "changeset_revision": "5ace5c7d1a86",
+        "name": "goenrichment",
+        "owner": "iuc",
+        "tool_shed": "toolshed.g2.bx.psu.edu"
+      },
+      "tool_state": "{\"cutoff\": \"\\\"0.01\\\"\", \"__page__\": null, \"graph\": \"\\\"png\\\"\", \"study\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\", \"relations\": \"\\\"false\\\"\", \"correction\": \"\\\"Benjamini-Hochberg\\\"\", \"go\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\", \"__rerun_remap_job_id__\": null, \"singletons\": \"\\\"true\\\"\", \"summarize\": \"\\\"true\\\"\", \"chromInfo\": \"\\\"/opt/galaxy/tool-data/shared/ucsc/chrom/?.len\\\"\", \"annotation\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\", \"population\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\"}",
+      "tool_version": "2.0.1",
+      "type": "tool",
+      "uuid": "902fb644-df7a-411e-89c7-4641ddc4c8a6",
+      "workflow_outputs": []
+    },
+    "13": {
+      "annotation": "",
+      "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/goslimmer/goslimmer/1.0.1",
+      "errors": null,
+      "id": 13,
+      "input_connections": {
+        "annotation": {
+          "id": 3,
+          "output_name": "output"
+        },
+        "go": {
+          "id": 1,
+          "output_name": "output"
+        },
+        "slim": {
+          "id": 6,
+          "output_name": "output"
+        }
+      },
+      "inputs": [
+        {
+          "description": "runtime parameter for tool GOSlimmer",
+          "name": "go"
+        },
+        {
+          "description": "runtime parameter for tool GOSlimmer",
+          "name": "slim"
+        },
+        {
+          "description": "runtime parameter for tool GOSlimmer",
+          "name": "annotation"
+        }
+      ],
+      "label": null,
+      "name": "GOSlimmer",
+      "outputs": [
+        {
+          "name": "output",
+          "type": "tabular"
+        }
+      ],
+      "position": {
+        "left": 420,
+        "top": 680
+      },
+      "post_job_actions": {},
+      "tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/goslimmer/goslimmer/1.0.1",
+      "tool_shed_repository": {
+        "changeset_revision": "294de027cb5d",
+        "name": "goslimmer",
+        "owner": "iuc",
+        "tool_shed": "toolshed.g2.bx.psu.edu"
+      },
+      "tool_state": "{\"__page__\": null, \"__rerun_remap_job_id__\": null, \"slim\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\", \"go\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\", \"chromInfo\": \"\\\"/opt/galaxy/tool-data/shared/ucsc/chrom/?.len\\\"\", \"annotation\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\"}",
+      "tool_version": "1.0.1",
+      "type": "tool",
+      "uuid": "15095c54-b1e7-43f5-9700-fc7d53232d45",
+      "workflow_outputs": []
+    },
+    "14": {
+      "annotation": "",
+      "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/goenrichment/goenrichment/2.0.1",
+      "errors": null,
+      "id": 14,
+      "input_connections": {
+        "annotation": {
+          "id": 3,
+          "output_name": "output"
+        },
+        "go": {
+          "id": 1,
+          "output_name": "output"
+        },
+        "population": {
+          "id": 4,
+          "output_name": "output"
+        },
+        "study": {
+          "id": 7,
+          "output_name": "output"
+        }
+      },
+      "inputs": [
+        {
+          "description": "runtime parameter for tool GOEnrichment",
+          "name": "study"
+        },
+        {
+          "description": "runtime parameter for tool GOEnrichment",
+          "name": "go"
+        },
+        {
+          "description": "runtime parameter for tool GOEnrichment",
+          "name": "population"
+        },
+        {
+          "description": "runtime parameter for tool GOEnrichment",
+          "name": "annotation"
+        }
+      ],
+      "label": null,
+      "name": "GOEnrichment",
+      "outputs": [
+        {
+          "name": "mf_result",
+          "type": "tabular"
+        },
+        {
+          "name": "bp_result",
+          "type": "tabular"
+        },
+        {
+          "name": "cc_result",
+          "type": "tabular"
+        },
+        {
+          "name": "mf_graph",
+          "type": "png"
+        },
+        {
+          "name": "bp_graph",
+          "type": "png"
+        },
+        {
+          "name": "cc_graph",
+          "type": "png"
+        }
+      ],
+      "position": {
+        "left": 420,
+        "top": 920
+      },
+      "post_job_actions": {},
+      "tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/goenrichment/goenrichment/2.0.1",
+      "tool_shed_repository": {
+        "changeset_revision": "5ace5c7d1a86",
+        "name": "goenrichment",
+        "owner": "iuc",
+        "tool_shed": "toolshed.g2.bx.psu.edu"
+      },
+      "tool_state": "{\"cutoff\": \"\\\"0.01\\\"\", \"__page__\": null, \"graph\": \"\\\"png\\\"\", \"study\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\", \"relations\": \"\\\"false\\\"\", \"correction\": \"\\\"Benjamini-Hochberg\\\"\", \"go\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\", \"__rerun_remap_job_id__\": null, \"singletons\": \"\\\"true\\\"\", \"summarize\": \"\\\"true\\\"\", \"chromInfo\": \"\\\"/opt/galaxy/tool-data/shared/ucsc/chrom/?.len\\\"\", \"annotation\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\", \"population\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\"}",
+      "tool_version": "2.0.1",
+      "type": "tool",
+      "uuid": "a18b5380-53e9-4565-8c8b-9c8494840726",
+      "workflow_outputs": []
+    },
+    "15": {
+      "annotation": "",
+      "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/goenrichment/goenrichment/2.0.1",
+      "errors": null,
+      "id": 15,
+      "input_connections": {
+        "annotation": {
+          "id": 3,
+          "output_name": "output"
+        },
+        "go": {
+          "id": 1,
+          "output_name": "output"
+        },
+        "population": {
+          "id": 4,
+          "output_name": "output"
+        },
+        "study": {
+          "id": 8,
+          "output_name": "output"
+        }
+      },
+      "inputs": [
+        {
+          "description": "runtime parameter for tool GOEnrichment",
+          "name": "study"
+        },
+        {
+          "description": "runtime parameter for tool GOEnrichment",
+          "name": "go"
+        },
+        {
+          "description": "runtime parameter for tool GOEnrichment",
+          "name": "population"
+        },
+        {
+          "description": "runtime parameter for tool GOEnrichment",
+          "name": "annotation"
+        }
+      ],
+      "label": null,
+      "name": "GOEnrichment",
+      "outputs": [
+        {
+          "name": "mf_result",
+          "type": "tabular"
+        },
+        {
+          "name": "bp_result",
+          "type": "tabular"
+        },
+        {
+          "name": "cc_result",
+          "type": "tabular"
+        },
+        {
+          "name": "mf_graph",
+          "type": "png"
+        },
+        {
+          "name": "bp_graph",
+          "type": "png"
+        },
+        {
+          "name": "cc_graph",
+          "type": "png"
+        }
+      ],
+      "position": {
+        "left": 420,
+        "top": 800
+      },
+      "post_job_actions": {},
+      "tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/goenrichment/goenrichment/2.0.1",
+      "tool_shed_repository": {
+        "changeset_revision": "5ace5c7d1a86",
+        "name": "goenrichment",
+        "owner": "iuc",
+        "tool_shed": "toolshed.g2.bx.psu.edu"
+      },
+      "tool_state": "{\"cutoff\": \"\\\"0.01\\\"\", \"__page__\": null, \"graph\": \"\\\"png\\\"\", \"study\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\", \"relations\": \"\\\"false\\\"\", \"correction\": \"\\\"Benjamini-Hochberg\\\"\", \"go\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\", \"__rerun_remap_job_id__\": null, \"singletons\": \"\\\"true\\\"\", \"summarize\": \"\\\"true\\\"\", \"chromInfo\": \"\\\"/opt/galaxy/tool-data/shared/ucsc/chrom/?.len\\\"\", \"annotation\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\", \"population\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\"}",
+      "tool_version": "2.0.1",
+      "type": "tool",
+      "uuid": "d21a0eb7-f0f2-49c3-9d08-eeb0a83ebc85",
+      "workflow_outputs": []
+    },
+    "16": {
+      "annotation": "",
+      "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/goenrichment/goenrichment/2.0.1",
+      "errors": null,
+      "id": 16,
+      "input_connections": {
+        "annotation": {
+          "id": 0,
+          "output_name": "output"
+        },
+        "go": {
+          "id": 1,
+          "output_name": "output"
+        },
+        "population": {
+          "id": 2,
+          "output_name": "output"
+        },
+        "study": {
+          "id": 9,
+          "output_name": "out_file1"
+        }
+      },
+      "inputs": [
+        {
+          "description": "runtime parameter for tool GOEnrichment",
+          "name": "study"
+        },
+        {
+          "description": "runtime parameter for tool GOEnrichment",
+          "name": "go"
+        },
+        {
+          "description": "runtime parameter for tool GOEnrichment",
+          "name": "population"
+        },
+        {
+          "description": "runtime parameter for tool GOEnrichment",
+          "name": "annotation"
+        }
+      ],
+      "label": null,
+      "name": "GOEnrichment",
+      "outputs": [
+        {
+          "name": "mf_result",
+          "type": "tabular"
+        },
+        {
+          "name": "bp_result",
+          "type": "tabular"
+        },
+        {
+          "name": "cc_result",
+          "type": "tabular"
+        },
+        {
+          "name": "mf_graph",
+          "type": "png"
+        },
+        {
+          "name": "bp_graph",
+          "type": "png"
+        },
+        {
+          "name": "cc_graph",
+          "type": "png"
+        }
+      ],
+      "position": {
+        "left": 640,
+        "top": 200
+      },
+      "post_job_actions": {},
+      "tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/goenrichment/goenrichment/2.0.1",
+      "tool_shed_repository": {
+        "changeset_revision": "5ace5c7d1a86",
+        "name": "goenrichment",
+        "owner": "iuc",
+        "tool_shed": "toolshed.g2.bx.psu.edu"
+      },
+      "tool_state": "{\"cutoff\": \"\\\"0.01\\\"\", \"__page__\": null, \"graph\": \"\\\"png\\\"\", \"study\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\", \"relations\": \"\\\"false\\\"\", \"correction\": \"\\\"Benjamini-Hochberg\\\"\", \"go\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\", \"__rerun_remap_job_id__\": null, \"singletons\": \"\\\"true\\\"\", \"summarize\": \"\\\"true\\\"\", \"chromInfo\": \"\\\"/opt/galaxy/tool-data/shared/ucsc/chrom/?.len\\\"\", \"annotation\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\", \"population\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\"}",
+      "tool_version": "2.0.1",
+      "type": "tool",
+      "uuid": "689b8724-53da-4d04-be51-d1fbffdd8a0c",
+      "workflow_outputs": []
+    },
+    "17": {
+      "annotation": "",
+      "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/goenrichment/goenrichment/2.0.1",
+      "errors": null,
+      "id": 17,
+      "input_connections": {
+        "annotation": {
+          "id": 0,
+          "output_name": "output"
+        },
+        "go": {
+          "id": 1,
+          "output_name": "output"
+        },
+        "population": {
+          "id": 10,
+          "output_name": "out_file1"
+        },
+        "study": {
+          "id": 9,
+          "output_name": "out_file1"
+        }
+      },
+      "inputs": [
+        {
+          "description": "runtime parameter for tool GOEnrichment",
+          "name": "study"
+        },
+        {
+          "description": "runtime parameter for tool GOEnrichment",
+          "name": "go"
+        },
+        {
+          "description": "runtime parameter for tool GOEnrichment",
+          "name": "population"
+        },
+        {
+          "description": "runtime parameter for tool GOEnrichment",
+          "name": "annotation"
+        }
+      ],
+      "label": null,
+      "name": "GOEnrichment",
+      "outputs": [
+        {
+          "name": "mf_result",
+          "type": "tabular"
+        },
+        {
+          "name": "bp_result",
+          "type": "tabular"
+        },
+        {
+          "name": "cc_result",
+          "type": "tabular"
+        },
+        {
+          "name": "mf_graph",
+          "type": "png"
+        },
+        {
+          "name": "bp_graph",
+          "type": "png"
+        },
+        {
+          "name": "cc_graph",
+          "type": "png"
+        }
+      ],
+      "position": {
+        "left": 640,
+        "top": 320
+      },
+      "post_job_actions": {},
+      "tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/goenrichment/goenrichment/2.0.1",
+      "tool_shed_repository": {
+        "changeset_revision": "5ace5c7d1a86",
+        "name": "goenrichment",
+        "owner": "iuc",
+        "tool_shed": "toolshed.g2.bx.psu.edu"
+      },
+      "tool_state": "{\"cutoff\": \"\\\"0.01\\\"\", \"__page__\": null, \"graph\": \"\\\"png\\\"\", \"study\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\", \"relations\": \"\\\"false\\\"\", \"correction\": \"\\\"Benjamini-Hochberg\\\"\", \"go\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\", \"__rerun_remap_job_id__\": null, \"singletons\": \"\\\"true\\\"\", \"summarize\": \"\\\"true\\\"\", \"chromInfo\": \"\\\"/opt/galaxy/tool-data/shared/ucsc/chrom/?.len\\\"\", \"annotation\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\", \"population\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\"}",
+      "tool_version": "2.0.1",
+      "type": "tool",
+      "uuid": "19212b8f-3f35-4277-9802-c6c9ea35f4b2",
+      "workflow_outputs": []
+    },
+    "18": {
+      "annotation": "",
+      "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/goenrichment/goenrichment/2.0.1",
+      "errors": null,
+      "id": 18,
+      "input_connections": {
+        "annotation": {
+          "id": 13,
+          "output_name": "output"
+        },
+        "go": {
+          "id": 6,
+          "output_name": "output"
+        },
+        "population": {
+          "id": 4,
+          "output_name": "output"
+        },
+        "study": {
+          "id": 5,
+          "output_name": "output"
+        }
+      },
+      "inputs": [
+        {
+          "description": "runtime parameter for tool GOEnrichment",
+          "name": "study"
+        },
+        {
+          "description": "runtime parameter for tool GOEnrichment",
+          "name": "go"
+        },
+        {
+          "description": "runtime parameter for tool GOEnrichment",
+          "name": "population"
+        },
+        {
+          "description": "runtime parameter for tool GOEnrichment",
+          "name": "annotation"
+        }
+      ],
+      "label": null,
+      "name": "GOEnrichment",
+      "outputs": [
+        {
+          "name": "mf_result",
+          "type": "tabular"
+        },
+        {
+          "name": "bp_result",
+          "type": "tabular"
+        },
+        {
+          "name": "cc_result",
+          "type": "tabular"
+        },
+        {
+          "name": "mf_graph",
+          "type": "png"
+        },
+        {
+          "name": "bp_graph",
+          "type": "png"
+        },
+        {
+          "name": "cc_graph",
+          "type": "png"
+        }
+      ],
+      "position": {
+        "left": 640,
+        "top": 440
+      },
+      "post_job_actions": {},
+      "tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/goenrichment/goenrichment/2.0.1",
+      "tool_shed_repository": {
+        "changeset_revision": "5ace5c7d1a86",
+        "name": "goenrichment",
+        "owner": "iuc",
+        "tool_shed": "toolshed.g2.bx.psu.edu"
+      },
+      "tool_state": "{\"cutoff\": \"\\\"0.01\\\"\", \"__page__\": null, \"graph\": \"\\\"png\\\"\", \"study\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\", \"relations\": \"\\\"false\\\"\", \"correction\": \"\\\"Benjamini-Hochberg\\\"\", \"go\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\", \"__rerun_remap_job_id__\": null, \"singletons\": \"\\\"true\\\"\", \"summarize\": \"\\\"true\\\"\", \"chromInfo\": \"\\\"/opt/galaxy/tool-data/shared/ucsc/chrom/?.len\\\"\", \"annotation\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\", \"population\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\"}",
+      "tool_version": "2.0.1",
+      "type": "tool",
+      "uuid": "6f8dc224-0781-4119-a4e5-96587d1a6622",
+      "workflow_outputs": []
+    },
+    "2": {
+      "annotation": "",
+      "content_id": null,
+      "errors": null,
+      "id": 2,
+      "input_connections": {},
+      "inputs": [
+        {
+          "description": "",
+          "name": "trapnellPopulation.tab"
+        }
+      ],
+      "label": "trapnellPopulation.tab",
+      "name": "Input dataset",
+      "outputs": [],
+      "position": {
+        "left": 200,
+        "top": 440
+      },
+      "tool_id": null,
+      "tool_state": "{\"name\": \"trapnellPopulation.tab\"}",
+      "tool_version": null,
+      "type": "data_input",
+      "uuid": "b9332a9d-0dee-4a27-826c-1213b93c9c20",
+      "workflow_outputs": []
+    },
+    "3": {
+      "annotation": "",
+      "content_id": null,
+      "errors": null,
+      "id": 3,
+      "input_connections": {},
+      "inputs": [
+        {
+          "description": "",
+          "name": "GO annotations Mus musculus"
+        }
+      ],
+      "label": "GO annotations Mus musculus",
+      "name": "Input dataset",
+      "outputs": [],
+      "position": {
+        "left": 200,
+        "top": 560
+      },
+      "tool_id": null,
+      "tool_state": "{\"name\": \"GO annotations Mus musculus\"}",
+      "tool_version": null,
+      "type": "data_input",
+      "uuid": "623b33b8-5edb-4f85-b377-127d0659504e",
+      "workflow_outputs": []
+    },
+    "4": {
+      "annotation": "",
+      "content_id": null,
+      "errors": null,
+      "id": 4,
+      "input_connections": {},
+      "inputs": [
+        {
+          "description": "",
+          "name": "Mouse population"
+        }
+      ],
+      "label": "Mouse population",
+      "name": "Input dataset",
+      "outputs": [],
+      "position": {
+        "left": 200,
+        "top": 680
+      },
+      "tool_id": null,
+      "tool_state": "{\"name\": \"Mouse population\"}",
+      "tool_version": null,
+      "type": "data_input",
+      "uuid": "ea004077-e2c7-4e92-a003-ec25f25df0a0",
+      "workflow_outputs": []
+    },
+    "5": {
+      "annotation": "",
+      "content_id": null,
+      "errors": null,
+      "id": 5,
+      "input_connections": {},
+      "inputs": [
+        {
+          "description": "",
+          "name": "Mouse diff"
+        }
+      ],
+      "label": "Mouse diff",
+      "name": "Input dataset",
+      "outputs": [],
+      "position": {
+        "left": 200,
+        "top": 800
+      },
+      "tool_id": null,
+      "tool_state": "{\"name\": \"Mouse diff\"}",
+      "tool_version": null,
+      "type": "data_input",
+      "uuid": "af1838d3-3af6-4e52-aa38-6ba38eae2c58",
+      "workflow_outputs": []
+    },
+    "6": {
+      "annotation": "",
+      "content_id": null,
+      "errors": null,
+      "id": 6,
+      "input_connections": {},
+      "inputs": [
+        {
+          "description": "",
+          "name": "GO Slim"
+        }
+      ],
+      "label": "GO Slim",
+      "name": "Input dataset",
+      "outputs": [],
+      "position": {
+        "left": 200,
+        "top": 920
+      },
+      "tool_id": null,
+      "tool_state": "{\"name\": \"GO Slim\"}",
+      "tool_version": null,
+      "type": "data_input",
+      "uuid": "bc59fd06-ef94-46ea-a20b-b884f3b9a1b2",
+      "workflow_outputs": []
+    },
+    "7": {
+      "annotation": "",
+      "content_id": null,
+      "errors": null,
+      "id": 7,
+      "input_connections": {},
+      "inputs": [
+        {
+          "description": "",
+          "name": "mouseUnderexpressed.txt"
+        }
+      ],
+      "label": "mouseUnderexpressed.txt",
+      "name": "Input dataset",
+      "outputs": [],
+      "position": {
+        "left": 200,
+        "top": 1040
+      },
+      "tool_id": null,
+      "tool_state": "{\"name\": \"mouseUnderexpressed.txt\"}",
+      "tool_version": null,
+      "type": "data_input",
+      "uuid": "3d85962e-96c5-4152-962d-0cbb1757e2ed",
+      "workflow_outputs": []
+    },
+    "8": {
+      "annotation": "",
+      "content_id": null,
+      "errors": null,
+      "id": 8,
+      "input_connections": {},
+      "inputs": [
+        {
+          "description": "",
+          "name": "mouseOverexpressed.txt"
+        }
+      ],
+      "label": "mouseOverexpressed.txt",
+      "name": "Input dataset",
+      "outputs": [],
+      "position": {
+        "left": 200,
+        "top": 1160
+      },
+      "tool_id": null,
+      "tool_state": "{\"name\": \"mouseOverexpressed.txt\"}",
+      "tool_version": null,
+      "type": "data_input",
+      "uuid": "a81fec4d-a0b7-4e26-b1be-55ae410e5b58",
+      "workflow_outputs": []
+    },
+    "9": {
+      "annotation": "",
+      "content_id": "Filter1",
+      "errors": null,
+      "id": 9,
+      "input_connections": {
+        "input": {
+          "id": 2,
+          "output_name": "output"
+        }
+      },
+      "inputs": [
+        {
+          "description": "runtime parameter for tool Filter",
+          "name": "input"
+        }
+      ],
+      "label": null,
+      "name": "Filter",
+      "outputs": [
+        {
+          "name": "out_file1",
+          "type": "input"
+        }
+      ],
+      "position": {
+        "left": 420,
+        "top": 200
+      },
+      "post_job_actions": {},
+      "tool_id": "Filter1",
+      "tool_state": "{\"__page__\": null, \"__rerun_remap_job_id__\": null, \"cond\": \"\\\"c7 < 0.05\\\"\", \"input\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\", \"header_lines\": \"\\\"0\\\"\", \"chromInfo\": \"\\\"/opt/galaxy/tool-data/shared/ucsc/chrom/?.len\\\"\"}",
+      "tool_version": "1.1.0",
+      "type": "tool",
+      "uuid": "4a267ae5-ab4a-42c2-8abb-217e3c4eaad8",
+      "workflow_outputs": []
+    }
+  },
+  "tags": [],
+  "uuid": "9f788b06-3aab-425d-8a14-0eb903e17f3a",
+  "version": 1
+}

--- a/topics/transcriptomics/tutorials/rna-seq-genes-to-pathways/workflows/rna-seq-genes-to-pathways.ga
+++ b/topics/transcriptomics/tutorials/rna-seq-genes-to-pathways/workflows/rna-seq-genes-to-pathways.ga
@@ -1,1 +1,655 @@
-{"uuid": "0a8ac077-a1ef-4b4d-b760-654972683023", "tags": [], "format-version": "0.1", "name": "RNA-seq genes to pathways", "version": 3, "steps": {"0": {"tool_id": null, "tool_version": null, "outputs": [], "workflow_outputs": [], "input_connections": {}, "tool_state": "{\"name\": \"seqdata\"}", "id": 0, "uuid": "530892fe-96db-4ac9-86da-57adf9dc569d", "errors": null, "name": "Input dataset", "label": "seqdata", "inputs": [{"name": "seqdata", "description": ""}], "position": {"top": 199.9921875, "left": 199.9921875}, "annotation": "", "content_id": null, "type": "data_input"}, "1": {"tool_id": null, "tool_version": null, "outputs": [], "workflow_outputs": [], "input_connections": {}, "tool_state": "{}", "id": 1, "uuid": "a7dfbd15-e384-4bbb-a30f-a8ff03b07784", "errors": null, "name": "Input dataset", "label": "factordata", "inputs": [], "position": {"top": 290.015625, "left": 199.9921875}, "annotation": "", "content_id": null, "type": "data_input"}, "2": {"tool_id": null, "tool_version": null, "outputs": [], "workflow_outputs": [], "input_connections": {}, "tool_state": "{\"collection_type\": \"list\"}", "id": 2, "uuid": "e3e247b3-de91-4ae4-af20-41fe85400e05", "errors": null, "name": "Input dataset collection", "label": "DE table", "inputs": [], "position": {"top": 380.0390625, "left": 199.9921875}, "annotation": "", "content_id": null, "type": "data_collection_input"}, "3": {"tool_id": null, "tool_version": null, "outputs": [], "workflow_outputs": [], "input_connections": {}, "tool_state": "{\"name\": \"mouse_hallmark_sets\"}", "id": 3, "uuid": "651a815a-cadf-4bdf-8d6e-d08379ed4684", "errors": null, "name": "Input dataset", "label": "mouse_hallmark_sets", "inputs": [{"name": "mouse_hallmark_sets", "description": ""}], "position": {"top": 470.0859375, "left": 199.9921875}, "annotation": "", "content_id": null, "type": "data_input"}, "4": {"tool_id": null, "tool_version": null, "outputs": [], "workflow_outputs": [], "input_connections": {}, "tool_state": "{}", "id": 4, "uuid": "9347a180-d878-4afe-95cb-9b6cfd383448", "errors": null, "name": "Input dataset", "label": "limma_filtered_counts", "inputs": [], "position": {"top": 599.109375, "left": 199.9921875}, "annotation": "", "content_id": null, "type": "data_input"}, "5": {"tool_id": "toolshed.g2.bx.psu.edu/repos/devteam/column_maker/Add_a_column1/1.1.0", "tool_version": "1.1.0", "outputs": [{"type": "input", "name": "out_file1"}], "workflow_outputs": [], "input_connections": {"input": {"output_name": "output", "id": 2}}, "tool_state": "{\"__page__\": null, \"__rerun_remap_job_id__\": null, \"round\": \"\\\"no\\\"\", \"cond\": \"\\\"bool(c8<0.01) and bool(abs(c4)>0.58)\\\"\", \"input\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\", \"chromInfo\": \"\\\"/usr/local/galaxy/galaxy-dist/tool-data/shared/ucsc/chrom/mm10.len\\\"\", \"input|__identifier__\": \"\\\"limma-voom_luminalpregnant-luminallactate\\\"\"}", "id": 5, "tool_shed_repository": {"owner": "devteam", "changeset_revision": "626658afe4cb", "name": "column_maker", "tool_shed": "toolshed.g2.bx.psu.edu"}, "uuid": "20efeeff-6096-48d2-9f1f-e3e776112b13", "errors": null, "name": "Compute", "post_job_actions": {}, "label": null, "inputs": [{"name": "input", "description": "runtime parameter for tool Compute"}], "position": {"top": 199.9921875, "left": 512.015625}, "annotation": "", "content_id": "toolshed.g2.bx.psu.edu/repos/devteam/column_maker/Add_a_column1/1.1.0", "type": "tool"}, "6": {"tool_id": "Cut1", "tool_version": "1.0.2", "outputs": [{"type": "tabular", "name": "out_file1"}], "workflow_outputs": [], "input_connections": {"input": {"output_name": "output", "id": 2}}, "tool_state": "{\"__page__\": null, \"__rerun_remap_job_id__\": null, \"delimiter\": \"\\\"T\\\"\", \"columnList\": \"\\\"c1,c6\\\"\", \"input\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\", \"chromInfo\": \"\\\"/usr/local/galaxy/galaxy-dist/tool-data/shared/ucsc/chrom/mm10.len\\\"\", \"input|__identifier__\": \"\\\"limma-voom_luminalpregnant-luminallactate\\\"\"}", "id": 6, "uuid": "a301610d-4e49-4dd6-b603-482674c9ec7f", "errors": null, "name": "Cut", "post_job_actions": {}, "label": null, "inputs": [{"name": "input", "description": "runtime parameter for tool Cut"}], "position": {"top": 326.015625, "left": 512.015625}, "annotation": "", "content_id": "Cut1", "type": "tool"}, "7": {"tool_id": "toolshed.g2.bx.psu.edu/repos/bgruening/text_processing/tp_cut_tool/1.1.0", "tool_version": "1.1.0", "outputs": [{"type": "tabular", "name": "output"}], "workflow_outputs": [], "input_connections": {"input": {"output_name": "output", "id": 4}}, "tool_state": "{\"__page__\": null, \"__rerun_remap_job_id__\": null, \"cut_type_options\": \"{\\\"__current_case__\\\": 0, \\\"cut_element\\\": \\\"-f\\\", \\\"list\\\": \\\"2,3\\\"}\", \"delimiter\": \"\\\"\\\"\", \"input\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\", \"complement\": \"\\\"--complement\\\"\"}", "id": 7, "tool_shed_repository": {"owner": "bgruening", "changeset_revision": "74a8bef53a00", "name": "text_processing", "tool_shed": "toolshed.g2.bx.psu.edu"}, "uuid": "74f84dac-988e-436e-80cf-e45720a1ca6d", "errors": null, "name": "Cut", "post_job_actions": {}, "label": null, "inputs": [{"name": "input", "description": "runtime parameter for tool Cut"}], "position": {"top": 452.0390625, "left": 512.015625}, "annotation": "", "content_id": "toolshed.g2.bx.psu.edu/repos/bgruening/text_processing/tp_cut_tool/1.1.0", "type": "tool"}, "8": {"tool_id": "toolshed.g2.bx.psu.edu/repos/bgruening/text_processing/tp_cut_tool/1.1.0", "tool_version": "1.1.0", "outputs": [{"type": "tabular", "name": "output"}], "workflow_outputs": [], "input_connections": {"input": {"output_name": "output", "id": 4}}, "tool_state": "{\"__page__\": null, \"__rerun_remap_job_id__\": null, \"cut_type_options\": \"{\\\"__current_case__\\\": 0, \\\"cut_element\\\": \\\"-f\\\", \\\"list\\\": \\\"1,2\\\"}\", \"delimiter\": \"\\\"\\\"\", \"input\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\", \"complement\": \"\\\"\\\"\"}", "id": 8, "tool_shed_repository": {"owner": "bgruening", "changeset_revision": "74a8bef53a00", "name": "text_processing", "tool_shed": "toolshed.g2.bx.psu.edu"}, "uuid": "e5c8206a-72d0-4faa-a19e-8d7ac0190316", "errors": null, "name": "Cut", "post_job_actions": {}, "label": null, "inputs": [{"name": "input", "description": "runtime parameter for tool Cut"}], "position": {"top": 572.0859375, "left": 512.015625}, "annotation": "", "content_id": "toolshed.g2.bx.psu.edu/repos/bgruening/text_processing/tp_cut_tool/1.1.0", "type": "tool"}, "9": {"tool_id": "join1", "tool_version": "2.1.1", "outputs": [{"type": "input", "name": "out_file1"}], "workflow_outputs": [], "input_connections": {"input2": {"output_name": "output", "id": 0}, "input1": {"output_name": "out_file1", "id": 5}}, "tool_state": "{\"input2\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\", \"__page__\": null, \"field1\": \"\\\"1\\\"\", \"partial\": \"\\\"\\\"\", \"field2\": \"\\\"1\\\"\", \"chromInfo\": \"\\\"/usr/local/galaxy/galaxy-dist/tool-data/shared/ucsc/chrom/mm10.len\\\"\", \"__rerun_remap_job_id__\": null, \"fill_empty_columns\": \"{\\\"__current_case__\\\": 0, \\\"fill_empty_columns_switch\\\": \\\"no_fill\\\"}\", \"unmatched\": \"\\\"\\\"\", \"header\": \"\\\"\\\"\", \"input1\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\", \"input1|__identifier__\": \"\\\"limma-voom_luminalpregnant-luminallactate\\\"\"}", "id": 9, "uuid": "2f81fad6-b41c-4c4b-b803-51a5ccd1c047", "errors": null, "name": "Join two Datasets", "post_job_actions": {}, "label": null, "inputs": [{"name": "input2", "description": "runtime parameter for tool Join two Datasets"}, {"name": "input1", "description": "runtime parameter for tool Join two Datasets"}], "position": {"top": 199.9921875, "left": 769.0546875}, "annotation": "", "content_id": "join1", "type": "tool"}, "10": {"tool_id": "toolshed.g2.bx.psu.edu/repos/bgruening/text_processing/tp_sort_header_tool/1.1.1", "tool_version": "1.1.1", "outputs": [{"type": "input", "name": "outfile"}], "workflow_outputs": [], "input_connections": {"infile": {"output_name": "out_file1", "id": 6}}, "tool_state": "{\"sortkeys\": \"[{\\\"__index__\\\": 0, \\\"column\\\": \\\"2\\\", \\\"order\\\": \\\"r\\\", \\\"style\\\": \\\"n\\\"}]\", \"__page__\": null, \"ignore_case\": \"\\\"false\\\"\", \"infile|__identifier__\": \"\\\"limma-voom_luminalpregnant-luminallactate\\\"\", \"__rerun_remap_job_id__\": null, \"header\": \"\\\"1\\\"\", \"unique\": \"\\\"false\\\"\", \"chromInfo\": \"\\\"/usr/local/galaxy/galaxy-dist/tool-data/shared/ucsc/chrom/mm10.len\\\"\", \"infile\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\"}", "id": 10, "tool_shed_repository": {"owner": "bgruening", "changeset_revision": "74a8bef53a00", "name": "text_processing", "tool_shed": "toolshed.g2.bx.psu.edu"}, "uuid": "ce9e6449-48c9-4857-b20a-e82f0a554685", "errors": null, "name": "Sort", "post_job_actions": {}, "label": null, "inputs": [{"name": "infile", "description": "runtime parameter for tool Sort"}], "position": {"top": 354.0234375, "left": 769.0546875}, "annotation": "", "content_id": "toolshed.g2.bx.psu.edu/repos/bgruening/text_processing/tp_sort_header_tool/1.1.1", "type": "tool"}, "11": {"tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/egsea/egsea/1.6.0.1", "tool_version": "1.6.0.1", "outputs": [{"type": "input", "name": "outTables"}, {"type": "html", "name": "outReport"}, {"type": "txt", "name": "outRscript"}, {"type": "rdata", "name": "outRdata"}], "workflow_outputs": [], "input_connections": {"input|counts": {"output_name": "output", "id": 7}, "genes": {"output_name": "output", "id": 8}, "input|fact|finfo": {"output_name": "output", "id": 1}}, "tool_state": "{\"msigdb\": \"{\\\"msigdb_gsets\\\": [\\\"h\\\"]}\", \"__page__\": null, \"gsdb\": \"{\\\"gsdb_gsets\\\": null}\", \"keggdb\": \"{\\\"kegg_updated\\\": \\\"false\\\", \\\"keggdb_gsets\\\": [\\\"keggmet\\\", \\\"keggsig\\\"]}\", \"__rerun_remap_job_id__\": null, \"genes\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\", \"base_methods\": \"[\\\"camera\\\", \\\"safe\\\", \\\"gage\\\", \\\"zscore\\\", \\\"gsva\\\", \\\"globaltest\\\", \\\"ora\\\", \\\"ssgsea\\\", \\\"padog\\\", \\\"plage\\\", \\\"fry\\\"]\", \"non_commercial_use\": \"\\\"true\\\"\", \"rep_contrast\": \"[{\\\"__index__\\\": 0, \\\"contrast\\\": \\\"basalpregnant-basallactate\\\"}, {\\\"__index__\\\": 1, \\\"contrast\\\": \\\"luminalpregnant-luminallactate\\\"}]\", \"input\": \"{\\\"__current_case__\\\": 1, \\\"counts\\\": {\\\"__class__\\\": \\\"RuntimeValue\\\"}, \\\"fact\\\": {\\\"__current_case__\\\": 0, \\\"ffile\\\": \\\"yes\\\", \\\"finfo\\\": {\\\"__class__\\\": \\\"RuntimeValue\\\"}}, \\\"format\\\": \\\"matrix\\\"}\", \"chromInfo\": \"\\\"/usr/local/galaxy/galaxy-dist/tool-data/shared/ucsc/chrom/mm10.len\\\"\", \"species\": \"\\\"mouse\\\"\", \"advanced\": \"{\\\"combine_method\\\": \\\"wilkinson\\\", \\\"display_top\\\": \\\"5\\\", \\\"fdr_cutoff\\\": \\\"0.05\\\", \\\"min_size\\\": \\\"2\\\", \\\"rdaOpt\\\": \\\"false\\\", \\\"rscriptOpt\\\": \\\"false\\\", \\\"sort_method\\\": \\\"med.rank\\\"}\"}", "id": 11, "tool_shed_repository": {"owner": "iuc", "changeset_revision": "73281fbdf6c1", "name": "egsea", "tool_shed": "toolshed.g2.bx.psu.edu"}, "uuid": "e9df8569-f438-4144-9f3a-ebb569ec2047", "errors": null, "name": "EGSEA", "post_job_actions": {}, "label": null, "inputs": [{"name": "genes", "description": "runtime parameter for tool EGSEA"}, {"name": "input", "description": "runtime parameter for tool EGSEA"}], "position": {"top": 480.046875, "left": 769.0546875}, "annotation": "", "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/egsea/egsea/1.6.0.1", "type": "tool"}, "12": {"tool_id": "Cut1", "tool_version": "1.0.2", "outputs": [{"type": "tabular", "name": "out_file1"}], "workflow_outputs": [], "input_connections": {"input": {"output_name": "out_file1", "id": 9}}, "tool_state": "{\"__page__\": null, \"__rerun_remap_job_id__\": null, \"delimiter\": \"\\\"T\\\"\", \"columnList\": \"\\\"c1,c9\\\"\", \"input\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\", \"chromInfo\": \"\\\"/usr/local/galaxy/galaxy-dist/tool-data/shared/ucsc/chrom/mm10.len\\\"\", \"input|__identifier__\": \"\\\"limma-voom_luminalpregnant-luminallactate\\\"\"}", "id": 12, "uuid": "af9206ae-98cc-4432-a81e-ee39bb2c2a8a", "errors": null, "name": "Cut", "post_job_actions": {}, "label": null, "inputs": [{"name": "input", "description": "runtime parameter for tool Cut"}], "position": {"top": 199.9921875, "left": 1038.09375}, "annotation": "", "content_id": "Cut1", "type": "tool"}, "13": {"tool_id": "Cut1", "tool_version": "1.0.2", "outputs": [{"type": "tabular", "name": "out_file1"}], "workflow_outputs": [], "input_connections": {"input": {"output_name": "out_file1", "id": 9}}, "tool_state": "{\"__page__\": null, \"__rerun_remap_job_id__\": null, \"delimiter\": \"\\\"T\\\"\", \"columnList\": \"\\\"c1,c11\\\"\", \"input\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\", \"chromInfo\": \"\\\"/usr/local/galaxy/galaxy-dist/tool-data/shared/ucsc/chrom/mm10.len\\\"\", \"input|__identifier__\": \"\\\"limma-voom_luminalpregnant-luminallactate\\\"\"}", "id": 13, "uuid": "4a72bc30-2d4e-4480-875b-507b2a7274b4", "errors": null, "name": "Cut", "post_job_actions": {}, "label": null, "inputs": [{"name": "input", "description": "runtime parameter for tool Cut"}], "position": {"top": 326.015625, "left": 1038.09375}, "annotation": "", "content_id": "Cut1", "type": "tool"}, "14": {"tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/fgsea/fgsea/1.6.0", "tool_version": "1.6.0", "outputs": [{"type": "tabular", "name": "out_tab"}, {"type": "pdf", "name": "out_pdf"}, {"type": "rdata", "name": "out_rdata"}], "workflow_outputs": [], "input_connections": {"rnk_file": {"output_name": "outfile", "id": 10}, "sets_file": {"output_name": "output", "id": 3}}, "tool_state": "{\"__page__\": null, \"rnk_file\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\", \"rda_opt\": \"\\\"false\\\"\", \"rnk_file|__identifier__\": \"\\\"limma-voom_luminalpregnant-luminallactate\\\"\", \"min_size\": \"\\\"15\\\"\", \"header\": \"\\\"true\\\"\", \"top_num\": \"\\\"10\\\"\", \"n_perm\": \"\\\"1000\\\"\", \"plot_opt\": \"\\\"true\\\"\", \"chromInfo\": \"\\\"/usr/local/galaxy/galaxy-dist/tool-data/shared/ucsc/chrom/mm10.len\\\"\", \"__rerun_remap_job_id__\": null, \"max_size\": \"\\\"500\\\"\", \"sets_file\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\"}", "id": 14, "tool_shed_repository": {"owner": "iuc", "changeset_revision": "9bb7943b5263", "name": "fgsea", "tool_shed": "toolshed.g2.bx.psu.edu"}, "uuid": "8e1c5077-edf1-4dcf-9a07-3b521c49a76f", "errors": null, "name": "fgsea", "post_job_actions": {}, "label": null, "inputs": [{"name": "rnk_file", "description": "runtime parameter for tool fgsea"}, {"name": "sets_file", "description": "runtime parameter for tool fgsea"}], "position": {"top": 452.0390625, "left": 1038.09375}, "annotation": "", "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/fgsea/fgsea/1.6.0", "type": "tool"}, "15": {"tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/goseq/goseq/1.30.1", "tool_version": "1.30.1", "outputs": [{"type": "tabular", "name": "wallenius_tab"}, {"type": "tabular", "name": "sampling_tab"}, {"type": "tabular", "name": "nobias_tab"}, {"type": "pdf", "name": "length_bias_plot"}, {"type": "pdf", "name": "sample_vs_wallenius_plot"}, {"type": "rdata", "name": "rdata"}, {"type": "pdf", "name": "top_plot"}], "workflow_outputs": [], "input_connections": {"dge_file": {"output_name": "out_file1", "id": 12}, "length_file": {"output_name": "out_file1", "id": 13}}, "tool_state": "{\"adv\": \"{\\\"p_adj_method\\\": \\\"BH\\\", \\\"use_genes_without_cat\\\": \\\"false\\\"}\", \"categorySource\": \"{\\\"__current_case__\\\": 0, \\\"catSource\\\": \\\"getgo\\\", \\\"fetchcats\\\": [\\\"GO:BP\\\"], \\\"gene_id\\\": \\\"knownGene\\\", \\\"genome\\\": \\\"mm10\\\"}\", \"methods\": \"{\\\"hypergeometric\\\": \\\"false\\\", \\\"repcnt\\\": \\\"0\\\", \\\"wallenius\\\": \\\"true\\\"}\", \"dge_file|__identifier__\": \"\\\"limma-voom_luminalpregnant-luminallactate\\\"\", \"__page__\": null, \"chromInfo\": \"\\\"/usr/local/galaxy/galaxy-dist/tool-data/shared/ucsc/chrom/mm10.len\\\"\", \"__rerun_remap_job_id__\": null, \"length_file\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\", \"length_file|__identifier__\": \"\\\"limma-voom_luminalpregnant-luminallactate\\\"\", \"dge_file\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\", \"out\": \"{\\\"make_plots\\\": \\\"false\\\", \\\"rdata_out\\\": \\\"false\\\", \\\"topgo_plot\\\": \\\"true\\\"}\"}", "id": 15, "tool_shed_repository": {"owner": "iuc", "changeset_revision": "ae39895af5fe", "name": "goseq", "tool_shed": "toolshed.g2.bx.psu.edu"}, "uuid": "cddd834a-87f6-470a-b4cd-3c7af7f75e50", "errors": null, "name": "goseq", "post_job_actions": {}, "label": null, "inputs": [{"name": "length_file", "description": "runtime parameter for tool goseq"}, {"name": "dge_file", "description": "runtime parameter for tool goseq"}], "position": {"top": 199.9921875, "left": 1293.1171875}, "annotation": "", "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/goseq/goseq/1.30.1", "type": "tool"}}, "annotation": "", "a_galaxy_workflow": "true"}
+{
+  "a_galaxy_workflow": "true",
+  "annotation": "",
+  "format-version": "0.1",
+  "name": "RNA-seq genes to pathways",
+  "steps": {
+    "0": {
+      "annotation": "",
+      "content_id": null,
+      "errors": null,
+      "id": 0,
+      "input_connections": {},
+      "inputs": [
+        {
+          "description": "",
+          "name": "seqdata"
+        }
+      ],
+      "label": "seqdata",
+      "name": "Input dataset",
+      "outputs": [],
+      "position": {
+        "left": 199.9921875,
+        "top": 199.9921875
+      },
+      "tool_id": null,
+      "tool_state": "{\"name\": \"seqdata\"}",
+      "tool_version": null,
+      "type": "data_input",
+      "uuid": "530892fe-96db-4ac9-86da-57adf9dc569d",
+      "workflow_outputs": []
+    },
+    "1": {
+      "annotation": "",
+      "content_id": null,
+      "errors": null,
+      "id": 1,
+      "input_connections": {},
+      "inputs": [],
+      "label": "factordata",
+      "name": "Input dataset",
+      "outputs": [],
+      "position": {
+        "left": 199.9921875,
+        "top": 290.015625
+      },
+      "tool_id": null,
+      "tool_state": "{}",
+      "tool_version": null,
+      "type": "data_input",
+      "uuid": "a7dfbd15-e384-4bbb-a30f-a8ff03b07784",
+      "workflow_outputs": []
+    },
+    "10": {
+      "annotation": "",
+      "content_id": "toolshed.g2.bx.psu.edu/repos/bgruening/text_processing/tp_sort_header_tool/1.1.1",
+      "errors": null,
+      "id": 10,
+      "input_connections": {
+        "infile": {
+          "id": 6,
+          "output_name": "out_file1"
+        }
+      },
+      "inputs": [
+        {
+          "description": "runtime parameter for tool Sort",
+          "name": "infile"
+        }
+      ],
+      "label": null,
+      "name": "Sort",
+      "outputs": [
+        {
+          "name": "outfile",
+          "type": "input"
+        }
+      ],
+      "position": {
+        "left": 769.0546875,
+        "top": 354.0234375
+      },
+      "post_job_actions": {},
+      "tool_id": "toolshed.g2.bx.psu.edu/repos/bgruening/text_processing/tp_sort_header_tool/1.1.1",
+      "tool_shed_repository": {
+        "changeset_revision": "74a8bef53a00",
+        "name": "text_processing",
+        "owner": "bgruening",
+        "tool_shed": "toolshed.g2.bx.psu.edu"
+      },
+      "tool_state": "{\"sortkeys\": \"[{\\\"__index__\\\": 0, \\\"column\\\": \\\"2\\\", \\\"order\\\": \\\"r\\\", \\\"style\\\": \\\"n\\\"}]\", \"__page__\": null, \"ignore_case\": \"\\\"false\\\"\", \"infile|__identifier__\": \"\\\"limma-voom_luminalpregnant-luminallactate\\\"\", \"__rerun_remap_job_id__\": null, \"header\": \"\\\"1\\\"\", \"unique\": \"\\\"false\\\"\", \"chromInfo\": \"\\\"/usr/local/galaxy/galaxy-dist/tool-data/shared/ucsc/chrom/mm10.len\\\"\", \"infile\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\"}",
+      "tool_version": "1.1.1",
+      "type": "tool",
+      "uuid": "ce9e6449-48c9-4857-b20a-e82f0a554685",
+      "workflow_outputs": []
+    },
+    "11": {
+      "annotation": "",
+      "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/egsea/egsea/1.6.0.1",
+      "errors": null,
+      "id": 11,
+      "input_connections": {
+        "genes": {
+          "id": 8,
+          "output_name": "output"
+        },
+        "input|counts": {
+          "id": 7,
+          "output_name": "output"
+        },
+        "input|fact|finfo": {
+          "id": 1,
+          "output_name": "output"
+        }
+      },
+      "inputs": [
+        {
+          "description": "runtime parameter for tool EGSEA",
+          "name": "genes"
+        },
+        {
+          "description": "runtime parameter for tool EGSEA",
+          "name": "input"
+        }
+      ],
+      "label": null,
+      "name": "EGSEA",
+      "outputs": [
+        {
+          "name": "outTables",
+          "type": "input"
+        },
+        {
+          "name": "outReport",
+          "type": "html"
+        },
+        {
+          "name": "outRscript",
+          "type": "txt"
+        },
+        {
+          "name": "outRdata",
+          "type": "rdata"
+        }
+      ],
+      "position": {
+        "left": 769.0546875,
+        "top": 480.046875
+      },
+      "post_job_actions": {},
+      "tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/egsea/egsea/1.6.0.1",
+      "tool_shed_repository": {
+        "changeset_revision": "73281fbdf6c1",
+        "name": "egsea",
+        "owner": "iuc",
+        "tool_shed": "toolshed.g2.bx.psu.edu"
+      },
+      "tool_state": "{\"msigdb\": \"{\\\"msigdb_gsets\\\": [\\\"h\\\"]}\", \"__page__\": null, \"gsdb\": \"{\\\"gsdb_gsets\\\": null}\", \"keggdb\": \"{\\\"kegg_updated\\\": \\\"false\\\", \\\"keggdb_gsets\\\": [\\\"keggmet\\\", \\\"keggsig\\\"]}\", \"__rerun_remap_job_id__\": null, \"genes\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\", \"base_methods\": \"[\\\"camera\\\", \\\"safe\\\", \\\"gage\\\", \\\"zscore\\\", \\\"gsva\\\", \\\"globaltest\\\", \\\"ora\\\", \\\"ssgsea\\\", \\\"padog\\\", \\\"plage\\\", \\\"fry\\\"]\", \"non_commercial_use\": \"\\\"true\\\"\", \"rep_contrast\": \"[{\\\"__index__\\\": 0, \\\"contrast\\\": \\\"basalpregnant-basallactate\\\"}, {\\\"__index__\\\": 1, \\\"contrast\\\": \\\"luminalpregnant-luminallactate\\\"}]\", \"input\": \"{\\\"__current_case__\\\": 1, \\\"counts\\\": {\\\"__class__\\\": \\\"RuntimeValue\\\"}, \\\"fact\\\": {\\\"__current_case__\\\": 0, \\\"ffile\\\": \\\"yes\\\", \\\"finfo\\\": {\\\"__class__\\\": \\\"RuntimeValue\\\"}}, \\\"format\\\": \\\"matrix\\\"}\", \"chromInfo\": \"\\\"/usr/local/galaxy/galaxy-dist/tool-data/shared/ucsc/chrom/mm10.len\\\"\", \"species\": \"\\\"mouse\\\"\", \"advanced\": \"{\\\"combine_method\\\": \\\"wilkinson\\\", \\\"display_top\\\": \\\"5\\\", \\\"fdr_cutoff\\\": \\\"0.05\\\", \\\"min_size\\\": \\\"2\\\", \\\"rdaOpt\\\": \\\"false\\\", \\\"rscriptOpt\\\": \\\"false\\\", \\\"sort_method\\\": \\\"med.rank\\\"}\"}",
+      "tool_version": "1.6.0.1",
+      "type": "tool",
+      "uuid": "e9df8569-f438-4144-9f3a-ebb569ec2047",
+      "workflow_outputs": []
+    },
+    "12": {
+      "annotation": "",
+      "content_id": "Cut1",
+      "errors": null,
+      "id": 12,
+      "input_connections": {
+        "input": {
+          "id": 9,
+          "output_name": "out_file1"
+        }
+      },
+      "inputs": [
+        {
+          "description": "runtime parameter for tool Cut",
+          "name": "input"
+        }
+      ],
+      "label": null,
+      "name": "Cut",
+      "outputs": [
+        {
+          "name": "out_file1",
+          "type": "tabular"
+        }
+      ],
+      "position": {
+        "left": 1038.09375,
+        "top": 199.9921875
+      },
+      "post_job_actions": {},
+      "tool_id": "Cut1",
+      "tool_state": "{\"__page__\": null, \"__rerun_remap_job_id__\": null, \"delimiter\": \"\\\"T\\\"\", \"columnList\": \"\\\"c1,c9\\\"\", \"input\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\", \"chromInfo\": \"\\\"/usr/local/galaxy/galaxy-dist/tool-data/shared/ucsc/chrom/mm10.len\\\"\", \"input|__identifier__\": \"\\\"limma-voom_luminalpregnant-luminallactate\\\"\"}",
+      "tool_version": "1.0.2",
+      "type": "tool",
+      "uuid": "af9206ae-98cc-4432-a81e-ee39bb2c2a8a",
+      "workflow_outputs": []
+    },
+    "13": {
+      "annotation": "",
+      "content_id": "Cut1",
+      "errors": null,
+      "id": 13,
+      "input_connections": {
+        "input": {
+          "id": 9,
+          "output_name": "out_file1"
+        }
+      },
+      "inputs": [
+        {
+          "description": "runtime parameter for tool Cut",
+          "name": "input"
+        }
+      ],
+      "label": null,
+      "name": "Cut",
+      "outputs": [
+        {
+          "name": "out_file1",
+          "type": "tabular"
+        }
+      ],
+      "position": {
+        "left": 1038.09375,
+        "top": 326.015625
+      },
+      "post_job_actions": {},
+      "tool_id": "Cut1",
+      "tool_state": "{\"__page__\": null, \"__rerun_remap_job_id__\": null, \"delimiter\": \"\\\"T\\\"\", \"columnList\": \"\\\"c1,c11\\\"\", \"input\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\", \"chromInfo\": \"\\\"/usr/local/galaxy/galaxy-dist/tool-data/shared/ucsc/chrom/mm10.len\\\"\", \"input|__identifier__\": \"\\\"limma-voom_luminalpregnant-luminallactate\\\"\"}",
+      "tool_version": "1.0.2",
+      "type": "tool",
+      "uuid": "4a72bc30-2d4e-4480-875b-507b2a7274b4",
+      "workflow_outputs": []
+    },
+    "14": {
+      "annotation": "",
+      "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/fgsea/fgsea/1.6.0",
+      "errors": null,
+      "id": 14,
+      "input_connections": {
+        "rnk_file": {
+          "id": 10,
+          "output_name": "outfile"
+        },
+        "sets_file": {
+          "id": 3,
+          "output_name": "output"
+        }
+      },
+      "inputs": [
+        {
+          "description": "runtime parameter for tool fgsea",
+          "name": "rnk_file"
+        },
+        {
+          "description": "runtime parameter for tool fgsea",
+          "name": "sets_file"
+        }
+      ],
+      "label": null,
+      "name": "fgsea",
+      "outputs": [
+        {
+          "name": "out_tab",
+          "type": "tabular"
+        },
+        {
+          "name": "out_pdf",
+          "type": "pdf"
+        },
+        {
+          "name": "out_rdata",
+          "type": "rdata"
+        }
+      ],
+      "position": {
+        "left": 1038.09375,
+        "top": 452.0390625
+      },
+      "post_job_actions": {},
+      "tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/fgsea/fgsea/1.6.0",
+      "tool_shed_repository": {
+        "changeset_revision": "9bb7943b5263",
+        "name": "fgsea",
+        "owner": "iuc",
+        "tool_shed": "toolshed.g2.bx.psu.edu"
+      },
+      "tool_state": "{\"__page__\": null, \"rnk_file\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\", \"rda_opt\": \"\\\"false\\\"\", \"rnk_file|__identifier__\": \"\\\"limma-voom_luminalpregnant-luminallactate\\\"\", \"min_size\": \"\\\"15\\\"\", \"header\": \"\\\"true\\\"\", \"top_num\": \"\\\"10\\\"\", \"n_perm\": \"\\\"1000\\\"\", \"plot_opt\": \"\\\"true\\\"\", \"chromInfo\": \"\\\"/usr/local/galaxy/galaxy-dist/tool-data/shared/ucsc/chrom/mm10.len\\\"\", \"__rerun_remap_job_id__\": null, \"max_size\": \"\\\"500\\\"\", \"sets_file\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\"}",
+      "tool_version": "1.6.0",
+      "type": "tool",
+      "uuid": "8e1c5077-edf1-4dcf-9a07-3b521c49a76f",
+      "workflow_outputs": []
+    },
+    "15": {
+      "annotation": "",
+      "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/goseq/goseq/1.30.1",
+      "errors": null,
+      "id": 15,
+      "input_connections": {
+        "dge_file": {
+          "id": 12,
+          "output_name": "out_file1"
+        },
+        "length_file": {
+          "id": 13,
+          "output_name": "out_file1"
+        }
+      },
+      "inputs": [
+        {
+          "description": "runtime parameter for tool goseq",
+          "name": "length_file"
+        },
+        {
+          "description": "runtime parameter for tool goseq",
+          "name": "dge_file"
+        }
+      ],
+      "label": null,
+      "name": "goseq",
+      "outputs": [
+        {
+          "name": "wallenius_tab",
+          "type": "tabular"
+        },
+        {
+          "name": "sampling_tab",
+          "type": "tabular"
+        },
+        {
+          "name": "nobias_tab",
+          "type": "tabular"
+        },
+        {
+          "name": "length_bias_plot",
+          "type": "pdf"
+        },
+        {
+          "name": "sample_vs_wallenius_plot",
+          "type": "pdf"
+        },
+        {
+          "name": "rdata",
+          "type": "rdata"
+        },
+        {
+          "name": "top_plot",
+          "type": "pdf"
+        }
+      ],
+      "position": {
+        "left": 1293.1171875,
+        "top": 199.9921875
+      },
+      "post_job_actions": {},
+      "tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/goseq/goseq/1.30.1",
+      "tool_shed_repository": {
+        "changeset_revision": "ae39895af5fe",
+        "name": "goseq",
+        "owner": "iuc",
+        "tool_shed": "toolshed.g2.bx.psu.edu"
+      },
+      "tool_state": "{\"adv\": \"{\\\"p_adj_method\\\": \\\"BH\\\", \\\"use_genes_without_cat\\\": \\\"false\\\"}\", \"categorySource\": \"{\\\"__current_case__\\\": 0, \\\"catSource\\\": \\\"getgo\\\", \\\"fetchcats\\\": [\\\"GO:BP\\\"], \\\"gene_id\\\": \\\"knownGene\\\", \\\"genome\\\": \\\"mm10\\\"}\", \"methods\": \"{\\\"hypergeometric\\\": \\\"false\\\", \\\"repcnt\\\": \\\"0\\\", \\\"wallenius\\\": \\\"true\\\"}\", \"dge_file|__identifier__\": \"\\\"limma-voom_luminalpregnant-luminallactate\\\"\", \"__page__\": null, \"chromInfo\": \"\\\"/usr/local/galaxy/galaxy-dist/tool-data/shared/ucsc/chrom/mm10.len\\\"\", \"__rerun_remap_job_id__\": null, \"length_file\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\", \"length_file|__identifier__\": \"\\\"limma-voom_luminalpregnant-luminallactate\\\"\", \"dge_file\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\", \"out\": \"{\\\"make_plots\\\": \\\"false\\\", \\\"rdata_out\\\": \\\"false\\\", \\\"topgo_plot\\\": \\\"true\\\"}\"}",
+      "tool_version": "1.30.1",
+      "type": "tool",
+      "uuid": "cddd834a-87f6-470a-b4cd-3c7af7f75e50",
+      "workflow_outputs": []
+    },
+    "2": {
+      "annotation": "",
+      "content_id": null,
+      "errors": null,
+      "id": 2,
+      "input_connections": {},
+      "inputs": [],
+      "label": "DE table",
+      "name": "Input dataset collection",
+      "outputs": [],
+      "position": {
+        "left": 199.9921875,
+        "top": 380.0390625
+      },
+      "tool_id": null,
+      "tool_state": "{\"collection_type\": \"list\"}",
+      "tool_version": null,
+      "type": "data_collection_input",
+      "uuid": "e3e247b3-de91-4ae4-af20-41fe85400e05",
+      "workflow_outputs": []
+    },
+    "3": {
+      "annotation": "",
+      "content_id": null,
+      "errors": null,
+      "id": 3,
+      "input_connections": {},
+      "inputs": [
+        {
+          "description": "",
+          "name": "mouse_hallmark_sets"
+        }
+      ],
+      "label": "mouse_hallmark_sets",
+      "name": "Input dataset",
+      "outputs": [],
+      "position": {
+        "left": 199.9921875,
+        "top": 470.0859375
+      },
+      "tool_id": null,
+      "tool_state": "{\"name\": \"mouse_hallmark_sets\"}",
+      "tool_version": null,
+      "type": "data_input",
+      "uuid": "651a815a-cadf-4bdf-8d6e-d08379ed4684",
+      "workflow_outputs": []
+    },
+    "4": {
+      "annotation": "",
+      "content_id": null,
+      "errors": null,
+      "id": 4,
+      "input_connections": {},
+      "inputs": [],
+      "label": "limma_filtered_counts",
+      "name": "Input dataset",
+      "outputs": [],
+      "position": {
+        "left": 199.9921875,
+        "top": 599.109375
+      },
+      "tool_id": null,
+      "tool_state": "{}",
+      "tool_version": null,
+      "type": "data_input",
+      "uuid": "9347a180-d878-4afe-95cb-9b6cfd383448",
+      "workflow_outputs": []
+    },
+    "5": {
+      "annotation": "",
+      "content_id": "toolshed.g2.bx.psu.edu/repos/devteam/column_maker/Add_a_column1/1.1.0",
+      "errors": null,
+      "id": 5,
+      "input_connections": {
+        "input": {
+          "id": 2,
+          "output_name": "output"
+        }
+      },
+      "inputs": [
+        {
+          "description": "runtime parameter for tool Compute",
+          "name": "input"
+        }
+      ],
+      "label": null,
+      "name": "Compute",
+      "outputs": [
+        {
+          "name": "out_file1",
+          "type": "input"
+        }
+      ],
+      "position": {
+        "left": 512.015625,
+        "top": 199.9921875
+      },
+      "post_job_actions": {},
+      "tool_id": "toolshed.g2.bx.psu.edu/repos/devteam/column_maker/Add_a_column1/1.1.0",
+      "tool_shed_repository": {
+        "changeset_revision": "626658afe4cb",
+        "name": "column_maker",
+        "owner": "devteam",
+        "tool_shed": "toolshed.g2.bx.psu.edu"
+      },
+      "tool_state": "{\"__page__\": null, \"__rerun_remap_job_id__\": null, \"round\": \"\\\"no\\\"\", \"cond\": \"\\\"bool(c8<0.01) and bool(abs(c4)>0.58)\\\"\", \"input\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\", \"chromInfo\": \"\\\"/usr/local/galaxy/galaxy-dist/tool-data/shared/ucsc/chrom/mm10.len\\\"\", \"input|__identifier__\": \"\\\"limma-voom_luminalpregnant-luminallactate\\\"\"}",
+      "tool_version": "1.1.0",
+      "type": "tool",
+      "uuid": "20efeeff-6096-48d2-9f1f-e3e776112b13",
+      "workflow_outputs": []
+    },
+    "6": {
+      "annotation": "",
+      "content_id": "Cut1",
+      "errors": null,
+      "id": 6,
+      "input_connections": {
+        "input": {
+          "id": 2,
+          "output_name": "output"
+        }
+      },
+      "inputs": [
+        {
+          "description": "runtime parameter for tool Cut",
+          "name": "input"
+        }
+      ],
+      "label": null,
+      "name": "Cut",
+      "outputs": [
+        {
+          "name": "out_file1",
+          "type": "tabular"
+        }
+      ],
+      "position": {
+        "left": 512.015625,
+        "top": 326.015625
+      },
+      "post_job_actions": {},
+      "tool_id": "Cut1",
+      "tool_state": "{\"__page__\": null, \"__rerun_remap_job_id__\": null, \"delimiter\": \"\\\"T\\\"\", \"columnList\": \"\\\"c1,c6\\\"\", \"input\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\", \"chromInfo\": \"\\\"/usr/local/galaxy/galaxy-dist/tool-data/shared/ucsc/chrom/mm10.len\\\"\", \"input|__identifier__\": \"\\\"limma-voom_luminalpregnant-luminallactate\\\"\"}",
+      "tool_version": "1.0.2",
+      "type": "tool",
+      "uuid": "a301610d-4e49-4dd6-b603-482674c9ec7f",
+      "workflow_outputs": []
+    },
+    "7": {
+      "annotation": "",
+      "content_id": "toolshed.g2.bx.psu.edu/repos/bgruening/text_processing/tp_cut_tool/1.1.0",
+      "errors": null,
+      "id": 7,
+      "input_connections": {
+        "input": {
+          "id": 4,
+          "output_name": "output"
+        }
+      },
+      "inputs": [
+        {
+          "description": "runtime parameter for tool Cut",
+          "name": "input"
+        }
+      ],
+      "label": null,
+      "name": "Cut",
+      "outputs": [
+        {
+          "name": "output",
+          "type": "tabular"
+        }
+      ],
+      "position": {
+        "left": 512.015625,
+        "top": 452.0390625
+      },
+      "post_job_actions": {},
+      "tool_id": "toolshed.g2.bx.psu.edu/repos/bgruening/text_processing/tp_cut_tool/1.1.0",
+      "tool_shed_repository": {
+        "changeset_revision": "74a8bef53a00",
+        "name": "text_processing",
+        "owner": "bgruening",
+        "tool_shed": "toolshed.g2.bx.psu.edu"
+      },
+      "tool_state": "{\"__page__\": null, \"__rerun_remap_job_id__\": null, \"cut_type_options\": \"{\\\"__current_case__\\\": 0, \\\"cut_element\\\": \\\"-f\\\", \\\"list\\\": \\\"2,3\\\"}\", \"delimiter\": \"\\\"\\\"\", \"input\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\", \"complement\": \"\\\"--complement\\\"\"}",
+      "tool_version": "1.1.0",
+      "type": "tool",
+      "uuid": "74f84dac-988e-436e-80cf-e45720a1ca6d",
+      "workflow_outputs": []
+    },
+    "8": {
+      "annotation": "",
+      "content_id": "toolshed.g2.bx.psu.edu/repos/bgruening/text_processing/tp_cut_tool/1.1.0",
+      "errors": null,
+      "id": 8,
+      "input_connections": {
+        "input": {
+          "id": 4,
+          "output_name": "output"
+        }
+      },
+      "inputs": [
+        {
+          "description": "runtime parameter for tool Cut",
+          "name": "input"
+        }
+      ],
+      "label": null,
+      "name": "Cut",
+      "outputs": [
+        {
+          "name": "output",
+          "type": "tabular"
+        }
+      ],
+      "position": {
+        "left": 512.015625,
+        "top": 572.0859375
+      },
+      "post_job_actions": {},
+      "tool_id": "toolshed.g2.bx.psu.edu/repos/bgruening/text_processing/tp_cut_tool/1.1.0",
+      "tool_shed_repository": {
+        "changeset_revision": "74a8bef53a00",
+        "name": "text_processing",
+        "owner": "bgruening",
+        "tool_shed": "toolshed.g2.bx.psu.edu"
+      },
+      "tool_state": "{\"__page__\": null, \"__rerun_remap_job_id__\": null, \"cut_type_options\": \"{\\\"__current_case__\\\": 0, \\\"cut_element\\\": \\\"-f\\\", \\\"list\\\": \\\"1,2\\\"}\", \"delimiter\": \"\\\"\\\"\", \"input\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\", \"complement\": \"\\\"\\\"\"}",
+      "tool_version": "1.1.0",
+      "type": "tool",
+      "uuid": "e5c8206a-72d0-4faa-a19e-8d7ac0190316",
+      "workflow_outputs": []
+    },
+    "9": {
+      "annotation": "",
+      "content_id": "join1",
+      "errors": null,
+      "id": 9,
+      "input_connections": {
+        "input1": {
+          "id": 5,
+          "output_name": "out_file1"
+        },
+        "input2": {
+          "id": 0,
+          "output_name": "output"
+        }
+      },
+      "inputs": [
+        {
+          "description": "runtime parameter for tool Join two Datasets",
+          "name": "input2"
+        },
+        {
+          "description": "runtime parameter for tool Join two Datasets",
+          "name": "input1"
+        }
+      ],
+      "label": null,
+      "name": "Join two Datasets",
+      "outputs": [
+        {
+          "name": "out_file1",
+          "type": "input"
+        }
+      ],
+      "position": {
+        "left": 769.0546875,
+        "top": 199.9921875
+      },
+      "post_job_actions": {},
+      "tool_id": "join1",
+      "tool_state": "{\"input2\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\", \"__page__\": null, \"field1\": \"\\\"1\\\"\", \"partial\": \"\\\"\\\"\", \"field2\": \"\\\"1\\\"\", \"chromInfo\": \"\\\"/usr/local/galaxy/galaxy-dist/tool-data/shared/ucsc/chrom/mm10.len\\\"\", \"__rerun_remap_job_id__\": null, \"fill_empty_columns\": \"{\\\"__current_case__\\\": 0, \\\"fill_empty_columns_switch\\\": \\\"no_fill\\\"}\", \"unmatched\": \"\\\"\\\"\", \"header\": \"\\\"\\\"\", \"input1\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\", \"input1|__identifier__\": \"\\\"limma-voom_luminalpregnant-luminallactate\\\"\"}",
+      "tool_version": "2.1.1",
+      "type": "tool",
+      "uuid": "2f81fad6-b41c-4c4b-b803-51a5ccd1c047",
+      "workflow_outputs": []
+    }
+  },
+  "tags": [],
+  "uuid": "0a8ac077-a1ef-4b4d-b760-654972683023",
+  "version": 3
+}

--- a/topics/transcriptomics/tutorials/rna-seq-reads-to-counts/workflows/rna-seq-reads-to-counts.ga
+++ b/topics/transcriptomics/tutorials/rna-seq-reads-to-counts/workflows/rna-seq-reads-to-counts.ga
@@ -1,1 +1,760 @@
-{"uuid": "c8e27380-d910-4a43-a03c-8a1afaf63308", "tags": [], "format-version": "0.1", "name": "RNA-seq reads to counts", "version": 5, "steps": {"0": {"tool_id": null, "tool_version": null, "outputs": [], "workflow_outputs": [], "input_connections": {}, "tool_state": "{\"collection_type\": \"list\"}", "id": 0, "uuid": "015f389e-94eb-40f2-82c8-267093ca8c8a", "errors": null, "name": "Input dataset collection", "label": "Input FASTQs collection", "inputs": [], "position": {"top": 199.9921875, "left": 199.9921875}, "annotation": "", "content_id": null, "type": "data_collection_input"}, "1": {"tool_id": null, "tool_version": null, "outputs": [], "workflow_outputs": [], "input_connections": {}, "tool_state": "{}", "id": 1, "uuid": "dc707df4-3c9d-4d76-98a8-53b60cc2f41d", "errors": null, "name": "Input dataset", "label": "Input Reference gene BED", "inputs": [], "position": {"top": 290.015625, "left": 199.9921875}, "annotation": "", "content_id": null, "type": "data_input"}, "2": {"tool_id": "toolshed.g2.bx.psu.edu/repos/devteam/fastqc/fastqc/0.72", "tool_version": "0.72", "outputs": [{"type": "html", "name": "html_file"}, {"type": "txt", "name": "text_file"}], "workflow_outputs": [], "input_connections": {"input_file": {"output_name": "output", "id": 0}}, "tool_state": "{\"__page__\": null, \"contaminants\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\", \"__rerun_remap_job_id__\": null, \"limits\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\", \"input_file\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\"}", "id": 2, "tool_shed_repository": {"owner": "devteam", "changeset_revision": "c15237684a01", "name": "fastqc", "tool_shed": "toolshed.g2.bx.psu.edu"}, "uuid": "4be5eb40-0b92-4c09-9b08-20def5aec1cb", "errors": null, "name": "FastQC", "post_job_actions": {}, "label": "FastQC raw reads", "inputs": [{"name": "contaminants", "description": "runtime parameter for tool FastQC"}, {"name": "limits", "description": "runtime parameter for tool FastQC"}, {"name": "input_file", "description": "runtime parameter for tool FastQC"}], "position": {"top": 199.9921875, "left": 509.015625}, "annotation": "", "content_id": "toolshed.g2.bx.psu.edu/repos/devteam/fastqc/fastqc/0.72", "type": "tool"}, "3": {"tool_id": "toolshed.g2.bx.psu.edu/repos/lparsons/cutadapt/cutadapt/1.16.3", "tool_version": "1.16.3", "outputs": [{"type": "fastqsanger", "name": "out1"}, {"type": "fastqsanger", "name": "out2"}, {"type": "txt", "name": "report"}, {"type": "txt", "name": "info_file"}, {"type": "fastqsanger", "name": "rest_output"}, {"type": "txt", "name": "wild_output"}, {"type": "fastqsanger", "name": "untrimmed_output"}, {"type": "fastqsanger", "name": "untrimmed_paired_output"}, {"type": "fastqsanger", "name": "too_short_output"}, {"type": "fastqsanger", "name": "too_short_paired_output"}, {"type": "fastqsanger", "name": "too_long_output"}, {"type": "fastqsanger", "name": "too_long_paired_output"}], "workflow_outputs": [], "input_connections": {"library|input_1": {"output_name": "output", "id": 0}}, "tool_state": "{\"__page__\": null, \"output_options\": \"{\\\"info_file\\\": \\\"false\\\", \\\"report\\\": \\\"true\\\", \\\"rest_file\\\": \\\"false\\\", \\\"too_long_file\\\": \\\"false\\\", \\\"too_short_file\\\": \\\"false\\\", \\\"untrimmed_file\\\": \\\"false\\\", \\\"wildcard_file\\\": \\\"false\\\"}\", \"read_mod_options\": \"{\\\"length\\\": \\\"0\\\", \\\"length_tag\\\": \\\"\\\", \\\"nextseq_trim\\\": \\\"0\\\", \\\"prefix\\\": \\\"\\\", \\\"quality_cutoff\\\": \\\"20\\\", \\\"strip_suffix\\\": \\\"\\\", \\\"suffix\\\": \\\"\\\", \\\"trim_n\\\": \\\"false\\\"}\", \"adapter_options\": \"{\\\"count\\\": \\\"1\\\", \\\"error_rate\\\": \\\"0.1\\\", \\\"match_read_wildcards\\\": \\\"false\\\", \\\"no_indels\\\": \\\"false\\\", \\\"overlap\\\": \\\"3\\\"}\", \"library\": \"{\\\"__current_case__\\\": 0, \\\"input_1\\\": {\\\"__class__\\\": \\\"RuntimeValue\\\"}, \\\"r1\\\": {\\\"adapters\\\": [{\\\"__index__\\\": 0, \\\"adapter_source\\\": {\\\"__current_case__\\\": 0, \\\"adapter\\\": \\\"AGATCGGAAGAGCACACGTCTGAACTCCAGTCAC\\\", \\\"adapter_name\\\": \\\"Illumina\\\", \\\"adapter_source_list\\\": \\\"user\\\"}}], \\\"anywhere_adapters\\\": [], \\\"cut\\\": \\\"0\\\", \\\"front_adapters\\\": []}, \\\"type\\\": \\\"single\\\"}\", \"filter_options\": \"{\\\"discard\\\": \\\"false\\\", \\\"discard_untrimmed\\\": \\\"false\\\", \\\"mask_adapter\\\": \\\"false\\\", \\\"max\\\": \\\"0\\\", \\\"max_n\\\": \\\"\\\", \\\"min\\\": \\\"20\\\", \\\"no_trim\\\": \\\"false\\\", \\\"pair_filter\\\": \\\"any\\\"}\", \"__rerun_remap_job_id__\": null}", "id": 3, "tool_shed_repository": {"owner": "lparsons", "changeset_revision": "660cffd8d92a", "name": "cutadapt", "tool_shed": "toolshed.g2.bx.psu.edu"}, "uuid": "eb524a8e-9b04-4eff-8b81-fc3c3bde5172", "errors": null, "name": "Cutadapt", "post_job_actions": {}, "label": null, "inputs": [{"name": "library", "description": "runtime parameter for tool Cutadapt"}], "position": {"top": 455.015625, "left": 509.015625}, "annotation": "", "content_id": "toolshed.g2.bx.psu.edu/repos/lparsons/cutadapt/cutadapt/1.16.3", "type": "tool"}, "4": {"tool_id": "toolshed.g2.bx.psu.edu/repos/devteam/fastqc/fastqc/0.72", "tool_version": "0.72", "outputs": [{"type": "html", "name": "html_file"}, {"type": "txt", "name": "text_file"}], "workflow_outputs": [], "input_connections": {"input_file": {"output_name": "out1", "id": 3}}, "tool_state": "{\"__page__\": null, \"contaminants\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\", \"__rerun_remap_job_id__\": null, \"limits\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\", \"input_file\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\"}", "id": 4, "tool_shed_repository": {"owner": "devteam", "changeset_revision": "c15237684a01", "name": "fastqc", "tool_shed": "toolshed.g2.bx.psu.edu"}, "uuid": "17946143-af6c-478c-b901-467263d8f299", "errors": null, "name": "FastQC", "post_job_actions": {}, "label": "FastQC post QC", "inputs": [{"name": "contaminants", "description": "runtime parameter for tool FastQC"}, {"name": "limits", "description": "runtime parameter for tool FastQC"}, {"name": "input_file", "description": "runtime parameter for tool FastQC"}], "position": {"top": 199.9921875, "left": 838.0546875}, "annotation": "", "content_id": "toolshed.g2.bx.psu.edu/repos/devteam/fastqc/fastqc/0.72", "type": "tool"}, "5": {"tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/hisat2/hisat2/2.1.0+galaxy3", "tool_version": "2.1.0+galaxy3", "outputs": [{"type": "bam", "name": "output_alignments"}, {"type": "fastqsanger", "name": "output_unaligned_reads_l"}, {"type": "fastqsanger", "name": "output_aligned_reads_l"}, {"type": "fastqsanger", "name": "output_unaligned_reads_r"}, {"type": "fastqsanger", "name": "output_aligned_reads_r"}, {"type": "txt", "name": "summary_file"}], "workflow_outputs": [], "input_connections": {"library|input_1": {"output_name": "out1", "id": 3}}, "tool_state": "{\"adv\": \"{\\\"alignment_options\\\": {\\\"__current_case__\\\": 0, \\\"alignment_options_selector\\\": \\\"defaults\\\"}, \\\"input_options\\\": {\\\"__current_case__\\\": 0, \\\"input_options_selector\\\": \\\"defaults\\\"}, \\\"other_options\\\": {\\\"__current_case__\\\": 0, \\\"other_options_selector\\\": \\\"defaults\\\"}, \\\"output_options\\\": {\\\"__current_case__\\\": 0, \\\"output_options_selector\\\": \\\"defaults\\\"}, \\\"reporting_options\\\": {\\\"__current_case__\\\": 0, \\\"reporting_options_selector\\\": \\\"defaults\\\"}, \\\"scoring_options\\\": {\\\"__current_case__\\\": 0, \\\"scoring_options_selector\\\": \\\"defaults\\\"}, \\\"spliced_options\\\": {\\\"__current_case__\\\": 0, \\\"spliced_options_selector\\\": \\\"defaults\\\"}}\", \"__page__\": null, \"sum\": \"{\\\"new_summary\\\": \\\"true\\\", \\\"summary_file\\\": \\\"true\\\"}\", \"library\": \"{\\\"__current_case__\\\": 0, \\\"input_1\\\": {\\\"__class__\\\": \\\"RuntimeValue\\\"}, \\\"rna_strandness\\\": \\\"\\\", \\\"type\\\": \\\"single\\\"}\", \"reference_genome\": \"{\\\"__current_case__\\\": 0, \\\"index\\\": \\\"mm10\\\", \\\"source\\\": \\\"indexed\\\"}\", \"__rerun_remap_job_id__\": null}", "id": 5, "tool_shed_repository": {"owner": "iuc", "changeset_revision": "6daca6da3059", "name": "hisat2", "tool_shed": "toolshed.g2.bx.psu.edu"}, "uuid": "83ae9e2d-0342-4cf1-bc6d-f9d24220b556", "errors": null, "name": "HISAT2", "post_job_actions": {}, "label": null, "inputs": [{"name": "library", "description": "runtime parameter for tool HISAT2"}], "position": {"top": 455.015625, "left": 838.0546875}, "annotation": "", "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/hisat2/hisat2/2.1.0+galaxy3", "type": "tool"}, "6": {"tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/featurecounts/featurecounts/1.6.3", "tool_version": "1.6.3", "outputs": [{"type": "tabular", "name": "output_medium"}, {"type": "bam", "name": "output_bam"}, {"type": "tabular", "name": "output_short"}, {"type": "tabular", "name": "output_full"}, {"type": "tabular", "name": "output_summary"}, {"type": "tabular", "name": "output_feature_lengths"}, {"type": "tabular", "name": "output_jcounts"}], "workflow_outputs": [], "input_connections": {"alignment": {"output_name": "output_alignments", "id": 5}}, "tool_state": "{\"pe_parameters\": \"{\\\"exclude_chimerics\\\": \\\"true\\\", \\\"fragment_counting_enabled\\\": {\\\"__current_case__\\\": 1, \\\"fragment_counting\\\": \\\"\\\"}, \\\"only_both_ends\\\": \\\"false\\\"}\", \"strand_specificity\": \"\\\"0\\\"\", \"__page__\": null, \"__rerun_remap_job_id__\": null, \"format\": \"\\\"tabdel_short\\\"\", \"include_feature_length_file\": \"\\\"false\\\"\", \"anno\": \"{\\\"__current_case__\\\": 0, \\\"anno_select\\\": \\\"builtin\\\", \\\"bgenome\\\": \\\"mm10\\\"}\", \"extended_parameters\": \"{\\\"R\\\": \\\"false\\\", \\\"by_read_group\\\": \\\"false\\\", \\\"contribute_to_multiple_features\\\": \\\"false\\\", \\\"count_split_alignments_only\\\": \\\"false\\\", \\\"exon_exon_junction_read_counting_enabled\\\": {\\\"__current_case__\\\": 1, \\\"count_exon_exon_junction_reads\\\": \\\"false\\\"}, \\\"frac_overlap\\\": \\\"0\\\", \\\"frac_overlap_feature\\\": \\\"0\\\", \\\"gff_feature_attribute\\\": \\\"gene_id\\\", \\\"gff_feature_type\\\": \\\"exon\\\", \\\"ignore_dup\\\": \\\"false\\\", \\\"largest_overlap\\\": \\\"false\\\", \\\"long_reads\\\": \\\"false\\\", \\\"mapping_quality\\\": \\\"12\\\", \\\"min_overlap\\\": \\\"1\\\", \\\"multimapping_enabled\\\": {\\\"__current_case__\\\": 1, \\\"multimapping_counts\\\": \\\"\\\"}, \\\"primary\\\": \\\"false\\\", \\\"read_extension_3p\\\": \\\"0\\\", \\\"read_extension_5p\\\": \\\"0\\\", \\\"read_reduction\\\": \\\"\\\", \\\"summarization_level\\\": \\\"false\\\"}\", \"alignment\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\"}", "id": 6, "tool_shed_repository": {"owner": "iuc", "changeset_revision": "1759d845181e", "name": "featurecounts", "tool_shed": "toolshed.g2.bx.psu.edu"}, "uuid": "eff44c06-bf51-46f3-b2af-3f98695f67fe", "errors": null, "name": "featureCounts", "post_job_actions": {}, "label": null, "inputs": [{"name": "alignment", "description": "runtime parameter for tool featureCounts"}], "position": {"top": 199.9921875, "left": 1167.09375}, "annotation": "", "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/featurecounts/featurecounts/1.6.3", "type": "tool"}, "7": {"tool_id": "toolshed.g2.bx.psu.edu/repos/devteam/picard/picard_MarkDuplicates/2.18.2.1", "tool_version": "2.18.2.1", "outputs": [{"type": "txt", "name": "metrics_file"}, {"type": "bam", "name": "outFile"}], "workflow_outputs": [], "input_connections": {"inputFile": {"output_name": "output_alignments", "id": 5}}, "tool_state": "{\"duplicate_scoring_strategy\": \"\\\"SUM_OF_BASE_QUALITIES\\\"\", \"remove_duplicates\": \"\\\"false\\\"\", \"read_name_regex\": \"\\\"\\\"\", \"barcode_tag\": \"\\\"\\\"\", \"__page__\": null, \"__rerun_remap_job_id__\": null, \"optical_duplicate_pixel_distance\": \"\\\"100\\\"\", \"comments\": \"[]\", \"assume_sorted\": \"\\\"true\\\"\", \"validation_stringency\": \"\\\"LENIENT\\\"\", \"inputFile\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\"}", "id": 7, "tool_shed_repository": {"owner": "devteam", "changeset_revision": "2a17c789e0a5", "name": "picard", "tool_shed": "toolshed.g2.bx.psu.edu"}, "uuid": "d68e12ea-a68a-49b0-a4cd-736e4dbd2178", "errors": null, "name": "MarkDuplicates", "post_job_actions": {}, "label": null, "inputs": [{"name": "inputFile", "description": "runtime parameter for tool MarkDuplicates"}], "position": {"top": 536.015625, "left": 1167.09375}, "annotation": "", "content_id": "toolshed.g2.bx.psu.edu/repos/devteam/picard/picard_MarkDuplicates/2.18.2.1", "type": "tool"}, "8": {"tool_id": "toolshed.g2.bx.psu.edu/repos/devteam/samtools_idxstats/samtools_idxstats/2.0.2", "tool_version": "2.0.2", "outputs": [{"type": "tabular", "name": "output"}], "workflow_outputs": [], "input_connections": {"input": {"output_name": "output_alignments", "id": 5}}, "tool_state": "{\"input\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\", \"__rerun_remap_job_id__\": null, \"__page__\": null}", "id": 8, "tool_shed_repository": {"owner": "devteam", "changeset_revision": "04d5581db1f5", "name": "samtools_idxstats", "tool_shed": "toolshed.g2.bx.psu.edu"}, "uuid": "f645b890-43fc-4f67-ae9f-bb63622a035e", "errors": null, "name": "Samtools idxstats", "post_job_actions": {}, "label": null, "inputs": [{"name": "input", "description": "runtime parameter for tool Samtools idxstats"}], "position": {"top": 713.0390625, "left": 1167.09375}, "annotation": "", "content_id": "toolshed.g2.bx.psu.edu/repos/devteam/samtools_idxstats/samtools_idxstats/2.0.2", "type": "tool"}, "9": {"tool_id": "toolshed.g2.bx.psu.edu/repos/nilesh/rseqc/rseqc_geneBody_coverage/2.6.4.3", "tool_version": "2.6.4.3", "outputs": [{"type": "pdf", "name": "outputcurvespdf"}, {"type": "pdf", "name": "outputheatmappdf"}, {"type": "txt", "name": "outputr"}, {"type": "txt", "name": "outputtxt"}], "workflow_outputs": [], "input_connections": {"batch_mode|input": {"output_name": "output_alignments", "id": 5}, "refgene": {"output_name": "output", "id": 1}}, "tool_state": "{\"__page__\": null, \"rscript_output\": \"\\\"false\\\"\", \"__rerun_remap_job_id__\": null, \"refgene\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\", \"minimum_length\": \"\\\"100\\\"\", \"batch_mode\": \"{\\\"__current_case__\\\": 0, \\\"batch_mode_selector\\\": \\\"batch\\\", \\\"input\\\": {\\\"__class__\\\": \\\"RuntimeValue\\\"}}\"}", "id": 9, "tool_shed_repository": {"owner": "nilesh", "changeset_revision": "f437057e46f1", "name": "rseqc", "tool_shed": "toolshed.g2.bx.psu.edu"}, "uuid": "7bac41c4-89b2-4c63-b14c-bed6eefb9fec", "errors": null, "name": "Gene Body Coverage (BAM)", "post_job_actions": {}, "label": null, "inputs": [{"name": "batch_mode", "description": "runtime parameter for tool Gene Body Coverage (BAM)"}, {"name": "refgene", "description": "runtime parameter for tool Gene Body Coverage (BAM)"}], "position": {"top": 839.0859375, "left": 1167.09375}, "annotation": "", "content_id": "toolshed.g2.bx.psu.edu/repos/nilesh/rseqc/rseqc_geneBody_coverage/2.6.4.3", "type": "tool"}, "10": {"tool_id": "toolshed.g2.bx.psu.edu/repos/nilesh/rseqc/rseqc_infer_experiment/2.6.4.1", "tool_version": "2.6.4.1", "outputs": [{"type": "txt", "name": "output"}], "workflow_outputs": [], "input_connections": {"input": {"output_name": "output_alignments", "id": 5}, "refgene": {"output_name": "output", "id": 1}}, "tool_state": "{\"__page__\": null, \"__rerun_remap_job_id__\": null, \"refgene\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\", \"sample_size\": \"\\\"200000\\\"\", \"mapq\": \"\\\"30\\\"\", \"input\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\"}", "id": 10, "tool_shed_repository": {"owner": "nilesh", "changeset_revision": "f437057e46f1", "name": "rseqc", "tool_shed": "toolshed.g2.bx.psu.edu"}, "uuid": "371f0800-0c81-4d42-92b8-daff436dee6b", "errors": null, "name": "Infer Experiment", "post_job_actions": {}, "label": null, "inputs": [{"name": "input", "description": "runtime parameter for tool Infer Experiment"}, {"name": "refgene", "description": "runtime parameter for tool Infer Experiment"}], "position": {"top": 1089.1171875, "left": 1167.09375}, "annotation": "", "content_id": "toolshed.g2.bx.psu.edu/repos/nilesh/rseqc/rseqc_infer_experiment/2.6.4.1", "type": "tool"}, "11": {"tool_id": "toolshed.g2.bx.psu.edu/repos/nilesh/rseqc/rseqc_read_distribution/2.6.4.1", "tool_version": "2.6.4.1", "outputs": [{"type": "txt", "name": "output"}], "workflow_outputs": [], "input_connections": {"input": {"output_name": "output_alignments", "id": 5}, "refgene": {"output_name": "output", "id": 1}}, "tool_state": "{\"__page__\": null, \"input\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\", \"__rerun_remap_job_id__\": null, \"refgene\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\"}", "id": 11, "tool_shed_repository": {"owner": "nilesh", "changeset_revision": "f437057e46f1", "name": "rseqc", "tool_shed": "toolshed.g2.bx.psu.edu"}, "uuid": "06c7b174-9dab-4387-a0e0-238df01a58de", "errors": null, "name": "Read Distribution", "post_job_actions": {}, "label": null, "inputs": [{"name": "input", "description": "runtime parameter for tool Read Distribution"}, {"name": "refgene", "description": "runtime parameter for tool Read Distribution"}], "position": {"top": 1245.140625, "left": 1167.09375}, "annotation": "", "content_id": "toolshed.g2.bx.psu.edu/repos/nilesh/rseqc/rseqc_read_distribution/2.6.4.1", "type": "tool"}, "12": {"tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/collection_column_join/collection_column_join/0.0.3", "tool_version": "0.0.3", "outputs": [{"type": "tabular", "name": "tabular_output"}, {"type": "txt", "name": "script_output"}], "workflow_outputs": [], "input_connections": {"input_tabular": {"output_name": "output_short", "id": 6}}, "tool_state": "{\"__page__\": null, \"identifier_column\": \"\\\"1\\\"\", \"include_outputs\": \"null\", \"__rerun_remap_job_id__\": null, \"input_tabular\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\", \"fill_char\": \"\\\".\\\"\", \"old_col_in_header\": \"\\\"false\\\"\", \"has_header\": \"\\\"1\\\"\"}", "id": 12, "tool_shed_repository": {"owner": "iuc", "changeset_revision": "58228a4d58fe", "name": "collection_column_join", "tool_shed": "toolshed.g2.bx.psu.edu"}, "uuid": "dbfbf0d9-41a5-4431-b2c6-f14f0b798d85", "errors": null, "name": "Column Join", "post_job_actions": {}, "label": null, "inputs": [{"name": "input_tabular", "description": "runtime parameter for tool Column Join"}], "position": {"top": 199.9921875, "left": 1494.1171875}, "annotation": "", "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/collection_column_join/collection_column_join/0.0.3", "type": "tool"}, "13": {"tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/multiqc/multiqc/1.6", "tool_version": "1.6", "outputs": [{"type": "input", "name": "stats"}, {"type": "html", "name": "html_report"}, {"type": "txt", "name": "log"}], "workflow_outputs": [], "input_connections": {"results_4|software_cond|output_0|type|input": {"output_name": "output", "id": 8}, "results_3|software_cond|output_0|input": {"output_name": "metrics_file", "id": 7}, "results_2|software_cond|output_0|type|input": {"output_name": "output", "id": 10}, "results_7|software_cond|input": {"output_name": "output_summary", "id": 6}, "results_5|software_cond|output_0|type|input": {"output_name": "outputtxt", "id": 9}, "results_6|software_cond|output_0|type|input": {"output_name": "output", "id": 11}, "results_0|software_cond|output_0|input": {"output_name": "text_file", "id": 4}, "results_1|software_cond|input": {"output_name": "report", "id": 3}, "results_8|software_cond|input": {"output_name": "summary_file", "id": 5}}, "tool_state": "{\"comment\": \"\\\"\\\"\", \"__page__\": null, \"title\": \"\\\"Tutorial RNA-seq reads to counts\\\"\", \"__rerun_remap_job_id__\": null, \"results\": \"[{\\\"__index__\\\": 0, \\\"software_cond\\\": {\\\"__current_case__\\\": 8, \\\"output\\\": [{\\\"__index__\\\": 0, \\\"input\\\": {\\\"__class__\\\": \\\"RuntimeValue\\\"}, \\\"type\\\": \\\"data\\\"}], \\\"software\\\": \\\"fastqc\\\"}}, {\\\"__index__\\\": 1, \\\"software_cond\\\": {\\\"__current_case__\\\": 5, \\\"input\\\": {\\\"__class__\\\": \\\"RuntimeValue\\\"}, \\\"software\\\": \\\"cutadapt\\\"}}, {\\\"__index__\\\": 2, \\\"software_cond\\\": {\\\"__current_case__\\\": 20, \\\"output\\\": [{\\\"__index__\\\": 0, \\\"type\\\": {\\\"__current_case__\\\": 2, \\\"input\\\": {\\\"__class__\\\": \\\"RuntimeValue\\\"}, \\\"type\\\": \\\"infer_experiment\\\"}}], \\\"software\\\": \\\"rseqc\\\"}}, {\\\"__index__\\\": 3, \\\"software_cond\\\": {\\\"__current_case__\\\": 17, \\\"output\\\": [{\\\"__index__\\\": 0, \\\"input\\\": {\\\"__class__\\\": \\\"RuntimeValue\\\"}, \\\"type\\\": \\\"markdups\\\"}], \\\"software\\\": \\\"picard\\\"}}, {\\\"__index__\\\": 4, \\\"software_cond\\\": {\\\"__current_case__\\\": 22, \\\"output\\\": [{\\\"__index__\\\": 0, \\\"type\\\": {\\\"__current_case__\\\": 2, \\\"input\\\": {\\\"__class__\\\": \\\"RuntimeValue\\\"}, \\\"type\\\": \\\"idxstats\\\"}}], \\\"software\\\": \\\"samtools\\\"}}, {\\\"__index__\\\": 5, \\\"software_cond\\\": {\\\"__current_case__\\\": 20, \\\"output\\\": [{\\\"__index__\\\": 0, \\\"type\\\": {\\\"__current_case__\\\": 1, \\\"input\\\": {\\\"__class__\\\": \\\"RuntimeValue\\\"}, \\\"type\\\": \\\"gene_body_coverage\\\"}}], \\\"software\\\": \\\"rseqc\\\"}}, {\\\"__index__\\\": 6, \\\"software_cond\\\": {\\\"__current_case__\\\": 20, \\\"output\\\": [{\\\"__index__\\\": 0, \\\"type\\\": {\\\"__current_case__\\\": 6, \\\"input\\\": {\\\"__class__\\\": \\\"RuntimeValue\\\"}, \\\"type\\\": \\\"read_distribution\\\"}}], \\\"software\\\": \\\"rseqc\\\"}}, {\\\"__index__\\\": 7, \\\"software_cond\\\": {\\\"__current_case__\\\": 9, \\\"input\\\": {\\\"__class__\\\": \\\"RuntimeValue\\\"}, \\\"software\\\": \\\"featureCounts\\\"}}, {\\\"__index__\\\": 8, \\\"software_cond\\\": {\\\"__current_case__\\\": 13, \\\"input\\\": {\\\"__class__\\\": \\\"RuntimeValue\\\"}, \\\"software\\\": \\\"hisat2\\\"}}]\", \"saveLog\": \"\\\"false\\\"\"}", "id": 13, "tool_shed_repository": {"owner": "iuc", "changeset_revision": "1c2db0054039", "name": "multiqc", "tool_shed": "toolshed.g2.bx.psu.edu"}, "uuid": "26bd346f-763c-471e-ad08-13eee603758b", "errors": null, "name": "MultiQC", "post_job_actions": {}, "label": null, "inputs": [], "position": {"top": 350.015625, "left": 1494.1171875}, "annotation": "", "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/multiqc/multiqc/1.6", "type": "tool"}}, "annotation": "", "a_galaxy_workflow": "true"}
+{
+  "a_galaxy_workflow": "true",
+  "annotation": "",
+  "format-version": "0.1",
+  "name": "RNA-seq reads to counts",
+  "steps": {
+    "0": {
+      "annotation": "",
+      "content_id": null,
+      "errors": null,
+      "id": 0,
+      "input_connections": {},
+      "inputs": [],
+      "label": "Input FASTQs collection",
+      "name": "Input dataset collection",
+      "outputs": [],
+      "position": {
+        "left": 199.9921875,
+        "top": 199.9921875
+      },
+      "tool_id": null,
+      "tool_state": "{\"collection_type\": \"list\"}",
+      "tool_version": null,
+      "type": "data_collection_input",
+      "uuid": "015f389e-94eb-40f2-82c8-267093ca8c8a",
+      "workflow_outputs": []
+    },
+    "1": {
+      "annotation": "",
+      "content_id": null,
+      "errors": null,
+      "id": 1,
+      "input_connections": {},
+      "inputs": [],
+      "label": "Input Reference gene BED",
+      "name": "Input dataset",
+      "outputs": [],
+      "position": {
+        "left": 199.9921875,
+        "top": 290.015625
+      },
+      "tool_id": null,
+      "tool_state": "{}",
+      "tool_version": null,
+      "type": "data_input",
+      "uuid": "dc707df4-3c9d-4d76-98a8-53b60cc2f41d",
+      "workflow_outputs": []
+    },
+    "10": {
+      "annotation": "",
+      "content_id": "toolshed.g2.bx.psu.edu/repos/nilesh/rseqc/rseqc_infer_experiment/2.6.4.1",
+      "errors": null,
+      "id": 10,
+      "input_connections": {
+        "input": {
+          "id": 5,
+          "output_name": "output_alignments"
+        },
+        "refgene": {
+          "id": 1,
+          "output_name": "output"
+        }
+      },
+      "inputs": [
+        {
+          "description": "runtime parameter for tool Infer Experiment",
+          "name": "input"
+        },
+        {
+          "description": "runtime parameter for tool Infer Experiment",
+          "name": "refgene"
+        }
+      ],
+      "label": null,
+      "name": "Infer Experiment",
+      "outputs": [
+        {
+          "name": "output",
+          "type": "txt"
+        }
+      ],
+      "position": {
+        "left": 1167.09375,
+        "top": 1089.1171875
+      },
+      "post_job_actions": {},
+      "tool_id": "toolshed.g2.bx.psu.edu/repos/nilesh/rseqc/rseqc_infer_experiment/2.6.4.1",
+      "tool_shed_repository": {
+        "changeset_revision": "f437057e46f1",
+        "name": "rseqc",
+        "owner": "nilesh",
+        "tool_shed": "toolshed.g2.bx.psu.edu"
+      },
+      "tool_state": "{\"__page__\": null, \"__rerun_remap_job_id__\": null, \"refgene\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\", \"sample_size\": \"\\\"200000\\\"\", \"mapq\": \"\\\"30\\\"\", \"input\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\"}",
+      "tool_version": "2.6.4.1",
+      "type": "tool",
+      "uuid": "371f0800-0c81-4d42-92b8-daff436dee6b",
+      "workflow_outputs": []
+    },
+    "11": {
+      "annotation": "",
+      "content_id": "toolshed.g2.bx.psu.edu/repos/nilesh/rseqc/rseqc_read_distribution/2.6.4.1",
+      "errors": null,
+      "id": 11,
+      "input_connections": {
+        "input": {
+          "id": 5,
+          "output_name": "output_alignments"
+        },
+        "refgene": {
+          "id": 1,
+          "output_name": "output"
+        }
+      },
+      "inputs": [
+        {
+          "description": "runtime parameter for tool Read Distribution",
+          "name": "input"
+        },
+        {
+          "description": "runtime parameter for tool Read Distribution",
+          "name": "refgene"
+        }
+      ],
+      "label": null,
+      "name": "Read Distribution",
+      "outputs": [
+        {
+          "name": "output",
+          "type": "txt"
+        }
+      ],
+      "position": {
+        "left": 1167.09375,
+        "top": 1245.140625
+      },
+      "post_job_actions": {},
+      "tool_id": "toolshed.g2.bx.psu.edu/repos/nilesh/rseqc/rseqc_read_distribution/2.6.4.1",
+      "tool_shed_repository": {
+        "changeset_revision": "f437057e46f1",
+        "name": "rseqc",
+        "owner": "nilesh",
+        "tool_shed": "toolshed.g2.bx.psu.edu"
+      },
+      "tool_state": "{\"__page__\": null, \"input\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\", \"__rerun_remap_job_id__\": null, \"refgene\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\"}",
+      "tool_version": "2.6.4.1",
+      "type": "tool",
+      "uuid": "06c7b174-9dab-4387-a0e0-238df01a58de",
+      "workflow_outputs": []
+    },
+    "12": {
+      "annotation": "",
+      "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/collection_column_join/collection_column_join/0.0.3",
+      "errors": null,
+      "id": 12,
+      "input_connections": {
+        "input_tabular": {
+          "id": 6,
+          "output_name": "output_short"
+        }
+      },
+      "inputs": [
+        {
+          "description": "runtime parameter for tool Column Join",
+          "name": "input_tabular"
+        }
+      ],
+      "label": null,
+      "name": "Column Join",
+      "outputs": [
+        {
+          "name": "tabular_output",
+          "type": "tabular"
+        },
+        {
+          "name": "script_output",
+          "type": "txt"
+        }
+      ],
+      "position": {
+        "left": 1494.1171875,
+        "top": 199.9921875
+      },
+      "post_job_actions": {},
+      "tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/collection_column_join/collection_column_join/0.0.3",
+      "tool_shed_repository": {
+        "changeset_revision": "58228a4d58fe",
+        "name": "collection_column_join",
+        "owner": "iuc",
+        "tool_shed": "toolshed.g2.bx.psu.edu"
+      },
+      "tool_state": "{\"__page__\": null, \"identifier_column\": \"\\\"1\\\"\", \"include_outputs\": \"null\", \"__rerun_remap_job_id__\": null, \"input_tabular\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\", \"fill_char\": \"\\\".\\\"\", \"old_col_in_header\": \"\\\"false\\\"\", \"has_header\": \"\\\"1\\\"\"}",
+      "tool_version": "0.0.3",
+      "type": "tool",
+      "uuid": "dbfbf0d9-41a5-4431-b2c6-f14f0b798d85",
+      "workflow_outputs": []
+    },
+    "13": {
+      "annotation": "",
+      "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/multiqc/multiqc/1.6",
+      "errors": null,
+      "id": 13,
+      "input_connections": {
+        "results_0|software_cond|output_0|input": {
+          "id": 4,
+          "output_name": "text_file"
+        },
+        "results_1|software_cond|input": {
+          "id": 3,
+          "output_name": "report"
+        },
+        "results_2|software_cond|output_0|type|input": {
+          "id": 10,
+          "output_name": "output"
+        },
+        "results_3|software_cond|output_0|input": {
+          "id": 7,
+          "output_name": "metrics_file"
+        },
+        "results_4|software_cond|output_0|type|input": {
+          "id": 8,
+          "output_name": "output"
+        },
+        "results_5|software_cond|output_0|type|input": {
+          "id": 9,
+          "output_name": "outputtxt"
+        },
+        "results_6|software_cond|output_0|type|input": {
+          "id": 11,
+          "output_name": "output"
+        },
+        "results_7|software_cond|input": {
+          "id": 6,
+          "output_name": "output_summary"
+        },
+        "results_8|software_cond|input": {
+          "id": 5,
+          "output_name": "summary_file"
+        }
+      },
+      "inputs": [],
+      "label": null,
+      "name": "MultiQC",
+      "outputs": [
+        {
+          "name": "stats",
+          "type": "input"
+        },
+        {
+          "name": "html_report",
+          "type": "html"
+        },
+        {
+          "name": "log",
+          "type": "txt"
+        }
+      ],
+      "position": {
+        "left": 1494.1171875,
+        "top": 350.015625
+      },
+      "post_job_actions": {},
+      "tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/multiqc/multiqc/1.6",
+      "tool_shed_repository": {
+        "changeset_revision": "1c2db0054039",
+        "name": "multiqc",
+        "owner": "iuc",
+        "tool_shed": "toolshed.g2.bx.psu.edu"
+      },
+      "tool_state": "{\"comment\": \"\\\"\\\"\", \"__page__\": null, \"title\": \"\\\"Tutorial RNA-seq reads to counts\\\"\", \"__rerun_remap_job_id__\": null, \"results\": \"[{\\\"__index__\\\": 0, \\\"software_cond\\\": {\\\"__current_case__\\\": 8, \\\"output\\\": [{\\\"__index__\\\": 0, \\\"input\\\": {\\\"__class__\\\": \\\"RuntimeValue\\\"}, \\\"type\\\": \\\"data\\\"}], \\\"software\\\": \\\"fastqc\\\"}}, {\\\"__index__\\\": 1, \\\"software_cond\\\": {\\\"__current_case__\\\": 5, \\\"input\\\": {\\\"__class__\\\": \\\"RuntimeValue\\\"}, \\\"software\\\": \\\"cutadapt\\\"}}, {\\\"__index__\\\": 2, \\\"software_cond\\\": {\\\"__current_case__\\\": 20, \\\"output\\\": [{\\\"__index__\\\": 0, \\\"type\\\": {\\\"__current_case__\\\": 2, \\\"input\\\": {\\\"__class__\\\": \\\"RuntimeValue\\\"}, \\\"type\\\": \\\"infer_experiment\\\"}}], \\\"software\\\": \\\"rseqc\\\"}}, {\\\"__index__\\\": 3, \\\"software_cond\\\": {\\\"__current_case__\\\": 17, \\\"output\\\": [{\\\"__index__\\\": 0, \\\"input\\\": {\\\"__class__\\\": \\\"RuntimeValue\\\"}, \\\"type\\\": \\\"markdups\\\"}], \\\"software\\\": \\\"picard\\\"}}, {\\\"__index__\\\": 4, \\\"software_cond\\\": {\\\"__current_case__\\\": 22, \\\"output\\\": [{\\\"__index__\\\": 0, \\\"type\\\": {\\\"__current_case__\\\": 2, \\\"input\\\": {\\\"__class__\\\": \\\"RuntimeValue\\\"}, \\\"type\\\": \\\"idxstats\\\"}}], \\\"software\\\": \\\"samtools\\\"}}, {\\\"__index__\\\": 5, \\\"software_cond\\\": {\\\"__current_case__\\\": 20, \\\"output\\\": [{\\\"__index__\\\": 0, \\\"type\\\": {\\\"__current_case__\\\": 1, \\\"input\\\": {\\\"__class__\\\": \\\"RuntimeValue\\\"}, \\\"type\\\": \\\"gene_body_coverage\\\"}}], \\\"software\\\": \\\"rseqc\\\"}}, {\\\"__index__\\\": 6, \\\"software_cond\\\": {\\\"__current_case__\\\": 20, \\\"output\\\": [{\\\"__index__\\\": 0, \\\"type\\\": {\\\"__current_case__\\\": 6, \\\"input\\\": {\\\"__class__\\\": \\\"RuntimeValue\\\"}, \\\"type\\\": \\\"read_distribution\\\"}}], \\\"software\\\": \\\"rseqc\\\"}}, {\\\"__index__\\\": 7, \\\"software_cond\\\": {\\\"__current_case__\\\": 9, \\\"input\\\": {\\\"__class__\\\": \\\"RuntimeValue\\\"}, \\\"software\\\": \\\"featureCounts\\\"}}, {\\\"__index__\\\": 8, \\\"software_cond\\\": {\\\"__current_case__\\\": 13, \\\"input\\\": {\\\"__class__\\\": \\\"RuntimeValue\\\"}, \\\"software\\\": \\\"hisat2\\\"}}]\", \"saveLog\": \"\\\"false\\\"\"}",
+      "tool_version": "1.6",
+      "type": "tool",
+      "uuid": "26bd346f-763c-471e-ad08-13eee603758b",
+      "workflow_outputs": []
+    },
+    "2": {
+      "annotation": "",
+      "content_id": "toolshed.g2.bx.psu.edu/repos/devteam/fastqc/fastqc/0.72",
+      "errors": null,
+      "id": 2,
+      "input_connections": {
+        "input_file": {
+          "id": 0,
+          "output_name": "output"
+        }
+      },
+      "inputs": [
+        {
+          "description": "runtime parameter for tool FastQC",
+          "name": "contaminants"
+        },
+        {
+          "description": "runtime parameter for tool FastQC",
+          "name": "limits"
+        },
+        {
+          "description": "runtime parameter for tool FastQC",
+          "name": "input_file"
+        }
+      ],
+      "label": "FastQC raw reads",
+      "name": "FastQC",
+      "outputs": [
+        {
+          "name": "html_file",
+          "type": "html"
+        },
+        {
+          "name": "text_file",
+          "type": "txt"
+        }
+      ],
+      "position": {
+        "left": 509.015625,
+        "top": 199.9921875
+      },
+      "post_job_actions": {},
+      "tool_id": "toolshed.g2.bx.psu.edu/repos/devteam/fastqc/fastqc/0.72",
+      "tool_shed_repository": {
+        "changeset_revision": "c15237684a01",
+        "name": "fastqc",
+        "owner": "devteam",
+        "tool_shed": "toolshed.g2.bx.psu.edu"
+      },
+      "tool_state": "{\"__page__\": null, \"contaminants\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\", \"__rerun_remap_job_id__\": null, \"limits\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\", \"input_file\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\"}",
+      "tool_version": "0.72",
+      "type": "tool",
+      "uuid": "4be5eb40-0b92-4c09-9b08-20def5aec1cb",
+      "workflow_outputs": []
+    },
+    "3": {
+      "annotation": "",
+      "content_id": "toolshed.g2.bx.psu.edu/repos/lparsons/cutadapt/cutadapt/1.16.3",
+      "errors": null,
+      "id": 3,
+      "input_connections": {
+        "library|input_1": {
+          "id": 0,
+          "output_name": "output"
+        }
+      },
+      "inputs": [
+        {
+          "description": "runtime parameter for tool Cutadapt",
+          "name": "library"
+        }
+      ],
+      "label": null,
+      "name": "Cutadapt",
+      "outputs": [
+        {
+          "name": "out1",
+          "type": "fastqsanger"
+        },
+        {
+          "name": "out2",
+          "type": "fastqsanger"
+        },
+        {
+          "name": "report",
+          "type": "txt"
+        },
+        {
+          "name": "info_file",
+          "type": "txt"
+        },
+        {
+          "name": "rest_output",
+          "type": "fastqsanger"
+        },
+        {
+          "name": "wild_output",
+          "type": "txt"
+        },
+        {
+          "name": "untrimmed_output",
+          "type": "fastqsanger"
+        },
+        {
+          "name": "untrimmed_paired_output",
+          "type": "fastqsanger"
+        },
+        {
+          "name": "too_short_output",
+          "type": "fastqsanger"
+        },
+        {
+          "name": "too_short_paired_output",
+          "type": "fastqsanger"
+        },
+        {
+          "name": "too_long_output",
+          "type": "fastqsanger"
+        },
+        {
+          "name": "too_long_paired_output",
+          "type": "fastqsanger"
+        }
+      ],
+      "position": {
+        "left": 509.015625,
+        "top": 455.015625
+      },
+      "post_job_actions": {},
+      "tool_id": "toolshed.g2.bx.psu.edu/repos/lparsons/cutadapt/cutadapt/1.16.3",
+      "tool_shed_repository": {
+        "changeset_revision": "660cffd8d92a",
+        "name": "cutadapt",
+        "owner": "lparsons",
+        "tool_shed": "toolshed.g2.bx.psu.edu"
+      },
+      "tool_state": "{\"__page__\": null, \"output_options\": \"{\\\"info_file\\\": \\\"false\\\", \\\"report\\\": \\\"true\\\", \\\"rest_file\\\": \\\"false\\\", \\\"too_long_file\\\": \\\"false\\\", \\\"too_short_file\\\": \\\"false\\\", \\\"untrimmed_file\\\": \\\"false\\\", \\\"wildcard_file\\\": \\\"false\\\"}\", \"read_mod_options\": \"{\\\"length\\\": \\\"0\\\", \\\"length_tag\\\": \\\"\\\", \\\"nextseq_trim\\\": \\\"0\\\", \\\"prefix\\\": \\\"\\\", \\\"quality_cutoff\\\": \\\"20\\\", \\\"strip_suffix\\\": \\\"\\\", \\\"suffix\\\": \\\"\\\", \\\"trim_n\\\": \\\"false\\\"}\", \"adapter_options\": \"{\\\"count\\\": \\\"1\\\", \\\"error_rate\\\": \\\"0.1\\\", \\\"match_read_wildcards\\\": \\\"false\\\", \\\"no_indels\\\": \\\"false\\\", \\\"overlap\\\": \\\"3\\\"}\", \"library\": \"{\\\"__current_case__\\\": 0, \\\"input_1\\\": {\\\"__class__\\\": \\\"RuntimeValue\\\"}, \\\"r1\\\": {\\\"adapters\\\": [{\\\"__index__\\\": 0, \\\"adapter_source\\\": {\\\"__current_case__\\\": 0, \\\"adapter\\\": \\\"AGATCGGAAGAGCACACGTCTGAACTCCAGTCAC\\\", \\\"adapter_name\\\": \\\"Illumina\\\", \\\"adapter_source_list\\\": \\\"user\\\"}}], \\\"anywhere_adapters\\\": [], \\\"cut\\\": \\\"0\\\", \\\"front_adapters\\\": []}, \\\"type\\\": \\\"single\\\"}\", \"filter_options\": \"{\\\"discard\\\": \\\"false\\\", \\\"discard_untrimmed\\\": \\\"false\\\", \\\"mask_adapter\\\": \\\"false\\\", \\\"max\\\": \\\"0\\\", \\\"max_n\\\": \\\"\\\", \\\"min\\\": \\\"20\\\", \\\"no_trim\\\": \\\"false\\\", \\\"pair_filter\\\": \\\"any\\\"}\", \"__rerun_remap_job_id__\": null}",
+      "tool_version": "1.16.3",
+      "type": "tool",
+      "uuid": "eb524a8e-9b04-4eff-8b81-fc3c3bde5172",
+      "workflow_outputs": []
+    },
+    "4": {
+      "annotation": "",
+      "content_id": "toolshed.g2.bx.psu.edu/repos/devteam/fastqc/fastqc/0.72",
+      "errors": null,
+      "id": 4,
+      "input_connections": {
+        "input_file": {
+          "id": 3,
+          "output_name": "out1"
+        }
+      },
+      "inputs": [
+        {
+          "description": "runtime parameter for tool FastQC",
+          "name": "contaminants"
+        },
+        {
+          "description": "runtime parameter for tool FastQC",
+          "name": "limits"
+        },
+        {
+          "description": "runtime parameter for tool FastQC",
+          "name": "input_file"
+        }
+      ],
+      "label": "FastQC post QC",
+      "name": "FastQC",
+      "outputs": [
+        {
+          "name": "html_file",
+          "type": "html"
+        },
+        {
+          "name": "text_file",
+          "type": "txt"
+        }
+      ],
+      "position": {
+        "left": 838.0546875,
+        "top": 199.9921875
+      },
+      "post_job_actions": {},
+      "tool_id": "toolshed.g2.bx.psu.edu/repos/devteam/fastqc/fastqc/0.72",
+      "tool_shed_repository": {
+        "changeset_revision": "c15237684a01",
+        "name": "fastqc",
+        "owner": "devteam",
+        "tool_shed": "toolshed.g2.bx.psu.edu"
+      },
+      "tool_state": "{\"__page__\": null, \"contaminants\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\", \"__rerun_remap_job_id__\": null, \"limits\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\", \"input_file\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\"}",
+      "tool_version": "0.72",
+      "type": "tool",
+      "uuid": "17946143-af6c-478c-b901-467263d8f299",
+      "workflow_outputs": []
+    },
+    "5": {
+      "annotation": "",
+      "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/hisat2/hisat2/2.1.0+galaxy3",
+      "errors": null,
+      "id": 5,
+      "input_connections": {
+        "library|input_1": {
+          "id": 3,
+          "output_name": "out1"
+        }
+      },
+      "inputs": [
+        {
+          "description": "runtime parameter for tool HISAT2",
+          "name": "library"
+        }
+      ],
+      "label": null,
+      "name": "HISAT2",
+      "outputs": [
+        {
+          "name": "output_alignments",
+          "type": "bam"
+        },
+        {
+          "name": "output_unaligned_reads_l",
+          "type": "fastqsanger"
+        },
+        {
+          "name": "output_aligned_reads_l",
+          "type": "fastqsanger"
+        },
+        {
+          "name": "output_unaligned_reads_r",
+          "type": "fastqsanger"
+        },
+        {
+          "name": "output_aligned_reads_r",
+          "type": "fastqsanger"
+        },
+        {
+          "name": "summary_file",
+          "type": "txt"
+        }
+      ],
+      "position": {
+        "left": 838.0546875,
+        "top": 455.015625
+      },
+      "post_job_actions": {},
+      "tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/hisat2/hisat2/2.1.0+galaxy3",
+      "tool_shed_repository": {
+        "changeset_revision": "6daca6da3059",
+        "name": "hisat2",
+        "owner": "iuc",
+        "tool_shed": "toolshed.g2.bx.psu.edu"
+      },
+      "tool_state": "{\"adv\": \"{\\\"alignment_options\\\": {\\\"__current_case__\\\": 0, \\\"alignment_options_selector\\\": \\\"defaults\\\"}, \\\"input_options\\\": {\\\"__current_case__\\\": 0, \\\"input_options_selector\\\": \\\"defaults\\\"}, \\\"other_options\\\": {\\\"__current_case__\\\": 0, \\\"other_options_selector\\\": \\\"defaults\\\"}, \\\"output_options\\\": {\\\"__current_case__\\\": 0, \\\"output_options_selector\\\": \\\"defaults\\\"}, \\\"reporting_options\\\": {\\\"__current_case__\\\": 0, \\\"reporting_options_selector\\\": \\\"defaults\\\"}, \\\"scoring_options\\\": {\\\"__current_case__\\\": 0, \\\"scoring_options_selector\\\": \\\"defaults\\\"}, \\\"spliced_options\\\": {\\\"__current_case__\\\": 0, \\\"spliced_options_selector\\\": \\\"defaults\\\"}}\", \"__page__\": null, \"sum\": \"{\\\"new_summary\\\": \\\"true\\\", \\\"summary_file\\\": \\\"true\\\"}\", \"library\": \"{\\\"__current_case__\\\": 0, \\\"input_1\\\": {\\\"__class__\\\": \\\"RuntimeValue\\\"}, \\\"rna_strandness\\\": \\\"\\\", \\\"type\\\": \\\"single\\\"}\", \"reference_genome\": \"{\\\"__current_case__\\\": 0, \\\"index\\\": \\\"mm10\\\", \\\"source\\\": \\\"indexed\\\"}\", \"__rerun_remap_job_id__\": null}",
+      "tool_version": "2.1.0+galaxy3",
+      "type": "tool",
+      "uuid": "83ae9e2d-0342-4cf1-bc6d-f9d24220b556",
+      "workflow_outputs": []
+    },
+    "6": {
+      "annotation": "",
+      "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/featurecounts/featurecounts/1.6.3",
+      "errors": null,
+      "id": 6,
+      "input_connections": {
+        "alignment": {
+          "id": 5,
+          "output_name": "output_alignments"
+        }
+      },
+      "inputs": [
+        {
+          "description": "runtime parameter for tool featureCounts",
+          "name": "alignment"
+        }
+      ],
+      "label": null,
+      "name": "featureCounts",
+      "outputs": [
+        {
+          "name": "output_medium",
+          "type": "tabular"
+        },
+        {
+          "name": "output_bam",
+          "type": "bam"
+        },
+        {
+          "name": "output_short",
+          "type": "tabular"
+        },
+        {
+          "name": "output_full",
+          "type": "tabular"
+        },
+        {
+          "name": "output_summary",
+          "type": "tabular"
+        },
+        {
+          "name": "output_feature_lengths",
+          "type": "tabular"
+        },
+        {
+          "name": "output_jcounts",
+          "type": "tabular"
+        }
+      ],
+      "position": {
+        "left": 1167.09375,
+        "top": 199.9921875
+      },
+      "post_job_actions": {},
+      "tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/featurecounts/featurecounts/1.6.3",
+      "tool_shed_repository": {
+        "changeset_revision": "1759d845181e",
+        "name": "featurecounts",
+        "owner": "iuc",
+        "tool_shed": "toolshed.g2.bx.psu.edu"
+      },
+      "tool_state": "{\"pe_parameters\": \"{\\\"exclude_chimerics\\\": \\\"true\\\", \\\"fragment_counting_enabled\\\": {\\\"__current_case__\\\": 1, \\\"fragment_counting\\\": \\\"\\\"}, \\\"only_both_ends\\\": \\\"false\\\"}\", \"strand_specificity\": \"\\\"0\\\"\", \"__page__\": null, \"__rerun_remap_job_id__\": null, \"format\": \"\\\"tabdel_short\\\"\", \"include_feature_length_file\": \"\\\"false\\\"\", \"anno\": \"{\\\"__current_case__\\\": 0, \\\"anno_select\\\": \\\"builtin\\\", \\\"bgenome\\\": \\\"mm10\\\"}\", \"extended_parameters\": \"{\\\"R\\\": \\\"false\\\", \\\"by_read_group\\\": \\\"false\\\", \\\"contribute_to_multiple_features\\\": \\\"false\\\", \\\"count_split_alignments_only\\\": \\\"false\\\", \\\"exon_exon_junction_read_counting_enabled\\\": {\\\"__current_case__\\\": 1, \\\"count_exon_exon_junction_reads\\\": \\\"false\\\"}, \\\"frac_overlap\\\": \\\"0\\\", \\\"frac_overlap_feature\\\": \\\"0\\\", \\\"gff_feature_attribute\\\": \\\"gene_id\\\", \\\"gff_feature_type\\\": \\\"exon\\\", \\\"ignore_dup\\\": \\\"false\\\", \\\"largest_overlap\\\": \\\"false\\\", \\\"long_reads\\\": \\\"false\\\", \\\"mapping_quality\\\": \\\"12\\\", \\\"min_overlap\\\": \\\"1\\\", \\\"multimapping_enabled\\\": {\\\"__current_case__\\\": 1, \\\"multimapping_counts\\\": \\\"\\\"}, \\\"primary\\\": \\\"false\\\", \\\"read_extension_3p\\\": \\\"0\\\", \\\"read_extension_5p\\\": \\\"0\\\", \\\"read_reduction\\\": \\\"\\\", \\\"summarization_level\\\": \\\"false\\\"}\", \"alignment\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\"}",
+      "tool_version": "1.6.3",
+      "type": "tool",
+      "uuid": "eff44c06-bf51-46f3-b2af-3f98695f67fe",
+      "workflow_outputs": []
+    },
+    "7": {
+      "annotation": "",
+      "content_id": "toolshed.g2.bx.psu.edu/repos/devteam/picard/picard_MarkDuplicates/2.18.2.1",
+      "errors": null,
+      "id": 7,
+      "input_connections": {
+        "inputFile": {
+          "id": 5,
+          "output_name": "output_alignments"
+        }
+      },
+      "inputs": [
+        {
+          "description": "runtime parameter for tool MarkDuplicates",
+          "name": "inputFile"
+        }
+      ],
+      "label": null,
+      "name": "MarkDuplicates",
+      "outputs": [
+        {
+          "name": "metrics_file",
+          "type": "txt"
+        },
+        {
+          "name": "outFile",
+          "type": "bam"
+        }
+      ],
+      "position": {
+        "left": 1167.09375,
+        "top": 536.015625
+      },
+      "post_job_actions": {},
+      "tool_id": "toolshed.g2.bx.psu.edu/repos/devteam/picard/picard_MarkDuplicates/2.18.2.1",
+      "tool_shed_repository": {
+        "changeset_revision": "2a17c789e0a5",
+        "name": "picard",
+        "owner": "devteam",
+        "tool_shed": "toolshed.g2.bx.psu.edu"
+      },
+      "tool_state": "{\"duplicate_scoring_strategy\": \"\\\"SUM_OF_BASE_QUALITIES\\\"\", \"remove_duplicates\": \"\\\"false\\\"\", \"read_name_regex\": \"\\\"\\\"\", \"barcode_tag\": \"\\\"\\\"\", \"__page__\": null, \"__rerun_remap_job_id__\": null, \"optical_duplicate_pixel_distance\": \"\\\"100\\\"\", \"comments\": \"[]\", \"assume_sorted\": \"\\\"true\\\"\", \"validation_stringency\": \"\\\"LENIENT\\\"\", \"inputFile\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\"}",
+      "tool_version": "2.18.2.1",
+      "type": "tool",
+      "uuid": "d68e12ea-a68a-49b0-a4cd-736e4dbd2178",
+      "workflow_outputs": []
+    },
+    "8": {
+      "annotation": "",
+      "content_id": "toolshed.g2.bx.psu.edu/repos/devteam/samtools_idxstats/samtools_idxstats/2.0.2",
+      "errors": null,
+      "id": 8,
+      "input_connections": {
+        "input": {
+          "id": 5,
+          "output_name": "output_alignments"
+        }
+      },
+      "inputs": [
+        {
+          "description": "runtime parameter for tool Samtools idxstats",
+          "name": "input"
+        }
+      ],
+      "label": null,
+      "name": "Samtools idxstats",
+      "outputs": [
+        {
+          "name": "output",
+          "type": "tabular"
+        }
+      ],
+      "position": {
+        "left": 1167.09375,
+        "top": 713.0390625
+      },
+      "post_job_actions": {},
+      "tool_id": "toolshed.g2.bx.psu.edu/repos/devteam/samtools_idxstats/samtools_idxstats/2.0.2",
+      "tool_shed_repository": {
+        "changeset_revision": "04d5581db1f5",
+        "name": "samtools_idxstats",
+        "owner": "devteam",
+        "tool_shed": "toolshed.g2.bx.psu.edu"
+      },
+      "tool_state": "{\"input\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\", \"__rerun_remap_job_id__\": null, \"__page__\": null}",
+      "tool_version": "2.0.2",
+      "type": "tool",
+      "uuid": "f645b890-43fc-4f67-ae9f-bb63622a035e",
+      "workflow_outputs": []
+    },
+    "9": {
+      "annotation": "",
+      "content_id": "toolshed.g2.bx.psu.edu/repos/nilesh/rseqc/rseqc_geneBody_coverage/2.6.4.3",
+      "errors": null,
+      "id": 9,
+      "input_connections": {
+        "batch_mode|input": {
+          "id": 5,
+          "output_name": "output_alignments"
+        },
+        "refgene": {
+          "id": 1,
+          "output_name": "output"
+        }
+      },
+      "inputs": [
+        {
+          "description": "runtime parameter for tool Gene Body Coverage (BAM)",
+          "name": "batch_mode"
+        },
+        {
+          "description": "runtime parameter for tool Gene Body Coverage (BAM)",
+          "name": "refgene"
+        }
+      ],
+      "label": null,
+      "name": "Gene Body Coverage (BAM)",
+      "outputs": [
+        {
+          "name": "outputcurvespdf",
+          "type": "pdf"
+        },
+        {
+          "name": "outputheatmappdf",
+          "type": "pdf"
+        },
+        {
+          "name": "outputr",
+          "type": "txt"
+        },
+        {
+          "name": "outputtxt",
+          "type": "txt"
+        }
+      ],
+      "position": {
+        "left": 1167.09375,
+        "top": 839.0859375
+      },
+      "post_job_actions": {},
+      "tool_id": "toolshed.g2.bx.psu.edu/repos/nilesh/rseqc/rseqc_geneBody_coverage/2.6.4.3",
+      "tool_shed_repository": {
+        "changeset_revision": "f437057e46f1",
+        "name": "rseqc",
+        "owner": "nilesh",
+        "tool_shed": "toolshed.g2.bx.psu.edu"
+      },
+      "tool_state": "{\"__page__\": null, \"rscript_output\": \"\\\"false\\\"\", \"__rerun_remap_job_id__\": null, \"refgene\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\", \"minimum_length\": \"\\\"100\\\"\", \"batch_mode\": \"{\\\"__current_case__\\\": 0, \\\"batch_mode_selector\\\": \\\"batch\\\", \\\"input\\\": {\\\"__class__\\\": \\\"RuntimeValue\\\"}}\"}",
+      "tool_version": "2.6.4.3",
+      "type": "tool",
+      "uuid": "7bac41c4-89b2-4c63-b14c-bed6eefb9fec",
+      "workflow_outputs": []
+    }
+  },
+  "tags": [],
+  "uuid": "c8e27380-d910-4a43-a03c-8a1afaf63308",
+  "version": 5
+}

--- a/topics/transcriptomics/tutorials/scrna-raceid/workflows/main_workflow.ga
+++ b/topics/transcriptomics/tutorials/scrna-raceid/workflows/main_workflow.ga
@@ -1,1 +1,455 @@
-{"a_galaxy_workflow": "true", "uuid": "555a5f76-4828-4058-8f1a-e0e0c9d27dc1", "tags": [], "format-version": "0.1", "version": 0, "steps": {"1": {"tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/raceid_filtnormconf/raceid_filtnormconf/3.0.2.1", "errors": null, "uuid": "e82e0f74-ca4f-48e9-9a79-a5b09b63512c", "tool_version": "3.0.2.1", "outputs": [{"type": "pdf", "name": "outpdf"}, {"type": "rdata", "name": "outrdat"}, {"type": "txt", "name": "outlog"}], "post_job_actions": {}, "workflow_outputs": [{"output_name": "outlog", "uuid": "5f4e6e0c-42c8-42c0-b5b4-69efe4222886", "label": "filterlog"}], "annotation": "", "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/raceid_filtnormconf/raceid_filtnormconf/3.0.2.1", "input_connections": {"intable": {"output_name": "output", "id": 0}}, "inputs": [{"name": "intable", "description": "runtime parameter for tool Filtering, Normalisation, and Confounder Removal using RaceID"}], "position": {"top": 332, "left": 200.5}, "tool_state": "{\"__page__\": null, \"__rerun_remap_job_id__\": null, \"intable\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\", \"filt\": \"{\\\"minexpr\\\": \\\"5\\\", \\\"minnumber\\\": \\\"5\\\", \\\"mintotal\\\": \\\"3000\\\", \\\"use\\\": {\\\"__current_case__\\\": 0, \\\"def\\\": \\\"yes\\\"}}\"}", "label": "Filtering, Normalisation, and Confounder Removal", "type": "tool", "id": 1, "tool_shed_repository": {"owner": "iuc", "changeset_revision": "8dc8ff057b0f", "name": "raceid_filtnormconf", "tool_shed": "toolshed.g2.bx.psu.edu"}, "name": "Filtering, Normalisation, and Confounder Removal using RaceID"}, "0": {"tool_id": null, "errors": null, "uuid": "7145fffc-b2d4-4661-8da8-0ce70cd874a7", "tool_version": null, "outputs": [], "workflow_outputs": [], "annotation": "", "content_id": null, "input_connections": {}, "inputs": [], "position": {"top": 233, "left": 215}, "tool_state": "{}", "label": "count_matrix", "type": "data_input", "id": 0, "name": "Input dataset"}, "3": {"tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/raceid_inspectclusters/raceid_inspectclusters/3.0.2.1", "errors": null, "uuid": "ee9b5cb1-dd43-48ec-982e-61d2893ec5d5", "tool_version": "3.0.2.1", "outputs": [{"type": "pdf", "name": "outpdf"}, {"type": "txt", "name": "outlog"}], "post_job_actions": {}, "workflow_outputs": [], "annotation": "", "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/raceid_inspectclusters/raceid_inspectclusters/3.0.2.1", "input_connections": {"inputrds": {"output_name": "outrdat", "id": 2}}, "inputs": [{"name": "inputrds", "description": "runtime parameter for tool Cluster Inspection using RaceID"}], "position": {"top": 246, "left": 740}, "tool_state": "{\"__page__\": null, \"gois\": \"{\\\"__current_case__\\\": 0, \\\"do_opt\\\": \\\"no\\\"}\", \"diffgtest\": \"{\\\"__current_case__\\\": 0, \\\"do_opt\\\": \\\"no\\\"}\", \"__rerun_remap_job_id__\": null, \"plotsym\": \"{\\\"__current_case__\\\": 0, \\\"do_opt\\\": \\\"no\\\"}\", \"inputrds\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\", \"plotgen\": \"{\\\"__current_case__\\\": 1, \\\"do_opt\\\": \\\"yes\\\"}\"}", "label": "Cluster Insp. (All Clusters)", "type": "tool", "id": 3, "tool_shed_repository": {"owner": "iuc", "changeset_revision": "9fec5dd8fbb9", "name": "raceid_inspectclusters", "tool_shed": "toolshed.g2.bx.psu.edu"}, "name": "Cluster Inspection using RaceID"}, "2": {"tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/raceid_clustering/raceid_clustering/3.0.2.1", "errors": null, "uuid": "1e2cdc00-219a-421c-9b2c-76da52d4f6c6", "tool_version": "3.0.2.1", "outputs": [{"type": "pdf", "name": "outpdf"}, {"type": "rdata", "name": "outrdat"}, {"type": "tabular", "name": "outgenelist"}, {"type": "txt", "name": "outlog"}], "post_job_actions": {}, "workflow_outputs": [{"output_name": "outlog", "uuid": "6f0b7aa8-dd05-414c-9b81-b2b26c181bc5", "label": "clustering_log"}, {"output_name": "outgenelist", "uuid": "619c2479-4e9f-4fef-85ed-ed4b27c4a78d", "label": "clustering_genelist"}], "annotation": "", "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/raceid_clustering/raceid_clustering/3.0.2.1", "input_connections": {"inputrds": {"output_name": "outrdat", "id": 1}}, "inputs": [{"name": "inputrds", "description": "runtime parameter for tool Clustering using RaceID"}], "position": {"top": 526, "left": 322}, "tool_state": "{\"__page__\": null, \"clust\": \"{\\\"funcluster\\\": \\\"kmedoids\\\", \\\"metric\\\": \\\"pearson\\\", \\\"use\\\": {\\\"__current_case__\\\": 0, \\\"def\\\": \\\"yes\\\"}}\", \"extra\": \"{\\\"foldchange\\\": \\\"1.0\\\", \\\"plotlim\\\": \\\"10\\\", \\\"pvalue\\\": \\\"0.01\\\", \\\"tablelim\\\": \\\"25\\\"}\", \"tsne\": \"{\\\"knn\\\": \\\"10\\\", \\\"perplexity\\\": \\\"30\\\", \\\"use\\\": {\\\"__current_case__\\\": 0, \\\"def\\\": \\\"yes\\\"}}\", \"__rerun_remap_job_id__\": null, \"outlier\": \"{\\\"final\\\": \\\"false\\\", \\\"outlg\\\": \\\"2\\\", \\\"outminc\\\": \\\"5\\\", \\\"use\\\": {\\\"__current_case__\\\": 0, \\\"def\\\": \\\"yes\\\"}}\", \"inputrds\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\"}", "label": "Computing Clusters", "type": "tool", "id": 2, "tool_shed_repository": {"owner": "iuc", "changeset_revision": "4ea021bd7513", "name": "raceid_clustering", "tool_shed": "toolshed.g2.bx.psu.edu"}, "name": "Clustering using RaceID"}, "5": {"tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/raceid_inspectclusters/raceid_inspectclusters/3.0.2.1", "errors": null, "uuid": "a057c85c-1b79-47d4-8e6b-82a9e3772a64", "tool_version": "3.0.2.1", "outputs": [{"type": "pdf", "name": "outpdf"}, {"type": "txt", "name": "outlog"}], "post_job_actions": {}, "workflow_outputs": [], "annotation": "", "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/raceid_inspectclusters/raceid_inspectclusters/3.0.2.1", "input_connections": {"inputrds": {"output_name": "outrdat", "id": 2}}, "inputs": [{"name": "inputrds", "description": "runtime parameter for tool Cluster Inspection using RaceID"}], "position": {"top": 504, "left": 738}, "tool_state": "{\"__page__\": null, \"gois\": \"{\\\"__current_case__\\\": 1, \\\"do_opt\\\": \\\"yes\\\", \\\"inspect_goi_cells\\\": \\\"\\\", \\\"inspect_goi_genes\\\": \\\"Ptma,Rps2\\\", \\\"use\\\": {\\\"__current_case__\\\": 0, \\\"def\\\": \\\"yes\\\"}}\", \"diffgtest\": \"{\\\"__current_case__\\\": 0, \\\"do_opt\\\": \\\"no\\\"}\", \"__rerun_remap_job_id__\": null, \"plotsym\": \"{\\\"__current_case__\\\": 0, \\\"do_opt\\\": \\\"no\\\"}\", \"inputrds\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\", \"plotgen\": \"{\\\"__current_case__\\\": 0, \\\"do_opt\\\": \\\"no\\\"}\"}", "label": "Cluster Insp. (GOI)", "type": "tool", "id": 5, "tool_shed_repository": {"owner": "iuc", "changeset_revision": "9fec5dd8fbb9", "name": "raceid_inspectclusters", "tool_shed": "toolshed.g2.bx.psu.edu"}, "name": "Cluster Inspection using RaceID"}, "4": {"tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/raceid_inspectclusters/raceid_inspectclusters/3.0.2.1", "errors": null, "uuid": "8678cbea-7a6a-445e-95ec-9afeabce6a1d", "tool_version": "3.0.2.1", "outputs": [{"type": "pdf", "name": "outpdf"}, {"type": "txt", "name": "outlog"}], "post_job_actions": {}, "workflow_outputs": [], "annotation": "", "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/raceid_inspectclusters/raceid_inspectclusters/3.0.2.1", "input_connections": {"inputrds": {"output_name": "outrdat", "id": 2}}, "inputs": [{"name": "inputrds", "description": "runtime parameter for tool Cluster Inspection using RaceID"}], "position": {"top": 372, "left": 741}, "tool_state": "{\"__page__\": null, \"gois\": \"{\\\"__current_case__\\\": 0, \\\"do_opt\\\": \\\"no\\\"}\", \"diffgtest\": \"{\\\"__current_case__\\\": 1, \\\"do_opt\\\": \\\"yes\\\", \\\"set_a\\\": {\\\"meth\\\": {\\\"__current_case__\\\": 0, \\\"selector\\\": \\\"1\\\", \\\"type\\\": \\\"cln\\\"}, \\\"name_set\\\": \\\"Cells in 1\\\"}, \\\"set_b\\\": {\\\"meth\\\": {\\\"__current_case__\\\": 0, \\\"selector\\\": \\\"3\\\", \\\"type\\\": \\\"cln\\\"}, \\\"name_set\\\": \\\"Cells in 3\\\"}, \\\"use\\\": {\\\"__current_case__\\\": 0, \\\"def\\\": \\\"yes\\\"}}\", \"__rerun_remap_job_id__\": null, \"plotsym\": \"{\\\"__current_case__\\\": 0, \\\"do_opt\\\": \\\"no\\\"}\", \"inputrds\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\", \"plotgen\": \"{\\\"__current_case__\\\": 0, \\\"do_opt\\\": \\\"no\\\"}\"}", "label": "Cluster Insp. (Diff Gene)", "type": "tool", "id": 4, "tool_shed_repository": {"owner": "iuc", "changeset_revision": "9fec5dd8fbb9", "name": "raceid_inspectclusters", "tool_shed": "toolshed.g2.bx.psu.edu"}, "name": "Cluster Inspection using RaceID"}, "7": {"tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/raceid_inspecttrajectory/raceid_inspecttrajectory/3.0.2.1", "errors": null, "uuid": "bc0f0c22-dbfc-4a6c-925d-2416228bedde", "tool_version": "3.0.2.1", "outputs": [{"type": "pdf", "name": "outpdf"}, {"type": "tabular", "name": "outdiffgenes"}, {"type": "txt", "name": "outlog"}], "post_job_actions": {}, "workflow_outputs": [{"output_name": "outdiffgenes", "uuid": "bac26527-3ac5-4ef2-a943-da34cf6fcc38", "label": "lineagebranch_stemid_diffgenes"}], "annotation": "", "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/raceid_inspecttrajectory/raceid_inspecttrajectory/3.0.2.1", "input_connections": {"inputrds": {"output_name": "outrdat", "id": 6}}, "inputs": [{"name": "inputrds", "description": "runtime parameter for tool Lineage Branch Analysis using StemID"}], "position": {"top": 680, "left": 985.5}, "tool_state": "{\"inputrds\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\", \"trjsid\": \"{\\\"basic\\\": {\\\"__current_case__\\\": 1, \\\"br\\\": \\\"1,3,5\\\", \\\"doit\\\": \\\"yes\\\", \\\"i\\\": \\\"1\\\", \\\"use\\\": {\\\"__current_case__\\\": 0, \\\"def\\\": \\\"yes\\\"}}}\", \"trjfid\": \"{\\\"basic\\\": {\\\"__current_case__\\\": 0, \\\"doit\\\": \\\"no\\\"}}\", \"__rerun_remap_job_id__\": null, \"__page__\": null}", "label": "Lineage Branch (StemID)", "type": "tool", "id": 7, "tool_shed_repository": {"owner": "iuc", "changeset_revision": "e0e9b24d76aa", "name": "raceid_inspecttrajectory", "tool_shed": "toolshed.g2.bx.psu.edu"}, "name": "Lineage Branch Analysis using StemID"}, "6": {"tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/raceid_trajectory/raceid_trajectory/3.0.2.1", "errors": null, "uuid": "074e6d61-83cf-41cc-a5ae-f657121f43d1", "tool_version": "3.0.2.1", "outputs": [{"type": "pdf", "name": "outpdf"}, {"type": "rdata", "name": "outrdat"}, {"type": "txt", "name": "outlog"}], "post_job_actions": {}, "workflow_outputs": [], "annotation": "", "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/raceid_trajectory/raceid_trajectory/3.0.2.1", "input_connections": {"inputrds": {"output_name": "outrdat", "id": 2}}, "inputs": [{"name": "inputrds", "description": "runtime parameter for tool Lineage computation using StemID"}], "position": {"top": 760, "left": 540}, "tool_state": "{\"compscore\": \"{\\\"nn\\\": \\\"1\\\", \\\"scthr\\\": \\\"0.0\\\"}\", \"__page__\": null, \"plotgraph\": \"{\\\"scthr\\\": \\\"0.0\\\", \\\"showcells\\\": \\\"false\\\", \\\"use\\\": {\\\"__current_case__\\\": 0, \\\"def\\\": \\\"yes\\\"}}\", \"__rerun_remap_job_id__\": null, \"comppval\": \"{\\\"pthr\\\": \\\"0.01\\\", \\\"sensitive\\\": \\\"false\\\"}\", \"use_log\": \"\\\"false\\\"\", \"inputrds\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\", \"projback\": \"{\\\"pdishuf\\\": \\\"2000\\\", \\\"use\\\": {\\\"__current_case__\\\": 0, \\\"def\\\": \\\"yes\\\"}}\", \"projcell\": \"{\\\"cthr\\\": \\\"5\\\", \\\"knn\\\": \\\"3\\\", \\\"use\\\": {\\\"__current_case__\\\": 0, \\\"def\\\": \\\"yes\\\"}}\"}", "label": null, "type": "tool", "id": 6, "tool_shed_repository": {"owner": "iuc", "changeset_revision": "ff7cd3c7c1df", "name": "raceid_trajectory", "tool_shed": "toolshed.g2.bx.psu.edu"}, "name": "Lineage computation using StemID"}, "8": {"tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/raceid_inspecttrajectory/raceid_inspecttrajectory/3.0.2.1", "errors": null, "uuid": "2d4d7829-e887-49a4-abb3-3c941c89bd70", "tool_version": "3.0.2.1", "outputs": [{"type": "pdf", "name": "outpdf"}, {"type": "tabular", "name": "outdiffgenes"}, {"type": "txt", "name": "outlog"}], "post_job_actions": {}, "workflow_outputs": [], "annotation": "", "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/raceid_inspecttrajectory/raceid_inspecttrajectory/3.0.2.1", "input_connections": {"inputrds": {"output_name": "outrdat", "id": 6}}, "inputs": [{"name": "inputrds", "description": "runtime parameter for tool Lineage Branch Analysis using StemID"}], "position": {"top": 867, "left": 979.5}, "tool_state": "{\"inputrds\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\", \"trjsid\": \"{\\\"basic\\\": {\\\"__current_case__\\\": 0, \\\"doit\\\": \\\"no\\\"}}\", \"trjfid\": \"{\\\"basic\\\": {\\\"__current_case__\\\": 1, \\\"cellsfromz\\\": \\\"1,3,5\\\", \\\"doit\\\": \\\"yes\\\", \\\"som\\\": {\\\"__current_case__\\\": 0, \\\"doit\\\": \\\"no\\\"}, \\\"use\\\": {\\\"__current_case__\\\": 0, \\\"def\\\": \\\"yes\\\"}}}\", \"__rerun_remap_job_id__\": null, \"__page__\": null}", "label": "Lineage Branch (FateID)", "type": "tool", "id": 8, "tool_shed_repository": {"owner": "iuc", "changeset_revision": "e0e9b24d76aa", "name": "raceid_inspecttrajectory", "tool_shed": "toolshed.g2.bx.psu.edu"}, "name": "Lineage Branch Analysis using StemID"}}, "annotation": "", "name": "RaceID3 Split Workflow"}
+{
+  "a_galaxy_workflow": "true",
+  "annotation": "",
+  "format-version": "0.1",
+  "name": "RaceID3 Split Workflow",
+  "steps": {
+    "0": {
+      "annotation": "",
+      "content_id": null,
+      "errors": null,
+      "id": 0,
+      "input_connections": {},
+      "inputs": [],
+      "label": "count_matrix",
+      "name": "Input dataset",
+      "outputs": [],
+      "position": {
+        "left": 215,
+        "top": 233
+      },
+      "tool_id": null,
+      "tool_state": "{}",
+      "tool_version": null,
+      "type": "data_input",
+      "uuid": "7145fffc-b2d4-4661-8da8-0ce70cd874a7",
+      "workflow_outputs": []
+    },
+    "1": {
+      "annotation": "",
+      "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/raceid_filtnormconf/raceid_filtnormconf/3.0.2.1",
+      "errors": null,
+      "id": 1,
+      "input_connections": {
+        "intable": {
+          "id": 0,
+          "output_name": "output"
+        }
+      },
+      "inputs": [
+        {
+          "description": "runtime parameter for tool Filtering, Normalisation, and Confounder Removal using RaceID",
+          "name": "intable"
+        }
+      ],
+      "label": "Filtering, Normalisation, and Confounder Removal",
+      "name": "Filtering, Normalisation, and Confounder Removal using RaceID",
+      "outputs": [
+        {
+          "name": "outpdf",
+          "type": "pdf"
+        },
+        {
+          "name": "outrdat",
+          "type": "rdata"
+        },
+        {
+          "name": "outlog",
+          "type": "txt"
+        }
+      ],
+      "position": {
+        "left": 200.5,
+        "top": 332
+      },
+      "post_job_actions": {},
+      "tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/raceid_filtnormconf/raceid_filtnormconf/3.0.2.1",
+      "tool_shed_repository": {
+        "changeset_revision": "8dc8ff057b0f",
+        "name": "raceid_filtnormconf",
+        "owner": "iuc",
+        "tool_shed": "toolshed.g2.bx.psu.edu"
+      },
+      "tool_state": "{\"__page__\": null, \"__rerun_remap_job_id__\": null, \"intable\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\", \"filt\": \"{\\\"minexpr\\\": \\\"5\\\", \\\"minnumber\\\": \\\"5\\\", \\\"mintotal\\\": \\\"3000\\\", \\\"use\\\": {\\\"__current_case__\\\": 0, \\\"def\\\": \\\"yes\\\"}}\"}",
+      "tool_version": "3.0.2.1",
+      "type": "tool",
+      "uuid": "e82e0f74-ca4f-48e9-9a79-a5b09b63512c",
+      "workflow_outputs": [
+        {
+          "label": "filterlog",
+          "output_name": "outlog",
+          "uuid": "5f4e6e0c-42c8-42c0-b5b4-69efe4222886"
+        }
+      ]
+    },
+    "2": {
+      "annotation": "",
+      "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/raceid_clustering/raceid_clustering/3.0.2.1",
+      "errors": null,
+      "id": 2,
+      "input_connections": {
+        "inputrds": {
+          "id": 1,
+          "output_name": "outrdat"
+        }
+      },
+      "inputs": [
+        {
+          "description": "runtime parameter for tool Clustering using RaceID",
+          "name": "inputrds"
+        }
+      ],
+      "label": "Computing Clusters",
+      "name": "Clustering using RaceID",
+      "outputs": [
+        {
+          "name": "outpdf",
+          "type": "pdf"
+        },
+        {
+          "name": "outrdat",
+          "type": "rdata"
+        },
+        {
+          "name": "outgenelist",
+          "type": "tabular"
+        },
+        {
+          "name": "outlog",
+          "type": "txt"
+        }
+      ],
+      "position": {
+        "left": 322,
+        "top": 526
+      },
+      "post_job_actions": {},
+      "tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/raceid_clustering/raceid_clustering/3.0.2.1",
+      "tool_shed_repository": {
+        "changeset_revision": "4ea021bd7513",
+        "name": "raceid_clustering",
+        "owner": "iuc",
+        "tool_shed": "toolshed.g2.bx.psu.edu"
+      },
+      "tool_state": "{\"__page__\": null, \"clust\": \"{\\\"funcluster\\\": \\\"kmedoids\\\", \\\"metric\\\": \\\"pearson\\\", \\\"use\\\": {\\\"__current_case__\\\": 0, \\\"def\\\": \\\"yes\\\"}}\", \"extra\": \"{\\\"foldchange\\\": \\\"1.0\\\", \\\"plotlim\\\": \\\"10\\\", \\\"pvalue\\\": \\\"0.01\\\", \\\"tablelim\\\": \\\"25\\\"}\", \"tsne\": \"{\\\"knn\\\": \\\"10\\\", \\\"perplexity\\\": \\\"30\\\", \\\"use\\\": {\\\"__current_case__\\\": 0, \\\"def\\\": \\\"yes\\\"}}\", \"__rerun_remap_job_id__\": null, \"outlier\": \"{\\\"final\\\": \\\"false\\\", \\\"outlg\\\": \\\"2\\\", \\\"outminc\\\": \\\"5\\\", \\\"use\\\": {\\\"__current_case__\\\": 0, \\\"def\\\": \\\"yes\\\"}}\", \"inputrds\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\"}",
+      "tool_version": "3.0.2.1",
+      "type": "tool",
+      "uuid": "1e2cdc00-219a-421c-9b2c-76da52d4f6c6",
+      "workflow_outputs": [
+        {
+          "label": "clustering_log",
+          "output_name": "outlog",
+          "uuid": "6f0b7aa8-dd05-414c-9b81-b2b26c181bc5"
+        },
+        {
+          "label": "clustering_genelist",
+          "output_name": "outgenelist",
+          "uuid": "619c2479-4e9f-4fef-85ed-ed4b27c4a78d"
+        }
+      ]
+    },
+    "3": {
+      "annotation": "",
+      "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/raceid_inspectclusters/raceid_inspectclusters/3.0.2.1",
+      "errors": null,
+      "id": 3,
+      "input_connections": {
+        "inputrds": {
+          "id": 2,
+          "output_name": "outrdat"
+        }
+      },
+      "inputs": [
+        {
+          "description": "runtime parameter for tool Cluster Inspection using RaceID",
+          "name": "inputrds"
+        }
+      ],
+      "label": "Cluster Insp. (All Clusters)",
+      "name": "Cluster Inspection using RaceID",
+      "outputs": [
+        {
+          "name": "outpdf",
+          "type": "pdf"
+        },
+        {
+          "name": "outlog",
+          "type": "txt"
+        }
+      ],
+      "position": {
+        "left": 740,
+        "top": 246
+      },
+      "post_job_actions": {},
+      "tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/raceid_inspectclusters/raceid_inspectclusters/3.0.2.1",
+      "tool_shed_repository": {
+        "changeset_revision": "9fec5dd8fbb9",
+        "name": "raceid_inspectclusters",
+        "owner": "iuc",
+        "tool_shed": "toolshed.g2.bx.psu.edu"
+      },
+      "tool_state": "{\"__page__\": null, \"gois\": \"{\\\"__current_case__\\\": 0, \\\"do_opt\\\": \\\"no\\\"}\", \"diffgtest\": \"{\\\"__current_case__\\\": 0, \\\"do_opt\\\": \\\"no\\\"}\", \"__rerun_remap_job_id__\": null, \"plotsym\": \"{\\\"__current_case__\\\": 0, \\\"do_opt\\\": \\\"no\\\"}\", \"inputrds\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\", \"plotgen\": \"{\\\"__current_case__\\\": 1, \\\"do_opt\\\": \\\"yes\\\"}\"}",
+      "tool_version": "3.0.2.1",
+      "type": "tool",
+      "uuid": "ee9b5cb1-dd43-48ec-982e-61d2893ec5d5",
+      "workflow_outputs": []
+    },
+    "4": {
+      "annotation": "",
+      "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/raceid_inspectclusters/raceid_inspectclusters/3.0.2.1",
+      "errors": null,
+      "id": 4,
+      "input_connections": {
+        "inputrds": {
+          "id": 2,
+          "output_name": "outrdat"
+        }
+      },
+      "inputs": [
+        {
+          "description": "runtime parameter for tool Cluster Inspection using RaceID",
+          "name": "inputrds"
+        }
+      ],
+      "label": "Cluster Insp. (Diff Gene)",
+      "name": "Cluster Inspection using RaceID",
+      "outputs": [
+        {
+          "name": "outpdf",
+          "type": "pdf"
+        },
+        {
+          "name": "outlog",
+          "type": "txt"
+        }
+      ],
+      "position": {
+        "left": 741,
+        "top": 372
+      },
+      "post_job_actions": {},
+      "tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/raceid_inspectclusters/raceid_inspectclusters/3.0.2.1",
+      "tool_shed_repository": {
+        "changeset_revision": "9fec5dd8fbb9",
+        "name": "raceid_inspectclusters",
+        "owner": "iuc",
+        "tool_shed": "toolshed.g2.bx.psu.edu"
+      },
+      "tool_state": "{\"__page__\": null, \"gois\": \"{\\\"__current_case__\\\": 0, \\\"do_opt\\\": \\\"no\\\"}\", \"diffgtest\": \"{\\\"__current_case__\\\": 1, \\\"do_opt\\\": \\\"yes\\\", \\\"set_a\\\": {\\\"meth\\\": {\\\"__current_case__\\\": 0, \\\"selector\\\": \\\"1\\\", \\\"type\\\": \\\"cln\\\"}, \\\"name_set\\\": \\\"Cells in 1\\\"}, \\\"set_b\\\": {\\\"meth\\\": {\\\"__current_case__\\\": 0, \\\"selector\\\": \\\"3\\\", \\\"type\\\": \\\"cln\\\"}, \\\"name_set\\\": \\\"Cells in 3\\\"}, \\\"use\\\": {\\\"__current_case__\\\": 0, \\\"def\\\": \\\"yes\\\"}}\", \"__rerun_remap_job_id__\": null, \"plotsym\": \"{\\\"__current_case__\\\": 0, \\\"do_opt\\\": \\\"no\\\"}\", \"inputrds\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\", \"plotgen\": \"{\\\"__current_case__\\\": 0, \\\"do_opt\\\": \\\"no\\\"}\"}",
+      "tool_version": "3.0.2.1",
+      "type": "tool",
+      "uuid": "8678cbea-7a6a-445e-95ec-9afeabce6a1d",
+      "workflow_outputs": []
+    },
+    "5": {
+      "annotation": "",
+      "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/raceid_inspectclusters/raceid_inspectclusters/3.0.2.1",
+      "errors": null,
+      "id": 5,
+      "input_connections": {
+        "inputrds": {
+          "id": 2,
+          "output_name": "outrdat"
+        }
+      },
+      "inputs": [
+        {
+          "description": "runtime parameter for tool Cluster Inspection using RaceID",
+          "name": "inputrds"
+        }
+      ],
+      "label": "Cluster Insp. (GOI)",
+      "name": "Cluster Inspection using RaceID",
+      "outputs": [
+        {
+          "name": "outpdf",
+          "type": "pdf"
+        },
+        {
+          "name": "outlog",
+          "type": "txt"
+        }
+      ],
+      "position": {
+        "left": 738,
+        "top": 504
+      },
+      "post_job_actions": {},
+      "tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/raceid_inspectclusters/raceid_inspectclusters/3.0.2.1",
+      "tool_shed_repository": {
+        "changeset_revision": "9fec5dd8fbb9",
+        "name": "raceid_inspectclusters",
+        "owner": "iuc",
+        "tool_shed": "toolshed.g2.bx.psu.edu"
+      },
+      "tool_state": "{\"__page__\": null, \"gois\": \"{\\\"__current_case__\\\": 1, \\\"do_opt\\\": \\\"yes\\\", \\\"inspect_goi_cells\\\": \\\"\\\", \\\"inspect_goi_genes\\\": \\\"Ptma,Rps2\\\", \\\"use\\\": {\\\"__current_case__\\\": 0, \\\"def\\\": \\\"yes\\\"}}\", \"diffgtest\": \"{\\\"__current_case__\\\": 0, \\\"do_opt\\\": \\\"no\\\"}\", \"__rerun_remap_job_id__\": null, \"plotsym\": \"{\\\"__current_case__\\\": 0, \\\"do_opt\\\": \\\"no\\\"}\", \"inputrds\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\", \"plotgen\": \"{\\\"__current_case__\\\": 0, \\\"do_opt\\\": \\\"no\\\"}\"}",
+      "tool_version": "3.0.2.1",
+      "type": "tool",
+      "uuid": "a057c85c-1b79-47d4-8e6b-82a9e3772a64",
+      "workflow_outputs": []
+    },
+    "6": {
+      "annotation": "",
+      "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/raceid_trajectory/raceid_trajectory/3.0.2.1",
+      "errors": null,
+      "id": 6,
+      "input_connections": {
+        "inputrds": {
+          "id": 2,
+          "output_name": "outrdat"
+        }
+      },
+      "inputs": [
+        {
+          "description": "runtime parameter for tool Lineage computation using StemID",
+          "name": "inputrds"
+        }
+      ],
+      "label": null,
+      "name": "Lineage computation using StemID",
+      "outputs": [
+        {
+          "name": "outpdf",
+          "type": "pdf"
+        },
+        {
+          "name": "outrdat",
+          "type": "rdata"
+        },
+        {
+          "name": "outlog",
+          "type": "txt"
+        }
+      ],
+      "position": {
+        "left": 540,
+        "top": 760
+      },
+      "post_job_actions": {},
+      "tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/raceid_trajectory/raceid_trajectory/3.0.2.1",
+      "tool_shed_repository": {
+        "changeset_revision": "ff7cd3c7c1df",
+        "name": "raceid_trajectory",
+        "owner": "iuc",
+        "tool_shed": "toolshed.g2.bx.psu.edu"
+      },
+      "tool_state": "{\"compscore\": \"{\\\"nn\\\": \\\"1\\\", \\\"scthr\\\": \\\"0.0\\\"}\", \"__page__\": null, \"plotgraph\": \"{\\\"scthr\\\": \\\"0.0\\\", \\\"showcells\\\": \\\"false\\\", \\\"use\\\": {\\\"__current_case__\\\": 0, \\\"def\\\": \\\"yes\\\"}}\", \"__rerun_remap_job_id__\": null, \"comppval\": \"{\\\"pthr\\\": \\\"0.01\\\", \\\"sensitive\\\": \\\"false\\\"}\", \"use_log\": \"\\\"false\\\"\", \"inputrds\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\", \"projback\": \"{\\\"pdishuf\\\": \\\"2000\\\", \\\"use\\\": {\\\"__current_case__\\\": 0, \\\"def\\\": \\\"yes\\\"}}\", \"projcell\": \"{\\\"cthr\\\": \\\"5\\\", \\\"knn\\\": \\\"3\\\", \\\"use\\\": {\\\"__current_case__\\\": 0, \\\"def\\\": \\\"yes\\\"}}\"}",
+      "tool_version": "3.0.2.1",
+      "type": "tool",
+      "uuid": "074e6d61-83cf-41cc-a5ae-f657121f43d1",
+      "workflow_outputs": []
+    },
+    "7": {
+      "annotation": "",
+      "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/raceid_inspecttrajectory/raceid_inspecttrajectory/3.0.2.1",
+      "errors": null,
+      "id": 7,
+      "input_connections": {
+        "inputrds": {
+          "id": 6,
+          "output_name": "outrdat"
+        }
+      },
+      "inputs": [
+        {
+          "description": "runtime parameter for tool Lineage Branch Analysis using StemID",
+          "name": "inputrds"
+        }
+      ],
+      "label": "Lineage Branch (StemID)",
+      "name": "Lineage Branch Analysis using StemID",
+      "outputs": [
+        {
+          "name": "outpdf",
+          "type": "pdf"
+        },
+        {
+          "name": "outdiffgenes",
+          "type": "tabular"
+        },
+        {
+          "name": "outlog",
+          "type": "txt"
+        }
+      ],
+      "position": {
+        "left": 985.5,
+        "top": 680
+      },
+      "post_job_actions": {},
+      "tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/raceid_inspecttrajectory/raceid_inspecttrajectory/3.0.2.1",
+      "tool_shed_repository": {
+        "changeset_revision": "e0e9b24d76aa",
+        "name": "raceid_inspecttrajectory",
+        "owner": "iuc",
+        "tool_shed": "toolshed.g2.bx.psu.edu"
+      },
+      "tool_state": "{\"inputrds\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\", \"trjsid\": \"{\\\"basic\\\": {\\\"__current_case__\\\": 1, \\\"br\\\": \\\"1,3,5\\\", \\\"doit\\\": \\\"yes\\\", \\\"i\\\": \\\"1\\\", \\\"use\\\": {\\\"__current_case__\\\": 0, \\\"def\\\": \\\"yes\\\"}}}\", \"trjfid\": \"{\\\"basic\\\": {\\\"__current_case__\\\": 0, \\\"doit\\\": \\\"no\\\"}}\", \"__rerun_remap_job_id__\": null, \"__page__\": null}",
+      "tool_version": "3.0.2.1",
+      "type": "tool",
+      "uuid": "bc0f0c22-dbfc-4a6c-925d-2416228bedde",
+      "workflow_outputs": [
+        {
+          "label": "lineagebranch_stemid_diffgenes",
+          "output_name": "outdiffgenes",
+          "uuid": "bac26527-3ac5-4ef2-a943-da34cf6fcc38"
+        }
+      ]
+    },
+    "8": {
+      "annotation": "",
+      "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/raceid_inspecttrajectory/raceid_inspecttrajectory/3.0.2.1",
+      "errors": null,
+      "id": 8,
+      "input_connections": {
+        "inputrds": {
+          "id": 6,
+          "output_name": "outrdat"
+        }
+      },
+      "inputs": [
+        {
+          "description": "runtime parameter for tool Lineage Branch Analysis using StemID",
+          "name": "inputrds"
+        }
+      ],
+      "label": "Lineage Branch (FateID)",
+      "name": "Lineage Branch Analysis using StemID",
+      "outputs": [
+        {
+          "name": "outpdf",
+          "type": "pdf"
+        },
+        {
+          "name": "outdiffgenes",
+          "type": "tabular"
+        },
+        {
+          "name": "outlog",
+          "type": "txt"
+        }
+      ],
+      "position": {
+        "left": 979.5,
+        "top": 867
+      },
+      "post_job_actions": {},
+      "tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/raceid_inspecttrajectory/raceid_inspecttrajectory/3.0.2.1",
+      "tool_shed_repository": {
+        "changeset_revision": "e0e9b24d76aa",
+        "name": "raceid_inspecttrajectory",
+        "owner": "iuc",
+        "tool_shed": "toolshed.g2.bx.psu.edu"
+      },
+      "tool_state": "{\"inputrds\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\", \"trjsid\": \"{\\\"basic\\\": {\\\"__current_case__\\\": 0, \\\"doit\\\": \\\"no\\\"}}\", \"trjfid\": \"{\\\"basic\\\": {\\\"__current_case__\\\": 1, \\\"cellsfromz\\\": \\\"1,3,5\\\", \\\"doit\\\": \\\"yes\\\", \\\"som\\\": {\\\"__current_case__\\\": 0, \\\"doit\\\": \\\"no\\\"}, \\\"use\\\": {\\\"__current_case__\\\": 0, \\\"def\\\": \\\"yes\\\"}}}\", \"__rerun_remap_job_id__\": null, \"__page__\": null}",
+      "tool_version": "3.0.2.1",
+      "type": "tool",
+      "uuid": "2d4d7829-e887-49a4-abb3-3c941c89bd70",
+      "workflow_outputs": []
+    }
+  },
+  "tags": [],
+  "uuid": "555a5f76-4828-4058-8f1a-e0e0c9d27dc1",
+  "version": 0
+}

--- a/topics/transcriptomics/tutorials/scrna_preprocessing/workflows/scrna_mp_celseq.ga
+++ b/topics/transcriptomics/tutorials/scrna_preprocessing/workflows/scrna_mp_celseq.ga
@@ -1,1 +1,971 @@
-{"uuid": "36a6e32e-5466-4ef8-915f-14332e21dc93", "tags": [], "format-version": "0.1", "name": "CelSeq2: Multi Batch mm10", "version": 5, "steps": {"0": {"tool_id": null, "tool_version": null, "outputs": [], "workflow_outputs": [{"output_name": "output", "uuid": "37307bc9-a8de-4fb4-8482-4a3554c9af36", "label": null}], "input_connections": {}, "tool_state": "{\"collection_type\": \"list:paired\"}", "id": 0, "uuid": "c50ee411-e25e-4570-97bf-f0a05af2458e", "errors": null, "name": "Input dataset collection", "label": "List of FACS pairs", "inputs": [], "position": {"top": 260, "left": 119.5}, "annotation": "", "content_id": null, "type": "data_collection_input"}, "1": {"tool_id": null, "tool_version": null, "outputs": [], "workflow_outputs": [{"output_name": "output", "uuid": "d863899f-2ea8-49d1-acc9-a2cca1f9fce3", "label": null}], "input_connections": {}, "tool_state": "{}", "id": 1, "uuid": "cb331533-4896-419f-83ca-196c5daf2c03", "errors": null, "name": "Input dataset", "label": "Barcodes", "inputs": [], "position": {"top": 429.5, "left": 566.5}, "annotation": "", "content_id": null, "type": "data_input"}, "2": {"tool_id": null, "tool_version": null, "outputs": [], "workflow_outputs": [{"output_name": "output", "uuid": "51046a1f-f629-4e6a-aac1-eb563eeb693b", "label": null}], "input_connections": {}, "tool_state": "{}", "id": 2, "uuid": "ac1f89bb-52b9-41ac-a6d4-f8dfd4d21550", "errors": null, "name": "Input dataset", "label": "GTF file (UCSC)", "inputs": [], "position": {"top": 521, "left": 568.5}, "annotation": "", "content_id": null, "type": "data_input"}, "3": {"tool_id": "__FLATTEN__", "tool_version": "1.0.0", "outputs": [{"type": "input", "name": "output"}], "workflow_outputs": [], "input_connections": {"input": {"output_name": "output", "id": 0}}, "tool_state": "{\"input\": \"{\\\"values\\\": [{\\\"id\\\": 93213, \\\"src\\\": \\\"hdca\\\"}]}\", \"__rerun_remap_job_id__\": null, \"join_identifier\": \"\\\"_\\\"\", \"__page__\": null}", "id": 3, "uuid": "413df6c7-4f25-4f13-b8d1-056c2bc14040", "errors": null, "name": "Flatten Collection", "post_job_actions": {"HideDatasetActionoutput": {"output_name": "output", "action_type": "HideDatasetAction", "action_arguments": {}}}, "label": null, "inputs": [], "position": {"top": 266, "left": 547}, "annotation": "", "content_id": "__FLATTEN__", "type": "tool"}, "4": {"tool_id": "0600e24fe786d72f", "inputs": [], "outputs": [], "subworkflow": {"uuid": "ee17e23b-42b1-48e8-ad5e-bcb0b7fa8cf0", "tags": "", "format-version": "0.1", "name": "CelSeq2: Single Batch mm10", "steps": {"0": {"tool_id": null, "tool_version": null, "outputs": [], "workflow_outputs": [{"output_name": "output", "uuid": "d46989fb-ef46-4506-8932-d66cee38e62a", "label": null}], "input_connections": {}, "tool_state": "{\"collection_type\": \"paired\"}", "id": 0, "uuid": "c451df86-a25e-409c-9f2e-33c22a0f1bb9", "errors": null, "name": "Input dataset collection", "label": "Batch", "inputs": [], "position": {"top": 470.90625, "left": 286}, "annotation": "", "content_id": null, "type": "data_collection_input"}, "1": {"tool_id": null, "tool_version": null, "outputs": [], "workflow_outputs": [{"output_name": "output", "uuid": "2c66b77f-5ee0-4991-971c-3c43d8e7841d", "label": null}], "input_connections": {}, "tool_state": "{}", "id": 1, "uuid": "4ac7860e-01d4-4009-b1fd-899fab778eb5", "errors": null, "name": "Input dataset", "label": "Barcodes (single-col)", "inputs": [], "position": {"top": 552, "left": 302.5}, "annotation": "", "content_id": null, "type": "data_input"}, "2": {"tool_id": null, "tool_version": null, "outputs": [], "workflow_outputs": [{"output_name": "output", "uuid": "7ca9e0df-159c-43f7-a0b3-e546fcd9b2c9", "label": null}], "input_connections": {}, "tool_state": "{}", "id": 2, "uuid": "0455bae6-58da-4ec3-9688-72aba9f676fe", "errors": null, "name": "Input dataset", "label": "GTF file (UCSC)", "inputs": [], "position": {"top": 828.90625, "left": 313.5}, "annotation": "", "content_id": null, "type": "data_input"}, "3": {"tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/umi_tools_extract/umi_tools_extract/0.5.3.2", "tool_version": "0.5.3.2", "outputs": [{"type": "input", "name": "out"}, {"type": "input", "name": "out1"}, {"type": "input", "name": "out2"}, {"type": "txt", "name": "out_log"}], "workflow_outputs": [{"output_name": "out2", "uuid": "c24e1482-bbff-4a22-8747-2ab0330fb5af", "label": null}], "input_connections": {"barcodes|filter_barcode_file": {"output_name": "output", "id": 1}, "input_type|input_readpair": {"output_name": "output", "id": 0}}, "tool_state": "{\"__page__\": null, \"extract_method\": \"\\\"string\\\"\", \"input_type\": \"{\\\"__current_case__\\\": 2, \\\"barcode\\\": {\\\"__current_case__\\\": 0, \\\"barcode_select\\\": \\\"first_read_only\\\"}, \\\"input_readpair\\\": {\\\"__class__\\\": \\\"RuntimeValue\\\"}, \\\"type\\\": \\\"paired_collection\\\"}\", \"__rerun_remap_job_id__\": null, \"bc_pattern\": \"\\\"NNNNNNCCCCCC\\\"\", \"print_log\": \"\\\"true\\\"\", \"prime3\": \"\\\"true\\\"\", \"quality\": \"{\\\"__current_case__\\\": 0, \\\"quality_selector\\\": \\\"false\\\"}\", \"barcodes\": \"{\\\"__current_case__\\\": 1, \\\"filter_barcode_file\\\": {\\\"__class__\\\": \\\"RuntimeValue\\\"}, \\\"filter_correct\\\": \\\"false\\\", \\\"use_barcodes\\\": \\\"yes\\\"}\"}", "id": 3, "tool_shed_repository": {"owner": "iuc", "changeset_revision": "99aea37a7ff7", "name": "umi_tools_extract", "tool_shed": "toolshed.g2.bx.psu.edu"}, "uuid": "0b94d2ea-1889-4b88-b0a2-ac7b0a3452e5", "errors": null, "name": "UMI-tools extract", "post_job_actions": {"HideDatasetActionout_log": {"output_name": "out_log", "action_type": "HideDatasetAction", "action_arguments": {}}, "HideDatasetActionout1": {"output_name": "out1", "action_type": "HideDatasetAction", "action_arguments": {}}, "HideDatasetActionout": {"output_name": "out", "action_type": "HideDatasetAction", "action_arguments": {}}}, "label": null, "inputs": [{"name": "input_type", "description": "runtime parameter for tool UMI-tools extract"}, {"name": "barcodes", "description": "runtime parameter for tool UMI-tools extract"}], "position": {"top": 469.90625, "left": 554.5}, "annotation": "", "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/umi_tools_extract/umi_tools_extract/0.5.3.2", "type": "tool"}, "4": {"tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/rgrnastar/rna_star/2.5.2b-2", "tool_version": "2.5.2b-2", "outputs": [{"type": "txt", "name": "output_log"}, {"type": "interval", "name": "chimeric_junctions"}, {"type": "bam", "name": "chimeric_reads"}, {"type": "interval", "name": "splice_junctions"}, {"type": "bam", "name": "mapped_reads"}, {"type": "tabular", "name": "reads_per_gene"}], "workflow_outputs": [{"output_name": "chimeric_reads", "uuid": "f44d1ce2-b0a0-4aca-b9da-d47a9151dd8f", "label": null}, {"output_name": "chimeric_junctions", "uuid": "a70f8d45-eaa8-40f4-a755-99e7004ad0ee", "label": null}, {"output_name": "reads_per_gene", "uuid": "70ef8c03-6a54-4c88-81b6-e178dbf776c7", "label": null}, {"output_name": "splice_junctions", "uuid": "0896bee8-d853-4467-8143-96a4d314774c", "label": null}, {"output_name": "mapped_reads", "uuid": "956818b5-dc81-440c-8c2a-b10869547c70", "label": null}, {"output_name": "output_log", "uuid": "5714f89a-1d7f-4634-95ce-2b089e5cc83d", "label": null}], "input_connections": {"refGenomeSource|GTFconditional|sjdbGTFfile": {"output_name": "output", "id": 2}, "singlePaired|input1": {"output_name": "out2", "id": 3}}, "tool_state": "{\"__page__\": null, \"singlePaired\": \"{\\\"__current_case__\\\": 0, \\\"input1\\\": {\\\"__class__\\\": \\\"RuntimeValue\\\"}, \\\"sPaired\\\": \\\"single\\\"}\", \"output_params\": \"{\\\"__current_case__\\\": 1, \\\"output_select\\\": \\\"no\\\"}\", \"__rerun_remap_job_id__\": null, \"params\": \"{\\\"__current_case__\\\": 0, \\\"settingsType\\\": \\\"default\\\"}\", \"refGenomeSource\": \"{\\\"GTFconditional\\\": {\\\"GTFselect\\\": \\\"without-gtf\\\", \\\"__current_case__\\\": 1, \\\"genomeDir\\\": \\\"mm10\\\", \\\"sjdbGTFfile\\\": {\\\"__class__\\\": \\\"RuntimeValue\\\"}, \\\"sjdbOverhang\\\": \\\"100\\\"}, \\\"__current_case__\\\": 0, \\\"geneSource\\\": \\\"indexed\\\"}\", \"quantMode\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\"}", "id": 4, "tool_shed_repository": {"owner": "iuc", "changeset_revision": "2055c2667eb3", "name": "rgrnastar", "tool_shed": "toolshed.g2.bx.psu.edu"}, "uuid": "1e4a54be-b2fb-496a-8247-ccba4ffe6f3b", "errors": null, "name": "RNA STAR", "post_job_actions": {}, "label": "Alignment (mm10)", "inputs": [{"name": "quantMode", "description": "runtime parameter for tool RNA STAR"}, {"name": "singlePaired", "description": "runtime parameter for tool RNA STAR"}], "position": {"top": 581.90625, "left": 832.5}, "annotation": "The genome should match that of the GTF file", "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/rgrnastar/rna_star/2.5.2b-2", "type": "tool"}, "5": {"tool_id": "toolshed.g2.bx.psu.edu/repos/devteam/samtools_stats/samtools_stats/2.0.1", "tool_version": "2.0.1", "outputs": [{"type": "tabular", "name": "output"}], "workflow_outputs": [{"output_name": "output", "uuid": "eed5af2c-48f7-4227-8d76-0686c0537ccc", "label": null}], "input_connections": {"input_file": {"output_name": "mapped_reads", "id": 4}}, "tool_state": "{\"coverage_max\": \"\\\"1000\\\"\", \"__page__\": null, \"input_file\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\", \"gc_depth\": \"\\\"20000.0\\\"\", \"insert_size\": \"\\\"8000\\\"\", \"most_inserts\": \"\\\"0.99\\\"\", \"coverage_step\": \"\\\"1\\\"\", \"coverage_min\": \"\\\"1\\\"\", \"read_length\": \"\\\"\\\"\", \"trim_quality\": \"\\\"0\\\"\", \"filter_by_flags\": \"{\\\"__current_case__\\\": 1, \\\"filter_flags\\\": \\\"nofilter\\\"}\", \"split_output\": \"{\\\"__current_case__\\\": 0, \\\"split_output_selector\\\": \\\"no\\\"}\", \"use_reference\": \"{\\\"__current_case__\\\": 1, \\\"use_ref_selector\\\": \\\"no\\\"}\", \"__rerun_remap_job_id__\": null, \"remove_dups\": \"\\\"false\\\"\"}", "id": 5, "tool_shed_repository": {"owner": "devteam", "changeset_revision": "24c5d43cb545", "name": "samtools_stats", "tool_shed": "toolshed.g2.bx.psu.edu"}, "uuid": "36ad81d4-f920-4ca6-83c2-66516b2229f2", "errors": null, "name": "Stats", "post_job_actions": {}, "label": null, "inputs": [{"name": "input_file", "description": "runtime parameter for tool Stats"}], "position": {"top": 403, "left": 1338.5}, "annotation": "", "content_id": "toolshed.g2.bx.psu.edu/repos/devteam/samtools_stats/samtools_stats/2.0.1", "type": "tool"}, "6": {"tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/featurecounts/featurecounts/1.6.2", "tool_version": "1.6.2", "outputs": [{"type": "tabular", "name": "output_medium"}, {"type": "bam", "name": "output_bam"}, {"type": "tabular", "name": "output_short"}, {"type": "tabular", "name": "output_full"}, {"type": "tabular", "name": "output_summary"}, {"type": "tabular", "name": "output_feature_lengths"}, {"type": "tabular", "name": "output_jcounts"}], "workflow_outputs": [{"output_name": "output_bam", "uuid": "87abf585-aae9-4af3-aed7-541795d65faf", "label": null}], "input_connections": {"alignment": {"output_name": "mapped_reads", "id": 4}, "anno|reference_gene_sets": {"output_name": "output", "id": 2}}, "tool_state": "{\"pe_parameters\": \"{\\\"exclude_chimerics\\\": \\\"true\\\", \\\"fragment_counting_enabled\\\": {\\\"__current_case__\\\": 1, \\\"fragment_counting\\\": \\\"\\\"}, \\\"only_both_ends\\\": \\\"false\\\"}\", \"strand_specificity\": \"\\\"0\\\"\", \"__page__\": null, \"__rerun_remap_job_id__\": null, \"format\": \"\\\"tabdel_short\\\"\", \"include_feature_length_file\": \"\\\"false\\\"\", \"anno\": \"{\\\"__current_case__\\\": 2, \\\"anno_select\\\": \\\"history\\\", \\\"reference_gene_sets\\\": {\\\"__class__\\\": \\\"RuntimeValue\\\"}}\", \"extended_parameters\": \"{\\\"R\\\": \\\"true\\\", \\\"by_read_group\\\": \\\"false\\\", \\\"contribute_to_multiple_features\\\": \\\"false\\\", \\\"count_split_alignments_only\\\": \\\"false\\\", \\\"exon_exon_junction_read_counting_enabled\\\": {\\\"__current_case__\\\": 1, \\\"count_exon_exon_junction_reads\\\": \\\"false\\\"}, \\\"frac_overlap\\\": \\\"0\\\", \\\"frac_overlap_feature\\\": \\\"0\\\", \\\"gff_feature_attribute\\\": \\\"gene_id\\\", \\\"gff_feature_type\\\": \\\"exon\\\", \\\"ignore_dup\\\": \\\"false\\\", \\\"largest_overlap\\\": \\\"false\\\", \\\"long_reads\\\": \\\"false\\\", \\\"mapping_quality\\\": \\\"12\\\", \\\"min_overlap\\\": \\\"1\\\", \\\"multimapping_enabled\\\": {\\\"__current_case__\\\": 1, \\\"multimapping_counts\\\": \\\"\\\"}, \\\"primary\\\": \\\"false\\\", \\\"read_extension_3p\\\": \\\"0\\\", \\\"read_extension_5p\\\": \\\"0\\\", \\\"read_reduction\\\": \\\"\\\", \\\"summarization_level\\\": \\\"false\\\"}\", \"alignment\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\"}", "id": 6, "tool_shed_repository": {"owner": "iuc", "changeset_revision": "f3a5f075498f", "name": "featurecounts", "tool_shed": "toolshed.g2.bx.psu.edu"}, "uuid": "9506153d-d997-43a4-8ce1-216690415561", "errors": null, "name": "featureCounts", "post_job_actions": {"HideDatasetActionoutput_short": {"output_name": "output_short", "action_type": "HideDatasetAction", "action_arguments": {}}, "HideDatasetActionoutput_jcounts": {"output_name": "output_jcounts", "action_type": "HideDatasetAction", "action_arguments": {}}, "HideDatasetActionoutput_full": {"output_name": "output_full", "action_type": "HideDatasetAction", "action_arguments": {}}, "HideDatasetActionoutput_feature_lengths": {"output_name": "output_feature_lengths", "action_type": "HideDatasetAction", "action_arguments": {}}, "HideDatasetActionoutput_medium": {"output_name": "output_medium", "action_type": "HideDatasetAction", "action_arguments": {}}, "HideDatasetActionoutput_summary": {"output_name": "output_summary", "action_type": "HideDatasetAction", "action_arguments": {}}}, "label": null, "inputs": [{"name": "anno", "description": "runtime parameter for tool featureCounts"}, {"name": "alignment", "description": "runtime parameter for tool featureCounts"}], "position": {"top": 814, "left": 1141.5}, "annotation": "", "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/featurecounts/featurecounts/1.6.2", "type": "tool"}, "7": {"tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/multiqc/multiqc/1.5.0", "tool_version": "1.5.0", "outputs": [{"type": "input", "name": "stats"}, {"type": "html", "name": "html_report"}, {"type": "txt", "name": "log"}], "workflow_outputs": [{"output_name": "stats", "uuid": "2845973b-96f5-44c6-b454-b3e09601972b", "label": null}, {"output_name": "log", "uuid": "9dfc4543-d1d9-40f4-b703-61993f05fbee", "label": null}, {"output_name": "html_report", "uuid": "452d04bd-cdcc-4074-839d-6a70ad44ba55", "label": null}], "input_connections": {"results_0|software_cond|output_0|type|input": {"output_name": "output", "id": 5}}, "tool_state": "{\"comment\": \"\\\"\\\"\", \"__page__\": null, \"title\": \"\\\"\\\"\", \"__rerun_remap_job_id__\": null, \"results\": \"[{\\\"__index__\\\": 0, \\\"software_cond\\\": {\\\"__current_case__\\\": 20, \\\"output\\\": [{\\\"__index__\\\": 0, \\\"type\\\": {\\\"__current_case__\\\": 0, \\\"input\\\": {\\\"__class__\\\": \\\"RuntimeValue\\\"}, \\\"type\\\": \\\"stats\\\"}}], \\\"software\\\": \\\"samtools\\\"}}, {\\\"__index__\\\": 1, \\\"software_cond\\\": {\\\"__current_case__\\\": 7, \\\"output\\\": [{\\\"__index__\\\": 0, \\\"input\\\": {\\\"__class__\\\": \\\"RuntimeValue\\\"}, \\\"type\\\": \\\"data\\\"}], \\\"software\\\": \\\"fastqc\\\"}}, {\\\"__index__\\\": 2, \\\"software_cond\\\": {\\\"__current_case__\\\": 7, \\\"output\\\": [{\\\"__index__\\\": 0, \\\"input\\\": {\\\"__class__\\\": \\\"RuntimeValue\\\"}, \\\"type\\\": \\\"data\\\"}], \\\"software\\\": \\\"fastqc\\\"}}]\", \"saveLog\": \"\\\"false\\\"\"}", "id": 7, "tool_shed_repository": {"owner": "iuc", "changeset_revision": "df99138d2776", "name": "multiqc", "tool_shed": "toolshed.g2.bx.psu.edu"}, "uuid": "c56b2cfb-18c4-4f17-9f5c-a84009e00050", "errors": null, "name": "MultiQC", "post_job_actions": {}, "label": null, "inputs": [], "position": {"top": 200, "left": 1643.5}, "annotation": "", "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/multiqc/multiqc/1.5.0", "type": "tool"}, "8": {"tool_id": "toolshed.g2.bx.psu.edu/repos/devteam/bamtools_filter/bamFilter/2.4.1", "tool_version": "2.4.1", "outputs": [{"type": "txt", "name": "out_file2"}, {"type": "bam", "name": "out_file1"}], "workflow_outputs": [{"output_name": "out_file1", "uuid": "50f1d2af-ca7e-46b1-a9a6-99931ee1fcb5", "label": null}], "input_connections": {"input_bam": {"output_name": "output_bam", "id": 6}}, "tool_state": "{\"input_bam\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\", \"__rerun_remap_job_id__\": null, \"rule_configuration\": \"{\\\"__current_case__\\\": 1, \\\"rules\\\": \\\"(1 | 2) & 3 & 4\\\", \\\"rules_selector\\\": \\\"true\\\"}\", \"conditions\": \"[{\\\"__index__\\\": 0, \\\"filters\\\": [{\\\"__index__\\\": 0, \\\"bam_property\\\": {\\\"__current_case__\\\": 0, \\\"bam_property_selector\\\": \\\"alignmentFlag\\\", \\\"bam_property_value\\\": \\\"0\\\"}}]}, {\\\"__index__\\\": 1, \\\"filters\\\": [{\\\"__index__\\\": 0, \\\"bam_property\\\": {\\\"__current_case__\\\": 0, \\\"bam_property_selector\\\": \\\"alignmentFlag\\\", \\\"bam_property_value\\\": \\\"16\\\"}}]}, {\\\"__index__\\\": 2, \\\"filters\\\": [{\\\"__index__\\\": 0, \\\"bam_property\\\": {\\\"__current_case__\\\": 21, \\\"bam_property_selector\\\": \\\"tag\\\", \\\"bam_property_value\\\": \\\"nM:<3\\\"}}]}, {\\\"__index__\\\": 3, \\\"filters\\\": [{\\\"__index__\\\": 0, \\\"bam_property\\\": {\\\"__current_case__\\\": 21, \\\"bam_property_selector\\\": \\\"tag\\\", \\\"bam_property_value\\\": \\\"NH:<2\\\"}}]}]\", \"__page__\": null}", "id": 8, "tool_shed_repository": {"owner": "devteam", "changeset_revision": "bd735cae4ce6", "name": "bamtools_filter", "tool_shed": "toolshed.g2.bx.psu.edu"}, "uuid": "e65c9b1a-65d2-46dc-8199-0f87acf7f6b1", "errors": null, "name": "Filter", "post_job_actions": {"HideDatasetActionout_file2": {"output_name": "out_file2", "action_type": "HideDatasetAction", "action_arguments": {}}}, "label": null, "inputs": [{"name": "input_bam", "description": "runtime parameter for tool Filter"}], "position": {"top": 627.5, "left": 1440.5}, "annotation": "", "content_id": "toolshed.g2.bx.psu.edu/repos/devteam/bamtools_filter/bamFilter/2.4.1", "type": "tool"}, "9": {"tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/umi_tools_count/umi_tools_count/0.5.3.2", "tool_version": "0.5.3.2", "outputs": [{"type": "tabular", "name": "out_counts"}], "workflow_outputs": [{"output_name": "out_counts", "uuid": "209f3dd6-974f-4e76-a206-c86114a6697f", "label": null}], "input_connections": {"input_bam": {"output_name": "out_file1", "id": 8}}, "tool_state": "{\"wide_format_cell_counts\": \"\\\"true\\\"\", \"cond_extra\": \"{\\\"__current_case__\\\": 1, \\\"prepender\\\": \\\"dataset name\\\"}\", \"__page__\": null, \"__rerun_remap_job_id__\": null, \"edit_distance_threshold\": \"\\\"1\\\"\", \"paired\": \"\\\"false\\\"\", \"input_bam\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\", \"method\": \"\\\"unique\\\"\", \"advanced\": \"{\\\"gene_tag\\\": \\\"XT\\\", \\\"mapping_quality\\\": \\\"0\\\", \\\"per_cell\\\": \\\"true\\\", \\\"per_contig\\\": \\\"false\\\", \\\"random_seed\\\": \\\"0\\\", \\\"skip_tags_regex\\\": \\\"\\\"}\", \"barcodes\": \"{\\\"__current_case__\\\": 0, \\\"extract_umi_method\\\": \\\"read_id\\\", \\\"umi_separator\\\": \\\"_\\\"}\"}", "id": 9, "tool_shed_repository": {"owner": "iuc", "changeset_revision": "b557acca0b56", "name": "umi_tools_count", "tool_shed": "toolshed.g2.bx.psu.edu"}, "uuid": "89675c5a-ef94-49a5-889c-c53ba1074f80", "errors": null, "name": "UMI-tools count", "post_job_actions": {}, "label": null, "inputs": [{"name": "input_bam", "description": "runtime parameter for tool UMI-tools count"}], "position": {"top": 590, "left": 1703.5}, "annotation": "", "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/umi_tools_count/umi_tools_count/0.5.3.2", "type": "tool"}, "10": {"tool_id": "toolshed.g2.bx.psu.edu/repos/bgruening/text_processing/tp_sed_tool/1.1.1", "tool_version": "1.1.1", "outputs": [{"type": "input", "name": "output"}], "workflow_outputs": [{"output_name": "output", "uuid": "2aa0f119-75c6-4b6b-8260-ff66f54167a4", "label": null}], "input_connections": {"infile": {"output_name": "out_counts", "id": 9}}, "tool_state": "{\"adv_opts\": \"{\\\"__current_case__\\\": 0, \\\"adv_opts_selector\\\": \\\"basic\\\"}\", \"__page__\": null, \"__rerun_remap_job_id__\": null, \"code\": \"\\\"1 s|\\\\\\\\w+_([ACTG]+)\\\\\\\\b|\\\\\\\\1|g\\\"\", \"infile\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\"}", "id": 10, "tool_shed_repository": {"owner": "bgruening", "changeset_revision": "a6f147a050a2", "name": "text_processing", "tool_shed": "toolshed.g2.bx.psu.edu"}, "uuid": "1d1e09f7-119f-4086-b8b7-a9fb61cea637", "errors": null, "name": "Text transformation", "post_job_actions": {}, "label": "Fix Headers", "inputs": [{"name": "infile", "description": "runtime parameter for tool Text transformation"}], "position": {"top": 528.40625, "left": 1919.90625}, "annotation": "", "content_id": "toolshed.g2.bx.psu.edu/repos/bgruening/text_processing/tp_sed_tool/1.1.1", "type": "tool"}}, "annotation": "", "a_galaxy_workflow": "true"}, "workflow_outputs": [{"output_name": "4:mapped_reads", "uuid": "0a5f54e7-09dc-4c35-980a-b617fcfaa2eb", "label": null}, {"output_name": "7:html_report", "uuid": "fea13497-e4cb-47b1-a64d-6883e19def0f", "label": null}, {"output_name": "0:output", "uuid": "65f46424-6d76-4d1f-acd0-aef24e26d10b", "label": null}, {"output_name": "10:output", "uuid": "cc791e7c-9cbb-481d-8deb-39d33f7b2857", "label": null}, {"output_name": "4:chimeric_reads", "uuid": "c6ad66bf-5fde-4440-ab54-4997211c2c3d", "label": null}, {"output_name": "4:reads_per_gene", "uuid": "b4ea5261-7733-4b7e-8e30-1d3535e9cb57", "label": null}, {"output_name": "9:out_counts", "uuid": "58562166-7b2d-4b0d-9172-14a02d7a989a", "label": null}, {"output_name": "4:chimeric_junctions", "uuid": "c33a7acd-f5bc-4ac5-b3d3-a6fb2892c9f6", "label": null}, {"output_name": "6:output_bam", "uuid": "1601b4a1-a302-425d-bad6-7b71d14f9726", "label": null}, {"output_name": "8:out_file1", "uuid": "a7b1aa8e-61cd-4b1c-8fa9-3c85d4113ea5", "label": null}, {"output_name": "7:stats", "uuid": "ac17c572-784c-456e-b3c7-ebaf15c2109e", "label": null}, {"output_name": "5:output", "uuid": "5c220f46-2525-471f-8fd6-0eb17dc689ad", "label": null}, {"output_name": "7:log", "uuid": "3ad7aac8-e4a0-4df1-beb6-88cdcb106e7a", "label": null}, {"output_name": "3:out2", "uuid": "4ff34341-786c-4c66-95c7-6985e4c66ad7", "label": null}, {"output_name": "1:output", "uuid": "78bfe4ce-528c-4d16-8e73-f721b09676be", "label": null}, {"output_name": "2:output", "uuid": "603d0608-7866-4f1d-be85-6a4f3116d5b8", "label": null}, {"output_name": "4:splice_junctions", "uuid": "7f85f228-75da-4933-8157-e6eb4f15bd98", "label": null}, {"output_name": "4:output_log", "uuid": "86003cab-1a90-4871-b489-27eb49715574", "label": null}], "input_connections": {"Barcodes (single-col)": {"input_subworkflow_step_id": 1, "output_name": "output", "id": 1}, "Batch": {"input_subworkflow_step_id": 0, "output_name": "output", "id": 3}, "GTF file (UCSC)": {"input_subworkflow_step_id": 2, "output_name": "output", "id": 2}}, "id": 4, "uuid": "e86d6331-50b9-412a-b895-0bda5408d366", "name": "CelSeq2: Single Batch mm10", "label": null, "position": {"top": 293.5, "left": 879}, "annotation": "", "type": "subworkflow"}, "5": {"tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/collection_column_join/collection_column_join/0.0.3", "tool_version": "0.0.3", "outputs": [{"type": "tabular", "name": "tabular_output"}, {"type": "txt", "name": "script_output"}], "workflow_outputs": [{"output_name": "tabular_output", "uuid": "2167fa1b-4865-40b1-9c61-82dd6ba8ccc7", "label": null}], "input_connections": {"input_tabular": {"output_name": "9:out_counts", "id": 4}}, "tool_state": "{\"__page__\": null, \"identifier_column\": \"\\\"1\\\"\", \"include_outputs\": \"null\", \"__rerun_remap_job_id__\": null, \"input_tabular\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\", \"fill_char\": \"\\\".\\\"\", \"old_col_in_header\": \"\\\"true\\\"\", \"has_header\": \"\\\"1\\\"\"}", "id": 5, "tool_shed_repository": {"owner": "iuc", "changeset_revision": "58228a4d58fe", "name": "collection_column_join", "tool_shed": "toolshed.g2.bx.psu.edu"}, "uuid": "174c32b6-444c-4762-b9c1-c84201e656ab", "errors": null, "name": "Column Join", "post_job_actions": {"HideDatasetActionscript_output": {"output_name": "script_output", "action_type": "HideDatasetAction", "action_arguments": {}}}, "label": null, "inputs": [{"name": "input_tabular", "description": "runtime parameter for tool Column Join"}], "position": {"top": 288, "left": 1277.5}, "annotation": "", "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/collection_column_join/collection_column_join/0.0.3", "type": "tool"}}, "annotation": "", "a_galaxy_workflow": "true"}
+{
+  "a_galaxy_workflow": "true",
+  "annotation": "",
+  "format-version": "0.1",
+  "name": "CelSeq2: Multi Batch mm10",
+  "steps": {
+    "0": {
+      "annotation": "",
+      "content_id": null,
+      "errors": null,
+      "id": 0,
+      "input_connections": {},
+      "inputs": [],
+      "label": "List of FACS pairs",
+      "name": "Input dataset collection",
+      "outputs": [],
+      "position": {
+        "left": 119.5,
+        "top": 260
+      },
+      "tool_id": null,
+      "tool_state": "{\"collection_type\": \"list:paired\"}",
+      "tool_version": null,
+      "type": "data_collection_input",
+      "uuid": "c50ee411-e25e-4570-97bf-f0a05af2458e",
+      "workflow_outputs": [
+        {
+          "label": null,
+          "output_name": "output",
+          "uuid": "37307bc9-a8de-4fb4-8482-4a3554c9af36"
+        }
+      ]
+    },
+    "1": {
+      "annotation": "",
+      "content_id": null,
+      "errors": null,
+      "id": 1,
+      "input_connections": {},
+      "inputs": [],
+      "label": "Barcodes",
+      "name": "Input dataset",
+      "outputs": [],
+      "position": {
+        "left": 566.5,
+        "top": 429.5
+      },
+      "tool_id": null,
+      "tool_state": "{}",
+      "tool_version": null,
+      "type": "data_input",
+      "uuid": "cb331533-4896-419f-83ca-196c5daf2c03",
+      "workflow_outputs": [
+        {
+          "label": null,
+          "output_name": "output",
+          "uuid": "d863899f-2ea8-49d1-acc9-a2cca1f9fce3"
+        }
+      ]
+    },
+    "2": {
+      "annotation": "",
+      "content_id": null,
+      "errors": null,
+      "id": 2,
+      "input_connections": {},
+      "inputs": [],
+      "label": "GTF file (UCSC)",
+      "name": "Input dataset",
+      "outputs": [],
+      "position": {
+        "left": 568.5,
+        "top": 521
+      },
+      "tool_id": null,
+      "tool_state": "{}",
+      "tool_version": null,
+      "type": "data_input",
+      "uuid": "ac1f89bb-52b9-41ac-a6d4-f8dfd4d21550",
+      "workflow_outputs": [
+        {
+          "label": null,
+          "output_name": "output",
+          "uuid": "51046a1f-f629-4e6a-aac1-eb563eeb693b"
+        }
+      ]
+    },
+    "3": {
+      "annotation": "",
+      "content_id": "__FLATTEN__",
+      "errors": null,
+      "id": 3,
+      "input_connections": {
+        "input": {
+          "id": 0,
+          "output_name": "output"
+        }
+      },
+      "inputs": [],
+      "label": null,
+      "name": "Flatten Collection",
+      "outputs": [
+        {
+          "name": "output",
+          "type": "input"
+        }
+      ],
+      "position": {
+        "left": 547,
+        "top": 266
+      },
+      "post_job_actions": {
+        "HideDatasetActionoutput": {
+          "action_arguments": {},
+          "action_type": "HideDatasetAction",
+          "output_name": "output"
+        }
+      },
+      "tool_id": "__FLATTEN__",
+      "tool_state": "{\"input\": \"{\\\"values\\\": [{\\\"id\\\": 93213, \\\"src\\\": \\\"hdca\\\"}]}\", \"__rerun_remap_job_id__\": null, \"join_identifier\": \"\\\"_\\\"\", \"__page__\": null}",
+      "tool_version": "1.0.0",
+      "type": "tool",
+      "uuid": "413df6c7-4f25-4f13-b8d1-056c2bc14040",
+      "workflow_outputs": []
+    },
+    "4": {
+      "annotation": "",
+      "id": 4,
+      "input_connections": {
+        "Barcodes (single-col)": {
+          "id": 1,
+          "input_subworkflow_step_id": 1,
+          "output_name": "output"
+        },
+        "Batch": {
+          "id": 3,
+          "input_subworkflow_step_id": 0,
+          "output_name": "output"
+        },
+        "GTF file (UCSC)": {
+          "id": 2,
+          "input_subworkflow_step_id": 2,
+          "output_name": "output"
+        }
+      },
+      "inputs": [],
+      "label": null,
+      "name": "CelSeq2: Single Batch mm10",
+      "outputs": [],
+      "position": {
+        "left": 879,
+        "top": 293.5
+      },
+      "subworkflow": {
+        "a_galaxy_workflow": "true",
+        "annotation": "",
+        "format-version": "0.1",
+        "name": "CelSeq2: Single Batch mm10",
+        "steps": {
+          "0": {
+            "annotation": "",
+            "content_id": null,
+            "errors": null,
+            "id": 0,
+            "input_connections": {},
+            "inputs": [],
+            "label": "Batch",
+            "name": "Input dataset collection",
+            "outputs": [],
+            "position": {
+              "left": 286,
+              "top": 470.90625
+            },
+            "tool_id": null,
+            "tool_state": "{\"collection_type\": \"paired\"}",
+            "tool_version": null,
+            "type": "data_collection_input",
+            "uuid": "c451df86-a25e-409c-9f2e-33c22a0f1bb9",
+            "workflow_outputs": [
+              {
+                "label": null,
+                "output_name": "output",
+                "uuid": "d46989fb-ef46-4506-8932-d66cee38e62a"
+              }
+            ]
+          },
+          "1": {
+            "annotation": "",
+            "content_id": null,
+            "errors": null,
+            "id": 1,
+            "input_connections": {},
+            "inputs": [],
+            "label": "Barcodes (single-col)",
+            "name": "Input dataset",
+            "outputs": [],
+            "position": {
+              "left": 302.5,
+              "top": 552
+            },
+            "tool_id": null,
+            "tool_state": "{}",
+            "tool_version": null,
+            "type": "data_input",
+            "uuid": "4ac7860e-01d4-4009-b1fd-899fab778eb5",
+            "workflow_outputs": [
+              {
+                "label": null,
+                "output_name": "output",
+                "uuid": "2c66b77f-5ee0-4991-971c-3c43d8e7841d"
+              }
+            ]
+          },
+          "10": {
+            "annotation": "",
+            "content_id": "toolshed.g2.bx.psu.edu/repos/bgruening/text_processing/tp_sed_tool/1.1.1",
+            "errors": null,
+            "id": 10,
+            "input_connections": {
+              "infile": {
+                "id": 9,
+                "output_name": "out_counts"
+              }
+            },
+            "inputs": [
+              {
+                "description": "runtime parameter for tool Text transformation",
+                "name": "infile"
+              }
+            ],
+            "label": "Fix Headers",
+            "name": "Text transformation",
+            "outputs": [
+              {
+                "name": "output",
+                "type": "input"
+              }
+            ],
+            "position": {
+              "left": 1919.90625,
+              "top": 528.40625
+            },
+            "post_job_actions": {},
+            "tool_id": "toolshed.g2.bx.psu.edu/repos/bgruening/text_processing/tp_sed_tool/1.1.1",
+            "tool_shed_repository": {
+              "changeset_revision": "a6f147a050a2",
+              "name": "text_processing",
+              "owner": "bgruening",
+              "tool_shed": "toolshed.g2.bx.psu.edu"
+            },
+            "tool_state": "{\"adv_opts\": \"{\\\"__current_case__\\\": 0, \\\"adv_opts_selector\\\": \\\"basic\\\"}\", \"__page__\": null, \"__rerun_remap_job_id__\": null, \"code\": \"\\\"1 s|\\\\\\\\w+_([ACTG]+)\\\\\\\\b|\\\\\\\\1|g\\\"\", \"infile\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\"}",
+            "tool_version": "1.1.1",
+            "type": "tool",
+            "uuid": "1d1e09f7-119f-4086-b8b7-a9fb61cea637",
+            "workflow_outputs": [
+              {
+                "label": null,
+                "output_name": "output",
+                "uuid": "2aa0f119-75c6-4b6b-8260-ff66f54167a4"
+              }
+            ]
+          },
+          "2": {
+            "annotation": "",
+            "content_id": null,
+            "errors": null,
+            "id": 2,
+            "input_connections": {},
+            "inputs": [],
+            "label": "GTF file (UCSC)",
+            "name": "Input dataset",
+            "outputs": [],
+            "position": {
+              "left": 313.5,
+              "top": 828.90625
+            },
+            "tool_id": null,
+            "tool_state": "{}",
+            "tool_version": null,
+            "type": "data_input",
+            "uuid": "0455bae6-58da-4ec3-9688-72aba9f676fe",
+            "workflow_outputs": [
+              {
+                "label": null,
+                "output_name": "output",
+                "uuid": "7ca9e0df-159c-43f7-a0b3-e546fcd9b2c9"
+              }
+            ]
+          },
+          "3": {
+            "annotation": "",
+            "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/umi_tools_extract/umi_tools_extract/0.5.3.2",
+            "errors": null,
+            "id": 3,
+            "input_connections": {
+              "barcodes|filter_barcode_file": {
+                "id": 1,
+                "output_name": "output"
+              },
+              "input_type|input_readpair": {
+                "id": 0,
+                "output_name": "output"
+              }
+            },
+            "inputs": [
+              {
+                "description": "runtime parameter for tool UMI-tools extract",
+                "name": "input_type"
+              },
+              {
+                "description": "runtime parameter for tool UMI-tools extract",
+                "name": "barcodes"
+              }
+            ],
+            "label": null,
+            "name": "UMI-tools extract",
+            "outputs": [
+              {
+                "name": "out",
+                "type": "input"
+              },
+              {
+                "name": "out1",
+                "type": "input"
+              },
+              {
+                "name": "out2",
+                "type": "input"
+              },
+              {
+                "name": "out_log",
+                "type": "txt"
+              }
+            ],
+            "position": {
+              "left": 554.5,
+              "top": 469.90625
+            },
+            "post_job_actions": {
+              "HideDatasetActionout": {
+                "action_arguments": {},
+                "action_type": "HideDatasetAction",
+                "output_name": "out"
+              },
+              "HideDatasetActionout1": {
+                "action_arguments": {},
+                "action_type": "HideDatasetAction",
+                "output_name": "out1"
+              },
+              "HideDatasetActionout_log": {
+                "action_arguments": {},
+                "action_type": "HideDatasetAction",
+                "output_name": "out_log"
+              }
+            },
+            "tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/umi_tools_extract/umi_tools_extract/0.5.3.2",
+            "tool_shed_repository": {
+              "changeset_revision": "99aea37a7ff7",
+              "name": "umi_tools_extract",
+              "owner": "iuc",
+              "tool_shed": "toolshed.g2.bx.psu.edu"
+            },
+            "tool_state": "{\"__page__\": null, \"extract_method\": \"\\\"string\\\"\", \"input_type\": \"{\\\"__current_case__\\\": 2, \\\"barcode\\\": {\\\"__current_case__\\\": 0, \\\"barcode_select\\\": \\\"first_read_only\\\"}, \\\"input_readpair\\\": {\\\"__class__\\\": \\\"RuntimeValue\\\"}, \\\"type\\\": \\\"paired_collection\\\"}\", \"__rerun_remap_job_id__\": null, \"bc_pattern\": \"\\\"NNNNNNCCCCCC\\\"\", \"print_log\": \"\\\"true\\\"\", \"prime3\": \"\\\"true\\\"\", \"quality\": \"{\\\"__current_case__\\\": 0, \\\"quality_selector\\\": \\\"false\\\"}\", \"barcodes\": \"{\\\"__current_case__\\\": 1, \\\"filter_barcode_file\\\": {\\\"__class__\\\": \\\"RuntimeValue\\\"}, \\\"filter_correct\\\": \\\"false\\\", \\\"use_barcodes\\\": \\\"yes\\\"}\"}",
+            "tool_version": "0.5.3.2",
+            "type": "tool",
+            "uuid": "0b94d2ea-1889-4b88-b0a2-ac7b0a3452e5",
+            "workflow_outputs": [
+              {
+                "label": null,
+                "output_name": "out2",
+                "uuid": "c24e1482-bbff-4a22-8747-2ab0330fb5af"
+              }
+            ]
+          },
+          "4": {
+            "annotation": "The genome should match that of the GTF file",
+            "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/rgrnastar/rna_star/2.5.2b-2",
+            "errors": null,
+            "id": 4,
+            "input_connections": {
+              "refGenomeSource|GTFconditional|sjdbGTFfile": {
+                "id": 2,
+                "output_name": "output"
+              },
+              "singlePaired|input1": {
+                "id": 3,
+                "output_name": "out2"
+              }
+            },
+            "inputs": [
+              {
+                "description": "runtime parameter for tool RNA STAR",
+                "name": "quantMode"
+              },
+              {
+                "description": "runtime parameter for tool RNA STAR",
+                "name": "singlePaired"
+              }
+            ],
+            "label": "Alignment (mm10)",
+            "name": "RNA STAR",
+            "outputs": [
+              {
+                "name": "output_log",
+                "type": "txt"
+              },
+              {
+                "name": "chimeric_junctions",
+                "type": "interval"
+              },
+              {
+                "name": "chimeric_reads",
+                "type": "bam"
+              },
+              {
+                "name": "splice_junctions",
+                "type": "interval"
+              },
+              {
+                "name": "mapped_reads",
+                "type": "bam"
+              },
+              {
+                "name": "reads_per_gene",
+                "type": "tabular"
+              }
+            ],
+            "position": {
+              "left": 832.5,
+              "top": 581.90625
+            },
+            "post_job_actions": {},
+            "tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/rgrnastar/rna_star/2.5.2b-2",
+            "tool_shed_repository": {
+              "changeset_revision": "2055c2667eb3",
+              "name": "rgrnastar",
+              "owner": "iuc",
+              "tool_shed": "toolshed.g2.bx.psu.edu"
+            },
+            "tool_state": "{\"__page__\": null, \"singlePaired\": \"{\\\"__current_case__\\\": 0, \\\"input1\\\": {\\\"__class__\\\": \\\"RuntimeValue\\\"}, \\\"sPaired\\\": \\\"single\\\"}\", \"output_params\": \"{\\\"__current_case__\\\": 1, \\\"output_select\\\": \\\"no\\\"}\", \"__rerun_remap_job_id__\": null, \"params\": \"{\\\"__current_case__\\\": 0, \\\"settingsType\\\": \\\"default\\\"}\", \"refGenomeSource\": \"{\\\"GTFconditional\\\": {\\\"GTFselect\\\": \\\"without-gtf\\\", \\\"__current_case__\\\": 1, \\\"genomeDir\\\": \\\"mm10\\\", \\\"sjdbGTFfile\\\": {\\\"__class__\\\": \\\"RuntimeValue\\\"}, \\\"sjdbOverhang\\\": \\\"100\\\"}, \\\"__current_case__\\\": 0, \\\"geneSource\\\": \\\"indexed\\\"}\", \"quantMode\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\"}",
+            "tool_version": "2.5.2b-2",
+            "type": "tool",
+            "uuid": "1e4a54be-b2fb-496a-8247-ccba4ffe6f3b",
+            "workflow_outputs": [
+              {
+                "label": null,
+                "output_name": "chimeric_reads",
+                "uuid": "f44d1ce2-b0a0-4aca-b9da-d47a9151dd8f"
+              },
+              {
+                "label": null,
+                "output_name": "chimeric_junctions",
+                "uuid": "a70f8d45-eaa8-40f4-a755-99e7004ad0ee"
+              },
+              {
+                "label": null,
+                "output_name": "reads_per_gene",
+                "uuid": "70ef8c03-6a54-4c88-81b6-e178dbf776c7"
+              },
+              {
+                "label": null,
+                "output_name": "splice_junctions",
+                "uuid": "0896bee8-d853-4467-8143-96a4d314774c"
+              },
+              {
+                "label": null,
+                "output_name": "mapped_reads",
+                "uuid": "956818b5-dc81-440c-8c2a-b10869547c70"
+              },
+              {
+                "label": null,
+                "output_name": "output_log",
+                "uuid": "5714f89a-1d7f-4634-95ce-2b089e5cc83d"
+              }
+            ]
+          },
+          "5": {
+            "annotation": "",
+            "content_id": "toolshed.g2.bx.psu.edu/repos/devteam/samtools_stats/samtools_stats/2.0.1",
+            "errors": null,
+            "id": 5,
+            "input_connections": {
+              "input_file": {
+                "id": 4,
+                "output_name": "mapped_reads"
+              }
+            },
+            "inputs": [
+              {
+                "description": "runtime parameter for tool Stats",
+                "name": "input_file"
+              }
+            ],
+            "label": null,
+            "name": "Stats",
+            "outputs": [
+              {
+                "name": "output",
+                "type": "tabular"
+              }
+            ],
+            "position": {
+              "left": 1338.5,
+              "top": 403
+            },
+            "post_job_actions": {},
+            "tool_id": "toolshed.g2.bx.psu.edu/repos/devteam/samtools_stats/samtools_stats/2.0.1",
+            "tool_shed_repository": {
+              "changeset_revision": "24c5d43cb545",
+              "name": "samtools_stats",
+              "owner": "devteam",
+              "tool_shed": "toolshed.g2.bx.psu.edu"
+            },
+            "tool_state": "{\"coverage_max\": \"\\\"1000\\\"\", \"__page__\": null, \"input_file\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\", \"gc_depth\": \"\\\"20000.0\\\"\", \"insert_size\": \"\\\"8000\\\"\", \"most_inserts\": \"\\\"0.99\\\"\", \"coverage_step\": \"\\\"1\\\"\", \"coverage_min\": \"\\\"1\\\"\", \"read_length\": \"\\\"\\\"\", \"trim_quality\": \"\\\"0\\\"\", \"filter_by_flags\": \"{\\\"__current_case__\\\": 1, \\\"filter_flags\\\": \\\"nofilter\\\"}\", \"split_output\": \"{\\\"__current_case__\\\": 0, \\\"split_output_selector\\\": \\\"no\\\"}\", \"use_reference\": \"{\\\"__current_case__\\\": 1, \\\"use_ref_selector\\\": \\\"no\\\"}\", \"__rerun_remap_job_id__\": null, \"remove_dups\": \"\\\"false\\\"\"}",
+            "tool_version": "2.0.1",
+            "type": "tool",
+            "uuid": "36ad81d4-f920-4ca6-83c2-66516b2229f2",
+            "workflow_outputs": [
+              {
+                "label": null,
+                "output_name": "output",
+                "uuid": "eed5af2c-48f7-4227-8d76-0686c0537ccc"
+              }
+            ]
+          },
+          "6": {
+            "annotation": "",
+            "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/featurecounts/featurecounts/1.6.2",
+            "errors": null,
+            "id": 6,
+            "input_connections": {
+              "alignment": {
+                "id": 4,
+                "output_name": "mapped_reads"
+              },
+              "anno|reference_gene_sets": {
+                "id": 2,
+                "output_name": "output"
+              }
+            },
+            "inputs": [
+              {
+                "description": "runtime parameter for tool featureCounts",
+                "name": "anno"
+              },
+              {
+                "description": "runtime parameter for tool featureCounts",
+                "name": "alignment"
+              }
+            ],
+            "label": null,
+            "name": "featureCounts",
+            "outputs": [
+              {
+                "name": "output_medium",
+                "type": "tabular"
+              },
+              {
+                "name": "output_bam",
+                "type": "bam"
+              },
+              {
+                "name": "output_short",
+                "type": "tabular"
+              },
+              {
+                "name": "output_full",
+                "type": "tabular"
+              },
+              {
+                "name": "output_summary",
+                "type": "tabular"
+              },
+              {
+                "name": "output_feature_lengths",
+                "type": "tabular"
+              },
+              {
+                "name": "output_jcounts",
+                "type": "tabular"
+              }
+            ],
+            "position": {
+              "left": 1141.5,
+              "top": 814
+            },
+            "post_job_actions": {
+              "HideDatasetActionoutput_feature_lengths": {
+                "action_arguments": {},
+                "action_type": "HideDatasetAction",
+                "output_name": "output_feature_lengths"
+              },
+              "HideDatasetActionoutput_full": {
+                "action_arguments": {},
+                "action_type": "HideDatasetAction",
+                "output_name": "output_full"
+              },
+              "HideDatasetActionoutput_jcounts": {
+                "action_arguments": {},
+                "action_type": "HideDatasetAction",
+                "output_name": "output_jcounts"
+              },
+              "HideDatasetActionoutput_medium": {
+                "action_arguments": {},
+                "action_type": "HideDatasetAction",
+                "output_name": "output_medium"
+              },
+              "HideDatasetActionoutput_short": {
+                "action_arguments": {},
+                "action_type": "HideDatasetAction",
+                "output_name": "output_short"
+              },
+              "HideDatasetActionoutput_summary": {
+                "action_arguments": {},
+                "action_type": "HideDatasetAction",
+                "output_name": "output_summary"
+              }
+            },
+            "tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/featurecounts/featurecounts/1.6.2",
+            "tool_shed_repository": {
+              "changeset_revision": "f3a5f075498f",
+              "name": "featurecounts",
+              "owner": "iuc",
+              "tool_shed": "toolshed.g2.bx.psu.edu"
+            },
+            "tool_state": "{\"pe_parameters\": \"{\\\"exclude_chimerics\\\": \\\"true\\\", \\\"fragment_counting_enabled\\\": {\\\"__current_case__\\\": 1, \\\"fragment_counting\\\": \\\"\\\"}, \\\"only_both_ends\\\": \\\"false\\\"}\", \"strand_specificity\": \"\\\"0\\\"\", \"__page__\": null, \"__rerun_remap_job_id__\": null, \"format\": \"\\\"tabdel_short\\\"\", \"include_feature_length_file\": \"\\\"false\\\"\", \"anno\": \"{\\\"__current_case__\\\": 2, \\\"anno_select\\\": \\\"history\\\", \\\"reference_gene_sets\\\": {\\\"__class__\\\": \\\"RuntimeValue\\\"}}\", \"extended_parameters\": \"{\\\"R\\\": \\\"true\\\", \\\"by_read_group\\\": \\\"false\\\", \\\"contribute_to_multiple_features\\\": \\\"false\\\", \\\"count_split_alignments_only\\\": \\\"false\\\", \\\"exon_exon_junction_read_counting_enabled\\\": {\\\"__current_case__\\\": 1, \\\"count_exon_exon_junction_reads\\\": \\\"false\\\"}, \\\"frac_overlap\\\": \\\"0\\\", \\\"frac_overlap_feature\\\": \\\"0\\\", \\\"gff_feature_attribute\\\": \\\"gene_id\\\", \\\"gff_feature_type\\\": \\\"exon\\\", \\\"ignore_dup\\\": \\\"false\\\", \\\"largest_overlap\\\": \\\"false\\\", \\\"long_reads\\\": \\\"false\\\", \\\"mapping_quality\\\": \\\"12\\\", \\\"min_overlap\\\": \\\"1\\\", \\\"multimapping_enabled\\\": {\\\"__current_case__\\\": 1, \\\"multimapping_counts\\\": \\\"\\\"}, \\\"primary\\\": \\\"false\\\", \\\"read_extension_3p\\\": \\\"0\\\", \\\"read_extension_5p\\\": \\\"0\\\", \\\"read_reduction\\\": \\\"\\\", \\\"summarization_level\\\": \\\"false\\\"}\", \"alignment\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\"}",
+            "tool_version": "1.6.2",
+            "type": "tool",
+            "uuid": "9506153d-d997-43a4-8ce1-216690415561",
+            "workflow_outputs": [
+              {
+                "label": null,
+                "output_name": "output_bam",
+                "uuid": "87abf585-aae9-4af3-aed7-541795d65faf"
+              }
+            ]
+          },
+          "7": {
+            "annotation": "",
+            "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/multiqc/multiqc/1.5.0",
+            "errors": null,
+            "id": 7,
+            "input_connections": {
+              "results_0|software_cond|output_0|type|input": {
+                "id": 5,
+                "output_name": "output"
+              }
+            },
+            "inputs": [],
+            "label": null,
+            "name": "MultiQC",
+            "outputs": [
+              {
+                "name": "stats",
+                "type": "input"
+              },
+              {
+                "name": "html_report",
+                "type": "html"
+              },
+              {
+                "name": "log",
+                "type": "txt"
+              }
+            ],
+            "position": {
+              "left": 1643.5,
+              "top": 200
+            },
+            "post_job_actions": {},
+            "tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/multiqc/multiqc/1.5.0",
+            "tool_shed_repository": {
+              "changeset_revision": "df99138d2776",
+              "name": "multiqc",
+              "owner": "iuc",
+              "tool_shed": "toolshed.g2.bx.psu.edu"
+            },
+            "tool_state": "{\"comment\": \"\\\"\\\"\", \"__page__\": null, \"title\": \"\\\"\\\"\", \"__rerun_remap_job_id__\": null, \"results\": \"[{\\\"__index__\\\": 0, \\\"software_cond\\\": {\\\"__current_case__\\\": 20, \\\"output\\\": [{\\\"__index__\\\": 0, \\\"type\\\": {\\\"__current_case__\\\": 0, \\\"input\\\": {\\\"__class__\\\": \\\"RuntimeValue\\\"}, \\\"type\\\": \\\"stats\\\"}}], \\\"software\\\": \\\"samtools\\\"}}, {\\\"__index__\\\": 1, \\\"software_cond\\\": {\\\"__current_case__\\\": 7, \\\"output\\\": [{\\\"__index__\\\": 0, \\\"input\\\": {\\\"__class__\\\": \\\"RuntimeValue\\\"}, \\\"type\\\": \\\"data\\\"}], \\\"software\\\": \\\"fastqc\\\"}}, {\\\"__index__\\\": 2, \\\"software_cond\\\": {\\\"__current_case__\\\": 7, \\\"output\\\": [{\\\"__index__\\\": 0, \\\"input\\\": {\\\"__class__\\\": \\\"RuntimeValue\\\"}, \\\"type\\\": \\\"data\\\"}], \\\"software\\\": \\\"fastqc\\\"}}]\", \"saveLog\": \"\\\"false\\\"\"}",
+            "tool_version": "1.5.0",
+            "type": "tool",
+            "uuid": "c56b2cfb-18c4-4f17-9f5c-a84009e00050",
+            "workflow_outputs": [
+              {
+                "label": null,
+                "output_name": "stats",
+                "uuid": "2845973b-96f5-44c6-b454-b3e09601972b"
+              },
+              {
+                "label": null,
+                "output_name": "log",
+                "uuid": "9dfc4543-d1d9-40f4-b703-61993f05fbee"
+              },
+              {
+                "label": null,
+                "output_name": "html_report",
+                "uuid": "452d04bd-cdcc-4074-839d-6a70ad44ba55"
+              }
+            ]
+          },
+          "8": {
+            "annotation": "",
+            "content_id": "toolshed.g2.bx.psu.edu/repos/devteam/bamtools_filter/bamFilter/2.4.1",
+            "errors": null,
+            "id": 8,
+            "input_connections": {
+              "input_bam": {
+                "id": 6,
+                "output_name": "output_bam"
+              }
+            },
+            "inputs": [
+              {
+                "description": "runtime parameter for tool Filter",
+                "name": "input_bam"
+              }
+            ],
+            "label": null,
+            "name": "Filter",
+            "outputs": [
+              {
+                "name": "out_file2",
+                "type": "txt"
+              },
+              {
+                "name": "out_file1",
+                "type": "bam"
+              }
+            ],
+            "position": {
+              "left": 1440.5,
+              "top": 627.5
+            },
+            "post_job_actions": {
+              "HideDatasetActionout_file2": {
+                "action_arguments": {},
+                "action_type": "HideDatasetAction",
+                "output_name": "out_file2"
+              }
+            },
+            "tool_id": "toolshed.g2.bx.psu.edu/repos/devteam/bamtools_filter/bamFilter/2.4.1",
+            "tool_shed_repository": {
+              "changeset_revision": "bd735cae4ce6",
+              "name": "bamtools_filter",
+              "owner": "devteam",
+              "tool_shed": "toolshed.g2.bx.psu.edu"
+            },
+            "tool_state": "{\"input_bam\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\", \"__rerun_remap_job_id__\": null, \"rule_configuration\": \"{\\\"__current_case__\\\": 1, \\\"rules\\\": \\\"(1 | 2) & 3 & 4\\\", \\\"rules_selector\\\": \\\"true\\\"}\", \"conditions\": \"[{\\\"__index__\\\": 0, \\\"filters\\\": [{\\\"__index__\\\": 0, \\\"bam_property\\\": {\\\"__current_case__\\\": 0, \\\"bam_property_selector\\\": \\\"alignmentFlag\\\", \\\"bam_property_value\\\": \\\"0\\\"}}]}, {\\\"__index__\\\": 1, \\\"filters\\\": [{\\\"__index__\\\": 0, \\\"bam_property\\\": {\\\"__current_case__\\\": 0, \\\"bam_property_selector\\\": \\\"alignmentFlag\\\", \\\"bam_property_value\\\": \\\"16\\\"}}]}, {\\\"__index__\\\": 2, \\\"filters\\\": [{\\\"__index__\\\": 0, \\\"bam_property\\\": {\\\"__current_case__\\\": 21, \\\"bam_property_selector\\\": \\\"tag\\\", \\\"bam_property_value\\\": \\\"nM:<3\\\"}}]}, {\\\"__index__\\\": 3, \\\"filters\\\": [{\\\"__index__\\\": 0, \\\"bam_property\\\": {\\\"__current_case__\\\": 21, \\\"bam_property_selector\\\": \\\"tag\\\", \\\"bam_property_value\\\": \\\"NH:<2\\\"}}]}]\", \"__page__\": null}",
+            "tool_version": "2.4.1",
+            "type": "tool",
+            "uuid": "e65c9b1a-65d2-46dc-8199-0f87acf7f6b1",
+            "workflow_outputs": [
+              {
+                "label": null,
+                "output_name": "out_file1",
+                "uuid": "50f1d2af-ca7e-46b1-a9a6-99931ee1fcb5"
+              }
+            ]
+          },
+          "9": {
+            "annotation": "",
+            "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/umi_tools_count/umi_tools_count/0.5.3.2",
+            "errors": null,
+            "id": 9,
+            "input_connections": {
+              "input_bam": {
+                "id": 8,
+                "output_name": "out_file1"
+              }
+            },
+            "inputs": [
+              {
+                "description": "runtime parameter for tool UMI-tools count",
+                "name": "input_bam"
+              }
+            ],
+            "label": null,
+            "name": "UMI-tools count",
+            "outputs": [
+              {
+                "name": "out_counts",
+                "type": "tabular"
+              }
+            ],
+            "position": {
+              "left": 1703.5,
+              "top": 590
+            },
+            "post_job_actions": {},
+            "tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/umi_tools_count/umi_tools_count/0.5.3.2",
+            "tool_shed_repository": {
+              "changeset_revision": "b557acca0b56",
+              "name": "umi_tools_count",
+              "owner": "iuc",
+              "tool_shed": "toolshed.g2.bx.psu.edu"
+            },
+            "tool_state": "{\"wide_format_cell_counts\": \"\\\"true\\\"\", \"cond_extra\": \"{\\\"__current_case__\\\": 1, \\\"prepender\\\": \\\"dataset name\\\"}\", \"__page__\": null, \"__rerun_remap_job_id__\": null, \"edit_distance_threshold\": \"\\\"1\\\"\", \"paired\": \"\\\"false\\\"\", \"input_bam\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\", \"method\": \"\\\"unique\\\"\", \"advanced\": \"{\\\"gene_tag\\\": \\\"XT\\\", \\\"mapping_quality\\\": \\\"0\\\", \\\"per_cell\\\": \\\"true\\\", \\\"per_contig\\\": \\\"false\\\", \\\"random_seed\\\": \\\"0\\\", \\\"skip_tags_regex\\\": \\\"\\\"}\", \"barcodes\": \"{\\\"__current_case__\\\": 0, \\\"extract_umi_method\\\": \\\"read_id\\\", \\\"umi_separator\\\": \\\"_\\\"}\"}",
+            "tool_version": "0.5.3.2",
+            "type": "tool",
+            "uuid": "89675c5a-ef94-49a5-889c-c53ba1074f80",
+            "workflow_outputs": [
+              {
+                "label": null,
+                "output_name": "out_counts",
+                "uuid": "209f3dd6-974f-4e76-a206-c86114a6697f"
+              }
+            ]
+          }
+        },
+        "tags": "",
+        "uuid": "ee17e23b-42b1-48e8-ad5e-bcb0b7fa8cf0"
+      },
+      "tool_id": "0600e24fe786d72f",
+      "type": "subworkflow",
+      "uuid": "e86d6331-50b9-412a-b895-0bda5408d366",
+      "workflow_outputs": [
+        {
+          "label": null,
+          "output_name": "4:mapped_reads",
+          "uuid": "0a5f54e7-09dc-4c35-980a-b617fcfaa2eb"
+        },
+        {
+          "label": null,
+          "output_name": "7:html_report",
+          "uuid": "fea13497-e4cb-47b1-a64d-6883e19def0f"
+        },
+        {
+          "label": null,
+          "output_name": "0:output",
+          "uuid": "65f46424-6d76-4d1f-acd0-aef24e26d10b"
+        },
+        {
+          "label": null,
+          "output_name": "10:output",
+          "uuid": "cc791e7c-9cbb-481d-8deb-39d33f7b2857"
+        },
+        {
+          "label": null,
+          "output_name": "4:chimeric_reads",
+          "uuid": "c6ad66bf-5fde-4440-ab54-4997211c2c3d"
+        },
+        {
+          "label": null,
+          "output_name": "4:reads_per_gene",
+          "uuid": "b4ea5261-7733-4b7e-8e30-1d3535e9cb57"
+        },
+        {
+          "label": null,
+          "output_name": "9:out_counts",
+          "uuid": "58562166-7b2d-4b0d-9172-14a02d7a989a"
+        },
+        {
+          "label": null,
+          "output_name": "4:chimeric_junctions",
+          "uuid": "c33a7acd-f5bc-4ac5-b3d3-a6fb2892c9f6"
+        },
+        {
+          "label": null,
+          "output_name": "6:output_bam",
+          "uuid": "1601b4a1-a302-425d-bad6-7b71d14f9726"
+        },
+        {
+          "label": null,
+          "output_name": "8:out_file1",
+          "uuid": "a7b1aa8e-61cd-4b1c-8fa9-3c85d4113ea5"
+        },
+        {
+          "label": null,
+          "output_name": "7:stats",
+          "uuid": "ac17c572-784c-456e-b3c7-ebaf15c2109e"
+        },
+        {
+          "label": null,
+          "output_name": "5:output",
+          "uuid": "5c220f46-2525-471f-8fd6-0eb17dc689ad"
+        },
+        {
+          "label": null,
+          "output_name": "7:log",
+          "uuid": "3ad7aac8-e4a0-4df1-beb6-88cdcb106e7a"
+        },
+        {
+          "label": null,
+          "output_name": "3:out2",
+          "uuid": "4ff34341-786c-4c66-95c7-6985e4c66ad7"
+        },
+        {
+          "label": null,
+          "output_name": "1:output",
+          "uuid": "78bfe4ce-528c-4d16-8e73-f721b09676be"
+        },
+        {
+          "label": null,
+          "output_name": "2:output",
+          "uuid": "603d0608-7866-4f1d-be85-6a4f3116d5b8"
+        },
+        {
+          "label": null,
+          "output_name": "4:splice_junctions",
+          "uuid": "7f85f228-75da-4933-8157-e6eb4f15bd98"
+        },
+        {
+          "label": null,
+          "output_name": "4:output_log",
+          "uuid": "86003cab-1a90-4871-b489-27eb49715574"
+        }
+      ]
+    },
+    "5": {
+      "annotation": "",
+      "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/collection_column_join/collection_column_join/0.0.3",
+      "errors": null,
+      "id": 5,
+      "input_connections": {
+        "input_tabular": {
+          "id": 4,
+          "output_name": "9:out_counts"
+        }
+      },
+      "inputs": [
+        {
+          "description": "runtime parameter for tool Column Join",
+          "name": "input_tabular"
+        }
+      ],
+      "label": null,
+      "name": "Column Join",
+      "outputs": [
+        {
+          "name": "tabular_output",
+          "type": "tabular"
+        },
+        {
+          "name": "script_output",
+          "type": "txt"
+        }
+      ],
+      "position": {
+        "left": 1277.5,
+        "top": 288
+      },
+      "post_job_actions": {
+        "HideDatasetActionscript_output": {
+          "action_arguments": {},
+          "action_type": "HideDatasetAction",
+          "output_name": "script_output"
+        }
+      },
+      "tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/collection_column_join/collection_column_join/0.0.3",
+      "tool_shed_repository": {
+        "changeset_revision": "58228a4d58fe",
+        "name": "collection_column_join",
+        "owner": "iuc",
+        "tool_shed": "toolshed.g2.bx.psu.edu"
+      },
+      "tool_state": "{\"__page__\": null, \"identifier_column\": \"\\\"1\\\"\", \"include_outputs\": \"null\", \"__rerun_remap_job_id__\": null, \"input_tabular\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\", \"fill_char\": \"\\\".\\\"\", \"old_col_in_header\": \"\\\"true\\\"\", \"has_header\": \"\\\"1\\\"\"}",
+      "tool_version": "0.0.3",
+      "type": "tool",
+      "uuid": "174c32b6-444c-4762-b9c1-c84201e656ab",
+      "workflow_outputs": [
+        {
+          "label": null,
+          "output_name": "tabular_output",
+          "uuid": "2167fa1b-4865-40b1-9c61-82dd6ba8ccc7"
+        }
+      ]
+    }
+  },
+  "tags": [],
+  "uuid": "36a6e32e-5466-4ef8-915f-14332e21dc93",
+  "version": 5
+}

--- a/topics/variant-analysis/tutorials/dunovo/workflows/dunovo.ga
+++ b/topics/variant-analysis/tutorials/dunovo/workflows/dunovo.ga
@@ -1,1 +1,495 @@
-{"uuid": "31bed17e-ceef-4581-95bf-db05c4234aa9", "tags": [], "format-version": "0.1", "name": "Du Novo GTN tutorial - Make consensus sequences", "steps": {"0": {"tool_id": null, "tool_version": null, "outputs": [], "workflow_outputs": [{"output_name": "output", "uuid": "5eb6af50-33a5-42ae-a34b-a92974ddec3c", "label": null}], "input_connections": {}, "tool_state": "{\"name\": \"SRR1799908_forward\"}", "id": 0, "uuid": "f9817ffe-4cdb-471f-a921-1b20e96e92d6", "errors": null, "name": "Input dataset", "label": "SRR1799908_forward", "inputs": [{"name": "SRR1799908_forward", "description": ""}], "position": {"top": 281, "left": 200}, "annotation": "", "content_id": null, "type": "data_input"}, "1": {"tool_id": null, "tool_version": null, "outputs": [], "workflow_outputs": [{"output_name": "output", "uuid": "9228fb67-0e41-4f3c-96fa-7da93c797649", "label": null}], "input_connections": {}, "tool_state": "{\"name\": \"SRR1799908_reverse\"}", "id": 1, "uuid": "efc0fed6-846f-467f-82a3-45898dc3e0a4", "errors": null, "name": "Input dataset", "label": "SRR1799908_reverse", "inputs": [{"name": "SRR1799908_reverse", "description": ""}], "position": {"top": 385, "left": 202}, "annotation": "", "content_id": null, "type": "data_input"}, "2": {"tool_id": "toolshed.g2.bx.psu.edu/repos/nick/dunovo/make_families/2.15", "tool_version": "2.15", "outputs": [{"type": "tabular", "name": "output"}], "workflow_outputs": [], "input_connections": {"fastq2": {"output_name": "output", "id": 1}, "fastq1": {"output_name": "output", "id": 0}}, "tool_state": "{\"__page__\": null, \"__rerun_remap_job_id__\": null, \"invariant\": \"\\\"5\\\"\", \"fastq2\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\", \"fastq1\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\", \"taglen\": \"\\\"12\\\"\", \"chromInfo\": \"\\\"/cvmfs/data.galaxyproject.org/managed/len/ucsc/?.len\\\"\"}", "id": 2, "tool_shed_repository": {"owner": "nick", "changeset_revision": "9dc43bf7d1db", "name": "dunovo", "tool_shed": "toolshed.g2.bx.psu.edu"}, "uuid": "99dae8c9-68c3-4870-a503-c1f3de75b152", "errors": null, "name": "Du Novo: Make families", "post_job_actions": {"HideDatasetActionoutput": {"output_name": "output", "action_type": "HideDatasetAction", "action_arguments": {}}}, "label": null, "inputs": [{"name": "fastq2", "description": "runtime parameter for tool Du Novo: Make families"}, {"name": "fastq1", "description": "runtime parameter for tool Du Novo: Make families"}], "position": {"top": 281, "left": 430}, "annotation": "", "content_id": "toolshed.g2.bx.psu.edu/repos/nick/dunovo/make_families/2.15", "type": "tool"}, "3": {"tool_id": "toolshed.g2.bx.psu.edu/repos/nick/dunovo/correct_barcodes/2.15", "tool_version": "2.15", "outputs": [{"type": "tabular", "name": "output"}], "workflow_outputs": [], "input_connections": {"input": {"output_name": "output", "id": 2}}, "tool_state": "{\"__page__\": null, \"dist\": \"\\\"3\\\"\", \"__rerun_remap_job_id__\": null, \"pos\": \"\\\"2\\\"\", \"phone\": \"\\\"false\\\"\", \"mapq\": \"\\\"20\\\"\", \"input\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\", \"check_ids\": \"\\\"true\\\"\", \"advanced\": \"{\\\"chunkmbs\\\": \\\"512\\\"}\"}", "id": 3, "tool_shed_repository": {"owner": "nick", "changeset_revision": "9dc43bf7d1db", "name": "dunovo", "tool_shed": "toolshed.g2.bx.psu.edu"}, "uuid": "c0f8cf5f-4975-403e-ac3f-c518f0ee293d", "errors": null, "name": "Du Novo: Correct barcodes", "post_job_actions": {"HideDatasetActionoutput": {"output_name": "output", "action_type": "HideDatasetAction", "action_arguments": {}}}, "label": null, "inputs": [{"name": "input", "description": "runtime parameter for tool Du Novo: Correct barcodes"}], "position": {"top": 282, "left": 691}, "annotation": "", "content_id": "toolshed.g2.bx.psu.edu/repos/nick/dunovo/correct_barcodes/2.15", "type": "tool"}, "4": {"tool_id": "toolshed.g2.bx.psu.edu/repos/nick/dunovo/align_families/2.15", "tool_version": "2.15", "outputs": [{"type": "tabular", "name": "output"}], "workflow_outputs": [], "input_connections": {"input": {"output_name": "output", "id": 3}}, "tool_state": "{\"__page__\": null, \"__rerun_remap_job_id__\": null, \"aligner\": \"\\\"kalign\\\"\", \"__job_resource\": \"{\\\"__current_case__\\\": 0, \\\"__job_resource__select\\\": \\\"no\\\"}\", \"phone\": \"\\\"false\\\"\", \"input\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\", \"check_ids\": \"\\\"true\\\"\"}", "id": 4, "tool_shed_repository": {"owner": "nick", "changeset_revision": "9dc43bf7d1db", "name": "dunovo", "tool_shed": "toolshed.g2.bx.psu.edu"}, "uuid": "350d6c9d-347a-4cc7-a271-80f08968cd2b", "errors": null, "name": "Du Novo: Align families", "post_job_actions": {"HideDatasetActionoutput": {"output_name": "output", "action_type": "HideDatasetAction", "action_arguments": {}}}, "label": null, "inputs": [{"name": "input", "description": "runtime parameter for tool Du Novo: Align families"}], "position": {"top": 394, "left": 693}, "annotation": "", "content_id": "toolshed.g2.bx.psu.edu/repos/nick/dunovo/align_families/2.15", "type": "tool"}, "5": {"tool_id": "toolshed.g2.bx.psu.edu/repos/nick/dunovo/dunovo/2.15", "tool_version": "2.15", "outputs": [{"type": "data", "name": "dcs1"}, {"type": "data", "name": "dcs2"}, {"type": "data", "name": "sscs1"}, {"type": "data", "name": "sscs2"}], "workflow_outputs": [], "input_connections": {"input": {"output_name": "output", "id": 4}}, "tool_state": "{\"out_format\": \"{\\\"qual\\\": \\\"40\\\", \\\"type\\\": \\\"fastq\\\", \\\"__current_case__\\\": 0}\", \"__page__\": null, \"min_cons_reads\": \"\\\"0\\\"\", \"cons_thres\": \"\\\"0.7\\\"\", \"qual_format\": \"\\\"sanger\\\"\", \"keep_sscs\": \"\\\"true\\\"\", \"phone\": \"\\\"false\\\"\", \"min_reads\": \"\\\"3\\\"\", \"qual_thres\": \"\\\"25\\\"\", \"input\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\", \"__rerun_remap_job_id__\": null}", "id": 5, "tool_shed_repository": {"owner": "nick", "changeset_revision": "9dc43bf7d1db", "name": "dunovo", "tool_shed": "toolshed.g2.bx.psu.edu"}, "uuid": "c81cbcb1-d3e0-4044-9c55-9edf699de6e7", "errors": null, "name": "Du Novo: Make consensus reads", "post_job_actions": {"HideDatasetActiondcs1": {"output_name": "dcs1", "action_type": "HideDatasetAction", "action_arguments": {}}, "ChangeDatatypeActionsscs2": {"output_name": "sscs2", "action_type": "ChangeDatatypeAction", "action_arguments": {"newtype": "fastqsanger"}}, "ChangeDatatypeActionsscs1": {"output_name": "sscs1", "action_type": "ChangeDatatypeAction", "action_arguments": {"newtype": "fastqsanger"}}, "HideDatasetActiondcs2": {"output_name": "dcs2", "action_type": "HideDatasetAction", "action_arguments": {}}, "ChangeDatatypeActiondcs1": {"output_name": "dcs1", "action_type": "ChangeDatatypeAction", "action_arguments": {"newtype": "fastqsanger"}}, "ChangeDatatypeActiondcs2": {"output_name": "dcs2", "action_type": "ChangeDatatypeAction", "action_arguments": {"newtype": "fastqsanger"}}, "HideDatasetActionsscs1": {"output_name": "sscs1", "action_type": "HideDatasetAction", "action_arguments": {}}, "HideDatasetActionsscs2": {"output_name": "sscs2", "action_type": "HideDatasetAction", "action_arguments": {}}}, "label": null, "inputs": [{"name": "input", "description": "runtime parameter for tool Du Novo: Make consensus reads"}], "position": {"top": 511, "left": 691}, "annotation": "", "content_id": "toolshed.g2.bx.psu.edu/repos/nick/dunovo/dunovo/2.15", "type": "tool"}, "6": {"tool_id": "toolshed.g2.bx.psu.edu/repos/nick/sequence_content_trimmer/sequence_content_trimmer/0.1", "tool_version": "0.1", "outputs": [{"type": "input", "name": "output1"}, {"type": "input", "name": "output2"}], "workflow_outputs": [{"output_name": "output2", "uuid": "0f994723-3603-4a3c-adfe-ae068a079661", "label": null}, {"output_name": "output1", "uuid": "e67c3c59-f6f6-486d-86e2-f68e8d54b863", "label": null}], "input_connections": {"paired|input1": {"output_name": "dcs1", "id": 5}, "paired|input2": {"output_name": "dcs2", "id": 5}}, "tool_state": "{\"__page__\": null, \"win_len\": \"\\\"10\\\"\", \"invert\": \"\\\"true\\\"\", \"min_len\": \"{\\\"value\\\": \\\"50\\\", \\\"__current_case__\\\": 0, \\\"has_min_len\\\": \\\"true\\\"}\", \"paired\": \"{\\\"input2\\\": {\\\"__class__\\\": \\\"RuntimeValue\\\"}, \\\"is_paired\\\": \\\"true\\\", \\\"input1\\\": {\\\"__class__\\\": \\\"RuntimeValue\\\"}, \\\"__current_case__\\\": 0}\", \"bases\": \"\\\"ACGT\\\"\", \"thres\": \"\\\"0.2\\\"\", \"__rerun_remap_job_id__\": null}", "id": 6, "tool_shed_repository": {"owner": "nick", "changeset_revision": "7f170cb06e2e", "name": "sequence_content_trimmer", "tool_shed": "toolshed.g2.bx.psu.edu"}, "uuid": "b214143b-75bf-41f1-9ca6-82e8c64f23ad", "errors": null, "name": "Sequence Content Trimmer", "post_job_actions": {"RenameDatasetActionoutput2": {"output_name": "output2", "action_type": "RenameDatasetAction", "action_arguments": {"newname": "Trimmed DCS (mate 2)"}}, "RenameDatasetActionoutput1": {"output_name": "output1", "action_type": "RenameDatasetAction", "action_arguments": {"newname": "Trimmed DCS (mate 1)"}}}, "label": "DCS: Sequence Content Trimmer", "inputs": [{"name": "paired", "description": "runtime parameter for tool Sequence Content Trimmer"}, {"name": "paired", "description": "runtime parameter for tool Sequence Content Trimmer"}], "position": {"top": 282, "left": 996}, "annotation": "", "content_id": "toolshed.g2.bx.psu.edu/repos/nick/sequence_content_trimmer/sequence_content_trimmer/0.1", "type": "tool"}, "7": {"tool_id": "toolshed.g2.bx.psu.edu/repos/nick/sequence_content_trimmer/sequence_content_trimmer/0.1", "tool_version": "0.1", "outputs": [{"type": "input", "name": "output1"}, {"type": "input", "name": "output2"}], "workflow_outputs": [{"output_name": "output2", "uuid": "d993247b-3ba4-4427-b711-f48034aa8c2a", "label": null}, {"output_name": "output1", "uuid": "75dfe52d-711e-4826-ba9b-b4feed30f5bf", "label": ""}], "input_connections": {"paired|input1": {"output_name": "sscs1", "id": 5}, "paired|input2": {"output_name": "sscs2", "id": 5}}, "tool_state": "{\"__page__\": null, \"win_len\": \"\\\"10\\\"\", \"invert\": \"\\\"true\\\"\", \"min_len\": \"{\\\"value\\\": \\\"50\\\", \\\"__current_case__\\\": 0, \\\"has_min_len\\\": \\\"true\\\"}\", \"paired\": \"{\\\"input2\\\": {\\\"__class__\\\": \\\"RuntimeValue\\\"}, \\\"is_paired\\\": \\\"true\\\", \\\"input1\\\": {\\\"__class__\\\": \\\"RuntimeValue\\\"}, \\\"__current_case__\\\": 0}\", \"bases\": \"\\\"ACGT\\\"\", \"thres\": \"\\\"0.2\\\"\", \"__rerun_remap_job_id__\": null}", "id": 7, "tool_shed_repository": {"owner": "nick", "changeset_revision": "7f170cb06e2e", "name": "sequence_content_trimmer", "tool_shed": "toolshed.g2.bx.psu.edu"}, "uuid": "f5ef3a57-7d34-4c4c-ba0e-67b2fb56a7b0", "errors": null, "name": "Sequence Content Trimmer", "post_job_actions": {"RenameDatasetActionoutput2": {"output_name": "output2", "action_type": "RenameDatasetAction", "action_arguments": {"newname": "Trimmed SSCS (mate 2)"}}, "RenameDatasetActionoutput1": {"output_name": "output1", "action_type": "RenameDatasetAction", "action_arguments": {"newname": "Trimmed SSCS (mate 1)"}}}, "label": "SSCS: Sequence Content Trimmer", "inputs": [{"name": "paired", "description": "runtime parameter for tool Sequence Content Trimmer"}, {"name": "paired", "description": "runtime parameter for tool Sequence Content Trimmer"}], "position": {"top": 472, "left": 998}, "annotation": "", "content_id": "toolshed.g2.bx.psu.edu/repos/nick/sequence_content_trimmer/sequence_content_trimmer/0.1", "type": "tool"}}, "annotation": "Run this on raw duplex sequencing reads to produce duplex consensus sequences.\n", "a_galaxy_workflow": "true"}
+{
+  "a_galaxy_workflow": "true",
+  "annotation": "Run this on raw duplex sequencing reads to produce duplex consensus sequences.\n",
+  "format-version": "0.1",
+  "name": "Du Novo GTN tutorial - Make consensus sequences",
+  "steps": {
+    "0": {
+      "annotation": "",
+      "content_id": null,
+      "errors": null,
+      "id": 0,
+      "input_connections": {},
+      "inputs": [
+        {
+          "description": "",
+          "name": "SRR1799908_forward"
+        }
+      ],
+      "label": "SRR1799908_forward",
+      "name": "Input dataset",
+      "outputs": [],
+      "position": {
+        "left": 200,
+        "top": 281
+      },
+      "tool_id": null,
+      "tool_state": "{\"name\": \"SRR1799908_forward\"}",
+      "tool_version": null,
+      "type": "data_input",
+      "uuid": "f9817ffe-4cdb-471f-a921-1b20e96e92d6",
+      "workflow_outputs": [
+        {
+          "label": null,
+          "output_name": "output",
+          "uuid": "5eb6af50-33a5-42ae-a34b-a92974ddec3c"
+        }
+      ]
+    },
+    "1": {
+      "annotation": "",
+      "content_id": null,
+      "errors": null,
+      "id": 1,
+      "input_connections": {},
+      "inputs": [
+        {
+          "description": "",
+          "name": "SRR1799908_reverse"
+        }
+      ],
+      "label": "SRR1799908_reverse",
+      "name": "Input dataset",
+      "outputs": [],
+      "position": {
+        "left": 202,
+        "top": 385
+      },
+      "tool_id": null,
+      "tool_state": "{\"name\": \"SRR1799908_reverse\"}",
+      "tool_version": null,
+      "type": "data_input",
+      "uuid": "efc0fed6-846f-467f-82a3-45898dc3e0a4",
+      "workflow_outputs": [
+        {
+          "label": null,
+          "output_name": "output",
+          "uuid": "9228fb67-0e41-4f3c-96fa-7da93c797649"
+        }
+      ]
+    },
+    "2": {
+      "annotation": "",
+      "content_id": "toolshed.g2.bx.psu.edu/repos/nick/dunovo/make_families/2.15",
+      "errors": null,
+      "id": 2,
+      "input_connections": {
+        "fastq1": {
+          "id": 0,
+          "output_name": "output"
+        },
+        "fastq2": {
+          "id": 1,
+          "output_name": "output"
+        }
+      },
+      "inputs": [
+        {
+          "description": "runtime parameter for tool Du Novo: Make families",
+          "name": "fastq2"
+        },
+        {
+          "description": "runtime parameter for tool Du Novo: Make families",
+          "name": "fastq1"
+        }
+      ],
+      "label": null,
+      "name": "Du Novo: Make families",
+      "outputs": [
+        {
+          "name": "output",
+          "type": "tabular"
+        }
+      ],
+      "position": {
+        "left": 430,
+        "top": 281
+      },
+      "post_job_actions": {
+        "HideDatasetActionoutput": {
+          "action_arguments": {},
+          "action_type": "HideDatasetAction",
+          "output_name": "output"
+        }
+      },
+      "tool_id": "toolshed.g2.bx.psu.edu/repos/nick/dunovo/make_families/2.15",
+      "tool_shed_repository": {
+        "changeset_revision": "9dc43bf7d1db",
+        "name": "dunovo",
+        "owner": "nick",
+        "tool_shed": "toolshed.g2.bx.psu.edu"
+      },
+      "tool_state": "{\"__page__\": null, \"__rerun_remap_job_id__\": null, \"invariant\": \"\\\"5\\\"\", \"fastq2\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\", \"fastq1\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\", \"taglen\": \"\\\"12\\\"\", \"chromInfo\": \"\\\"/cvmfs/data.galaxyproject.org/managed/len/ucsc/?.len\\\"\"}",
+      "tool_version": "2.15",
+      "type": "tool",
+      "uuid": "99dae8c9-68c3-4870-a503-c1f3de75b152",
+      "workflow_outputs": []
+    },
+    "3": {
+      "annotation": "",
+      "content_id": "toolshed.g2.bx.psu.edu/repos/nick/dunovo/correct_barcodes/2.15",
+      "errors": null,
+      "id": 3,
+      "input_connections": {
+        "input": {
+          "id": 2,
+          "output_name": "output"
+        }
+      },
+      "inputs": [
+        {
+          "description": "runtime parameter for tool Du Novo: Correct barcodes",
+          "name": "input"
+        }
+      ],
+      "label": null,
+      "name": "Du Novo: Correct barcodes",
+      "outputs": [
+        {
+          "name": "output",
+          "type": "tabular"
+        }
+      ],
+      "position": {
+        "left": 691,
+        "top": 282
+      },
+      "post_job_actions": {
+        "HideDatasetActionoutput": {
+          "action_arguments": {},
+          "action_type": "HideDatasetAction",
+          "output_name": "output"
+        }
+      },
+      "tool_id": "toolshed.g2.bx.psu.edu/repos/nick/dunovo/correct_barcodes/2.15",
+      "tool_shed_repository": {
+        "changeset_revision": "9dc43bf7d1db",
+        "name": "dunovo",
+        "owner": "nick",
+        "tool_shed": "toolshed.g2.bx.psu.edu"
+      },
+      "tool_state": "{\"__page__\": null, \"dist\": \"\\\"3\\\"\", \"__rerun_remap_job_id__\": null, \"pos\": \"\\\"2\\\"\", \"phone\": \"\\\"false\\\"\", \"mapq\": \"\\\"20\\\"\", \"input\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\", \"check_ids\": \"\\\"true\\\"\", \"advanced\": \"{\\\"chunkmbs\\\": \\\"512\\\"}\"}",
+      "tool_version": "2.15",
+      "type": "tool",
+      "uuid": "c0f8cf5f-4975-403e-ac3f-c518f0ee293d",
+      "workflow_outputs": []
+    },
+    "4": {
+      "annotation": "",
+      "content_id": "toolshed.g2.bx.psu.edu/repos/nick/dunovo/align_families/2.15",
+      "errors": null,
+      "id": 4,
+      "input_connections": {
+        "input": {
+          "id": 3,
+          "output_name": "output"
+        }
+      },
+      "inputs": [
+        {
+          "description": "runtime parameter for tool Du Novo: Align families",
+          "name": "input"
+        }
+      ],
+      "label": null,
+      "name": "Du Novo: Align families",
+      "outputs": [
+        {
+          "name": "output",
+          "type": "tabular"
+        }
+      ],
+      "position": {
+        "left": 693,
+        "top": 394
+      },
+      "post_job_actions": {
+        "HideDatasetActionoutput": {
+          "action_arguments": {},
+          "action_type": "HideDatasetAction",
+          "output_name": "output"
+        }
+      },
+      "tool_id": "toolshed.g2.bx.psu.edu/repos/nick/dunovo/align_families/2.15",
+      "tool_shed_repository": {
+        "changeset_revision": "9dc43bf7d1db",
+        "name": "dunovo",
+        "owner": "nick",
+        "tool_shed": "toolshed.g2.bx.psu.edu"
+      },
+      "tool_state": "{\"__page__\": null, \"__rerun_remap_job_id__\": null, \"aligner\": \"\\\"kalign\\\"\", \"__job_resource\": \"{\\\"__current_case__\\\": 0, \\\"__job_resource__select\\\": \\\"no\\\"}\", \"phone\": \"\\\"false\\\"\", \"input\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\", \"check_ids\": \"\\\"true\\\"\"}",
+      "tool_version": "2.15",
+      "type": "tool",
+      "uuid": "350d6c9d-347a-4cc7-a271-80f08968cd2b",
+      "workflow_outputs": []
+    },
+    "5": {
+      "annotation": "",
+      "content_id": "toolshed.g2.bx.psu.edu/repos/nick/dunovo/dunovo/2.15",
+      "errors": null,
+      "id": 5,
+      "input_connections": {
+        "input": {
+          "id": 4,
+          "output_name": "output"
+        }
+      },
+      "inputs": [
+        {
+          "description": "runtime parameter for tool Du Novo: Make consensus reads",
+          "name": "input"
+        }
+      ],
+      "label": null,
+      "name": "Du Novo: Make consensus reads",
+      "outputs": [
+        {
+          "name": "dcs1",
+          "type": "data"
+        },
+        {
+          "name": "dcs2",
+          "type": "data"
+        },
+        {
+          "name": "sscs1",
+          "type": "data"
+        },
+        {
+          "name": "sscs2",
+          "type": "data"
+        }
+      ],
+      "position": {
+        "left": 691,
+        "top": 511
+      },
+      "post_job_actions": {
+        "ChangeDatatypeActiondcs1": {
+          "action_arguments": {
+            "newtype": "fastqsanger"
+          },
+          "action_type": "ChangeDatatypeAction",
+          "output_name": "dcs1"
+        },
+        "ChangeDatatypeActiondcs2": {
+          "action_arguments": {
+            "newtype": "fastqsanger"
+          },
+          "action_type": "ChangeDatatypeAction",
+          "output_name": "dcs2"
+        },
+        "ChangeDatatypeActionsscs1": {
+          "action_arguments": {
+            "newtype": "fastqsanger"
+          },
+          "action_type": "ChangeDatatypeAction",
+          "output_name": "sscs1"
+        },
+        "ChangeDatatypeActionsscs2": {
+          "action_arguments": {
+            "newtype": "fastqsanger"
+          },
+          "action_type": "ChangeDatatypeAction",
+          "output_name": "sscs2"
+        },
+        "HideDatasetActiondcs1": {
+          "action_arguments": {},
+          "action_type": "HideDatasetAction",
+          "output_name": "dcs1"
+        },
+        "HideDatasetActiondcs2": {
+          "action_arguments": {},
+          "action_type": "HideDatasetAction",
+          "output_name": "dcs2"
+        },
+        "HideDatasetActionsscs1": {
+          "action_arguments": {},
+          "action_type": "HideDatasetAction",
+          "output_name": "sscs1"
+        },
+        "HideDatasetActionsscs2": {
+          "action_arguments": {},
+          "action_type": "HideDatasetAction",
+          "output_name": "sscs2"
+        }
+      },
+      "tool_id": "toolshed.g2.bx.psu.edu/repos/nick/dunovo/dunovo/2.15",
+      "tool_shed_repository": {
+        "changeset_revision": "9dc43bf7d1db",
+        "name": "dunovo",
+        "owner": "nick",
+        "tool_shed": "toolshed.g2.bx.psu.edu"
+      },
+      "tool_state": "{\"out_format\": \"{\\\"qual\\\": \\\"40\\\", \\\"type\\\": \\\"fastq\\\", \\\"__current_case__\\\": 0}\", \"__page__\": null, \"min_cons_reads\": \"\\\"0\\\"\", \"cons_thres\": \"\\\"0.7\\\"\", \"qual_format\": \"\\\"sanger\\\"\", \"keep_sscs\": \"\\\"true\\\"\", \"phone\": \"\\\"false\\\"\", \"min_reads\": \"\\\"3\\\"\", \"qual_thres\": \"\\\"25\\\"\", \"input\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\", \"__rerun_remap_job_id__\": null}",
+      "tool_version": "2.15",
+      "type": "tool",
+      "uuid": "c81cbcb1-d3e0-4044-9c55-9edf699de6e7",
+      "workflow_outputs": []
+    },
+    "6": {
+      "annotation": "",
+      "content_id": "toolshed.g2.bx.psu.edu/repos/nick/sequence_content_trimmer/sequence_content_trimmer/0.1",
+      "errors": null,
+      "id": 6,
+      "input_connections": {
+        "paired|input1": {
+          "id": 5,
+          "output_name": "dcs1"
+        },
+        "paired|input2": {
+          "id": 5,
+          "output_name": "dcs2"
+        }
+      },
+      "inputs": [
+        {
+          "description": "runtime parameter for tool Sequence Content Trimmer",
+          "name": "paired"
+        },
+        {
+          "description": "runtime parameter for tool Sequence Content Trimmer",
+          "name": "paired"
+        }
+      ],
+      "label": "DCS: Sequence Content Trimmer",
+      "name": "Sequence Content Trimmer",
+      "outputs": [
+        {
+          "name": "output1",
+          "type": "input"
+        },
+        {
+          "name": "output2",
+          "type": "input"
+        }
+      ],
+      "position": {
+        "left": 996,
+        "top": 282
+      },
+      "post_job_actions": {
+        "RenameDatasetActionoutput1": {
+          "action_arguments": {
+            "newname": "Trimmed DCS (mate 1)"
+          },
+          "action_type": "RenameDatasetAction",
+          "output_name": "output1"
+        },
+        "RenameDatasetActionoutput2": {
+          "action_arguments": {
+            "newname": "Trimmed DCS (mate 2)"
+          },
+          "action_type": "RenameDatasetAction",
+          "output_name": "output2"
+        }
+      },
+      "tool_id": "toolshed.g2.bx.psu.edu/repos/nick/sequence_content_trimmer/sequence_content_trimmer/0.1",
+      "tool_shed_repository": {
+        "changeset_revision": "7f170cb06e2e",
+        "name": "sequence_content_trimmer",
+        "owner": "nick",
+        "tool_shed": "toolshed.g2.bx.psu.edu"
+      },
+      "tool_state": "{\"__page__\": null, \"win_len\": \"\\\"10\\\"\", \"invert\": \"\\\"true\\\"\", \"min_len\": \"{\\\"value\\\": \\\"50\\\", \\\"__current_case__\\\": 0, \\\"has_min_len\\\": \\\"true\\\"}\", \"paired\": \"{\\\"input2\\\": {\\\"__class__\\\": \\\"RuntimeValue\\\"}, \\\"is_paired\\\": \\\"true\\\", \\\"input1\\\": {\\\"__class__\\\": \\\"RuntimeValue\\\"}, \\\"__current_case__\\\": 0}\", \"bases\": \"\\\"ACGT\\\"\", \"thres\": \"\\\"0.2\\\"\", \"__rerun_remap_job_id__\": null}",
+      "tool_version": "0.1",
+      "type": "tool",
+      "uuid": "b214143b-75bf-41f1-9ca6-82e8c64f23ad",
+      "workflow_outputs": [
+        {
+          "label": null,
+          "output_name": "output2",
+          "uuid": "0f994723-3603-4a3c-adfe-ae068a079661"
+        },
+        {
+          "label": null,
+          "output_name": "output1",
+          "uuid": "e67c3c59-f6f6-486d-86e2-f68e8d54b863"
+        }
+      ]
+    },
+    "7": {
+      "annotation": "",
+      "content_id": "toolshed.g2.bx.psu.edu/repos/nick/sequence_content_trimmer/sequence_content_trimmer/0.1",
+      "errors": null,
+      "id": 7,
+      "input_connections": {
+        "paired|input1": {
+          "id": 5,
+          "output_name": "sscs1"
+        },
+        "paired|input2": {
+          "id": 5,
+          "output_name": "sscs2"
+        }
+      },
+      "inputs": [
+        {
+          "description": "runtime parameter for tool Sequence Content Trimmer",
+          "name": "paired"
+        },
+        {
+          "description": "runtime parameter for tool Sequence Content Trimmer",
+          "name": "paired"
+        }
+      ],
+      "label": "SSCS: Sequence Content Trimmer",
+      "name": "Sequence Content Trimmer",
+      "outputs": [
+        {
+          "name": "output1",
+          "type": "input"
+        },
+        {
+          "name": "output2",
+          "type": "input"
+        }
+      ],
+      "position": {
+        "left": 998,
+        "top": 472
+      },
+      "post_job_actions": {
+        "RenameDatasetActionoutput1": {
+          "action_arguments": {
+            "newname": "Trimmed SSCS (mate 1)"
+          },
+          "action_type": "RenameDatasetAction",
+          "output_name": "output1"
+        },
+        "RenameDatasetActionoutput2": {
+          "action_arguments": {
+            "newname": "Trimmed SSCS (mate 2)"
+          },
+          "action_type": "RenameDatasetAction",
+          "output_name": "output2"
+        }
+      },
+      "tool_id": "toolshed.g2.bx.psu.edu/repos/nick/sequence_content_trimmer/sequence_content_trimmer/0.1",
+      "tool_shed_repository": {
+        "changeset_revision": "7f170cb06e2e",
+        "name": "sequence_content_trimmer",
+        "owner": "nick",
+        "tool_shed": "toolshed.g2.bx.psu.edu"
+      },
+      "tool_state": "{\"__page__\": null, \"win_len\": \"\\\"10\\\"\", \"invert\": \"\\\"true\\\"\", \"min_len\": \"{\\\"value\\\": \\\"50\\\", \\\"__current_case__\\\": 0, \\\"has_min_len\\\": \\\"true\\\"}\", \"paired\": \"{\\\"input2\\\": {\\\"__class__\\\": \\\"RuntimeValue\\\"}, \\\"is_paired\\\": \\\"true\\\", \\\"input1\\\": {\\\"__class__\\\": \\\"RuntimeValue\\\"}, \\\"__current_case__\\\": 0}\", \"bases\": \"\\\"ACGT\\\"\", \"thres\": \"\\\"0.2\\\"\", \"__rerun_remap_job_id__\": null}",
+      "tool_version": "0.1",
+      "type": "tool",
+      "uuid": "f5ef3a57-7d34-4c4c-ba0e-67b2fb56a7b0",
+      "workflow_outputs": [
+        {
+          "label": null,
+          "output_name": "output2",
+          "uuid": "d993247b-3ba4-4427-b711-f48034aa8c2a"
+        },
+        {
+          "label": "",
+          "output_name": "output1",
+          "uuid": "75dfe52d-711e-4826-ba9b-b4feed30f5bf"
+        }
+      ]
+    }
+  },
+  "tags": [],
+  "uuid": "31bed17e-ceef-4581-95bf-db05c4234aa9"
+}

--- a/topics/variant-analysis/tutorials/dunovo/workflows/variant-calling.ga
+++ b/topics/variant-analysis/tutorials/dunovo/workflows/variant-calling.ga
@@ -1,1 +1,322 @@
-{"uuid": "73d76159-35a3-4e1a-a229-1953dbc18f12", "tags": [], "format-version": "0.1", "name": "Du Novo GTN tutorial - Variant calling", "steps": {"0": {"tool_id": null, "tool_version": null, "outputs": [], "workflow_outputs": [{"output_name": "output", "uuid": "d9cf4c1c-9b41-49e6-8eed-20f201143897", "label": null}], "input_connections": {}, "tool_state": "{}", "id": 0, "uuid": "f9817ffe-4cdb-471f-a921-1b20e96e92d6", "errors": null, "name": "Input dataset", "label": "Trimmed reads (mate 1)", "inputs": [], "position": {"top": 284, "left": 200}, "annotation": "", "content_id": null, "type": "data_input"}, "1": {"tool_id": null, "tool_version": null, "outputs": [], "workflow_outputs": [{"output_name": "output", "uuid": "347dcece-5ddc-40fb-a5ed-4ff05f2d2d3a", "label": null}], "input_connections": {}, "tool_state": "{}", "id": 1, "uuid": "efc0fed6-846f-467f-82a3-45898dc3e0a4", "errors": null, "name": "Input dataset", "label": "Trimmed reads (mate 2)", "inputs": [], "position": {"top": 383, "left": 201}, "annotation": "", "content_id": null, "type": "data_input"}, "2": {"tool_id": "toolshed.g2.bx.psu.edu/repos/devteam/bwa/bwa_mem/0.7.17.1", "tool_version": "0.7.17.1", "outputs": [{"type": "bam", "name": "bam_output"}], "workflow_outputs": [], "input_connections": {"fastq_input|fastq_input1": {"output_name": "output", "id": 0}, "fastq_input|fastq_input2": {"output_name": "output", "id": 1}}, "tool_state": "{\"__page__\": null, \"__rerun_remap_job_id__\": null, \"__job_resource\": \"{\\\"__current_case__\\\": 0, \\\"__job_resource__select\\\": \\\"no\\\"}\", \"rg\": \"{\\\"rg_selector\\\": \\\"do_not_set\\\", \\\"__current_case__\\\": 3}\", \"fastq_input\": \"{\\\"iset_stats\\\": \\\"\\\", \\\"fastq_input2\\\": {\\\"__class__\\\": \\\"RuntimeValue\\\"}, \\\"__current_case__\\\": 0, \\\"fastq_input_selector\\\": \\\"paired\\\", \\\"fastq_input1\\\": {\\\"__class__\\\": \\\"RuntimeValue\\\"}}\", \"analysis_type\": \"{\\\"analysis_type_selector\\\": \\\"illumina\\\", \\\"__current_case__\\\": 0}\", \"reference_source\": \"{\\\"ref_file\\\": \\\"hg38\\\", \\\"reference_source_selector\\\": \\\"cached\\\", \\\"__current_case__\\\": 0}\", \"chromInfo\": \"\\\"/cvmfs/data.galaxyproject.org/managed/len/ucsc/?.len\\\"\"}", "id": 2, "tool_shed_repository": {"owner": "devteam", "changeset_revision": "4f774c1e6049", "name": "bwa", "tool_shed": "toolshed.g2.bx.psu.edu"}, "uuid": "a4e278e2-b0b2-41ce-80e7-0823e4e8f4a6", "errors": null, "name": "Map with BWA-MEM", "post_job_actions": {"HideDatasetActionbam_output": {"output_name": "bam_output", "action_type": "HideDatasetAction", "action_arguments": {}}}, "label": null, "inputs": [{"name": "fastq_input", "description": "runtime parameter for tool Map with BWA-MEM"}, {"name": "fastq_input", "description": "runtime parameter for tool Map with BWA-MEM"}], "position": {"top": 283, "left": 457}, "annotation": "", "content_id": "toolshed.g2.bx.psu.edu/repos/devteam/bwa/bwa_mem/0.7.17.1", "type": "tool"}, "3": {"tool_id": "toolshed.g2.bx.psu.edu/repos/devteam/freebayes/bamleftalign/1.1.0.46-0", "tool_version": "1.1.0.46-0", "outputs": [{"type": "bam", "name": "output_bam"}], "workflow_outputs": [], "input_connections": {"reference_source|input_bam": {"output_name": "bam_output", "id": 2}}, "tool_state": "{\"reference_source\": \"{\\\"ref_file\\\": \\\"hg38\\\", \\\"reference_source_selector\\\": \\\"cached\\\", \\\"input_bam\\\": {\\\"__class__\\\": \\\"RuntimeValue\\\"}, \\\"__current_case__\\\": 0}\", \"__rerun_remap_job_id__\": null, \"chromInfo\": \"\\\"/cvmfs/data.galaxyproject.org/managed/len/ucsc/hg38.len\\\"\", \"iterations\": \"\\\"5\\\"\", \"__page__\": null}", "id": 3, "tool_shed_repository": {"owner": "devteam", "changeset_revision": "156b60c1530f", "name": "freebayes", "tool_shed": "toolshed.g2.bx.psu.edu"}, "uuid": "36f6b523-9f11-4d6d-9316-dc14bf82e3fe", "errors": null, "name": "BamLeftAlign", "post_job_actions": {"HideDatasetActionoutput_bam": {"output_name": "output_bam", "action_type": "HideDatasetAction", "action_arguments": {}}}, "label": null, "inputs": [{"name": "reference_source", "description": "runtime parameter for tool BamLeftAlign"}], "position": {"top": 283, "left": 712}, "annotation": "", "content_id": "toolshed.g2.bx.psu.edu/repos/devteam/freebayes/bamleftalign/1.1.0.46-0", "type": "tool"}, "4": {"tool_id": "toolshed.g2.bx.psu.edu/repos/blankenberg/naive_variant_caller/naive_variant_caller/0.0.4", "tool_version": "0.0.4", "outputs": [{"type": "vcf", "name": "output_vcf"}], "workflow_outputs": [], "input_connections": {"reference_source|input_bams_0|input_bam": {"output_name": "output_bam", "id": 3}}, "tool_state": "{\"__page__\": null, \"ploidy\": \"\\\"1\\\"\", \"use_strand\": \"\\\"true\\\"\", \"min_mapping_quality\": \"\\\"20\\\"\", \"region_files\": \"[]\", \"__rerun_remap_job_id__\": null, \"regions\": \"[{\\\"__index__\\\": 0, \\\"end\\\": \\\"\\\", \\\"chromosome\\\": \\\"chr9\\\", \\\"start\\\": \\\"\\\"}]\", \"advanced_options\": \"{\\\"advanced_options_selector\\\": \\\"basic\\\", \\\"__current_case__\\\": 0}\", \"min_base_quality\": \"\\\"0\\\"\", \"reference_source\": \"{\\\"ref_file\\\": \\\"hg38\\\", \\\"reference_source_selector\\\": \\\"cached\\\", \\\"input_bams\\\": [{\\\"__index__\\\": 0, \\\"input_bam\\\": {\\\"__class__\\\": \\\"RuntimeValue\\\"}}], \\\"__current_case__\\\": 0}\", \"variants_only\": \"\\\"false\\\"\", \"min_support_depth\": \"\\\"0\\\"\", \"chromInfo\": \"\\\"/cvmfs/data.galaxyproject.org/managed/len/ucsc/hg38.len\\\"\"}", "id": 4, "tool_shed_repository": {"owner": "blankenberg", "changeset_revision": "07e71cf6c8ef", "name": "naive_variant_caller", "tool_shed": "toolshed.g2.bx.psu.edu"}, "uuid": "3214b873-94e1-46e5-bbd2-ad52d1ef43b5", "errors": null, "name": "Naive Variant Caller (NVC)", "post_job_actions": {"HideDatasetActionoutput_vcf": {"output_name": "output_vcf", "action_type": "HideDatasetAction", "action_arguments": {}}}, "label": null, "inputs": [], "position": {"top": 503, "left": 200}, "annotation": "", "content_id": "toolshed.g2.bx.psu.edu/repos/blankenberg/naive_variant_caller/naive_variant_caller/0.0.4", "type": "tool"}, "5": {"tool_id": "toolshed.g2.bx.psu.edu/repos/nick/allele_counts/allele_counts_1/1.2", "tool_version": "1.2", "outputs": [{"type": "tabular", "name": "output"}], "workflow_outputs": [{"output_name": "output", "uuid": "ad99c585-39c1-4888-9726-28c30317ec21", "label": null}], "input_connections": {"input": {"output_name": "output_vcf", "id": 4}}, "tool_state": "{\"__page__\": null, \"__rerun_remap_job_id__\": null, \"stranded\": \"\\\"true\\\"\", \"covg\": \"\\\"10\\\"\", \"header\": \"\\\"true\\\"\", \"seed\": \"\\\"\\\"\", \"input\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\", \"freq\": \"\\\"0.0\\\"\", \"nofilt\": \"\\\"false\\\"\"}", "id": 5, "tool_shed_repository": {"owner": "nick", "changeset_revision": "411adeff1eec", "name": "allele_counts", "tool_shed": "toolshed.g2.bx.psu.edu"}, "uuid": "b27aa8b9-adb8-43b4-9a70-53025ae1f9f1", "errors": null, "name": "Variant Annotator", "post_job_actions": {"RenameDatasetActionoutput": {"output_name": "output", "action_type": "RenameDatasetAction", "action_arguments": {"newname": "All variants"}}}, "label": null, "inputs": [{"name": "input", "description": "runtime parameter for tool Variant Annotator"}], "position": {"top": 502, "left": 474}, "annotation": "", "content_id": "toolshed.g2.bx.psu.edu/repos/nick/allele_counts/allele_counts_1/1.2", "type": "tool"}, "6": {"tool_id": "Filter1", "tool_version": "1.1.0", "outputs": [{"type": "input", "name": "out_file1"}], "workflow_outputs": [{"output_name": "out_file1", "uuid": "dcdddac9-bd96-4f27-b585-bd3167fef38d", "label": null}], "input_connections": {"input": {"output_name": "output", "id": 5}}, "tool_state": "{\"input\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\", \"__rerun_remap_job_id__\": null, \"header_lines\": \"\\\"1\\\"\", \"cond\": \"\\\"c16 >= 0.01\\\"\", \"__page__\": null}", "id": 6, "uuid": "3ada37c0-11f6-4d2c-bf53-cf1e228ee91e", "errors": null, "name": "Filter", "post_job_actions": {"RenameDatasetActionout_file1": {"output_name": "out_file1", "action_type": "RenameDatasetAction", "action_arguments": {"newname": "Filtered variants"}}}, "label": null, "inputs": [{"name": "input", "description": "runtime parameter for tool Filter"}], "position": {"top": 503, "left": 765}, "annotation": "", "content_id": "Filter1", "type": "tool"}}, "annotation": "Run this on the trimmed consensus reads (DCS or SSCS) from Du Novo.\n", "a_galaxy_workflow": "true"}
+{
+  "a_galaxy_workflow": "true",
+  "annotation": "Run this on the trimmed consensus reads (DCS or SSCS) from Du Novo.\n",
+  "format-version": "0.1",
+  "name": "Du Novo GTN tutorial - Variant calling",
+  "steps": {
+    "0": {
+      "annotation": "",
+      "content_id": null,
+      "errors": null,
+      "id": 0,
+      "input_connections": {},
+      "inputs": [],
+      "label": "Trimmed reads (mate 1)",
+      "name": "Input dataset",
+      "outputs": [],
+      "position": {
+        "left": 200,
+        "top": 284
+      },
+      "tool_id": null,
+      "tool_state": "{}",
+      "tool_version": null,
+      "type": "data_input",
+      "uuid": "f9817ffe-4cdb-471f-a921-1b20e96e92d6",
+      "workflow_outputs": [
+        {
+          "label": null,
+          "output_name": "output",
+          "uuid": "d9cf4c1c-9b41-49e6-8eed-20f201143897"
+        }
+      ]
+    },
+    "1": {
+      "annotation": "",
+      "content_id": null,
+      "errors": null,
+      "id": 1,
+      "input_connections": {},
+      "inputs": [],
+      "label": "Trimmed reads (mate 2)",
+      "name": "Input dataset",
+      "outputs": [],
+      "position": {
+        "left": 201,
+        "top": 383
+      },
+      "tool_id": null,
+      "tool_state": "{}",
+      "tool_version": null,
+      "type": "data_input",
+      "uuid": "efc0fed6-846f-467f-82a3-45898dc3e0a4",
+      "workflow_outputs": [
+        {
+          "label": null,
+          "output_name": "output",
+          "uuid": "347dcece-5ddc-40fb-a5ed-4ff05f2d2d3a"
+        }
+      ]
+    },
+    "2": {
+      "annotation": "",
+      "content_id": "toolshed.g2.bx.psu.edu/repos/devteam/bwa/bwa_mem/0.7.17.1",
+      "errors": null,
+      "id": 2,
+      "input_connections": {
+        "fastq_input|fastq_input1": {
+          "id": 0,
+          "output_name": "output"
+        },
+        "fastq_input|fastq_input2": {
+          "id": 1,
+          "output_name": "output"
+        }
+      },
+      "inputs": [
+        {
+          "description": "runtime parameter for tool Map with BWA-MEM",
+          "name": "fastq_input"
+        },
+        {
+          "description": "runtime parameter for tool Map with BWA-MEM",
+          "name": "fastq_input"
+        }
+      ],
+      "label": null,
+      "name": "Map with BWA-MEM",
+      "outputs": [
+        {
+          "name": "bam_output",
+          "type": "bam"
+        }
+      ],
+      "position": {
+        "left": 457,
+        "top": 283
+      },
+      "post_job_actions": {
+        "HideDatasetActionbam_output": {
+          "action_arguments": {},
+          "action_type": "HideDatasetAction",
+          "output_name": "bam_output"
+        }
+      },
+      "tool_id": "toolshed.g2.bx.psu.edu/repos/devteam/bwa/bwa_mem/0.7.17.1",
+      "tool_shed_repository": {
+        "changeset_revision": "4f774c1e6049",
+        "name": "bwa",
+        "owner": "devteam",
+        "tool_shed": "toolshed.g2.bx.psu.edu"
+      },
+      "tool_state": "{\"__page__\": null, \"__rerun_remap_job_id__\": null, \"__job_resource\": \"{\\\"__current_case__\\\": 0, \\\"__job_resource__select\\\": \\\"no\\\"}\", \"rg\": \"{\\\"rg_selector\\\": \\\"do_not_set\\\", \\\"__current_case__\\\": 3}\", \"fastq_input\": \"{\\\"iset_stats\\\": \\\"\\\", \\\"fastq_input2\\\": {\\\"__class__\\\": \\\"RuntimeValue\\\"}, \\\"__current_case__\\\": 0, \\\"fastq_input_selector\\\": \\\"paired\\\", \\\"fastq_input1\\\": {\\\"__class__\\\": \\\"RuntimeValue\\\"}}\", \"analysis_type\": \"{\\\"analysis_type_selector\\\": \\\"illumina\\\", \\\"__current_case__\\\": 0}\", \"reference_source\": \"{\\\"ref_file\\\": \\\"hg38\\\", \\\"reference_source_selector\\\": \\\"cached\\\", \\\"__current_case__\\\": 0}\", \"chromInfo\": \"\\\"/cvmfs/data.galaxyproject.org/managed/len/ucsc/?.len\\\"\"}",
+      "tool_version": "0.7.17.1",
+      "type": "tool",
+      "uuid": "a4e278e2-b0b2-41ce-80e7-0823e4e8f4a6",
+      "workflow_outputs": []
+    },
+    "3": {
+      "annotation": "",
+      "content_id": "toolshed.g2.bx.psu.edu/repos/devteam/freebayes/bamleftalign/1.1.0.46-0",
+      "errors": null,
+      "id": 3,
+      "input_connections": {
+        "reference_source|input_bam": {
+          "id": 2,
+          "output_name": "bam_output"
+        }
+      },
+      "inputs": [
+        {
+          "description": "runtime parameter for tool BamLeftAlign",
+          "name": "reference_source"
+        }
+      ],
+      "label": null,
+      "name": "BamLeftAlign",
+      "outputs": [
+        {
+          "name": "output_bam",
+          "type": "bam"
+        }
+      ],
+      "position": {
+        "left": 712,
+        "top": 283
+      },
+      "post_job_actions": {
+        "HideDatasetActionoutput_bam": {
+          "action_arguments": {},
+          "action_type": "HideDatasetAction",
+          "output_name": "output_bam"
+        }
+      },
+      "tool_id": "toolshed.g2.bx.psu.edu/repos/devteam/freebayes/bamleftalign/1.1.0.46-0",
+      "tool_shed_repository": {
+        "changeset_revision": "156b60c1530f",
+        "name": "freebayes",
+        "owner": "devteam",
+        "tool_shed": "toolshed.g2.bx.psu.edu"
+      },
+      "tool_state": "{\"reference_source\": \"{\\\"ref_file\\\": \\\"hg38\\\", \\\"reference_source_selector\\\": \\\"cached\\\", \\\"input_bam\\\": {\\\"__class__\\\": \\\"RuntimeValue\\\"}, \\\"__current_case__\\\": 0}\", \"__rerun_remap_job_id__\": null, \"chromInfo\": \"\\\"/cvmfs/data.galaxyproject.org/managed/len/ucsc/hg38.len\\\"\", \"iterations\": \"\\\"5\\\"\", \"__page__\": null}",
+      "tool_version": "1.1.0.46-0",
+      "type": "tool",
+      "uuid": "36f6b523-9f11-4d6d-9316-dc14bf82e3fe",
+      "workflow_outputs": []
+    },
+    "4": {
+      "annotation": "",
+      "content_id": "toolshed.g2.bx.psu.edu/repos/blankenberg/naive_variant_caller/naive_variant_caller/0.0.4",
+      "errors": null,
+      "id": 4,
+      "input_connections": {
+        "reference_source|input_bams_0|input_bam": {
+          "id": 3,
+          "output_name": "output_bam"
+        }
+      },
+      "inputs": [],
+      "label": null,
+      "name": "Naive Variant Caller (NVC)",
+      "outputs": [
+        {
+          "name": "output_vcf",
+          "type": "vcf"
+        }
+      ],
+      "position": {
+        "left": 200,
+        "top": 503
+      },
+      "post_job_actions": {
+        "HideDatasetActionoutput_vcf": {
+          "action_arguments": {},
+          "action_type": "HideDatasetAction",
+          "output_name": "output_vcf"
+        }
+      },
+      "tool_id": "toolshed.g2.bx.psu.edu/repos/blankenberg/naive_variant_caller/naive_variant_caller/0.0.4",
+      "tool_shed_repository": {
+        "changeset_revision": "07e71cf6c8ef",
+        "name": "naive_variant_caller",
+        "owner": "blankenberg",
+        "tool_shed": "toolshed.g2.bx.psu.edu"
+      },
+      "tool_state": "{\"__page__\": null, \"ploidy\": \"\\\"1\\\"\", \"use_strand\": \"\\\"true\\\"\", \"min_mapping_quality\": \"\\\"20\\\"\", \"region_files\": \"[]\", \"__rerun_remap_job_id__\": null, \"regions\": \"[{\\\"__index__\\\": 0, \\\"end\\\": \\\"\\\", \\\"chromosome\\\": \\\"chr9\\\", \\\"start\\\": \\\"\\\"}]\", \"advanced_options\": \"{\\\"advanced_options_selector\\\": \\\"basic\\\", \\\"__current_case__\\\": 0}\", \"min_base_quality\": \"\\\"0\\\"\", \"reference_source\": \"{\\\"ref_file\\\": \\\"hg38\\\", \\\"reference_source_selector\\\": \\\"cached\\\", \\\"input_bams\\\": [{\\\"__index__\\\": 0, \\\"input_bam\\\": {\\\"__class__\\\": \\\"RuntimeValue\\\"}}], \\\"__current_case__\\\": 0}\", \"variants_only\": \"\\\"false\\\"\", \"min_support_depth\": \"\\\"0\\\"\", \"chromInfo\": \"\\\"/cvmfs/data.galaxyproject.org/managed/len/ucsc/hg38.len\\\"\"}",
+      "tool_version": "0.0.4",
+      "type": "tool",
+      "uuid": "3214b873-94e1-46e5-bbd2-ad52d1ef43b5",
+      "workflow_outputs": []
+    },
+    "5": {
+      "annotation": "",
+      "content_id": "toolshed.g2.bx.psu.edu/repos/nick/allele_counts/allele_counts_1/1.2",
+      "errors": null,
+      "id": 5,
+      "input_connections": {
+        "input": {
+          "id": 4,
+          "output_name": "output_vcf"
+        }
+      },
+      "inputs": [
+        {
+          "description": "runtime parameter for tool Variant Annotator",
+          "name": "input"
+        }
+      ],
+      "label": null,
+      "name": "Variant Annotator",
+      "outputs": [
+        {
+          "name": "output",
+          "type": "tabular"
+        }
+      ],
+      "position": {
+        "left": 474,
+        "top": 502
+      },
+      "post_job_actions": {
+        "RenameDatasetActionoutput": {
+          "action_arguments": {
+            "newname": "All variants"
+          },
+          "action_type": "RenameDatasetAction",
+          "output_name": "output"
+        }
+      },
+      "tool_id": "toolshed.g2.bx.psu.edu/repos/nick/allele_counts/allele_counts_1/1.2",
+      "tool_shed_repository": {
+        "changeset_revision": "411adeff1eec",
+        "name": "allele_counts",
+        "owner": "nick",
+        "tool_shed": "toolshed.g2.bx.psu.edu"
+      },
+      "tool_state": "{\"__page__\": null, \"__rerun_remap_job_id__\": null, \"stranded\": \"\\\"true\\\"\", \"covg\": \"\\\"10\\\"\", \"header\": \"\\\"true\\\"\", \"seed\": \"\\\"\\\"\", \"input\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\", \"freq\": \"\\\"0.0\\\"\", \"nofilt\": \"\\\"false\\\"\"}",
+      "tool_version": "1.2",
+      "type": "tool",
+      "uuid": "b27aa8b9-adb8-43b4-9a70-53025ae1f9f1",
+      "workflow_outputs": [
+        {
+          "label": null,
+          "output_name": "output",
+          "uuid": "ad99c585-39c1-4888-9726-28c30317ec21"
+        }
+      ]
+    },
+    "6": {
+      "annotation": "",
+      "content_id": "Filter1",
+      "errors": null,
+      "id": 6,
+      "input_connections": {
+        "input": {
+          "id": 5,
+          "output_name": "output"
+        }
+      },
+      "inputs": [
+        {
+          "description": "runtime parameter for tool Filter",
+          "name": "input"
+        }
+      ],
+      "label": null,
+      "name": "Filter",
+      "outputs": [
+        {
+          "name": "out_file1",
+          "type": "input"
+        }
+      ],
+      "position": {
+        "left": 765,
+        "top": 503
+      },
+      "post_job_actions": {
+        "RenameDatasetActionout_file1": {
+          "action_arguments": {
+            "newname": "Filtered variants"
+          },
+          "action_type": "RenameDatasetAction",
+          "output_name": "out_file1"
+        }
+      },
+      "tool_id": "Filter1",
+      "tool_state": "{\"input\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\", \"__rerun_remap_job_id__\": null, \"header_lines\": \"\\\"1\\\"\", \"cond\": \"\\\"c16 >= 0.01\\\"\", \"__page__\": null}",
+      "tool_version": "1.1.0",
+      "type": "tool",
+      "uuid": "3ada37c0-11f6-4d2c-bf53-cf1e228ee91e",
+      "workflow_outputs": [
+        {
+          "label": null,
+          "output_name": "out_file1",
+          "uuid": "dcdddac9-bd96-4f27-b585-bd3167fef38d"
+        }
+      ]
+    }
+  },
+  "tags": [],
+  "uuid": "73d76159-35a3-4e1a-a229-1953dbc18f12"
+}


### PR DESCRIPTION
Changed all oneline workflows to the unflattened JSON one using 
```
cat wf.ga | jq . -S > out.ga
```
from https://github.com/usegalaxy-eu/workflow-testing

This way small changes to the workflow can be easily compared.