### PR TITLE
add copy functionality for code blocks on slides

### DIFF
--- a/_layouts/base_slides.html
+++ b/_layouts/base_slides.html
@@ -119,9 +119,17 @@ This material is the result of a collaborative work. Thanks to the [Galaxy Train
     </textarea>
     <script src="{{ "/assets/js/remark-latest.min.js" | prepend: site.baseurl }}" type="text/javascript">
     </script>
+    <script type="text/javascript" src="{{ "/assets/js/clipboard.min.js" | prepend: site.baseurl }}"></script>
     <script type="text/javascript">
       var slideshow = remark.create({navigation: {scroll: false,}});
       var hljs = remark.highlighter.engine;
+      var snippets = document.querySelectorAll('code.remark-code');
+        [].forEach.call(snippets,function(snippet){
+          snippet.firstChild.insertAdjacentHTML('beforebegin','<button class="btn btn-light" data-clipboard-snippet><i class="fa fa-copy"></i>&nbsp;Copy</button>');
+        });
+      var clipboardSnippets=new ClipboardJS('[data-clipboard-snippet]',{
+        target:function(trigger){return trigger.parentElement;
+      }});
     </script>
   </body>
 </html>

--- a/assets/css/slides.css
+++ b/assets/css/slides.css
@@ -366,3 +366,50 @@ th {
   padding-right: 0.25em;
   padding-left: 0.25em;
 }
+
+
+.btn {
+	display: inline-block;
+	font-weight: 400;
+	text-align: center;
+	white-space: nowrap;
+	vertical-align: middle;
+	-webkit-user-select: none;
+	-moz-user-select: none;
+	-ms-user-select: none;
+	user-select: none;
+	border: 1px solid transparent;
+	padding: .5rem .75rem;
+	font-size: 1rem;
+	line-height: 1.25;
+	border-radius: .25rem;
+	transition: all .15s ease-in-out;
+}
+
+.remark-code .btn-light {
+	color: #111;
+	background-color: #f8f9fa;
+	border-color: #f8f9fa;
+}
+
+.remark-code {
+	position: relative;
+}
+
+.remark-code .btn{
+	-webkit-transition:opacity .3s ease-in-out;
+	-o-transition:opacity .3s ease-in-out;
+	transition:opacity .3s ease-in-out;
+	opacity:0;
+	padding:2px 6px;
+	position:absolute;
+	right:4px;
+	top:4px;
+	font-family: -apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,"Helvetica Neue",Arial,sans-serif;
+}
+
+.remark-code:hover .btn,.remark-code .btn:focus{
+	opacity:1
+}
+
+


### PR DESCRIPTION
@erasche implemented awesome copy functionality for code blocks in tuturials in https://github.com/galaxyproject/training-material/pull/1383, this does the same for slides, which could be useful for admin/dev slides that have hands-on assignments in slides 