### PR TITLE
Move header items to overview box

### DIFF
--- a/_includes/instance-dropdown.html
+++ b/_includes/instance-dropdown.html
@@ -1,0 +1,23 @@
+{% if include.instances[include.topic].supported or include.docker %}
+{% if include.instances[include.topic]['tutorials'][include.tuto].supported or include.docker %}
+    <a href="#" class="btn btn-default dropdown-toggle" data-toggle="dropdown" aria-expanded="false" title="Where to run the tutorial">
+        {% icon instances %}
+    </a>
+    <ul class="dropdown-menu">
+    {% if include.docker %}
+        <li>
+            <a class="dropdown-item" href="{{ site.github.repository_url }}/tree/{{ site.repository_branch }}/topics/{{ include.topic }}/docker" title="Docker image for this tutorial">
+                {% icon docker_image %} Docker image
+            </a>
+        </li>
+    {% endif %}
+    {% for inst in include.instances[include.topic]['tutorials'][include.tuto]['instances'] %}
+        {% if inst[1].supported %}
+        <a class="dropdown-item" href="{{ inst[1].url }}" title="{{ inst[0] }}">
+            {{ inst[0] }}
+        </a>
+        {% endif %}
+    {% endfor %}
+    </ul>
+{% endif %}
+{% endif %}

--- a/_includes/instance-dropdown.html
+++ b/_includes/instance-dropdown.html
@@ -1,7 +1,7 @@
 {% if include.instances[include.topic].supported or include.docker %}
 {% if include.instances[include.topic]['tutorials'][include.tuto].supported or include.docker %}
-    <a href="#" class="btn btn-default dropdown-toggle" data-toggle="dropdown" aria-expanded="false" title="Where to run the tutorial">
-        {% icon instances %}
+    <a href="#" class="btn btn-default dropdown-toggle topic-icon" data-toggle="dropdown" aria-expanded="false" title="Where to run the tutorial">
+        {% icon instances %}{% if include.label %} Galaxies{% endif %}
     </a>
     <ul class="dropdown-menu">
     {% if include.docker %}

--- a/_includes/resource-handson.html
+++ b/_includes/resource-handson.html
@@ -1,0 +1,24 @@
+{% if include.material.hands_on == "external" %}
+<a class="topic-icon" href="{{ include.material.hands_on_url }}">
+    {% icon tutorial %}
+</a>
+{% elsif include.material.hands_on == "github" %}
+<a href="{{ site.github.repository_url }}/tree/master/topics/{{ include.topic }}/tutorials/{{ include.material.tutorial_name }}/tutorial.md">
+    {% icon tutorial %}
+</a>
+{% elsif include.material.hands_on %}
+    <span class="btn-group">
+        <a href="{{ site.baseurl }}/topics/{{ include.topic }}/tutorials/{{ include.material.tutorial_name }}/tutorial.html" class="btn btn-default" title="Where to run the tutorial">
+            {% icon tutorial %}
+        </a>
+        <a href="#" class="btn btn-default dropdown-toggle dropdown-toggle-split" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+            <span class="sr-only">Toggle Dropdown</span>
+        </a>
+        <ul class="dropdown-menu">
+        {% for lang in language %}
+            <a class="dropdown-item" href="https://translate.google.com/translate?hl=jp&sl=en&tl={{ lang }}&u=https%3A%2F%2Ftraining.galaxyproject.org%2Ftopics%2F{{ include.topic }}%2Ftutorials%2F{{ include.material.tutorial_name }}%2Ftutorial.html&edit-text=&act=url" title="{{ inst[0] }}">
+                {{ lang | upcase }}
+            </a>
+        {% endfor %}
+    </span>
+{% endif %}

--- a/_includes/resource-slides.html
+++ b/_includes/resource-slides.html
@@ -1,0 +1,5 @@
+{% if include.material.slides %}
+    <a class="topic-icon" href="{{ site.baseurl }}/topics/{{ include.topic }}/tutorials/{{ include.material.tutorial_name }}/slides.html">
+    {% icon slides %}
+</a>
+{% endif %}

--- a/_includes/resource-tours.html
+++ b/_includes/resource-tours.html
@@ -1,5 +1,5 @@
 {% if include.material.tours %}
