### PR TITLE
Fix of broken zenodo links for tour data

### DIFF
--- a/topics/transcriptomics/tutorials/de-novo/tours/tour.yaml
+++ b/topics/transcriptomics/tutorials/de-novo/tours/tour.yaml
@@ -77,21 +77,21 @@ steps:
       href="https://zenodo.org/record/583140">Zenodo</a>.
     placement: right
     textinsert: >-
-      https://zenodo.org/record/583140/files/G1E_rep1_forward_read%28SRR549355_1%29
+      https://zenodo.org/record/583140/files/G1E_rep1_forward_read_%28SRR549355_1%29
 
-      https://zenodo.org/record/583140/files/G1E_rep1_reverse_read%28SRR549355_2%29
+      https://zenodo.org/record/583140/files/G1E_rep1_reverse_read_%28SRR549355_2%29
 
-      https://zenodo.org/record/583140/files/G1E_rep2_forward_read%28SRR549356_1%29
+      https://zenodo.org/record/583140/files/G1E_rep2_forward_read_%28SRR549356_1%29
 
-      https://zenodo.org/record/583140/files/G1E_rep2_reverse_read%28SRR549356_2%29
+      https://zenodo.org/record/583140/files/G1E_rep2_reverse_read_%28SRR549356_2%29
 
-      https://zenodo.org/record/583140/files/Megakaryocyte_rep1_forward_read%28SRR549357_1%29
+      https://zenodo.org/record/583140/files/Megakaryocyte_rep1_forward_read_%28SRR549357_1%29
 
-      https://zenodo.org/record/583140/files/Megakaryocyte_rep1_reverse_read%28SRR549357_2%29
+      https://zenodo.org/record/583140/files/Megakaryocyte_rep1_reverse_read_%28SRR549357_2%29
 
-      https://zenodo.org/record/583140/files/Megakaryocyte_rep2_forward_read%28SRR549358_1%29
+      https://zenodo.org/record/583140/files/Megakaryocyte_rep2_forward_read_%28SRR549358_1%29
 
-      https://zenodo.org/record/583140/files/Megakaryocyte_rep2_reverse_read%28SRR549358_2%29
+      https://zenodo.org/record/583140/files/Megakaryocyte_rep2_reverse_read_%28SRR549358_2%29
 
       https://zenodo.org/record/583140/files/RefSeq_reference_GTF_%28DSv2%29
   - title: Data types

--- a/topics/transcriptomics/tutorials/de-novo/tours/tour.yaml
+++ b/topics/transcriptomics/tutorials/de-novo/tours/tour.yaml
@@ -77,21 +77,21 @@ steps:
       href="https://zenodo.org/record/583140">Zenodo</a>.
     placement: right
     textinsert: >-
-      https://zenodo.org/record/583140/files/G1E_rep1forward_read%28SRR549355_1%29
+      https://zenodo.org/record/583140/files/G1E_rep1_forward_read%28SRR549355_1%29
 
-      https://zenodo.org/record/583140/files/G1E_rep1reverse_read%28SRR549355_2%29
+      https://zenodo.org/record/583140/files/G1E_rep1_reverse_read%28SRR549355_2%29
 
-      https://zenodo.org/record/583140/files/G1E_rep2forward_read%28SRR549356_1%29
+      https://zenodo.org/record/583140/files/G1E_rep2_forward_read%28SRR549356_1%29
 
-      https://zenodo.org/record/583140/files/G1E_rep2reverse_read%28SRR549356_2%29
+      https://zenodo.org/record/583140/files/G1E_rep2_reverse_read%28SRR549356_2%29
 
-      https://zenodo.org/record/583140/files/Megakaryocyte_rep1forward_read%28SRR549357_1%29
+      https://zenodo.org/record/583140/files/Megakaryocyte_rep1_forward_read%28SRR549357_1%29
 
-      https://zenodo.org/record/583140/files/Megakaryocyte_rep1reverse_read%28SRR549357_2%29
+      https://zenodo.org/record/583140/files/Megakaryocyte_rep1_reverse_read%28SRR549357_2%29
 
-      https://zenodo.org/record/583140/files/Megakaryocyte_rep2forward_read%28SRR549358_1%29
+      https://zenodo.org/record/583140/files/Megakaryocyte_rep2_forward_read%28SRR549358_1%29
 
-      https://zenodo.org/record/583140/files/Megakaryocyte_rep2reverse_read%28SRR549358_2%29
+      https://zenodo.org/record/583140/files/Megakaryocyte_rep2_reverse_read%28SRR549358_2%29
 
       https://zenodo.org/record/583140/files/RefSeq_reference_GTF_%28DSv2%29
   - title: Data types


### PR DESCRIPTION
Seems there is a _ between repX and forward/reverse missing!
Working:
https://zenodo.org/record/583140/files/G1E_rep1_forward_read_%28SRR549355_1%29?download=1
Currently not working:
https://zenodo.org/record/583140/files/G1E_rep1forward_read%28SRR549355_1%29