### PR TITLE
Fix build ordering

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -89,15 +89,15 @@ after_success:
       make annotate
       make build
 
+      # Publish to GH
+      bin/publish
+
       # monthly cron job to make release
       if [ "$TRAVIS_EVENT_TYPE" == "cron" ]
       then
         python bin/make_release.py
         bin/publish-archive
       fi
-
-      # Publish to GH
-      bin/publish
     elif [ "$TRAVIS_PULL_REQUEST" == "false" -a "$TRAVIS_TAG" != "" -a "$CHECK" == "site-build" ]
     then
       # Do not publish old versions live, and do not update badges since not pushing to gh-pages.


### PR DESCRIPTION
The monthly cron job deployed to gh-pages, because that task was second. I've moved it to be first so that the proper version gets deployed to gh-pages before the custom version is built in `bin/publish-archive`.