-<a href="{{ site.github.repository_url }}/tree/{{ site.repository_branch }}/topics/{{ include.topic }}/tutorials/{{ include.material.tutorial_name }}/tours/">
-    {% icon interactive_tour %}
+<a class="topic-icon" href="{{ site.github.repository_url }}/tree/{{ site.repository_branch }}/topics/{{ include.topic }}/tutorials/{{ include.material.tutorial_name }}/tours/">
+    {% icon interactive_tour %}{% if include.label %} Tours{% endif %}
 </a>
 {% endif %}

--- a/_includes/resource-tours.html
+++ b/_includes/resource-tours.html
@@ -1,0 +1,5 @@
+{% if include.material.tours %}
+<a href="{{ site.github.repository_url }}/tree/{{ site.repository_branch }}/topics/{{ include.topic }}/tutorials/{{ include.material.tutorial_name }}/tours/">
+    {% icon interactive_tour %}
+</a>
+{% endif %}

--- a/_includes/resource-workflows.html
+++ b/_includes/resource-workflows.html
@@ -1,0 +1,5 @@
+{% if include.material.workflows %}
+    <a href="{{ site.github.repository_url }}/tree/{{ site.repository_branch }}/topics/{{ include.topic }}/tutorials/{{ include.material.tutorial_name }}/workflows/" title="Workflows" alt="{{ include.material.title }} workflows">
+        {% icon workflow %}
+    </a>
+{% endif %}

--- a/_includes/resource-workflows.html
+++ b/_includes/resource-workflows.html
@@ -1,5 +1,5 @@
 {% if include.material.workflows %}
-    <a href="{{ site.github.repository_url }}/tree/{{ site.repository_branch }}/topics/{{ include.topic }}/tutorials/{{ include.material.tutorial_name }}/workflows/" title="Workflows" alt="{{ include.material.title }} workflows">
-        {% icon workflow %}
+    <a class="topic-icon" href="{{ site.github.repository_url }}/tree/{{ site.repository_branch }}/topics/{{ include.topic }}/tutorials/{{ include.material.tutorial_name }}/workflows/" title="Workflows" alt="{{ include.material.title }} workflows">
+        {% icon workflow %}{% if include.label %} Workflows{% endif %}
     </a>
 {% endif %}

--- a/_includes/resource-zenodo.html
+++ b/_includes/resource-zenodo.html
@@ -1,5 +1,5 @@
 {% if include.material.zenodo_link != nil and include.material.zenodo_link != "" %}
-<a class="topic-icon" h href="{{ include.material.zenodo_link }}">
-    {% icon zenodo_link %}
+<a class="topic-icon" href="{{ include.material.zenodo_link }}">
+    {% icon zenodo_link %}{% if include.label %} Datasets{% endif %}
 </a>
 {% endif %}

--- a/_includes/resource-zenodo.html
+++ b/_includes/resource-zenodo.html
@@ -1,0 +1,5 @@
+{% if include.material.zenodo_link != nil and include.material.zenodo_link != "" %}
+<a class="topic-icon" h href="{{ include.material.zenodo_link }}">
+    {% icon zenodo_link %}
+</a>
+{% endif %}

--- a/_layouts/topic.html
+++ b/_layouts/topic.html
@@ -59,7 +59,7 @@ layout: base
                                        <span class="label label-default" style="{{ tag | colour_tag }}">{{ tag  }}</span>
                                   {% endfor %}
                             {% endif %}
-                            </div>
+                        </div>
                         </td>
                         {% if material.type == "introduction" %}
                             <td>
@@ -79,81 +79,27 @@ layout: base
                             {% endif %}
                         {% elsif material.type == "tutorial" %}
                             <td>
-                                {% if material.slides %}
-                                    <a class="topic-icon" href="{{ site.baseurl }}/topics/{{ topic.name }}/tutorials/{{ material.tutorial_name }}/slides.html">
-                                    {% icon slides %}
-                                </a>
-                                {% endif %}
+                                {% include _includes/resource-slides.html material=material topic=topic.name %}
                             </td>
                             <td>
