### PR TITLE
Try to fix makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,7 @@ endif
 
 CONDA=$(shell which conda)
 ifeq ($(CONDA),)
-	CONDA=${HOME}/miniconda3/bin/conda/
+	CONDA=${HOME}/miniconda3/bin/conda
 endif
 
 default: help
@@ -41,7 +41,7 @@ create-env: ## create conda environment
 	fi
 .PHONY: create-env
 
-ACTIVATE_ENV = source $(dir ${CONDA})activate ${CONDA_ENV}
+ACTIVATE_ENV = source $(shell dirname $(dir $(CONDA)))/bin/activate $(CONDA_ENV)
 
 install: clean ## install dependencies
 	$(ACTIVATE_ENV) && \

--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,7 @@ endif
 
 CONDA=$(shell which conda)
 ifeq ($(CONDA),)
-	CONDA=${HOME}/miniconda3/bin/conda
+	CONDA=${HOME}/miniconda3/bin/conda/
 endif
 
 default: help


### PR DESCRIPTION
> miniconda changed, not dropping the slash, just now has an additional folder named condabin, which contains just the executable conda, and the rest like activate are still in regular bin folder

solution finally figured out by @shiltemann <3

Apparently makefile doesn't have a parent directory function (and everything online just implements their own), so shelling out.