### PR TITLE
Formatting of installation command

### DIFF
--- a/topics/admin/tutorials/uwsgi/slides.html
+++ b/topics/admin/tutorials/uwsgi/slides.html
@@ -199,7 +199,9 @@ class: middle, top-title, largeish
 
 ## uWSGI Wheel
 
-The uWSGI wheel is built differently than when built from source with `pip install uwsgi`
+The uWSGI wheel is built differently than when built from source with
+
+`pip install uwsgi`
 
 - From source by pip:
   - Built as a single `uwsgi` ELF binary embedding the CPython interpreter


### PR DESCRIPTION
It may be clearer to have the installation command in its own line ("pip" at the end of the row may be missed by readers)