-                                {% if material.hands_on == "external" %}
-                                <a class="topic-icon" href="{{ material.hands_on_url }}">
-                                    {% icon tutorial %}
-                                </a>
-                                {% elsif material.hands_on == "github" %}
-                                <a href="{{ site.github.repository_url }}/tree/master/topics/{{ topic.name }}/tutorials/{{ material.tutorial_name }}/tutorial.md">
-                                    {% icon tutorial %}
-                                </a>
-                                {% elsif material.hands_on %}
-                                    <span class="btn-group">
-                                        <a href="{{ site.baseurl }}/topics/{{ topic.name }}/tutorials/{{ material.tutorial_name }}/tutorial.html" class="btn btn-default" title="Where to run the tutorial">
-                                            {% icon tutorial %}
-                                        </a>
-                                        <a href="#" class="btn btn-default dropdown-toggle dropdown-toggle-split" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
-                                            <span class="sr-only">Toggle Dropdown</span>
-                                        </a>
-                                        <ul class="dropdown-menu">
-                                        {% for lang in language %}
-                                            <a class="dropdown-item" href="https://translate.google.com/translate?hl=jp&sl=en&tl={{ lang }}&u=https%3A%2F%2Ftraining.galaxyproject.org%2Ftopics%2F{{ topic.name }}%2Ftutorials%2F{{ material.tutorial_name }}%2Ftutorial.html&edit-text=&act=url" title="{{ inst[0] }}">
-                                                {{ lang | upcase }}
-                                            </a>
-                                        {% endfor %}
-                                    </span>
-                                {% endif %}
+                                {% include _includes/resource-handson.html material=material topic=topic.name %}
                             </td>
 
                             {% if topic.type == "use" %}
                                 <td>
-                                    {% if material.zenodo_link != nil and material.zenodo_link != "" %}
-                                    <a class="topic-icon" h href="{{ material.zenodo_link }}">
-                                        {% icon zenodo_link %}
-                                    </a>
-                                    {% endif %}
+                                    {% include _includes/resource-zenodo.html material=material topic=topic.name %}
                                 </td>
                                 <td>
-                                    {% if material.workflows %}
-                                        <a href="{{ site.github.repository_url }}/tree/{{ site.repository_branch }}/topics/{{ topic.name }}/tutorials/{{ material.tutorial_name }}/workflows/" title="{{ workflow.title }}" alt="{{ material.title }} workflows">
-                                            {% icon workflow %}
-                                        </a>
-                                    {% endif %}
+                                    {% include _includes/resource-workflows.html material=material topic=topic.name %}
                                 </td>
                                 <td>
-                                    {% if material.tours %}
-                                    <a href="{{ site.github.repository_url }}/tree/{{ site.repository_branch }}/topics/{{ topic.name }}/tutorials/{{ material.tutorial_name }}/tours/">
-                                        {% icon interactive_tour %}
-                                    </a>
-                                    {% endif %}
+                                    {% include _includes/resource-tours.html material=material topic=topic.name %}
                                 </td>
                             {% endif %}
 
-                            {% if instances[topic.name].supported %}
-                                <td>
-                                {% if instances[topic.name]['tutorials'][material.tutorial_name].supported %}
-                                    <a href="#" class="btn btn-default dropdown-toggle" data-toggle="dropdown" aria-expanded="false" title="Where to run the tutorial">
-                                        {% icon instances %}
-                                    </a>
-                                    <ul class="dropdown-menu">
-                                    {% for inst in instances[topic.name]['tutorials'][material.tutorial_name]['instances'] %}
-                                        {% if inst[1].supported %}
-                                        <a class="dropdown-item" href="{{ inst[1].url }}" title="{{ inst[0] }}">
-                                            {{ inst[0] }}
-                                        </a>
-                                        {% endif %}
-                                    {% endfor %}
-                                    </ul>
-                                {% endif %}
-                                </td>
-                            {% endif %}
+                            <td>
+                                {% include _includes/instance-dropdown.html instances=instances topic=topic.name tuto=material.tutorial_name %}
+                            </td>
                         {% endif %}
                     </tr>
                 {% endif %}

