### PR TITLE
Ansible:  consistently use "inventory" file instead of "hosts"

### DIFF
--- a/topics/admin/tutorials/ansible-galaxy/tutorial.md
+++ b/topics/admin/tutorials/ansible-galaxy/tutorial.md
@@ -29,7 +29,7 @@ requirements:
 # Overview
 {:.no_toc}
 
-This tutorial assumes you have some familiarity with [Ansible](https://www.ansible.com/resources/get-started) and are comfortable with writing and running playbooks. Here we'll see how to install a Galaxy server using an Ansible playbook. Galaxy Project has decided on Ansible for all of its deployment recipes. For our project, Ansible is even more fitting due to its name:
+This tutorial assumes you have some familiarity with [Ansible](https://www.ansible.com/resources/get-started) and are comfortable with writing and running playbooks. Here we'll see how to install a Galaxy server using an Ansible playbook. The Galaxy Project has decided on Ansible for all of its deployment recipes. For our project, Ansible is even more fitting due to its name:
 
 > An ansible is a category of fictional device or technology capable of instantaneous or faster-than-light communication. It can send and receive messages to and from a corresponding device over any distance or obstacle whatsoever with no delay, even between star systems (Source: [Wikipedia](https://en.wikipedia.org/wiki/Ansible))
 {: .quote}
@@ -173,7 +173,7 @@ Installation of Galaxy with the playbook follows generally the steps you would e
 - Any database updates are applied
 
 It would not be difficult to write a role that does this yourself, but by using
-the galaxyproject.galaxy role, you know that you're getting all of the Galaxy
+the `galaxyproject.galaxy` role, you know that you're getting all of the Galaxy
 best practices and knowledge from previous admins codified for you.
 
 # Installing Galaxy
@@ -185,10 +185,10 @@ To proceed from here it is expected that:
 - You have [Ansible installed](https://docs.ansible.com/ansible/latest/installation_guide/intro_installation.html) on your local machine
 
   > ### {% icon comment %} Comment: Running Ansible on your remote machine
-  > It is possible to have Ansible installed on the remote machine and run it there as well. You will need to update your hosts file to point to localhost, and pass the `-c local` parameter. Be **certain** that the playbook that you're building is stored somewhere safe like your user home directory. We will remove data at one point during this tutorial and would not want you to lose your progress.
+  > It is possible to have Ansible installed on the remote machine and run it there as well. You will need to update your inventory file to point to localhost, and pass the `-c local` parameter. Be **certain** that the playbook that you're building is stored somewhere safe like your user home directory. We will remove data at one point during this tutorial and would not want you to lose your progress.
   {: .comment}
 
-- You have a [hosts file](../ansible/tutorial.html#hosts-file) with the VM or host specified where you will deploy galaxy. We will refer to this group of hosts as "galaxyservers." You can use a different name if you prefer or are working on an existing playbook, just be sure to update all references later on.
+- You have an [inventory file](../ansible/tutorial.html#inventory-file) with the VM or host specified where you will deploy Galaxy. We will refer to this group of hosts as "galaxyservers." You can use a different name if you prefer or are working on an existing playbook, just be sure to update all references later on.
 
 ## Requirements
 
@@ -217,7 +217,7 @@ We have codified all of the dependencies you will need into a yaml file that `an
 >
 > 3. In the same directory, run `ansible-galaxy install -p roles -r requirements.yml`. This will install all of the required modules for this training into the `roles/` folder. We choose to install to a folder to give you easy access to look through the different roles when you have questions on their behaviour.
 >
-> 4. Create the hosts file if you have not done so, include a group for `[galaxyservers]` with the address of the host where you will install Galaxy.
+> 4. Create the `hosts` inventory file if you have not done so, include a group for `[galaxyservers]` with the address of the host where you want to install Galaxy.
 >
 > 5. Inspect the contents of the newly created `roles` directory in your working directory.
 >
@@ -358,7 +358,7 @@ The configuration is quite simple thanks to the many sensible defaults that are 
 >    `galaxy_root`                | `/srv/galaxy`                              | This is the root of the Galaxy deployment.
 >    `galaxy_file_path`           | `/data`                                    | The directory where Galaxy datasets (user data) will be stored. On a real deployment, this would likely be a mounted network filesystem.
 >    `galaxy_user`                | `{name: galaxy, shell: /bin/bash}`         | The user that Galaxy will run as.
->    `galaxy_commit_id`           | `release_18.09`                            | The git reference to check out, which in this case is the <br>branch for Galaxy Release 18.09.
+>    `galaxy_commit_id`           | `release_18.09`                            | The git reference to check out, which in this case is the <br>branch for Galaxy release 18.09.
 >    `galaxy_config_style`        | `yaml`                                     | We want to opt-in to the new style YAML configuration.
 >    `galaxy_force_checkout`      | `true`                                     | If we make any modifications to the Galaxy codebase, they will be removed. This way we know we're getting an unmodified Galaxy and no one has made any unexpected changes to the codebase.
 >    `check_migrate_tools`        | `false`                                    | Must be set to false in this case due to a new install of Galaxy
@@ -516,7 +516,7 @@ The configuration is quite simple thanks to the many sensible defaults that are 
 >
 > Pipelining will make [ansible run faster](https://docs.ansible.com/ansible/latest/reference_appendices/config.html#ansible-pipelining) by significantly reducing the number of new SSH connections that must be opened. Setting `retry_files_enabled = false` will prevent Ansible from creating `playbook.retry` files whenever a playbook crashes before finishing. These are rarely useful for the cases in which we run Ansible.
 >
-> For users running with the local connection, you can specify this in your `hosts` file:
+> For users running with the local connection, you can specify this in your `hosts` inventory file:
 >
 > ```ini
 > [galaxyservers]
@@ -564,7 +564,7 @@ Launching Galaxy by hand is not a good use of your time, so we will immediately 
 >    ```
 >    {% endraw %}
 >
->    Here we've defined a `galaxy` command that should be `present`. It will run the command `uwsgi ...` and is set to automatically start when supervisord starts and restart if it crashes, with 1 second between the retries. It will wait 10 seconds to see if the program has not crashed, and if it reaches this threshold it will be marked as `running`. It starts as the galaxy user with a umask of `022` (files created will be world readable by default). Its working directory on startup is the root of the Galaxy (cloned) code, and will run with the defined environment variables set.
+>    Here we've defined a `galaxy` command that should be `present`. It will run the command `uwsgi ...` and is set to automatically start when supervisord starts and restart if it crashes, with 1 second between the retries. It will wait 10 seconds to see if the program has not crashed, and if it reaches this threshold it will be marked as `running`. It starts as the `galaxy` user with a umask of `022` (files created will be world readable by default). Its working directory on startup is the root of the Galaxy (cloned) code, and will run with the defined environment variables set.
 >
 > 3. Now that we have defined a process manager for Galaxy, we can also instruct `galaxyproject.galaxy` to use Supervisor to restart it when Galaxy is upgraded or config changes are made. To do so, open `playbook.yml` and add a `handlers:` section at the same level as `pre_tasks:` and `roles:`, and add a task to restart Galaxy using the [supervisorctl Ansible module](https://docs.ansible.com/ansible/latest/modules/supervisorctl_module.html). Handlers are structured just like tasks:
 >
@@ -881,7 +881,7 @@ For this "disaster", we will pretend that:
 
 Your entire Galaxy server is gone. You were a responsible admin and had your user data and database stored on a separate system (and backed up), so at least those survived. Nevertheless, this is when most of us start feeling really bad; bosses start yelling, we start crying or reaching for bad coping habits.
 
-But not you! You spent the day writing this Ansible playbook that describes your environment completely; all of the software that was installed, all of the configuration changes you've made. It leverages many community maintained roles and can be used to completely rebuild the server! With minimal effort on your part.
+But not you! You spent the day writing this Ansible playbook that describes your environment completely; all of the software that was installed, all of the configuration changes you have made. It leverages many community maintained roles and can be used to completely rebuild the server! With minimal effort on your part.
 
 > ### {% icon hands_on %} Hands-on: Revert the Apocalypse
 >

--- a/topics/admin/tutorials/ansible-galaxy/tutorial.md
+++ b/topics/admin/tutorials/ansible-galaxy/tutorial.md
@@ -31,7 +31,8 @@ requirements:
 
 This tutorial assumes you have some familiarity with [Ansible](https://www.ansible.com/resources/get-started) and are comfortable with writing and running playbooks. Here we'll see how to install a Galaxy server using an Ansible playbook. Galaxy Project has decided on Ansible for all of its deployment recipes. For our project, Ansible is even more fitting due to its name:
 
-> An ansible is a category of fictional device or technology capable of instantaneous or faster-than-light communication. It can send and receive messages to and from a corresponding device over any distance or obstacle whatsoever with no delay, even between star systems ([wikipedia](https://en.wikipedia.org/wiki/Ansible))
+> An ansible is a category of fictional device or technology capable of instantaneous or faster-than-light communication. It can send and receive messages to and from a corresponding device over any distance or obstacle whatsoever with no delay, even between star systems (Source: [Wikipedia](https://en.wikipedia.org/wiki/Ansible))
+{: .quote}
 
 We want to give you a comprehensive understanding of how the Galaxy installation occurs, but we want to avoid you having to write a "custom" Galaxy installation playbook which you would eventually throw away, in order to use the official playbooks. Given these goals, we will go through the playbook in depth first, and then move to a hands-on portion later. If you are not interested in the inner workings, you can [skip to that section now](#installing-galaxy).
 
@@ -127,7 +128,7 @@ galaxy_config:
 ```
 {% endraw %}
 
-So the references in `galaxy_config_file` to `galaxy_config` are done to ensure that the setting for e.g. "location of the blacklist file" is the same between where we have configured Galaxy to looking for it, and where the file has been deployed, without requiring us to make variables changes in numerous places.
+So the references in `galaxy_config_files` to `galaxy_config` are done to ensure that the setting for e.g. "location of the blacklist file" is the same between where we have configured Galaxy to looking for it, and where the file has been deployed, without requiring us to make variables changes in numerous places.
 
 ### Dependencies
 
@@ -177,7 +178,7 @@ best practices and knowledge from previous admins codified for you.
 
 # Installing Galaxy
 
-With the necessary background in place, you're ready to install Galaxy with Ansible. The playbooks will start simple, and grow over time. We will start with the minimal Galaxy playbook which only requires setting the `galaxy_server_dir` and expand from there. First, however, we need a database for Galaxy to connect to, so we will do that now.
+With the necessary background in place, you are ready to install Galaxy with Ansible. The playbooks will start simple, and grow over time. We will start with the minimal Galaxy playbook which only requires setting the `galaxy_server_dir` and expand from there. First, however, we need a database for Galaxy to connect to, so we will do that now.
 
 To proceed from here it is expected that:
 

--- a/topics/admin/tutorials/ansible/slides.html
+++ b/topics/admin/tutorials/ansible/slides.html
@@ -69,7 +69,7 @@ What if:
 
 ---
 
-### Hosts File
+### Inventory File
 
 ```ini
 [webservers]
@@ -79,6 +79,14 @@ What if:
 [databases]
 db_1.example.org ansible_user=root
 ```
+
+???
+
+Defines the systems (called "hosts") against which Ansible will work.
+
+The headings in square brackets are group names, used to select a set of systems on which Ansible should operate.
+
+It is possible to assign variables to hosts and groups to be used later in playbooks.
 
 ---
 
@@ -102,7 +110,7 @@ db_1.example.org ansible_user=root
 
 Tasks are module invocations with their configuration.
 
-Here is an example of invoking the `copy` module and the package module. Copy copies a file from src on the local host to destination (the remote host) and sets some attributes about the file
+Here is an example of invoking the `copy` module and the package module. Copy copies a file from `src` on the local host to destination (the remote host) and sets some attributes about the file
 
 Next we see an example of the `package` module, a generic OS package manager. It ensures that for the package named `ntpdate`, its state is `present` (i.e. installed)
 

--- a/topics/admin/tutorials/ansible/tutorial.md
+++ b/topics/admin/tutorials/ansible/tutorial.md
@@ -44,8 +44,8 @@ Ansible runs commands on local or remote computers. It can move files around, cr
 
 Some terms that you should know first:
 
-host files
-:    An Ansible-specific file that defines groups of hosts (not be confused with `/etc/hosts`).
+Inventory file
+:    An Ansible-specific file that defines the systems ("hosts") and groups of hosts on which Ansible should operate.
 
 Ansible module
 :    A piece of Python code that converts some parameters into an invocation. An example would be the `command` module which converts parameters like `command: ls` into a command line that is executed. There are pre-built modules for just about everything.
@@ -64,7 +64,7 @@ vault
 
 Looking at each of these briefly:
 
-## Hosts file
+## Inventory file
 
 ```ini
 [webservers]
@@ -78,7 +78,7 @@ db_1.example.org ansible_user=root
 Here we've defined two groups of computers, `webservers` and `databases`. `ansible_user` is used to specify which user to connect with.
 
 > ### {% icon details %} Ansible Inventory Documentation
-> For more advanced features of the hosts file or "inventory", check out [the official documentation on this topic](https://docs.ansible.com/ansible/latest/user_guide/intro_inventory.html).
+> For more advanced features of the inventory file, check out [the official documentation on this topic](https://docs.ansible.com/ansible/latest/user_guide/intro_inventory.html).
 {: .details}
 
 ## Roles
@@ -236,15 +236,15 @@ The above introduction was certainly not enough for you to feel confident in Ans
 >
 > 2. Create an empty directory and `cd` into it
 >
-> 2. Create your hosts file, name it `hosts`, in the folder you have just entered.
+> 2. Create your inventory file, name it `hosts`, in the folder you have just entered.
 >
 >    1. Identify a host you have `SSH` access to. If you do not have access to any remote machines, `localhost` is fine.
 >    2. Make sure you can SSH into it. Test it now.
 >    3. We will call our group "my_hosts".
->    4. Create a hosts file with the group `my_hosts` and the host you have chosen.
+>    4. Populate the inventory file with the group `my_hosts` and the host you have chosen.
 >
 >    > ### {% icon solution %} Solution
->    > The file should look like:
+>    > The `hosts` file should look like:
 >    >
 >    > ```ini
 >    > [my_hosts]
@@ -389,7 +389,7 @@ The [`setup`](https://docs.ansible.com/ansible/latest/modules/setup_module.html)
 >
 > 1. Run the command `ansible -i hosts -c local -m setup my_hosts`.
 >
->    The `my_hosts` at the end refers to the group we defined in our hosts file.
+>    The `my_hosts` at the end of the command refers to the group we defined in our `hosts` inventory file.
 >
 > 2. Investigate the output. See what sort of information is made available to you.
 >


### PR DESCRIPTION
And some small fixes to the ansible-galaxy tutorial.