### PR TITLE
Replace / in badge labels and values

### DIFF
--- a/bin/add_galaxy_instance_badges.py
+++ b/bin/add_galaxy_instance_badges.py
@@ -48,8 +48,8 @@ def safe_name(server, dashes=True):
 
 def get_badge_path(label, value, color):
     """Return a string representing the expected badge filename. Returns something like 'Training Name|Supported' or 'Training Name|Unsupported'."""
-    safe_label = label.replace('@', '%40').replace(' ', '%20').replace('-', '--')
-    safe_value = value.replace('@', '%40').replace(' ', '%20').replace('-', '--')
+    safe_label = label.replace('@', '%40').replace(' ', '%20').replace('-', '--').replace('/', '%2F')
+    safe_value = value.replace('@', '%40').replace(' ', '%20').replace('-', '--').replace('/', '%2F')
     return '%s-%s-%s.svg' % (safe_label, safe_value, color)
 
 


### PR DESCRIPTION
Jekyll is currently failing on master for `make annotate` for badge creation. Indeed, if there is a `/` in the tutorial title, it will be added in the path where to create the badge:

```
badges/cache/Annotating%20a%20protein%20list%20identified%20by%20LC--MS/MS%20experiments-Supported-green.svg: No such file or directory

Traceback (most recent call last):

  File "bin/add_galaxy_instance_badges.py", line 175, in <module>

    CACHE_DIR, (instance, topic, training), args.output

  File "bin/add_galaxy_instance_badges.py", line 77, in badge_it

    ), CACHE_DIR)

  File "bin/add_galaxy_instance_badges.py", line 65, in realise_badge

    subprocess.check_call(cmd)

  File "/home/travis/miniconda3/envs/galaxy_training_material/lib/python3.6/subprocess.py", line 291, in check_call

    raise CalledProcessError(retcode, cmd)

subprocess.CalledProcessError: Command '['wget', 'https://img.shields.io/badge/Annotating%20a%20protein%20list%20identified%20by%20LC--MS/MS%20experiments-Supported-green.svg', '--quiet', '-O', 'badges/cache/Annotating%20a%20protein%20list%20identified%20by%20LC--MS/MS%20experiments-Supported-green.svg']' returned non-zero exit status 1.
```

We have our 1st case for such title with #1354.

This PR should fix that by replacing the `/` in the label of the badge. 