--- a/_layouts/tutorial_hands_on.html
+++ b/_layouts/tutorial_hands_on.html
@@ -22,7 +22,8 @@ layout: base
         {% endif %}
         {% if material.type == "introduction" %}
             {% assign intro_link = true %}
-            {% assign intro_target = site.base_url | append: '/topics/' | append: topic.name | append: '/slides/' | append: material.tutorial_name | append: '.html' %}
+            {% assign intro_target = material.tutorial_name | append: '.html' %}
+
         {% endif %}
     {% endif %}
 {% endfor %}
@@ -129,7 +130,7 @@ layout: base
                     </div>
                     {% elsif intro_link %}
                     <div>
-                        <a class="topic-icon" href="{{ intro_target }}">
+                        <a class="topic-icon" href="{{ site.baseurl }}/topics/{{ topic.name }}/slides/{{ intro_target }}" title="Introduction slides">
                             {% icon slides %} Introduction Slides
                         </a>
                     </div>

--- a/_layouts/tutorial_hands_on.html
+++ b/_layouts/tutorial_hands_on.html
@@ -142,14 +142,6 @@ layout: base
                     </div>
                     {% endif %}
 
-                    {% if topic.references and topic.references != "" %}
-                    <div>
-                        <a class="topic-icon" href="{{ site.baseurl }}/topics/{{ topic.name }}#references" title="References">
-                            {% icon references %} Literature
-                        </a>
-                    </div>
-                    {% endif %}
-
                     {% if own_material.workflows %}
                     <div>
                         {% include _includes/resource-workflows.html material=own_material topic=topic.name label=true %}

--- a/_layouts/tutorial_hands_on.html
+++ b/_layouts/tutorial_hands_on.html
@@ -9,25 +9,20 @@ layout: base
 {% assign language = site.other_languages | split: ", " %}
 
 {% assign intro_link = false %}
-{% capture intro_target %}
-{{ site.baseurl }}/topics/{{ topic.name }}/tutorials/{{ page.tutorial_name }}/slides.html
-{% endcapture %}
+{% assign intro_target = "" %}
 {% assign associated_slides = false %}
 {% assign own_material = null %}
 {% for material in topic_material %}
     {% if material.enable != "false" %}
         {% if material.tutorial_name == page.tutorial_name %}
+            {% assign own_material = material %}
             {% if material.slides  %}
                 {% assign associated_slides = true %}
-            {% else %}
-                {% assign own_material = material %}
             {% endif %}
         {% endif %}
         {% if material.type == "introduction" %}
             {% assign intro_link = true %}
-            {%- capture intro_target -%}
-                {{ site.baseurl }}/topics/{{ topic.name }}/slides/{{ material.tutorial_name }}.html
-            {%- endcapture -%}
+            {% assign intro_target = site.base_url | append: '/topics/' | append: topic.name | append: '/slides/' | append: material.tutorial_name | append: '.html' %}
         {% endif %}
     {% endif %}
 {% endfor %}
@@ -50,14 +45,6 @@ layout: base
                             {% icon topic %} {{ topic.title }}
                         </a>
                     </li>
-
-                    {% if topic.references and topic.references != "" %}
-                    <li class="nav-item">
-                        <a class="nav-link" href="{{ site.baseurl }}/topics/{{ topic.name }}#references" title="References">
-                            {% icon references %} Literature
-                        </a>
-                    </li>
-                    {% endif %}
 
                     <li class="nav-item dropdown">
                         <a href="#" class="nav-link dropdown-toggle" data-toggle="dropdown" aria-expanded="false" title="EN">
@@ -129,30 +116,47 @@ layout: base
 
 
             <div>
-                <div><strong>Supporting Materials</strong></div>
-
+                <div><strong><i class="fa fa-external-link" aria-hidden="true"></i> Supporting Materials</strong></div>
                 <div id="supporting_materials">
-                    {% if associated_slides or intro_link %}
-                        <div>
-                        <a class="topic-icon" href="{{ intro_target }}">
-                            {% icon slides %}
+                    <ul>
+                        <li>
+                            <div>
+                    {% if associated_slides %}
+                    <div>
+                        <a class="topic-icon" href="{{ site.baseurl }}/topics/{{ topic.name }}/tutorials/{{ page.tutorial_name }}/slides.html" title="Slides for this tutorial">
+                            {% icon slides %} Slides
                         </a>
