### PR TITLE
Add pip as requirement in environment.yml

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -11,6 +11,7 @@ dependencies:
   - nodejs=9.11.1
   - openssl=1.0.2o
   - pandas=0.22.0
+  - pip
   - pip:
     - pathspec==0.5.6
     - oyaml


### PR DESCRIPTION
Fixes warning during `make create-env`