### PR TITLE
Remove QC step from mapping tutorial and refer to QC tutorial

### DIFF
--- a/topics/sequence-analysis/tutorials/mapping/tutorial.md
+++ b/topics/sequence-analysis/tutorials/mapping/tutorial.md
@@ -87,27 +87,9 @@ In the following we will process a dataset with the mapper **Bowtie2** and we wi
 
 We just imported in Galaxy FASTQ files corresponding to paired-end data as we could get directly from a sequencing facility.
 
-During sequencing, errors are introduced, such as incorrect nucleotides being called. Sequencing errors might bias the analysis and can lead to a misinterpretation of the data. The first step for any type of sequencing data is to check their quality.
+During sequencing, errors are introduced, such as incorrect nucleotides being called. Sequencing errors might bias the analysis and can lead to a misinterpretation of the data. The first step for any type of sequencing data is always to check their quality. 
 
-> ### {% icon comment %} Required Knowledge: Quality Control basics
-> In order to understand the tools we run in the next step, and how to interpret their outputs, you must have completed the [quality control](../quality-control/tutorial.html) tutorial.
-{: .comment}
-
-> ### {% icon hands_on %} Hands-on: Quality control
-> 1. **FastQC** {% icon tool %} on both datasets
->    - {% icon param-files %} *"Short read data from your current history"*: Both fastq files that you uploaded
->
-> 2. **MultiQC** {% icon tool %} on the outputs of **FastQC** {% icon tool %}
->      - In *"Results"*
->        - *"Which tool was used generate logs?"*: `FastQC`
->        - In *"FastQC output"*
->           - *"Type of FastQC output?"*: `Raw data`
->           - {% icon param-files %} *"FastQC output"*: `Raw data` files (output of both **FastQC** {% icon tool %})
-> 3. **Trim Galore!** {% icon tool %} on the paired-end datasets
->    - *"Is this paired- or single-end"*: `Paired-end`
->       - {% icon param-file %} *"Reads in FASTQ format #1"*: `wt_H3K4me3_read1.fastq.gz`
->       - {% icon param-file %} *"Reads in FASTQ format #2"*: `wt_H3K4me3_read2.fastq.gz`
-{: .hands_on}
+There is a dedicated tutorial for [quality control]({{ site.baseurl }}{% link topics/sequence-analysis/tutorials/quality-control/tutorial.md %}) of sequencing data. We will not repeat the steps there. You should follow the [tutorial]({{ site.baseurl }}{% link topics/sequence-analysis/tutorials/quality-control/tutorial.md %}) and apply it to your data before going further. 
 
 # Map reads on a reference genome
 


### PR DESCRIPTION
There is a QC step at the beginning of the mapping tutorial. We discussed @erasche, @shiltemann and others to remove it and link to the QC tutorial instead to then avoid duplications.

We also plan to expand the QC tutorial with more explanations about the different outputs to FastQC and things expected given the different sequencing technologies