-                        </div>
+                    </div>
+                    {% elsif intro_link %}
+                    <div>
+                        <a class="topic-icon" href="{{ intro_target }}">
+                            {% icon slides %} Introduction Slides
+                        </a>
+                    </div>
                     {% endif %}
 
                     {% if own_material.zenodo_link %}
                     <div>
-                        {% include _includes/resource-zenodo.html material=own_material topic=topic.name %}
+                        {% include _includes/resource-zenodo.html material=own_material topic=topic.name label=true %}
                     </div>
                     {% endif %}
+
+                    {% if topic.references and topic.references != "" %}
+                    <div>
+                        <a class="topic-icon" href="{{ site.baseurl }}/topics/{{ topic.name }}#references" title="References">
+                            {% icon references %} Literature
+                        </a>
+                    </div>
+                    {% endif %}
+
                     {% if own_material.workflows %}
                     <div>
-                        {% include _includes/resource-workflows.html material=own_material topic=topic.name %}
+                        {% include _includes/resource-workflows.html material=own_material topic=topic.name label=true %}
                     </div>
                     {% endif %}
                     {% if own_material.tours %}
                     <div>
-                        {% include _includes/resource-tours.html material=own_material topic=topic.name %}
+                        {% include _includes/resource-tours.html material=own_material topic=topic.name label=true %}
                     </div>
                     {% endif %}
 
@@ -160,10 +164,13 @@ layout: base
                     {% if instances[topic.name].supported or topic.docker_image %}
                     {% if instances[topic.name]['tutorials'][own_material.tutorial_name].supported or topic.docker_image %}
                     <div>
-                        {% include _includes/instance-dropdown.html instances=instances topic=topic.name tuto=own_material.tutorial_name docker=topic.docker_image %}
+                        {% include _includes/instance-dropdown.html instances=instances topic=topic.name tuto=own_material.tutorial_name docker=topic.docker_image label=true %}
                     </div>
                     {% endif %}
                     {% endif %}
+                            </div>
+                        </li>
+                    </ul>
                 </div>
 
             </div>

--- a/_layouts/tutorial_hands_on.html
+++ b/_layouts/tutorial_hands_on.html
@@ -40,76 +40,6 @@ layout: base
                         {% endif %}
                     {% endfor %}
 
