### PR TITLE
Fix topic table display for introduction slides

### DIFF
--- a/_includes/tutorial_list.html
+++ b/_includes/tutorial_list.html
@@ -54,21 +54,24 @@
             {% if topic.type == "use" %}
               <td></td>
               <td></td>
+              <td></td>
             {% endif %}
             {% if instances[topic.name].supported %}
               <td></td>
             {% endif %}
-            {% elsif material.type == "tutorial" %}
-              <td> {% include _includes/resource-slides.html material=material topic=topic.name %} </td>
-              <td> {% include _includes/resource-handson.html material=material topic=topic.name %} </td>
+          {% elsif material.type == "tutorial" %}
+            <td> {% include _includes/resource-slides.html material=material topic=topic.name %} </td>
+            <td> {% include _includes/resource-handson.html material=material topic=topic.name %} </td>
 
-              {% if topic.type == "use" %}
-                <td> {% include _includes/resource-zenodo.html material=material topic=topic.name %} </td>
-                <td> {% include _includes/resource-workflows.html material=material topic=topic.name %} </td>
-                <td> {% include _includes/resource-tours.html material=material topic=topic.name %} </td>
-                <td> {% include _includes/instance-dropdown.html instances=instances topic=topic.name tuto=material.tutorial_name %} </td>
-              {% endif %}
-           {% endif %}
+            {% if topic.type == "use" %}
+              <td> {% include _includes/resource-zenodo.html material=material topic=topic.name %} </td>
+              <td> {% include _includes/resource-workflows.html material=material topic=topic.name %} </td>
+              <td> {% include _includes/resource-tours.html material=material topic=topic.name %} </td>
+            {% endif %}
+            {% if instances[topic.name].supported %}
+              <td> {% include _includes/instance-dropdown.html instances=instances topic=topic.name tuto=material.tutorial_name %} </td>
+            {% endif %}
+          {% endif %}
          </tr>
          {% endif %}
        {% endif %}


### PR DESCRIPTION
To fix the display of the first line (Introduction) in topics:

![Screenshot 2019-07-23 at 17 26 21](https://user-images.githubusercontent.com/1842467/61725900-f3383400-ad70-11e9-952b-c55bdb1a04ea.png)

And also remove the line extension if no Galaxy instances:

![Screenshot 2019-07-23 at 17 47 13](https://user-images.githubusercontent.com/1842467/61726462-f54ec280-ad71-11e9-9c76-5eec4c90cfbb.png)

