### PR TITLE
Handle zenodo_link: "" case

### DIFF
--- a/_layouts/tutorial_hands_on.html
+++ b/_layouts/tutorial_hands_on.html
@@ -136,7 +136,7 @@ layout: base
                     </div>
                     {% endif %}
 
-                    {% if own_material.zenodo_link %}
+                    {% if own_material.zenodo_link and own_material.zenodo_link != "" %}
                     <div>
                         {% include _includes/resource-zenodo.html material=own_material topic=topic.name label=true %}
                     </div>


### PR DESCRIPTION
Because *of course* an empty string is truthy.

Fixes cases like:

![image](https://user-images.githubusercontent.com/458683/58409496-78081980-8070-11e9-96f8-e70ad638cb0d.png)

Thanks for the report @shiltemann 