-                    {% if associated_slides %}
-                    <li class="nav-item">
-                        <a class="nav-link" href="{{ site.baseurl }}/topics/{{ topic.name }}/tutorials/{{ page.tutorial_name }}/slides.html" title="Slides for this tutorial">
-                            {% icon slides %} Associated slides
-                        </a>
-                    </li>
-                    {% else %}
-                        {% if intro_link %}
-                            <li class="nav-item dropdown">
-                                <a href="#" class="nav-link dropdown-toggle" data-toggle="dropdown" aria-expanded="false" title="Introduction slides">
-                                    {% icon slides %} Introduction slides
-                                </a>
-                                <div class="dropdown-menu">
-                                    {% for material in topic_material %}
-                                        {% if material.enable != "false" %}
-                                            {% if material.type == "introduction" %}
-                                                <a class="dropdown-item" href="{{ site.baseurl }}/topics/{{ topic.name }}/slides/{{ material.tutorial_name }}.html">
-                                                    {{ material.title }}
-                                                </a>
-                                            {% endif %}
-                                        {% endif %}
-                                    {% endfor %}
-                                </div>
-                            </li>
-                        {% endif %}
-                    {% endif %}
-
-                    {% if topic.docker_image or instances[topic.name].supported and instances[topic.name]['tutorials'][page.tutorial_name].supported %}
-                        <li class="nav-item dropdown">
-                            <a href="#" class="nav-link dropdown-toggle" data-toggle="dropdown" aria-expanded="false" title="Where to run the tutorial">
-                                {% icon instances %} Galaxy Instances
-                            </a>
-                            <div class="dropdown-menu">
-                                {% if topic.docker_image %}
-                                    <a class="dropdown-item" href="{{ site.github.repository_url }}/tree/{{ site.repository_branch }}/topics/{{ topic.name }}/docker" title="Docker image for this tutorial">
-                                        {% icon docker_image %} Docker image
-                                    </a>
-                                {% endif %}
-                                {% if topic.docker_image and instances[topic.name].supported and instances[topic.name]['tutorials'][page.tutorial_name].supported %}
-                                    <div class="dropdown-divider"></div>
-                                {% endif %}
-                                {% if instances[topic.name]['tutorials'][page.tutorial_name].supported %}
-                                    {% for inst in instances[topic.name]['tutorials'][page.tutorial_name]['instances'] %}
-                                        {% if inst[1].supported %}
-                                        <a class="dropdown-item" href="{{ inst[1].url }}" title="{{ inst[0] }}">
-                                            {{ inst[0] }}
-                                        </a>
-                                        {% endif %}
-                                    {% endfor %}
-                                {% endif %}
-                            </div>
-                        </li>
-                    {% endif %}
-
-                    {% if page.tutorial_galaxy_instance %}
-                    <li class="nav-item">
-                        <a class="nav-link" href="{{ page.tutorial_galaxy_instance }}" title="Galaxy instance for this tutorial">
-                            {% icon galaxy_instance %} Galaxy instance
-                        </a>
-                    </li>
-                    {% endif %}
-
-                    {% if page.zenodo_link != "" %}
-                    <li class="nav-item">
-                        <a class="nav-link" href="{{ page.zenodo_link }}" title="Links to data">
-                            {% icon zenodo_link %} Input Dataset
-                        </a>
-                    </li>
-                    {% endif %}
-
                     {% if topic.references and topic.references != "" %}
                     <li class="nav-item">
                         <a class="nav-link" href="{{ site.baseurl }}/topics/{{ topic.name }}#references" title="References">
@@ -154,6 +84,26 @@ layout: base
         <div class="contributors-line">By: {% include _includes/contributor-badge-list.html contributors=page.contributors %}</div>
         <blockquote class="overview">
             <h3>Overview</h3>
+            <p><strong>{% icon slides %} Slides</strong>
+            {% if associated_slides %}
+            <a href="{{ site.baseurl }}/topics/{{ topic.name }}/tutorials/{{ page.tutorial_name }}/slides.html" title="Slides for this tutorial">
+                {% icon slides %} Associated slides
+            </a>
+            {% else %}
+                {% if intro_link %}
+                        {% for material in topic_material %}
+                            {% if material.enable != "false" %}
+                                {% if material.type == "introduction" %}
+                                    <a href="{{ site.baseurl }}/topics/{{ topic.name }}/slides/{{ material.tutorial_name }}.html">
+                                        {{ material.title }}
+                                    </a>
+                                {% endif %}
+                            {% endif %}
+                        {% endfor %}
+                {% endif %}
+            {% endif %}
+            </p>
+
 
             <strong>{% icon question %} Questions</strong>
             <ul>
@@ -185,6 +135,37 @@ layout: base
             <p><strong>{% icon level %} Level: </strong>
             {% include _includes/difficulty-indicator.html level=page.level textlabel=true %}</p>
             {% endif %}
+
+            {% if page.zenodo_link != "" %}
+            <p><strong>{% icon zenodo_link %} Input Datasets:</strong> <a href="{{ page.zenodo_link }}" title="Links to data">{{ page.zenodo_link }}</a>
+            </p>
+            {% endif %}
+
+
+            {% if topic.docker_image or instances[topic.name].supported and instances[topic.name]['tutorials'][page.tutorial_name].supported %}
+            <strong>{% icon instances %} Galaxy Instances: </strong>
+            <ul>
+                {% if topic.docker_image %}
+                <li>
+                    <a href="{{ site.github.repository_url }}/tree/{{ site.repository_branch }}/topics/{{ topic.name }}/docker" title="Docker image for this tutorial">
+                        {% icon docker_image %} Docker image
+                    </a>
+                </li>
+                {% endif %}
+
+                {% if instances[topic.name]['tutorials'][page.tutorial_name].supported %}
+                    {% for inst in instances[topic.name]['tutorials'][page.tutorial_name]['instances'] %}
+                        {% if inst[1].supported %}
+                        <li>
+                        <a href="{{ inst[1].url }}" title="{{ inst[0] }}">
+                            {{ inst[0] }}
+                        </a>
+                        </li>
+                        {% endif %}
+                    {% endfor %}
+                {% endif %}
+            {% endif %}
+
         </blockquote>
 
         <div class="container">

