### PR TITLE
Miniconda prefix must be in double quotes

### DIFF
--- a/topics/admin/tutorials/ansible-galaxy/tutorial.md
+++ b/topics/admin/tutorials/ansible-galaxy/tutorial.md
@@ -367,7 +367,7 @@ The configuration is quite simple thanks to the many sensible defaults that are 
 >    `galaxy_commit_id`           | `release_19.05`                    | The git reference to check out, which in this case is the branch for Galaxy Release 19.05
 >    `galaxy_config_style`        | `yaml`                             | We want to opt-in to the new style YAML configuration.
 >    `galaxy_force_checkout`      | `true`                             | If we make any modifications to the Galaxy codebase, they will be removed. This way we know we're getting an unmodified Galaxy and no one has made any unexpected changes to the codebase.
->    `miniconda_prefix`           | `{{ galaxy_tool_dependency_dir }}/_conda` | We will manually install conda as well. Normally Galaxy will attempt to auto-install this, but since we will set up a production-ready instance with multiple handlers, there is the chance that they can get stuck.
+>    `miniconda_prefix`           | `"{{ galaxy_tool_dependency_dir }}/_conda"` | We will manually install conda as well. Normally Galaxy will attempt to auto-install this, but since we will set up a production-ready instance with multiple handlers, there is the chance that they can get stuck.
 >    {% endraw %}
 >
 >


### PR DESCRIPTION
As opposed to other values, miniconda_prefix must be in double quotes (as the solution shows), otherwise the user gets an error.