### PR TITLE
Fix archival builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -89,7 +89,6 @@ after_success:
       make annotate
       make build
       bin/publish
-      bin/publish-archive
     elif [ "$TRAVIS_PULL_REQUEST" == "false" -a "$TRAVIS_TAG" != "" -a "$CHECK" == "site-build" ]
     then
       # Do not publish old versions live, and do not update badges since not pushing to gh-pages.

--- a/.travis.yml
+++ b/.travis.yml
@@ -90,4 +90,8 @@ after_success:
       make build
       bin/publish
       bin/publish-archive
+    elif [ "$TRAVIS_PULL_REQUEST" == "false" -a "$TRAVIS_TAG" != "" -a "$CHECK" == "site-build" ]
+    then
+      # Do not publish old versions live, and do not update badges since not pushing to gh-pages.
+      bin/publish-archive
     fi

--- a/bin/publish-archive
+++ b/bin/publish-archive
@@ -1,57 +1,16 @@
 #!/usr/bin/env bash
 
-# Check if a specific tag has been built. "check_built_version [tagname]"
-check_built_version() {
-	tag=$1
+# Adjust baseurl
+sed -i s"|^baseurl: .*|baseurl: '/archive/${tag}'|g" _config.yml
+sed -i s"|^github_repository_branch: .*|github_repository_branch: '${tag}'|g" _config.yml
 
-	# List all objects with the prefix matching that folder. We don't just list
-	# root because if one version has more than max files, we won't see the
-	# other versions in the list.
-	#
-	# Only request 1 item max since we just need to know if /something/ exists there.
-	aws s3api list-objects \
-		--bucket galaxy-training \
-		--prefix "archive/${tag}/" \
-		--max-items 1 \
-		| wc -l
-}
+# Clean in order to remove anything from previous build
+make clean
+# And then rebuild with new version + updated _config.yml
+make build
 
-build_version() {
-	tag=$1
-	# Go into repo dir
-
-	# Checkout tag
-	git checkout $tag
-	if (( $? == 0 )); then
-		# Adjust baseurl
-		sed -i s"|^baseurl: .*|baseurl: '/archive/${tag}'|g" _config.yml
-		sed -i s"|^github_repository_branch: .*|github_repository_branch: '${tag}'|g" _config.yml
-		# Clean in order to remove anything from previous build
-		make clean
-		# And then rebuild with new version + updated _config.yml
-		make build
-		# Reset the config now that the site is built, since we no longer need
-		# it.
-		git checkout -- _config.yml
-
-		# Deploy
-		aws s3 sync _site/training-material/ s3://galaxy-training/archive/${tag}/
-	else
-		echo "Could not checkout ${tag}, probably older than Travis 50 commit clone depth."
-	fi
-}
-
-# For all tags
-for tag in $(git tag -l); do
-	# Has it been build?
-	result=$(check_built_version "$tag")
-	if [[ "$result" == "0" ]]; then
-		echo "$tag needs to be built"
-		build_version "$tag"
-	else
-		echo "$tag is already built, not rebuilding [${BUILD_DIR}/${tag}]"
-	fi
-done
+# Deploy
+aws s3 sync _site/training-material/ s3://galaxy-training/archive/${tag}/
 
 INDEX_PAGE_DIR=$(mktemp -d)
 INDEX="${INDEX_PAGE_DIR}/index.html"

--- a/bin/publish-archive
+++ b/bin/publish-archive
@@ -1,8 +1,8 @@
 #!/usr/bin/env bash
 
 # Adjust baseurl
-sed -i s"|^baseurl: .*|baseurl: '/archive/${tag}'|g" _config.yml
-sed -i s"|^github_repository_branch: .*|github_repository_branch: '${tag}'|g" _config.yml
+sed -i s"|^baseurl: .*|baseurl: '/archive/${TRAVIS_TAG}'|g" _config.yml
+sed -i s"|^github_repository_branch: .*|github_repository_branch: '${TRAVIS_TAG}'|g" _config.yml
 
 # Clean in order to remove anything from previous build
 make clean
@@ -10,7 +10,7 @@ make clean
 make build
 
 # Deploy
-aws s3 sync _site/training-material/ s3://galaxy-training/archive/${tag}/
+aws s3 sync _site/training-material/ s3://galaxy-training/archive/${TRAVIS_TAG}/
 
 INDEX_PAGE_DIR=$(mktemp -d)
 INDEX="${INDEX_PAGE_DIR}/index.html"


### PR DESCRIPTION
I don't know what I was thinking with the original implementation. It's clearly written like it's meant to be run on a cron job somewhere, and that's not the case here. Travis gets notified of new tags, and builds those, so all of my concerns with "tagging stuff that's too old because travis does shallow clones" goes away completely.

I've scrapped most of the publish-archive, it should be much simpler now, just builds the current version if it's building a git tag.