--- a/_layouts/tutorial_hands_on.html
+++ b/_layouts/tutorial_hands_on.html
@@ -8,6 +8,30 @@ layout: base
 {% assign topic_material = site.pages | topic_filter:page.topic_name %}
 {% assign language = site.other_languages | split: ", " %}
 
+{% assign intro_link = false %}
+{% capture intro_target %}
+{{ site.baseurl }}/topics/{{ topic.name }}/tutorials/{{ page.tutorial_name }}/slides.html
+{% endcapture %}
+{% assign associated_slides = false %}
+{% assign own_material = null %}
+{% for material in topic_material %}
+    {% if material.enable != "false" %}
+        {% if material.tutorial_name == page.tutorial_name %}
+            {% if material.slides  %}
+                {% assign associated_slides = true %}
+            {% else %}
+                {% assign own_material = material %}
+            {% endif %}
+        {% endif %}
+        {% if material.type == "introduction" %}
+            {% assign intro_link = true %}
+            {%- capture intro_target -%}
+                {{ site.baseurl }}/topics/{{ topic.name }}/slides/{{ material.tutorial_name }}.html
+            {%- endcapture -%}
+        {% endif %}
+    {% endif %}
+{% endfor %}
+
 <header>
     <nav class="navbar navbar-expand-lg navbar-dark">
         <div class="container">
@@ -26,19 +50,6 @@ layout: base
                             {% icon topic %} {{ topic.title }}
                         </a>
                     </li>
-
-                    {% assign intro_link = false %}
-                    {% assign associated_slides = false %}
-                    {% for material in topic_material %}
-                        {% if material.enable != "false" %}
-                            {% if material.slides and material.tutorial_name == page.tutorial_name %}
-                                {% assign associated_slides = true %}
-                            {% endif %}
-                            {% if material.type == "introduction" %}
-                                {% assign intro_link = true %}
-                            {% endif %}
-                        {% endif %}
-                    {% endfor %}
 
                     {% if topic.references and topic.references != "" %}
                     <li class="nav-item">
@@ -84,27 +95,6 @@ layout: base
         <div class="contributors-line">By: {% include _includes/contributor-badge-list.html contributors=page.contributors %}</div>
         <blockquote class="overview">
             <h3>Overview</h3>
-            <p><strong>{% icon slides %} Slides</strong>
-            {% if associated_slides %}
-            <a href="{{ site.baseurl }}/topics/{{ topic.name }}/tutorials/{{ page.tutorial_name }}/slides.html" title="Slides for this tutorial">
-                {% icon slides %} Associated slides
-            </a>
-            {% else %}
-                {% if intro_link %}
-                        {% for material in topic_material %}
-                            {% if material.enable != "false" %}
-                                {% if material.type == "introduction" %}
-                                    <a href="{{ site.baseurl }}/topics/{{ topic.name }}/slides/{{ material.tutorial_name }}.html">
-                                        {{ material.title }}
-                                    </a>
-                                {% endif %}
-                            {% endif %}
-                        {% endfor %}
-                {% endif %}
-            {% endif %}
-            </p>
-
-
             <strong>{% icon question %} Questions</strong>
             <ul>
             {% for question in page.questions %}
@@ -136,35 +126,47 @@ layout: base
             {% include _includes/difficulty-indicator.html level=page.level textlabel=true %}</p>
             {% endif %}
 
