### PR TITLE
Automatic monthly releases (and archive builds)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -58,6 +58,11 @@ script:
     then
       make check-links-gh-pages
     else
+      # if this is the monthly cron job on master, also add a tag/release (and trigger archive build)
+      if ["TRAVIS_BRANCH" == "master" && "TRAVIS_EVENT_TYPE" == "cron" ]
+      then
+        python bin/make_release.py
+      fi
       if [ "$CHECK" == "htmlproofer" ]
       then
         make check-html

--- a/.travis.yml
+++ b/.travis.yml
@@ -57,12 +57,10 @@ script:
     if [ "$TRAVIS_BRANCH" == "gh-pages" ]
     then
       make check-links-gh-pages
+    elif ["TRAVIS_BRANCH" == "master" && "TRAVIS_EVENT_TYPE" == "cron" ]
+    then
+       python bin/make_release.py
     else
-      # if this is the monthly cron job on master, also add a tag/release (and trigger archive build)
-      if ["TRAVIS_BRANCH" == "master" && "TRAVIS_EVENT_TYPE" == "cron" ]
-      then
-        python bin/make_release.py
-      fi
       if [ "$CHECK" == "htmlproofer" ]
       then
         make check-html

--- a/.travis.yml
+++ b/.travis.yml
@@ -87,7 +87,7 @@ after_success:
       make annotate
       make build
       bin/publish
-    elif ["TRAVIS_BRANCH" == "master" -a "TRAVIS_EVENT_TYPE" == "cron" -a "$CHECK" == "site-build" ]
+    elif [ "$TRAVIS_BRANCH" == "master" -a "$TRAVIS_EVENT_TYPE" == "cron" -a "$CHECK" == "site-build" ]
     then
        # montly cron job to make release
        python bin/make_release.py

--- a/.travis.yml
+++ b/.travis.yml
@@ -57,9 +57,6 @@ script:
     if [ "$TRAVIS_BRANCH" == "gh-pages" ]
     then
       make check-links-gh-pages
-    elif ["TRAVIS_BRANCH" == "master" && "TRAVIS_EVENT_TYPE" == "cron" ]
-    then
-       python bin/make_release.py
     else
       if [ "$CHECK" == "htmlproofer" ]
       then
@@ -90,6 +87,11 @@ after_success:
       make annotate
       make build
       bin/publish
+    elif ["TRAVIS_BRANCH" == "master" -a "TRAVIS_EVENT_TYPE" == "cron" -a "$CHECK" == "site-build" ]
+    then
+       # montly cron job to make release
+       python bin/make_release.py
+       bin/publish-archive
     elif [ "$TRAVIS_PULL_REQUEST" == "false" -a "$TRAVIS_TAG" != "" -a "$CHECK" == "site-build" ]
     then
       # Do not publish old versions live, and do not update badges since not pushing to gh-pages.

--- a/.travis.yml
+++ b/.travis.yml
@@ -86,16 +86,18 @@ after_success:
       # update badges and instances and rebuild
       make annotate
       make build
+
+      # monthly cron job to make release
+      if [ "$TRAVIS_EVENT_TYPE" == "cron" ]
+      then
+        python bin/make_release.py
+        bin/publish-archive
+      fi
+
+      # Publish to GH
       bin/publish
     elif [ "$TRAVIS_PULL_REQUEST" == "false" -a "$TRAVIS_TAG" != "" -a "$CHECK" == "site-build" ]
     then
       # Do not publish old versions live, and do not update badges since not pushing to gh-pages.
       bin/publish-archive
-    fi
-
-    # montly cron job to make release
-    if [ "$TRAVIS_BRANCH" == "master" -a "$TRAVIS_EVENT_TYPE" == "cron" -a "$CHECK" == "site-build" ]
-    then
-       python bin/make_release.py
-       bin/publish-archive
     fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -87,13 +87,15 @@ after_success:
       make annotate
       make build
       bin/publish
-    elif [ "$TRAVIS_BRANCH" == "master" -a "$TRAVIS_EVENT_TYPE" == "cron" -a "$CHECK" == "site-build" ]
-    then
-       # montly cron job to make release
-       python bin/make_release.py
-       bin/publish-archive
     elif [ "$TRAVIS_PULL_REQUEST" == "false" -a "$TRAVIS_TAG" != "" -a "$CHECK" == "site-build" ]
     then
       # Do not publish old versions live, and do not update badges since not pushing to gh-pages.
       bin/publish-archive
+    fi
+
+    # montly cron job to make release
+    if [ "$TRAVIS_BRANCH" == "master" -a "$TRAVIS_EVENT_TYPE" == "cron" -a "$CHECK" == "site-build" ]
+    then
+       python bin/make_release.py
+       bin/publish-archive
     fi

--- a/bin/add_galaxy_instance_badges.py
+++ b/bin/add_galaxy_instance_badges.py
@@ -48,7 +48,6 @@ def safe_name(server, dashes=True):
 
 def get_badge_path(label, value, color):
     """Return a string representing the expected badge filename. Returns something like 'Training Name|Supported' or 'Training Name|Unsupported'."""
-    print(label, value, color)
     safe_label = label.replace('@', '%40').replace(' ', '%20').replace('-', '--')
     safe_value = value.replace('@', '%40').replace(' ', '%20').replace('-', '--')
     return '%s-%s-%s.svg' % (safe_label, safe_value, color)

--- a/bin/make_release.py
+++ b/bin/make_release.py
@@ -1,11 +1,10 @@
 import datetime
-import json
 import os
 import requests
 
 
 # repository info
-repo = "https://api.github.com/repos/shiltemann/training-material/releases"
+repo = "https://api.github.com/repos/galaxyproject/training-material/releases"
 gh_token = os.environ['GH_TOKEN_RELEASES']
 
 

--- a/bin/make_release.py
+++ b/bin/make_release.py
@@ -11,7 +11,7 @@ gh_token = os.environ['GH_TOKEN_RELEASES']
 
 # create release name from today's date
 now = datetime.datetime.now()
-release_name = str(now.year) + "-" + str(now.month) + "-" + str(now.day)
+release_name = now.strftime("%Y-%m-%d")
 
 # prepare the release
 release = {

--- a/bin/make_release.py
+++ b/bin/make_release.py
@@ -1,0 +1,30 @@
+import datetime
+import json
+import os
+import requests
+
+
+# repository info
+repo = "https://api.github.com/repos/shiltemann/training-material/releases"
+gh_token = os.environ['GH_TOKEN_RELEASES']
+
+
+# create release name from today's date
+now = datetime.datetime.now()
+release_name = str(now.year) + "-" + str(now.month) + "-" + str(now.day)
+
+# prepare the release
+release = {
+  "tag_name": release_name,
+  "target_commitish": "master",
+  "name": release_name,
+  "body": "Monthly release of the GTN materials",
+  "draft": False,
+  "prerelease": False
+}
+
+# push the release
+r = requests.post(repo, json=release, headers={'Authorization': 'token %s' % gh_token})
+
+# print the response
+print(r.text)


### PR DESCRIPTION
@erasche set up the infrastructure to automatically create [archives of the website](https://training.galaxyproject.org/archive/) every time we create a release. This PR creates a release and archive build during our monthly travis cron job 

WIP til @erasche can test it for me, thanks!