### PR TITLE
Standardise contributor lists everywhere

### DIFF
--- a/_includes/contributor-badge-list.html
+++ b/_includes/contributor-badge-list.html
@@ -1,0 +1,6 @@
+{% if include.contributors %}
+{% capture people %}
+{% for id in include.contributors %}, {% assign name = contributors[id].name | default: id -%}{% include _includes/contributor-badge.html id=id name=name %}{% endfor %}
+{% endcapture %}
+{% endif %}
+{{ people | remove_first: ', ' }}

--- a/_includes/contributor-badge.html
+++ b/_includes/contributor-badge.html
@@ -1,0 +1,1 @@
+<a href="{{ site.baseurl }}/hall-of-fame#{{ include.id }}" class="contributor-badge"><img src="https://avatars.githubusercontent.com/{{ include.id }}" alt="{{ include.name }}">{{ include.name }}</a>

--- a/_layouts/base_slides.html
+++ b/_layouts/base_slides.html
@@ -91,7 +91,13 @@ Before diving into this slide deck, we recommend you to have a look at:
 
 ## Thank you!
 
-This material is the result of a collaborative work. Thanks the [Galaxy Training Network](https://wiki.galaxyproject.org/Teach/GTN) and all the contributors {% if tutorial.contributors %}{% capture contributors %}{% for c in tutorial.contributors %}, [{{ contributors[c].name | default: c }}]({{ site.baseurl }}/hall-of-fame#{{ c }}){% endfor %}{% endcapture %} ({{ contributors | remove_first: ', ' }}) {% endif %}!
+This material is the result of a collaborative work. Thanks to the [Galaxy Training Network](https://wiki.galaxyproject.org/Teach/GTN) and all the contributors!
+
+{% if tutorial.contributors %}
+<div class="contributors-line">
+{% include _includes/contributor-badge-list.html contributors=tutorial.contributors %}
+</div>
+{% endif %}
 
 {% if page.logo == "GTN" %}
 <img src="{{ site.baseurl }}/{{ site.logo }}" alt="Galaxy Training Network" style="height: 100px;"/>

--- a/_layouts/topic.html
+++ b/_layouts/topic.html
@@ -169,24 +169,8 @@ layout: base
 
         <h2 id="maintainers">Maintainers</h2>
         <p>This material is maintained by:</p>
-        <ul>
         {% assign maintainers = topic.maintainers | sorted %}
-        {% for maintainer in maintainers %}
-            <li>
-                <a href="{{ site.baseurl }}/hall-of-fame#{{ maintainer }}">{{ contributors[maintainer].name | default: maintainer}}</a>
-                {% if contributors[maintainer].maintainer_contact %}
-                    {% if contributors[maintainer].maintainer_contact == 'email' %}
-                    (<a href="mailto:{{ contributors[maintainer].email }}">Contact {% icon email %}</a> )
-                    {% elsif contributors[maintainer].maintainer_contact == 'gitter' %}
-                    (<a href="https://gitter.im/{{ contributors[maintainer].gitter }}">Contact {% icon gitter %}</a> )
-                    {% else %}
-                    (<a href="{{ contributors[maintainer].maintainer_contact }}">Contact</a>)
-                    {% endif %}
-
-                {% endif %}
-            </li>
-        {% endfor %}
-        </ul>
+        {% include _includes/contributor-badge-list.html contributors=maintainers %}
 
         <p>
             <em>For any question related to this topic and the content, you can contact them or visit our <a href="https://gitter.im/Galaxy-Training-Network/Lobby">Gitter channel</a>.</em>
@@ -194,8 +178,6 @@ layout: base
 
         <h2 id="contributors">Contributors</h2>
         <p>This material was contributed to by:</p>
-
-        <!-- get list of unique contributors for all materials in the topic -->
         {% assign contributors_list = "" | split: ',' %}
         {% for material in topic_material %}
             {% for c in material.contributors %}
@@ -205,16 +187,8 @@ layout: base
                 {% endif %}
             {% endfor %}
         {% endfor %}
-
-        <ul>
         {% assign contributors_list_sorted = contributors_list | sorted %}
-        {% for username in contributors_list_sorted %}
-            {% assign contributor = contributors[username] | default: username %}
-            <li>
-                <a href="{{ site.baseurl }}/hall-of-fame#{{ username }}">{% if contributor.name %}{{ contributor.name }}{% else %}{{ username }}{% endif %}</a>
-            </li>
-        {% endfor %}
-        </ul>
+        {% include _includes/contributor-badge-list.html contributors=contributors_list_sorted %}
 
         {% if topic.references %}
         <h2 id="references">References</h2>

--- a/_layouts/tutorial_hands_on.html
+++ b/_layouts/tutorial_hands_on.html
@@ -7,13 +7,6 @@ layout: base
 {% assign instances = site.data['instances'] %}
 {% assign topic_material = site.pages | topic_filter:page.topic_name %}
 {% assign language = site.other_languages | split: ", " %}
-{% if page.contributors %}
-  {% assign contrib = page.contributors %}
-  {% capture contributors %}
-  {% for contributor_id in contrib %}, {% assign c = contributors[contributor_id].name | default: contributor_id %}
-  <a href="{{ site.baseurl }}/hall-of-fame#{{ contributor_id }}" class="contributor-badge"><img src="https://avatars.githubusercontent.com/{{ contributor_id }}" alt="{{ c }}">{{ c }}</a>
-  {%- endfor %}{% endcapture %}
-{% endif %}
 
 <header>
     <nav class="navbar navbar-expand-lg navbar-dark">
@@ -158,7 +151,7 @@ layout: base
 
     <section class="tutorial">
         <h1 data-toc-skip>{{ page.title }}</h1>
-        <div class="contributors-line">By: {{ contributors | remove_first: ', ' }} </div>
+        <div class="contributors-line">By: {% include _includes/contributor-badge-list.html contributors=page.contributors %}</div>
         <blockquote class="overview">
             <h3>Overview</h3>
 

--- a/assets/css/slides.css
+++ b/assets/css/slides.css
@@ -299,3 +299,21 @@ th {
     position: absolute;
     width: 1px;
 }
+
+.contributors-line {
+    color: $gray;
+    font-size: 1.1em;
+    margin-bottom: 5rem;
+}
+
+.contributor-badge {
+  /* prevent breaking across lines */
+  white-space: nowrap;
+}
+
+.contributor-badge img {
+  height: 0.9em;
+  border-radius: 50%;
+  padding-right: 0.25em;
+  padding-left: 0.25em;
+}


### PR DESCRIPTION
Slides and topics now use the same icon+name, as in the byline of the tutorials.

![image](https://user-images.githubusercontent.com/458683/56799753-d5af0900-6819-11e9-964a-6788e82aac3f.png)

![image](https://user-images.githubusercontent.com/458683/56799772-df387100-6819-11e9-98dc-317d075a7b65.png)
