### PR TITLE
Fixed an incorrect input data file error in Generic Filter section

### DIFF
--- a/topics/metabolomics/tutorials/lcms/tutorial.md
+++ b/topics/metabolomics/tutorials/lcms/tutorial.md
@@ -1035,7 +1035,7 @@ absolute value above 0.9.
 >
 > 1. **Generic_Filter** {% icon tool %} with the following parameters:
 >    - *"Data matrix file"*: `Generic_Filter_Batch_correction_linear_dataMatrix.tsv`
->    - *"Sample metadata file"*: `Generic_Filter_Batch_correction_linear_dataMatrix.tsv`
+>    - *"Sample metadata file"*: `Generic_Filter_Quality Metrics_sampleMetadata_completed.tsv`
 >    - *"Variable metadata file"*: `Univariate_Generic_Filter_Quality Metrics_Batch_correction_linear_variableMetadata.tsv`
 >    - *"Deleting samples and/or variables according to Numerical values"*: `yes`
 >        - {% icon param-repeat %} *"Identify the parameter to filter "*

--- a/topics/metabolomics/tutorials/lcms/tutorial.md
+++ b/topics/metabolomics/tutorials/lcms/tutorial.md
@@ -983,7 +983,7 @@ and the ions that we have in our dataset. For this calculation we can use **Univ
 >
 > 1. **Univariate** {% icon tool %} with the following parameters:
 >    - *"Data matrix file"*: `Generic_Filter_Batch_correction_linear_dataMatrix.tsv`
->    - *"Sample metadata file"*: `Generic_Filter_Batch_correction_linear_dataMatrix.tsv`
+>    - *"Sample metadata file"*: `Generic_Filter_Quality Metrics_sampleMetadata_completed.tsv`
 >    - *"Variable metadata file"*: `Generic_Filter_Quality Metrics_Batch_correction_linear_variableMetadata.tsv`
 >    - *"Factor of interest"*: `bmi`
 >    - *"Test"*: `Spearman correlation rank test (quantitative)`


### PR DESCRIPTION
In the hands on section of **Reducing the dataset to keep ions of interest only** the `Sample metadata file` is set to `Generic_Filter_Batch_correction_linear_dataMatrix.tsv`.

This results in an error. 

Should it instead be: 
`Generic_Filter_Quality Metrics_sampleMetadata_completed.tsv`?

This results in no error.