-            {% if page.zenodo_link != "" %}
-            <p><strong>{% icon zenodo_link %} Input Datasets:</strong> <a href="{{ page.zenodo_link }}" title="Links to data">{{ page.zenodo_link }}</a>
-            </p>
-            {% endif %}
 
 
-            {% if topic.docker_image or instances[topic.name].supported and instances[topic.name]['tutorials'][page.tutorial_name].supported %}
-            <strong>{% icon instances %} Galaxy Instances: </strong>
-            <ul>
-                {% if topic.docker_image %}
-                <li>
-                    <a href="{{ site.github.repository_url }}/tree/{{ site.repository_branch }}/topics/{{ topic.name }}/docker" title="Docker image for this tutorial">
-                        {% icon docker_image %} Docker image
-                    </a>
-                </li>
-                {% endif %}
+            <div>
+                <div><strong>Supporting Materials</strong></div>
 
-                {% if instances[topic.name]['tutorials'][page.tutorial_name].supported %}
-                    {% for inst in instances[topic.name]['tutorials'][page.tutorial_name]['instances'] %}
-                        {% if inst[1].supported %}
-                        <li>
-                        <a href="{{ inst[1].url }}" title="{{ inst[0] }}">
-                            {{ inst[0] }}
+                <div id="supporting_materials">
+                    {% if associated_slides or intro_link %}
+                        <div>
+                        <a class="topic-icon" href="{{ intro_target }}">
+                            {% icon slides %}
                         </a>
-                        </li>
-                        {% endif %}
-                    {% endfor %}
-                {% endif %}
-            {% endif %}
+                        </div>
+                    {% endif %}
+
+                    {% if own_material.zenodo_link %}
+                    <div>
+                        {% include _includes/resource-zenodo.html material=own_material topic=topic.name %}
+                    </div>
+                    {% endif %}
+                    {% if own_material.workflows %}
+                    <div>
+                        {% include _includes/resource-workflows.html material=own_material topic=topic.name %}
+                    </div>
+                    {% endif %}
+                    {% if own_material.tours %}
+                    <div>
+                        {% include _includes/resource-tours.html material=own_material topic=topic.name %}
+                    </div>
+                    {% endif %}
+
+
+                    {% if instances[topic.name].supported or topic.docker_image %}
+                    {% if instances[topic.name]['tutorials'][own_material.tutorial_name].supported or topic.docker_image %}
+                    <div>
+                        {% include _includes/instance-dropdown.html instances=instances topic=topic.name tuto=own_material.tutorial_name docker=topic.docker_image %}
+                    </div>
+                    {% endif %}
+                    {% endif %}
+                </div>
+
+            </div>
 
         </blockquote>
 

--- a/assets/css/main.scss
+++ b/assets/css/main.scss
@@ -593,12 +593,31 @@ div.highlight:hover .btn,div.highlight .btn:focus{
 	opacity:1
 }
 
-#supporting_materials {
-    display: flex;
-    flex-direction: row;
-    align-items: center;
-
+#supporting_materials ul li {
     div {
-        padding: 0.5em;
+        display: flex;
+        flex-direction: row;
+        align-items: center;
+
+        div {
+            a.topic-icon {
+                padding: 0 .5rem 0 .5rem;
+            }
+
+            a.topic-icon.btn {
+                padding-top: 0;
+                padding-bottom: 0;
+            }
+        }
+
+        div:first-child {
+            a.topic-icon {
+                padding-left: 0;
+            }
+        }
+
+        div:not(:first-child):before {
+            content: " - ";
+        }
     }
 }

--- a/assets/css/main.scss
+++ b/assets/css/main.scss
@@ -592,3 +592,13 @@ div.highlight .btn{
 div.highlight:hover .btn,div.highlight .btn:focus{
 	opacity:1
 }
+
+#supporting_materials {
+    display: flex;
+    flex-direction: row;
+    align-items: center;
+
+    div {
+        padding: 0.5em;
+    }
+}


### PR DESCRIPTION
Per discussion in #1389 it was discussed that a number of items could be moved to the overview box, which would give us some more room in the header for things in the future. (E.g. search box more nicely integrated.)

![image](https://user-images.githubusercontent.com/458683/58329803-b4036a80-7e35-11e9-9dcc-c7a490c5e171.png)

![image](https://user-images.githubusercontent.com/458683/58329849-d301fc80-7e35-11e9-964a-5ee06c7d058e.png)

I thought about a two column layout (for large screens) but haven't really tested that yet. 