### PR TITLE
Fix jekyll version & update nokogiri version

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,7 @@
 source "https://rubygems.org"
-gem 'nokogiri'
+gem "nokogiri", ">= 1.10.4"
 gem 'addressable'
-gem 'jekyll'
+gem 'jekyll', '3.8.6'
 gem 'jekyll-feed'
 gem 'jekyll-environment-variables'
 gem 'jekyll-github-metadata'

--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,7 @@
 source "https://rubygems.org"
 gem "nokogiri", ">= 1.10.4"
 gem 'addressable'
-gem 'jekyll', '3.8.6'
+gem 'jekyll', '< 4'
 gem 'jekyll-feed'
 gem 'jekyll-environment-variables'
 gem 'jekyll-github-metadata'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -126,7 +126,7 @@ DEPENDENCIES
   awesome_bot
   csl-styles
   html-proofer
-  jekyll (= 3.8.6)
+  jekyll (< 4)
   jekyll-environment-variables
   jekyll-feed
   jekyll-github-metadata

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -8,8 +8,8 @@ GEM
       tzinfo (~> 1.1)
     addressable (2.6.0)
       public_suffix (>= 2.0.2, < 4.0)
-    awesome_bot (1.18.0)
-      parallel (= 1.12.0)
+    awesome_bot (1.19.1)
+      parallel (= 1.17.0)
     bibtex-ruby (4.4.7)
       latex-decode (~> 0.0)
     citeproc (1.0.9)
@@ -33,7 +33,7 @@ GEM
       multipart-post (>= 1.2, < 3)
     ffi (1.11.1)
     forwardable-extended (2.6.0)
-    html-proofer (3.11.0)
+    html-proofer (3.11.1)
       activesupport (>= 4.2, < 6.0)
       addressable (~> 2.3)
       mercenary (~> 0.3.2)
@@ -67,7 +67,7 @@ GEM
       octokit (~> 4.0, != 4.4.0)
     jekyll-sass-converter (1.5.2)
       sass (~> 3.4)
-    jekyll-scholar (5.14.2)
+    jekyll-scholar (5.16.0)
       bibtex-ruby (~> 4.0, >= 4.0.13)
       citeproc-ruby (~> 1.0)
       csl-styles (~> 1.0)
@@ -87,20 +87,20 @@ GEM
     minitest (5.11.3)
     multipart-post (2.1.1)
     namae (1.0.1)
-    nokogiri (1.10.3)
+    nokogiri (1.10.4)
       mini_portile2 (~> 2.4.0)
     octokit (4.14.0)
       sawyer (~> 0.8.0, >= 0.5.3)
-    parallel (1.12.0)
+    parallel (1.17.0)
     pathutil (0.16.2)
       forwardable-extended (~> 2.6)
-    pkg-config (1.3.7)
+    pkg-config (1.3.8)
     public_suffix (3.1.1)
     rainbow (3.0.0)
     rb-fsevent (0.10.3)
     rb-inotify (0.10.0)
       ffi (~> 1.0)
-    rouge (3.5.1)
+    rouge (3.9.0)
     ruby_dep (1.5.0)
     safe_yaml (1.0.5)
     sass (3.7.4)
@@ -126,13 +126,13 @@ DEPENDENCIES
   awesome_bot
   csl-styles
   html-proofer
-  jekyll
+  jekyll (= 3.8.6)
   jekyll-environment-variables
   jekyll-feed
   jekyll-github-metadata
   jekyll-scholar
   kwalify
-  nokogiri
+  nokogiri (>= 1.10.4)
   pkg-config
 
 BUNDLED WITH

--- a/Makefile
+++ b/Makefile
@@ -45,10 +45,8 @@ ACTIVATE_ENV = source $(shell dirname $(dir $(CONDA)))/bin/activate $(CONDA_ENV)
 
 install: clean ## install dependencies
 	$(ACTIVATE_ENV) && \
-		npm install decktape && \
 		gem update --system && \
-		gem install nokogiri:'1.10.0' -- --use-system-libraries --with-xml=$(CONDA_PREFIX)/lib && \
-		gem install addressable:'2.5.2' jekyll jekyll-feed jekyll-environment-variables jekyll-github-metadata jekyll-scholar csl-styles awesome_bot html-proofer pkg-config kwalify
+		gem install addressable:'2.5.2' jekyll:'3.8.6' jekyll-feed jekyll-environment-variables jekyll-github-metadata jekyll-scholar csl-styles awesome_bot html-proofer pkg-config kwalify
 .PHONY: install
 
 serve: ## run a local server (You can specify PORT=, HOST=, and FLAGS= to set the port, host or to pass additional flags)
@@ -174,6 +172,7 @@ check-links-gh-pages:  ## validate HTML on gh-pages branch (for daily cron job)
 
 
 pdf: detached-serve ## generate the PDF of the tutorials and slides
+	npm install decktape
 	mkdir -p _pdf
 	@for t in $(TUTORIALS); do \
 		name="$(PDF_DIR)/$$(echo $$t | tr '/' '-' | sed -e 's/html/pdf/' -e 's/topics-//' -e 's/tutorials-//')"; \

--- a/Makefile
+++ b/Makefile
@@ -46,7 +46,7 @@ ACTIVATE_ENV = source $(shell dirname $(dir $(CONDA)))/bin/activate $(CONDA_ENV)
 install: clean ## install dependencies
 	$(ACTIVATE_ENV) && \
 		gem update --system && \
-		gem install addressable:'2.5.2' jekyll:'3.8.6' jekyll-feed jekyll-environment-variables jekyll-github-metadata jekyll-scholar csl-styles awesome_bot html-proofer pkg-config kwalify
+		gem install addressable:'2.5.2' jekyll:'< 4' jekyll-feed jekyll-environment-variables jekyll-github-metadata jekyll-scholar csl-styles awesome_bot html-proofer pkg-config kwalify
 .PHONY: install
 
 serve: ## run a local server (You can specify PORT=, HOST=, and FLAGS= to set the port, host or to pass additional flags)


### PR DESCRIPTION
Jekyll has been updated 2 days ago to version 4.0.0. Some changes will be interested for us. But some of the external plugins we are using are incompatibles (e.g. `jekyll-environment-variables`) and then `jekyll serve` is not working (locally and on Travis).
This PR fixes Jekyll to the previous version

The nokogiri version in the Gemfile.lock was reported as a potential security vulnerability. I updated it