### PR TITLE
Nginx templates should be in the main directory

### DIFF
--- a/topics/admin/tutorials/ansible-galaxy/tutorial.md
+++ b/topics/admin/tutorials/ansible-galaxy/tutorial.md
@@ -703,7 +703,7 @@ For this, we will use NGINX. It is possible to configure Galaxy with Apache and 
 >      - galaxy
 >    ```
 >
->    The `galaxyproject.galaxy` role expects to find two files with these names in `templates/nginx/redirect-ssl.j2` and `templates/nginx/galaxy.j2`
+>    The `galaxyproject.galaxy` role expects to find two files with these names in `templates/nginx/redirect-ssl.j2` and `templates/nginx/galaxy.j2`. Please be advised that that `templates` directory is at the main directory level (at the same level of the `roles` directory).
 >
 >    Create the `redirect-ssl.j2` with the following contents:
 >


### PR DESCRIPTION
Less confusing wording for the templates. That main level directory was never mentioned before (and problably it does not exists). Also, these templates could go into the `galaxyproject.nginx` role, but it may be too confusing so it's better to avoid mentioning that here.