### PR TITLE
LICENSE update: Add MIT license for infrastructure / scripts

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,1 +1,21 @@
-This work is licensed under the Creative Commons Attribution 4.0 International License. To view a copy of this license, visit https://creativecommons.org/licenses/by/4.0/ or send a letter to Creative Commons, PO Box 1866, Mountain View, CA 94042, USA.
+The MIT License (MIT)
+
+Copyright (c) 2019 Galaxy Training Network
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ If you want to build the website locally, please have a look at the [tutorial](h
 
 # License
 
-This content of this work is licensed under the [Creative Commons Attribution 4.0 International License](https://creativecommons.org/licenses/by/4.0).
+The content of the tutorials and website are licensed under the [Creative Commons Attribution 4.0 International License](https://creativecommons.org/licenses/by/4.0).
 
 The code behind the infrastructure is licensed under the [MIT License](LICENSE.md)
 

--- a/README.md
+++ b/README.md
@@ -18,7 +18,9 @@ If you want to build the website locally, please have a look at the [tutorial](h
 
 # License
 
-This work is licensed under the [Creative Commons Attribution 4.0 International License](https://creativecommons.org/licenses/by/4.0).
+This content of this work is licensed under the [Creative Commons Attribution 4.0 International License](https://creativecommons.org/licenses/by/4.0).
+
+The code behind the infrastructure is licensed under the [MIT License](LICENSE.md)
 
 # Acknowledgment and Funding
 

--- a/_includes/default-footer.html
+++ b/_includes/default-footer.html
@@ -4,5 +4,6 @@
             The <a href="https://galaxyproject.org/teach/gtn/">Galaxy Training Network</a>
             provides researchers with online training materials, connects them with local trainers, and helps promoting open data analysis practices worldwide.
         </p>
+        {% include _includes/license.html %}
     </div>
 </footer>

--- a/_includes/license.html
+++ b/_includes/license.html
@@ -1,0 +1,3 @@
+<p>
+    The content of the tutorials and website is licensed under the <a rel="license" href="https://creativecommons.org/licenses/by/4.0/">Creative Commons Attribution 4.0 International License</a>.
+</p>

--- a/_layouts/base_slides.html
+++ b/_layouts/base_slides.html
@@ -113,6 +113,8 @@ This material is the result of a collaborative work. Thanks to the [Galaxy Train
 <img src="{{ page.logo }}" alt="page logo" style="height: 40px;"/>
 {% endif %}
 
+This material is licensed under the <a rel="license" href="https://creativecommons.org/licenses/by/4.0/">Creative Commons Attribution 4.0 International License</a>.
+
 {% if page.layout == "base_slides" %}
 .footnote[Found a typo? Something is wrong in this tutorial? <br/>Edit it on [GitHub]({{ site.github.repository_url }}/tree/master{{ page.url }})]
 {% endif %}

--- a/_layouts/home.html
+++ b/_layouts/home.html
@@ -184,9 +184,6 @@ layout: base
 
                 <p>Do you want to help with this project and join our Hall of Fame? Please see our <a href="{{ site.baseurl }}/topics/contributing/">dedicated tutorials</a> or our <a href="{{ site.baseurl }}/faq">Frequently Asked Questions</a> to get you started.</p>
 
-                <h2>License</h2>
-                <p>This work is licensed under the <a rel="license" href="https://creativecommons.org/licenses/by/4.0/">Creative Commons Attribution 4.0 International License</a>.</p>
-
             </div>
             <div class="col-md-6">
                 <h2>The Galaxy Training Network<h2>

--- a/_layouts/tutorial_hands_on.html
+++ b/_layouts/tutorial_hands_on.html
@@ -283,6 +283,9 @@ layout: base
             and all the <a href="{{ site.baseurl }}/hall-of-fame">contributors</a> ({% include _includes/contributor-text-list.html contributors=page.contributors %})!
         </p>
         <p>
+            This material is licensed under the <a rel="license" href="https://creativecommons.org/licenses/by/4.0/">Creative Commons Attribution 4.0 International License</a>.
+        </p>
+        <p>
             Found a typo? Something is wrong in this tutorial? Edit it on
             <a href="{{ site.github.repository_url }}/tree/{{ site.repository_branch }}/topics/{{ topic.name }}/tutorials/{{ page.tutorial_name }}/tutorial.md">GitHub</a>.
         </p>

--- a/_layouts/tutorial_hands_on.html
+++ b/_layouts/tutorial_hands_on.html
@@ -283,11 +283,9 @@ layout: base
             and all the <a href="{{ site.baseurl }}/hall-of-fame">contributors</a> ({% include _includes/contributor-text-list.html contributors=page.contributors %})!
         </p>
         <p>
-            This material is licensed under the <a rel="license" href="https://creativecommons.org/licenses/by/4.0/">Creative Commons Attribution 4.0 International License</a>.
-        </p>
-        <p>
             Found a typo? Something is wrong in this tutorial? Edit it on
             <a href="{{ site.github.repository_url }}/tree/{{ site.repository_branch }}/topics/{{ topic.name }}/tutorials/{{ page.tutorial_name }}/tutorial.md">GitHub</a>.
         </p>
+        {% include _includes/license.html %}
     </div>
 </footer>


### PR DESCRIPTION
Someone asked lately if he could reuse the infrastructure and scripts. We realized that the current LICENSE (CC-BY) is not covering that.

So here I changed the LICENSE file to MIT and made sure that CC-BY 4.0 (for content) is mentioned on the README, home page, FAQ.

Hopefully we can get the explicit approval of all the contributors.