### PR TITLE
CODEOWNERS: update to include subfolders

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -3,35 +3,35 @@
 #
 # Anybody is free to add their name here
 
-assets/*     @bebatut @shiltemann @erasche
-bin/*        @bebatut @shiltemann @erasche
-metadata/*   @bebatut @shiltemann @erasche
-badges/*     @erasche
-_layouts/*   @bebatut @shiltemann @erasche
-_includes/*  @bebatut @shiltemann @erasche
-_plugins/*   @bebatut @erasche
+assets/     @bebatut @shiltemann @erasche
+bin/        @bebatut @shiltemann @erasche
+metadata/   @bebatut @shiltemann @erasche
+badges/     @erasche
+_layouts/   @bebatut @shiltemann @erasche
+_includes/  @bebatut @shiltemann @erasche
+_plugins/   @bebatut @erasche
 
 # Topic maintainers are placed in github teams @galaxyproject/training-<topic-name>
-topics/admin/*                      @galaxyproject/training-admin
-topics/assembly/*                   @galaxyproject/training-assembly
-topics/chip-seq/*                   @galaxyproject/training-chip-seq
-topics/computational-chemistry/*    @galaxyproject/training-computational-chemistry
-topics/contributing/*               @galaxyproject/training-contributing
-topics/dev/*                        @galaxyproject/training-dev @abretaud
-topics/ecology/*                    @galaxyproject/training-ecology
-topics/epigenetics/*                @galaxyproject/training-epigenetics
-topics/galaxy-data-manipulation/*   @galaxyproject/training-galaxy-data-manipulation
-topics/galaxy-ui/*                  @galaxyproject/training-galaxy-ui
-topics/genome-annotation/*          @galaxyproject/training-genome-annotation
-topics/instructors/*                @galaxyproject/training-instructors
-topics/introduction/*               @galaxyproject/training-introduction
-topics/metabolomics/*               @galaxyproject/training-metabolomics
-topics/metagenomics/*               @galaxyproject/training-metagenomics
-topics/proteomics/*                 @galaxyproject/training-proteomics
-topics/sequence-analysis/*          @galaxyproject/training-sequence-analysis
-topics/statistics/*                 @galaxyproject/training-statistics
-topics/transcriptomics/*            @galaxyproject/training-transcriptomics
-topics/variant-analysis/*           @galaxyproject/training-variant-analysis
+topics/admin/                      @galaxyproject/training-admin
+topics/assembly/                   @galaxyproject/training-assembly
+topics/chip-seq/                   @galaxyproject/training-chip-seq
+topics/computational-chemistry/    @galaxyproject/training-computational-chemistry
+topics/contributing/               @galaxyproject/training-contributing
+topics/dev/                        @galaxyproject/training-dev @abretaud
+topics/ecology/                    @galaxyproject/training-ecology
+topics/epigenetics/                @galaxyproject/training-epigenetics
+topics/galaxy-data-manipulation/   @galaxyproject/training-galaxy-data-manipulation
+topics/galaxy-ui/                  @galaxyproject/training-galaxy-ui
+topics/genome-annotation/          @galaxyproject/training-genome-annotation
+topics/instructors/                @galaxyproject/training-instructors
+topics/introduction/               @galaxyproject/training-introduction
+topics/metabolomics/               @galaxyproject/training-metabolomics
+topics/metagenomics/               @galaxyproject/training-metagenomics
+topics/proteomics/                 @galaxyproject/training-proteomics
+topics/sequence-analysis/          @galaxyproject/training-sequence-analysis
+topics/statistics/                 @galaxyproject/training-statistics
+topics/transcriptomics/            @galaxyproject/training-transcriptomics
+topics/variant-analysis/           @galaxyproject/training-variant-analysis
 
 # Lines starting with '#' are comments.
 # # Order is important. The last matching pattern has the most precedence.


### PR DESCRIPTION
the trailing `*` only matches files directly in the folder, while intended match was any files in any subfolders
