### PR TITLE
Force ordering of linting

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -144,7 +144,12 @@ check-framework:
 check: check-yaml check-frontmatter check-html-internal check-html check-slides check-workflows check-references check-snippets ## run all checks
 .PHONY: check
 
-lint: check-yaml check-frontmatter check-workflows check-references check-snippets ## run all linting checks
+lint: ## run all linting checks
+	$(MAKE) check-yaml
+	$(MAKE) check-frontmatter
+	$(MAKE) check-workflows
+	$(MAKE) check-references
+	$(MAKE) check-snippets
 .PHONY: lint
 
 check-links-gh-pages:  ## validate HTML on gh-pages branch (for daily cron job)


### PR DESCRIPTION
It's not [necessarily guaranteed](https://stackoverflow.com/questions/1647480/in-what-order-prerequisites-will-be-made-by-the-gnu-make) what the ordering will be.

Some of the dependencies depend on `build`, others do not. The `check-frontmatter` does not depend on build, and catches errors that can kill the build. So if another task is executed first (depending on build), and fails to build, the user will never see the useful error message. This ensure that that never happens, and that they're executed in safe order.