### PR TITLE
Add gitter sidecar for admin/dev topics

### DIFF
--- a/_layouts/topic.html
+++ b/_layouts/topic.html
@@ -10,6 +10,15 @@ layout: base
 {% assign topic_material = site.pages | topic_filter:page.topic_name %}
 {% assign language = site.other_languages | split: ", " %}
 
+{% if topic.gitter %}
+<script>
+  ((window.gitter = {}).chat = {}).options = {
+  room: '{{ topic.gitter }}'
+  };
+</script>
+<script src="https://sidecar.gitter.im/dist/sidecar.v1.js" async defer></script>
+{% endif %}
+
 <div class="container main-content">
     <section>
         <h1>{{ topic.title }}</h1>

--- a/_layouts/tutorial_hands_on.html
+++ b/_layouts/tutorial_hands_on.html
@@ -28,6 +28,15 @@ layout: base
     {% endif %}
 {% endfor %}
 
+{% if topic.gitter %}
+<script>
+  ((window.gitter = {}).chat = {}).options = {
+  room: '{{ topic.gitter }}'
+  };
+</script>
+<script src="https://sidecar.gitter.im/dist/sidecar.v1.js" async defer></script>
+{% endif %}
+
 <header>
     <nav class="navbar navbar-expand-lg navbar-dark">
         <div class="container">

--- a/bin/schema-topic.yaml
+++ b/bin/schema-topic.yaml
@@ -82,3 +82,7 @@ mapping:
                       required: true
                   summary:
                       type: str
+    gitter:
+        type: str
+        required: false
+        pattern: /^[a-zA-Z0-9]+\/[a-zA-Z0-9]+/

--- a/topics/admin/metadata.yaml
+++ b/topics/admin/metadata.yaml
@@ -18,3 +18,5 @@ maintainers:
   - martenson
   - erasche
   - slugger70
+
+gitter: galaxyproject/admins

--- a/topics/contributing/tutorials/create-new-topic/tutorial.md
+++ b/topics/contributing/tutorials/create-new-topic/tutorial.md
@@ -174,6 +174,7 @@ Several metadata are defined in `metadata.yaml` file in your topic folder to :
   tutorials can be assigned to subtopics by adding e.g. `subtopic: singlecell` to the tutorial metadata. An example of this subtopic division can be found in the [admin section]({{site.baseurl}}/topics/admin/ )
 
 - `maintainers`: GitHub username of people maintaining the topic
+- `gitter`: The name of the chatroom on Gitter, if enabled, it will be embedded on the topic and tutorial pages. Should be formatted like `../..`, without the `https://gitter.im`, e.g. `galaxyproject/dev`
 
 > ### {% icon hands_on %} Hands-on: Update the new topic to the website
 >

--- a/topics/dev/metadata.yaml
+++ b/topics/dev/metadata.yaml
@@ -9,3 +9,5 @@ maintainers:
   - lecorguille
   - bebatut
   - erasche
+
+gitter: galaxyproject/dev


### PR DESCRIPTION
This embeds the admin and dev chat channels on their respective tutorial and topic pages, to provide better support to people attempting the tutorials.

![image](https://user-images.githubusercontent.com/458683/64034955-ef59b780-cb4f-11e9-9585-1a08bd39e79f.png)

![image](https://user-images.githubusercontent.com/458683/64034984-f8e31f80-cb4f-11e9-83e1-3cd03f5f1635.png)
