### PR TITLE
Add maintainer teams as codeowners

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -11,7 +11,7 @@ _layouts/*   @bebatut @shiltemann @erasche
 _includes/*  @bebatut @shiltemann @erasche
 _plugins/*   @bebatut @erasche
 
-# Topic maintainers are placed in github teams @training-topic-name
+# Topic maintainers are placed in github teams @galaxyproject/training-topic-name
 topics/admin/*                      @galaxyproject/training-admin
 topics/assembly/*                   @galaxyproject/training-assembly
 topics/chip-seq/*                   @galaxyproject/training-chip-seq

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,5 +1,7 @@
 # See documentation here:
 # https://blog.github.com/2017-07-06-introducing-code-owners/
+#
+# Anybody is free to add their name here
 
 assets/*     @bebatut @shiltemann @erasche
 bin/*        @bebatut @shiltemann @erasche
@@ -9,14 +11,27 @@ _layouts/*   @bebatut @shiltemann @erasche
 _includes/*  @bebatut @shiltemann @erasche
 _plugins/*   @bebatut @erasche
 
-# Topics
-topics/dev/*               @erasche @shiltemann @abretaud @lecorguille
-topics/admin/*             @erasche
-topics/instructors/*       @erasche
-topics/transcriptomics/*   @mblue9
-topics/genome-annotation/* @abretaud
-topics/metabolomics/*      @lecorguille
-topics/assembly/*          @Slugger70
+# Topic maintainers are placed in github teams @training-topic-name
+topics/admin/*                      @training-admin
+topics/assembly/*                   @training-assembly
+topics/chip-seq/*                   @training-chip-seq
+topics/computational-chemistry/*    @training-computational-chemistry
+topics/contributing/*               @training-contributing
+topics/dev/*                        @training-dev @abretaud
+topics/ecology/*                    @training-ecology
+topics/epigenetics/*                @training-epigenetics
+topics/galaxy-data-manipulation/*   @training-galaxy-data-manipulation
+topics/galaxy-ui/*                  @training-galaxy-ui
+topics/genome-annotation/*          @training-genome-annotation
+topics/instructors/*                @training-instructors
+topics/introduction/*               @training-introduction
+topics/metabolomics/*               @training-metabolomics
+topics/metagenomics/*               @training-metagenomics
+topics/proteomics/*                 @training-proteomics
+topics/sequence-analysis/*          @training-sequence-analysis
+topics/statistics/*                 @training-statistics
+topics/transcriptomics/*            @training-transcriptomics
+topics/variant-analysis/*           @training-variant-analysis
 
 # Lines starting with '#' are comments.
 # # Order is important. The last matching pattern has the most precedence.

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -11,7 +11,7 @@ _layouts/*   @bebatut @shiltemann @erasche
 _includes/*  @bebatut @shiltemann @erasche
 _plugins/*   @bebatut @erasche
 
-# Topic maintainers are placed in github teams @galaxyproject/training-topic-name
+# Topic maintainers are placed in github teams @galaxyproject/training-<topic-name>
 topics/admin/*                      @galaxyproject/training-admin
 topics/assembly/*                   @galaxyproject/training-assembly
 topics/chip-seq/*                   @galaxyproject/training-chip-seq

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -12,26 +12,26 @@ _includes/*  @bebatut @shiltemann @erasche
 _plugins/*   @bebatut @erasche
 
 # Topic maintainers are placed in github teams @training-topic-name
-topics/admin/*                      @training-admin
-topics/assembly/*                   @training-assembly
-topics/chip-seq/*                   @training-chip-seq
-topics/computational-chemistry/*    @training-computational-chemistry
-topics/contributing/*               @training-contributing
-topics/dev/*                        @training-dev @abretaud
-topics/ecology/*                    @training-ecology
-topics/epigenetics/*                @training-epigenetics
-topics/galaxy-data-manipulation/*   @training-galaxy-data-manipulation
-topics/galaxy-ui/*                  @training-galaxy-ui
-topics/genome-annotation/*          @training-genome-annotation
-topics/instructors/*                @training-instructors
-topics/introduction/*               @training-introduction
-topics/metabolomics/*               @training-metabolomics
-topics/metagenomics/*               @training-metagenomics
-topics/proteomics/*                 @training-proteomics
-topics/sequence-analysis/*          @training-sequence-analysis
-topics/statistics/*                 @training-statistics
-topics/transcriptomics/*            @training-transcriptomics
-topics/variant-analysis/*           @training-variant-analysis
+topics/admin/*                      @galaxyproject/training-admin
+topics/assembly/*                   @galaxyproject/training-assembly
+topics/chip-seq/*                   @galaxyproject/training-chip-seq
+topics/computational-chemistry/*    @galaxyproject/training-computational-chemistry
+topics/contributing/*               @galaxyproject/training-contributing
+topics/dev/*                        @galaxyproject/training-dev @abretaud
+topics/ecology/*                    @galaxyproject/training-ecology
+topics/epigenetics/*                @galaxyproject/training-epigenetics
+topics/galaxy-data-manipulation/*   @galaxyproject/training-galaxy-data-manipulation
+topics/galaxy-ui/*                  @galaxyproject/training-galaxy-ui
+topics/genome-annotation/*          @galaxyproject/training-genome-annotation
+topics/instructors/*                @galaxyproject/training-instructors
+topics/introduction/*               @galaxyproject/training-introduction
+topics/metabolomics/*               @galaxyproject/training-metabolomics
+topics/metagenomics/*               @galaxyproject/training-metagenomics
+topics/proteomics/*                 @galaxyproject/training-proteomics
+topics/sequence-analysis/*          @galaxyproject/training-sequence-analysis
+topics/statistics/*                 @galaxyproject/training-statistics
+topics/transcriptomics/*            @galaxyproject/training-transcriptomics
+topics/variant-analysis/*           @galaxyproject/training-variant-analysis
 
 # Lines starting with '#' are comments.
 # # Order is important. The last matching pattern has the most precedence.

--- a/topics/chip-seq/metadata.yaml
+++ b/topics/chip-seq/metadata.yaml
@@ -17,7 +17,6 @@ requirements:
       - mapping
 
 maintainers:
-  - malloryfreeberg
   - moheydarian
   - friedue
 

--- a/topics/transcriptomics/metadata.yaml
+++ b/topics/transcriptomics/metadata.yaml
@@ -18,7 +18,6 @@ requirements:
 
 maintainers:
   - bebatut
-  - malloryfreeberg
   - mblue9
 
 


### PR DESCRIPTION
We created GitHub teams for the maintainers of each topic (thanks @martenson & @erasche!). Adding them in CODEOWNERS file for automatic review requests to this team whenever changes are made to their topic. 

All maintainers should now also have the ability to approve and merge pull requests (and please feel free to do so for your topic!)

ping @galaxyproject/training 

P.S. Please let us know if you are no longer able to be a maintainer for a topic (or if you would like to volunteer to become a maintainer)