### PR TITLE
Add script to check contributors

### DIFF
--- a/bin/check-contributors.rb
+++ b/bin/check-contributors.rb
@@ -1,6 +1,5 @@
 #!/usr/bin/env ruby
 require 'yaml'
-require 'pathname'
 
 fn = ARGV[0]
 
@@ -21,7 +20,7 @@ contributor_emails = CONTRIBUTORS.map{ |k, v|
 }.compact.to_h
 
 # Private map of emails to github usernames
-if Pathname.new('private-contrib-map.yaml').exist?
+if File.file?('private-contrib-map.yaml')
   private_contrib_map = YAML.load_file('private-contrib-map.yaml')
   contributor_emails.merge!(private_contrib_map)
 end
@@ -47,8 +46,13 @@ fixed_contribs = file_contributors.map{ |email|
 known = fixed_contribs.select{ |x| ! /@/.match(x) }
 unknown = fixed_contribs.select{ |x| /@/.match(x) }
 
+missing = (known - current_contributors).sort.uniq
 # These contributors not yet recognised
-puts "Missing contributors: #{(known - current_contributors).sort.uniq}"
+if missing.length > 0
+  puts "Missing contributors: #{missing}"
+end
+
+# These emails might map to known users, but we don't know yet.
 if unknown.length > 0
   puts "Unknown emails: #{unknown.sort.uniq}"
 end

--- a/bin/check-contributors.rb
+++ b/bin/check-contributors.rb
@@ -1,0 +1,54 @@
+#!/usr/bin/env ruby
+require 'yaml'
+require 'pathname'
+
+fn = ARGV[0]
+
+# Any error messages
+#errs = []
+data = YAML.load_file(fn)
+current_contributors = data['contributors']
+
+
+# Full Contributors Data
+CONTRIBUTORS = YAML.load_file('CONTRIBUTORS.yaml')
+contributor_emails = CONTRIBUTORS.map{ |k, v|
+  if v
+    if v.has_key?("email")
+      [v['email'], k]
+    end
+  end
+}.compact.to_h
+
+# Private map of emails to github usernames
+if Pathname.new('private-contrib-map.yaml').exist?
+  private_contrib_map = YAML.load_file('private-contrib-map.yaml')
+  contributor_emails.merge!(private_contrib_map)
+end
+
+file_contributors = `git log --follow --pretty=%aE #{fn}`.lines.sort.uniq
+
+fixed_contribs = file_contributors.map{ |email|
+  email = email.strip
+  if /users.noreply.github.com/.match(email)
+    parts = /^([0-9]+\+)?(?<id>.*)@users.noreply.github.com/.match(email)
+    # we just want their gh id
+    parts[:id]
+  else
+    if contributor_emails.has_key?(email)
+      contributor_emails[email]
+    else
+      email
+    end
+  end
+}
+
+# known contributors
+known = fixed_contribs.select{ |x| ! /@/.match(x) }
+unknown = fixed_contribs.select{ |x| /@/.match(x) }
+
+# These contributors not yet recognised
+puts "Missing contributors: #{(known - current_contributors).sort.uniq}"
+if unknown.length > 0
+  puts "Unknown emails: #{unknown.sort.uniq}"
+end

--- a/bin/check-contributors.rb
+++ b/bin/check-contributors.rb
@@ -1,6 +1,11 @@
 #!/usr/bin/env ruby
 require 'yaml'
 
+
+# If there are unknown contributors, write a .mailmap file like:
+# <gh-username> <user@earlham.ac.uk>
+# <gh-username> <user@gmail.com>
+
 fn = ARGV[0]
 
 # Any error messages
@@ -19,13 +24,7 @@ contributor_emails = CONTRIBUTORS.map{ |k, v|
   end
 }.compact.to_h
 
-# Private map of emails to github usernames
-if File.file?('private-contrib-map.yaml')
-  private_contrib_map = YAML.load_file('private-contrib-map.yaml')
-  contributor_emails.merge!(private_contrib_map)
-end
-
-file_contributors = `git log --follow --pretty=%aE #{fn}`.lines.sort.uniq
+file_contributors = `git log --use-mailmap --follow --pretty=%aE #{fn}`.lines.sort.uniq
 
 fixed_contribs = file_contributors.map{ |email|
   email = email.strip

--- a/bin/check-contributors.rb
+++ b/bin/check-contributors.rb
@@ -1,10 +1,24 @@
 #!/usr/bin/env ruby
-require 'yaml'
-
-
-# If there are unknown contributors, write a .mailmap file like:
+# Checks the header of a tutorial or slides file fo the current contributor list
+# Then compares against the people who have touched that file in git using the git log
+#
+# Each tutorial or slides file needs to be checked individually.
+#
+# If there are unknown contributors, create a .mailmap file like:
 # <gh-username> <user@earlham.ac.uk>
 # <gh-username> <user@gmail.com>
+#
+# This is the format of git's mail-map
+# https://www.git-scm.com/docs/git-check-mailmap
+# We probably should not commit this file, some people don't want their old emails
+# listed so publicly.
+
+require 'yaml'
+
+if ARGV.size != 1
+  puts "Please run with ./bin/check-contributors path/to/tutorial.md/or/slides.html"
+  exit
+end
 
 fn = ARGV[0]
 


### PR DESCRIPTION
Wrote this as a break between papers, it will check the git log of a given file for the contributors which could be missing.

There is commonly the case of a user using multiple emails, and so this script can read from a local map of emails → usernames.

We could just add these extra emails to the yaml file, but given my personal perspective on the issue, I think maybe it's fine just to have a local map since not so many people might be running this to find missing contributors. (E.g. I know if I have old emails addresses that were included as commits, I'm not sure I want those in a more public contributors.yaml file and I'm sure I'm not alone.)

@bebatut 