### PR TITLE
travis: use language: ruby

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,8 @@
 ---
 sudo: required
-language: python
-python: 3.6
+language: ruby
+rvm:
+  - 2.4.4
 branches:
   only:
     - gh-pages


### PR DESCRIPTION
When our travis jobs are assigned a xenial machine, the wrong version of ruby was being picked up in the tests (e.g. like in https://github.com/galaxyproject/training-material/pull/1527) this appears to fix that