### PR TITLE
Update variant analysis tutorials

### DIFF
--- a/topics/variant-analysis/tutorials/exome-seq/tutorial.md
+++ b/topics/variant-analysis/tutorials/exome-seq/tutorial.md
@@ -498,13 +498,14 @@ reads before passing them to a variant caller.
 
 The optimal set of postprocessing steps required depends on the variant calling
 software used at the next step. The **FreeBayes** variant caller that we are
-going to use in this tutorial is particularly well suited for use with minimal mapped reads postprocessing pipelines, so all we are going to do here is:
+going to use in this tutorial is particularly well suited for use with minimal
+mapped reads postprocessing pipelines, so all we are going to do here is:
 
 - filter the paired-end reads of all samples to retain only those read pairs,
   for which both the forward and the reverse read have been mapped to the
   reference successfully
 
-  For such *proper pairs of reads*, we can be extra confident that they don't
+  For such pairs of reads, we can be extra confident that they don't
   come from some non-human contaminant DNA or represent a sequencing artefact
   of some sort.
 
@@ -525,8 +526,7 @@ going to use in this tutorial is particularly well suited for use with minimal m
 
 ## Filtering on mapped reads properties
 
-To produce new filtered BAM datasets with only those reads retained that are
-mapped in a proper pair:
+To produce new filtered BAM datasets with only mapped reads the mate of which is also mapped:
 
 > ### {% icon hands_on %} Hands-on: Filtering for read pair mapping status
 >
@@ -537,11 +537,62 @@ mapped in a proper pair:
 >     {% icon tool %}
 >   - *"Filter on bitwise flag"*: `yes`
 >     - *"Only output alignments with all of these flag bits set"*:
->        - {% icon param-check %} *"Read is mapped in a proper pair"*
+>       Do not select anything here!
+>     - *"Skip alignments with any of these flag bits set"*:
+>        - {% icon param-check %} *"The read is unmapped"*
+>        - {% icon param-check %} *"The mate is unmapped"*
 >
 {: .hands_on}
 
 This will result in three new datasets, one for each sample in the analysis.
+
+> ### {% icon details %} More than one way to filter
+> Instead of the above filter conditions we could also have exploited the
+> *Read is mapped in a proper pair* flag bit.
+>
+> For a read to be flagged as being mapped in a proper pair its mate needs to
+> be mapped, but the mapped pair also needs to meet additional,
+> aligner-specific criteria. These may include (and do so for **BWA-MEM**):
+>
+> - both reads need to map to the same chomosome
+> - the two reads need to map to the reference in the orientation expected by
+>   the aligner
+> - the two read pairs need to map to the reference within an
+>   aligner-determined distance
+>
+> Thus, filtering based on the flag has two consequences:
+>
+> - filtering will be stricter than with just the *Read is unmapped* and *Mate
+>   is unmapped* flags above
+> - you will eliminate read pairs that could be informative with regard to
+>   chromosomal rearrangements and insertion/deletion events
+>
+>   => Do not filter for properly paired reads if you plan to detect such
+>   structural variants!
+>
+> In addition, the *proper pair* flag is considered undefined if the read
+> itself is unmapped, so a *proper pair* filter should eliminate unmapped reads
+> explicitly to be on the safe side.
+>
+> Thus, if you would like to use proper pair filtering (we have no intention to
+> detect structural variants in this tutorial) instead of just filtering for
+> mapped reads with a mapped mate, you could run the alternative:
+>
+> > ### {% icon hands_on %} Hands-on:
+> >
+> > 1. **Filter SAM or BAM, output SAM or BAM** {% icon tool %}:
+> >   - {% icon param-files %} *"SAM or BAM file to filter"*: all 3 mapped
+> >     reads datasets of the family trio, outputs of **Map with BWA-MEM**
+> >     {% icon tool %}
+> >   - *"Filter on bitwise flag"*: `yes`
+> >     - *"Only output alignments with all of these flag bits set"*:
+> >       - {% icon param-check %} *"Read is mapped in a proper pair"*
+> >     - *"Skip alignments with any of these flag bits set"*:
+> >       - {% icon param-check %} *"The read is unmapped"*
+> >
+> {: .hands_on}
+>
+{: .details}
 
 ## Removing duplicate reads
 

--- a/topics/variant-analysis/tutorials/exome-seq/workflows/workflow_exome_seq_from_premapped.ga
+++ b/topics/variant-analysis/tutorials/exome-seq/workflows/workflow_exome_seq_from_premapped.ga
@@ -3,7 +3,7 @@
     "tags": [],
     "format-version": "0.1",
     "name": "exome_seq_training_short_w_cached_ref",
-    "version": 3,
+    "version": 4,
     "steps": {
         "0": {
             "tool_id": null,
@@ -114,207 +114,186 @@
             "type": "data_input"
         },
         "4": {
-            "tool_id": "toolshed.g2.bx.psu.edu/repos/devteam/bamtools_filter/bamFilter/2.4.1",
-            "tool_version": "2.4.1",
+            "tool_id": "toolshed.g2.bx.psu.edu/repos/devteam/samtool_filter2/samtool_filter2/1.8+galaxy1",
+            "tool_version": "1.8+galaxy1",
             "outputs": [
                 {
-                    "type": "txt",
-                    "name": "out_file2"
-                },
-                {
-                    "type": "bam",
-                    "name": "out_file1"
+                    "type": "sam",
+                    "name": "output1"
                 }
             ],
-            "workflow_outputs": [
-                {
-                    "output_name": "out_file2",
-                    "uuid": "f18826ff-d5d7-4bd2-b3ba-f1457b745fc8",
-                    "label": null
-                },
-                {
-                    "output_name": "out_file1",
-                    "uuid": "c6653b3c-b9ce-4eea-b493-3048631734c0",
-                    "label": null
-                }
-            ],
+            "workflow_outputs": [],
             "input_connections": {
-                "input_bam": {
+                "input1": {
                     "output_name": "output",
                     "id": 0
                 }
             },
-            "tool_state": "{\"input_bam\": \"{\\\"__class__\\\": \\\"ConnectedValue\\\"}\", \"__rerun_remap_job_id__\": null, \"rule_configuration\": \"{\\\"__current_case__\\\": 0, \\\"rules_selector\\\": \\\"false\\\"}\", \"conditions\": \"[{\\\"__index__\\\": 0, \\\"filters\\\": [{\\\"__index__\\\": 0, \\\"bam_property\\\": {\\\"__current_case__\\\": 11, \\\"bam_property_selector\\\": \\\"isProperPair\\\", \\\"bam_property_value\\\": \\\"true\\\"}}]}]\", \"__page__\": null}",
+            "tool_state": "{\"__page__\": null, \"bed_file\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\", \"input1\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\", \"possibly_select_inverse\": \"\\\"false\\\"\", \"outputtype\": \"\\\"bam\\\"\", \"library\": \"\\\"\\\"\", \"regions\": \"\\\"\\\"\", \"header\": \"\\\"-h\\\"\", \"flag\": \"{\\\"__current_case__\\\": 1, \\\"filter\\\": \\\"yes\\\", \\\"reqBits\\\": null, \\\"skipBits\\\": [\\\"0x0004\\\", \\\"0x0008\\\"]}\", \"mapq\": \"\\\"0\\\"\", \"read_group\": \"\\\"\\\"\", \"__rerun_remap_job_id__\": null}",
             "id": 4,
             "tool_shed_repository": {
                 "owner": "devteam",
-                "changeset_revision": "bd735cae4ce6",
-                "name": "bamtools_filter",
+                "changeset_revision": "a7add3e93cc5",
+                "name": "samtool_filter2",
                 "tool_shed": "toolshed.g2.bx.psu.edu"
             },
-            "uuid": "c2bf2c6f-f243-4766-89d3-8f9ec8f07faa",
+            "uuid": "3479ed8e-baf1-425f-9082-a5dd365b86a0",
             "errors": null,
-            "name": "Filter",
+            "name": "Filter SAM or BAM, output SAM or BAM",
             "post_job_actions": {
-                "TagDatasetActionout_file1": {
-                    "output_name": "out_file1",
-                    "action_type": "TagDatasetAction",
-                    "action_arguments": {
-                        "tags": "#father"
-                    }
-                },
-                "TagDatasetActionout_file2": {
-                    "output_name": "out_file2",
-                    "action_type": "TagDatasetAction",
-                    "action_arguments": {
-                        "tags": "#father"
-                    }
+                "HideDatasetActionoutput1": {
+                    "output_name": "output1",
+                    "action_type": "HideDatasetAction",
+                    "action_arguments": {}
                 }
             },
             "label": null,
-            "inputs": [],
+            "inputs": [
+                {
+                    "name": "bed_file",
+                    "description": "runtime parameter for tool Filter SAM or BAM, output SAM or BAM"
+                },
+                {
+                    "name": "input1",
+                    "description": "runtime parameter for tool Filter SAM or BAM, output SAM or BAM"
+                },
+                {
+                    "name": "flag",
+                    "description": "runtime parameter for tool Filter SAM or BAM, output SAM or BAM"
+                }
+            ],
             "position": {
-                "top": 201,
-                "left": 386.796875
+                "top": 289,
+                "left": 373.33331298828125
             },
             "annotation": "",
-            "content_id": "toolshed.g2.bx.psu.edu/repos/devteam/bamtools_filter/bamFilter/2.4.1",
+            "content_id": "toolshed.g2.bx.psu.edu/repos/devteam/samtool_filter2/samtool_filter2/1.8+galaxy1",
             "type": "tool"
         },
         "5": {
-            "tool_id": "toolshed.g2.bx.psu.edu/repos/devteam/bamtools_filter/bamFilter/2.4.1",
-            "tool_version": "2.4.1",
+            "tool_id": "toolshed.g2.bx.psu.edu/repos/devteam/samtool_filter2/samtool_filter2/1.8+galaxy1",
+            "tool_version": "1.8+galaxy1",
             "outputs": [
                 {
-                    "type": "txt",
-                    "name": "out_file2"
-                },
-                {
-                    "type": "bam",
-                    "name": "out_file1"
+                    "type": "sam",
+                    "name": "output1"
                 }
             ],
             "workflow_outputs": [
                 {
-                    "output_name": "out_file2",
-                    "uuid": "9d80d7df-be29-4f97-a25e-899ad6ad7ac7",
-                    "label": null
-                },
-                {
-                    "output_name": "out_file1",
-                    "uuid": "5ae44b36-5567-496e-b59e-26ea46f25db8",
+                    "output_name": "output1",
+                    "uuid": "3fbd0ea8-4682-4e90-a5fc-50ffb395fa5b",
                     "label": null
                 }
             ],
             "input_connections": {
-                "input_bam": {
+                "input1": {
                     "output_name": "output",
                     "id": 1
                 }
             },
-            "tool_state": "{\"input_bam\": \"{\\\"__class__\\\": \\\"ConnectedValue\\\"}\", \"__rerun_remap_job_id__\": null, \"rule_configuration\": \"{\\\"__current_case__\\\": 0, \\\"rules_selector\\\": \\\"false\\\"}\", \"conditions\": \"[{\\\"__index__\\\": 0, \\\"filters\\\": [{\\\"__index__\\\": 0, \\\"bam_property\\\": {\\\"__current_case__\\\": 11, \\\"bam_property_selector\\\": \\\"isProperPair\\\", \\\"bam_property_value\\\": \\\"true\\\"}}]}]\", \"__page__\": null}",
+            "tool_state": "{\"__page__\": null, \"bed_file\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\", \"input1\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\", \"possibly_select_inverse\": \"\\\"false\\\"\", \"outputtype\": \"\\\"bam\\\"\", \"library\": \"\\\"\\\"\", \"regions\": \"\\\"\\\"\", \"header\": \"\\\"-h\\\"\", \"flag\": \"{\\\"__current_case__\\\": 1, \\\"filter\\\": \\\"yes\\\", \\\"reqBits\\\": null, \\\"skipBits\\\": [\\\"0x0004\\\", \\\"0x0008\\\"]}\", \"mapq\": \"\\\"0\\\"\", \"read_group\": \"\\\"\\\"\", \"__rerun_remap_job_id__\": null}",
             "id": 5,
             "tool_shed_repository": {
                 "owner": "devteam",
-                "changeset_revision": "bd735cae4ce6",
-                "name": "bamtools_filter",
+                "changeset_revision": "a7add3e93cc5",
+                "name": "samtool_filter2",
                 "tool_shed": "toolshed.g2.bx.psu.edu"
             },
-            "uuid": "d51e28bf-561a-448c-839b-dcfb7725fe3d",
+            "uuid": "887c2e21-95ad-481b-bed8-6400741a70c4",
             "errors": null,
-            "name": "Filter",
+            "name": "Filter SAM or BAM, output SAM or BAM",
             "post_job_actions": {
-                "TagDatasetActionout_file1": {
-                    "output_name": "out_file1",
-                    "action_type": "TagDatasetAction",
-                    "action_arguments": {
-                        "tags": "#mother"
-                    }
-                },
-                "TagDatasetActionout_file2": {
-                    "output_name": "out_file2",
-                    "action_type": "TagDatasetAction",
-                    "action_arguments": {
-                        "tags": "#mother"
-                    }
+                "HideDatasetActionoutput1": {
+                    "output_name": "output1",
+                    "action_type": "HideDatasetAction",
+                    "action_arguments": {}
                 }
             },
             "label": null,
-            "inputs": [],
+            "inputs": [
+                {
+                    "name": "bed_file",
+                    "description": "runtime parameter for tool Filter SAM or BAM, output SAM or BAM"
+                },
+                {
+                    "name": "input1",
+                    "description": "runtime parameter for tool Filter SAM or BAM, output SAM or BAM"
+                },
+                {
+                    "name": "flag",
+                    "description": "runtime parameter for tool Filter SAM or BAM, output SAM or BAM"
+                }
+            ],
             "position": {
-                "top": 402.796875,
-                "left": 393.1875
+                "top": 519.9999847412109,
+                "left": 381.33331298828125
             },
             "annotation": "",
-            "content_id": "toolshed.g2.bx.psu.edu/repos/devteam/bamtools_filter/bamFilter/2.4.1",
+            "content_id": "toolshed.g2.bx.psu.edu/repos/devteam/samtool_filter2/samtool_filter2/1.8+galaxy1",
             "type": "tool"
         },
         "6": {
-            "tool_id": "toolshed.g2.bx.psu.edu/repos/devteam/bamtools_filter/bamFilter/2.4.1",
-            "tool_version": "2.4.1",
+            "tool_id": "toolshed.g2.bx.psu.edu/repos/devteam/samtool_filter2/samtool_filter2/1.8+galaxy1",
+            "tool_version": "1.8+galaxy1",
             "outputs": [
                 {
-                    "type": "txt",
-                    "name": "out_file2"
-                },
-                {
-                    "type": "bam",
-                    "name": "out_file1"
+                    "type": "sam",
+                    "name": "output1"
                 }
             ],
             "workflow_outputs": [
                 {
-                    "output_name": "out_file2",
-                    "uuid": "46a89aeb-b33f-4378-b0dd-3f197579497a",
-                    "label": null
-                },
-                {
-                    "output_name": "out_file1",
-                    "uuid": "001628ec-b058-40af-8bef-38be7103623b",
+                    "output_name": "output1",
+                    "uuid": "7241442e-9274-4c77-bfe6-8d9cdfd953e2",
                     "label": null
                 }
             ],
             "input_connections": {
-                "input_bam": {
+                "input1": {
                     "output_name": "output",
                     "id": 2
                 }
             },
-            "tool_state": "{\"input_bam\": \"{\\\"__class__\\\": \\\"ConnectedValue\\\"}\", \"__rerun_remap_job_id__\": null, \"rule_configuration\": \"{\\\"__current_case__\\\": 0, \\\"rules_selector\\\": \\\"false\\\"}\", \"conditions\": \"[{\\\"__index__\\\": 0, \\\"filters\\\": [{\\\"__index__\\\": 0, \\\"bam_property\\\": {\\\"__current_case__\\\": 11, \\\"bam_property_selector\\\": \\\"isProperPair\\\", \\\"bam_property_value\\\": \\\"true\\\"}}]}]\", \"__page__\": null}",
+            "tool_state": "{\"__page__\": null, \"bed_file\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\", \"input1\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\", \"possibly_select_inverse\": \"\\\"false\\\"\", \"outputtype\": \"\\\"bam\\\"\", \"library\": \"\\\"\\\"\", \"regions\": \"\\\"\\\"\", \"header\": \"\\\"-h\\\"\", \"flag\": \"{\\\"__current_case__\\\": 1, \\\"filter\\\": \\\"yes\\\", \\\"reqBits\\\": null, \\\"skipBits\\\": [\\\"0x0004\\\", \\\"0x0008\\\"]}\", \"mapq\": \"\\\"0\\\"\", \"read_group\": \"\\\"\\\"\", \"__rerun_remap_job_id__\": null}",
             "id": 6,
             "tool_shed_repository": {
                 "owner": "devteam",
-                "changeset_revision": "bd735cae4ce6",
-                "name": "bamtools_filter",
+                "changeset_revision": "a7add3e93cc5",
+                "name": "samtool_filter2",
                 "tool_shed": "toolshed.g2.bx.psu.edu"
             },
-            "uuid": "ffdd103f-4b08-49c7-a212-e8659a1196ad",
+            "uuid": "8af8801a-a1de-4a59-b0e7-b8b162754b65",
             "errors": null,
-            "name": "Filter",
+            "name": "Filter SAM or BAM, output SAM or BAM",
             "post_job_actions": {
-                "TagDatasetActionout_file1": {
-                    "output_name": "out_file1",
-                    "action_type": "TagDatasetAction",
-                    "action_arguments": {
-                        "tags": "#child"
-                    }
-                },
-                "TagDatasetActionout_file2": {
-                    "output_name": "out_file2",
-                    "action_type": "TagDatasetAction",
-                    "action_arguments": {
-                        "tags": "#child"
-                    }
+                "HideDatasetActionoutput1": {
+                    "output_name": "output1",
+                    "action_type": "HideDatasetAction",
+                    "action_arguments": {}
                 }
             },
             "label": null,
-            "inputs": [],
+            "inputs": [
+                {
+                    "name": "bed_file",
+                    "description": "runtime parameter for tool Filter SAM or BAM, output SAM or BAM"
+                },
+                {
+                    "name": "input1",
+                    "description": "runtime parameter for tool Filter SAM or BAM, output SAM or BAM"
+                },
+                {
+                    "name": "flag",
+                    "description": "runtime parameter for tool Filter SAM or BAM, output SAM or BAM"
+                }
+            ],
             "position": {
-                "top": 657.203125,
-                "left": 469
+                "top": 789.3333129882812,
+                "left": 445.33331298828125
             },
             "annotation": "",
-            "content_id": "toolshed.g2.bx.psu.edu/repos/devteam/bamtools_filter/bamFilter/2.4.1",
+            "content_id": "toolshed.g2.bx.psu.edu/repos/devteam/samtool_filter2/samtool_filter2/1.8+galaxy1",
             "type": "tool"
         },
         "7": {
@@ -335,7 +314,7 @@
             ],
             "input_connections": {
                 "input1": {
-                    "output_name": "out_file1",
+                    "output_name": "output1",
                     "id": 4
                 }
             },
@@ -379,7 +358,7 @@
             ],
             "input_connections": {
                 "input1": {
-                    "output_name": "out_file1",
+                    "output_name": "output1",
                     "id": 5
                 }
             },
@@ -423,7 +402,7 @@
             ],
             "input_connections": {
                 "input1": {
-                    "output_name": "out_file1",
+                    "output_name": "output1",
                     "id": 6
                 }
             },
@@ -481,7 +460,7 @@
                     }
                 ]
             },
-            "tool_state": "{\"__page__\": null, \"reference_source\": \"{\\\"__current_case__\\\": 0, \\\"batchmode\\\": {\\\"__current_case__\\\": 0, \\\"input_bams\\\": {\\\"__class__\\\": \\\"RuntimeValue\\\"}, \\\"processmode\\\": \\\"individual\\\"}, \\\"ref_file\\\": \\\"hg19\\\", \\\"reference_source_selector\\\": \\\"cached\\\"}\", \"__rerun_remap_job_id__\": null, \"options_type\": \"{\\\"__current_case__\\\": 1, \\\"options_type_selector\\\": \\\"simple\\\"}\", \"target_limit_type\": \"{\\\"__current_case__\\\": 0, \\\"target_limit_type_selector\\\": \\\"do_not_limit\\\"}\"}",
+            "tool_state": "{\"__page__\": null, \"reference_source\": \"{\\\"__current_case__\\\": 0, \\\"batchmode\\\": {\\\"__current_case__\\\": 0, \\\"input_bams\\\": {\\\"__class__\\\": \\\"RuntimeValue\\\"}, \\\"processmode\\\": \\\"merge\\\"}, \\\"ref_file\\\": \\\"hg19\\\", \\\"reference_source_selector\\\": \\\"cached\\\"}\", \"__rerun_remap_job_id__\": null, \"options_type\": \"{\\\"__current_case__\\\": 1, \\\"options_type_selector\\\": \\\"simple\\\"}\", \"target_limit_type\": \"{\\\"__current_case__\\\": 0, \\\"target_limit_type_selector\\\": \\\"do_not_limit\\\"}\"}",
             "id": 10,
             "tool_shed_repository": {
                 "owner": "devteam",

--- a/topics/variant-analysis/tutorials/exome-seq/workflows/workflow_exome_seq_full.ga
+++ b/topics/variant-analysis/tutorials/exome-seq/workflows/workflow_exome_seq_full.ga
@@ -1,32 +1,26 @@
 {
-    "uuid": "a91c3939-0699-4972-b008-b8f60e0b7f41",
+    "uuid": "f335133d-e1ad-4fef-965d-34f1a21b9498",
     "tags": [],
     "format-version": "0.1",
     "name": "exome_seq_training_full_w_cached_ref",
-    "version": 3,
+    "version": 2,
     "steps": {
         "0": {
             "tool_id": null,
             "tool_version": null,
             "outputs": [],
-            "workflow_outputs": [
-                {
-                    "output_name": "output",
-                    "uuid": "ebe4816a-df24-48e2-8bed-ce50089d039b",
-                    "label": null
-                }
-            ],
+            "workflow_outputs": [],
             "input_connections": {},
             "tool_state": "{}",
             "id": 0,
-            "uuid": "338957bc-ce31-401b-8152-2c5c22cd58e2",
+            "uuid": "7e8d3069-39ef-4f4f-8721-40018121e84f",
             "errors": null,
             "name": "Input dataset",
             "label": "father_R1",
             "inputs": [],
             "position": {
-                "top": 729.078125,
-                "left": 426.828125
+                "top": 729.0833282470703,
+                "left": 426.8333282470703
             },
             "annotation": "",
             "content_id": null,
@@ -36,24 +30,18 @@
             "tool_id": null,
             "tool_version": null,
             "outputs": [],
-            "workflow_outputs": [
-                {
-                    "output_name": "output",
-                    "uuid": "e4b71a0e-980d-4dae-a746-b5c8ac1054d5",
-                    "label": null
-                }
-            ],
+            "workflow_outputs": [],
             "input_connections": {},
             "tool_state": "{}",
             "id": 1,
-            "uuid": "bf4e5c39-282a-489b-92d0-c30419d8430d",
+            "uuid": "5cec5d52-6afe-4f28-812a-da04da8eee27",
             "errors": null,
             "name": "Input dataset",
             "label": "father_R2",
             "inputs": [],
             "position": {
-                "top": 826.28125,
-                "left": 433.328125
+                "top": 826.2833404541016,
+                "left": 433.3333282470703
             },
             "annotation": "",
             "content_id": null,
@@ -63,24 +51,18 @@
             "tool_id": null,
             "tool_version": null,
             "outputs": [],
-            "workflow_outputs": [
-                {
-                    "output_name": "output",
-                    "uuid": "76c239e8-d472-450d-974e-17d4f15fb5bc",
-                    "label": null
-                }
-            ],
+            "workflow_outputs": [],
             "input_connections": {},
             "tool_state": "{}",
             "id": 2,
-            "uuid": "88e6e637-dd0c-4208-bfe5-5ece6e474aae",
+            "uuid": "3df84923-4a73-4adb-8656-823fe6a54bc8",
             "errors": null,
             "name": "Input dataset",
             "label": "mother_R1",
             "inputs": [],
             "position": {
-                "top": 940.09375,
-                "left": 448.578125
+                "top": 940.1000061035156,
+                "left": 448.5833282470703
             },
             "annotation": "",
             "content_id": null,
@@ -90,24 +72,18 @@
             "tool_id": null,
             "tool_version": null,
             "outputs": [],
-            "workflow_outputs": [
-                {
-                    "output_name": "output",
-                    "uuid": "14d07c95-bb76-4f6f-a839-a029ab2cfa7e",
-                    "label": null
-                }
-            ],
+            "workflow_outputs": [],
             "input_connections": {},
             "tool_state": "{}",
             "id": 3,
-            "uuid": "dd5a7515-17f4-487c-80ac-62b3c6dee91d",
+            "uuid": "0b84ff85-cf80-4c75-8f94-70a4ae5c7b62",
             "errors": null,
             "name": "Input dataset",
             "label": "mother_R2",
             "inputs": [],
             "position": {
-                "top": 1035.140625,
-                "left": 447.859375
+                "top": 1035.1333312988281,
+                "left": 447.8666687011719
             },
             "annotation": "",
             "content_id": null,
@@ -117,24 +93,18 @@
             "tool_id": null,
             "tool_version": null,
             "outputs": [],
-            "workflow_outputs": [
-                {
-                    "output_name": "output",
-                    "uuid": "67798674-7412-4c28-8d70-6630e2a0c4e8",
-                    "label": null
-                }
-            ],
+            "workflow_outputs": [],
             "input_connections": {},
             "tool_state": "{}",
             "id": 4,
-            "uuid": "013f4c9f-e0f3-4c34-a313-06a98b2b8e87",
+            "uuid": "d085976e-0b16-4fc4-8cc1-d22d13276e95",
             "errors": null,
             "name": "Input dataset",
             "label": "proband_R1",
             "inputs": [],
             "position": {
-                "top": 1164.03125,
-                "left": 461.546875
+                "top": 1164.0333251953125,
+                "left": 461.5500030517578
             },
             "annotation": "",
             "content_id": null,
@@ -144,24 +114,18 @@
             "tool_id": null,
             "tool_version": null,
             "outputs": [],
-            "workflow_outputs": [
-                {
-                    "output_name": "output",
-                    "uuid": "25f505a9-6ef3-42c0-b389-a72bdb5daf15",
-                    "label": null
-                }
-            ],
+            "workflow_outputs": [],
             "input_connections": {},
             "tool_state": "{}",
             "id": 5,
-            "uuid": "cd70f94c-db59-4aa4-ba6d-7e8b14a5b4d9",
+            "uuid": "e4b41228-d950-4b21-8293-76c80c54e1a8",
             "errors": null,
             "name": "Input dataset",
             "label": "proband_R2",
             "inputs": [],
             "position": {
-                "top": 1227.46875,
-                "left": 462.265625
+                "top": 1227.4666748046875,
+                "left": 462.26666259765625
             },
             "annotation": "",
             "content_id": null,
@@ -171,24 +135,18 @@
             "tool_id": null,
             "tool_version": null,
             "outputs": [],
-            "workflow_outputs": [
-                {
-                    "output_name": "output",
-                    "uuid": "e0652b69-badf-46bf-8fb4-01b94561e1f0",
-                    "label": null
-                }
-            ],
+            "workflow_outputs": [],
             "input_connections": {},
             "tool_state": "{}",
             "id": 6,
-            "uuid": "d96cc94b-e30c-492e-b96a-e3f169b940be",
+            "uuid": "35c029e1-1165-4895-a6be-495d138d1e37",
             "errors": null,
             "name": "Input dataset",
             "label": "PEDigree data",
             "inputs": [],
             "position": {
-                "top": 1381.265625,
-                "left": 1428.78125
+                "top": 1381.2666625976562,
+                "left": 1428.7833251953125
             },
             "annotation": "",
             "content_id": null,
@@ -210,7 +168,7 @@
             "workflow_outputs": [
                 {
                     "output_name": "html_file",
-                    "uuid": "148714a7-377c-4c09-a9ec-dda1e8d71ccf",
+                    "uuid": "db16d9c3-f4c3-4b7a-b690-01932932f206",
                     "label": null
                 }
             ],
@@ -228,7 +186,7 @@
                 "name": "fastqc",
                 "tool_shed": "toolshed.g2.bx.psu.edu"
             },
-            "uuid": "ee4e0fcf-69b9-43f7-9044-e4ebf23a54eb",
+            "uuid": "e78dc509-b827-45c9-a258-670063ed1114",
             "errors": null,
             "name": "FastQC",
             "post_job_actions": {
@@ -264,8 +222,8 @@
                 }
             ],
             "position": {
-                "top": 227.71875,
-                "left": 256.890625
+                "top": 227.7166748046875,
+                "left": 256.8833312988281
             },
             "annotation": "",
             "content_id": "toolshed.g2.bx.psu.edu/repos/devteam/fastqc/fastqc/0.72",
@@ -287,7 +245,7 @@
             "workflow_outputs": [
                 {
                     "output_name": "html_file",
-                    "uuid": "ce551164-93df-4b42-9985-27573d22aa95",
+                    "uuid": "ca829ab0-1a88-470f-8fe8-5c12783f8711",
                     "label": null
                 }
             ],
@@ -305,7 +263,7 @@
                 "name": "fastqc",
                 "tool_shed": "toolshed.g2.bx.psu.edu"
             },
-            "uuid": "4cd47e31-ca2c-4a90-b89d-1ac46de8a38c",
+            "uuid": "3e6191aa-9ac5-4f75-ab61-42b0f3fc000b",
             "errors": null,
             "name": "FastQC",
             "post_job_actions": {
@@ -341,8 +299,8 @@
                 }
             ],
             "position": {
-                "top": 499.4375,
-                "left": 224.28125
+                "top": 499.43333435058594,
+                "left": 224.28334045410156
             },
             "annotation": "",
             "content_id": "toolshed.g2.bx.psu.edu/repos/devteam/fastqc/fastqc/0.72",
@@ -360,7 +318,7 @@
             "workflow_outputs": [
                 {
                     "output_name": "bam_output",
-                    "uuid": "1953ec7f-115f-49ec-9404-448800ee8129",
+                    "uuid": "518d4bb5-4481-4bbf-b6d6-b9de90e99d59",
                     "label": null
                 }
             ],
@@ -374,7 +332,7 @@
                     "id": 1
                 }
             },
-            "tool_state": "{\"__page__\": null, \"__rerun_remap_job_id__\": null, \"rg\": \"{\\\"CN\\\": \\\"\\\", \\\"DS\\\": \\\"\\\", \\\"DT\\\": \\\"\\\", \\\"FO\\\": \\\"\\\", \\\"KS\\\": \\\"\\\", \\\"PG\\\": \\\"\\\", \\\"PI\\\": \\\"\\\", \\\"PL\\\": \\\"ILLUMINA\\\", \\\"PU\\\": \\\"\\\", \\\"__current_case__\\\": 1, \\\"read_group_id_conditional\\\": {\\\"ID\\\": \\\"001\\\", \\\"__current_case__\\\": 1, \\\"do_auto_name\\\": \\\"false\\\"}, \\\"read_group_lb_conditional\\\": {\\\"LB\\\": \\\"\\\", \\\"__current_case__\\\": 1, \\\"do_auto_name\\\": \\\"false\\\"}, \\\"read_group_sm_conditional\\\": {\\\"SM\\\": \\\"father\\\", \\\"__current_case__\\\": 1, \\\"do_auto_name\\\": \\\"false\\\"}, \\\"rg_selector\\\": \\\"set\\\"}\", \"fastq_input\": \"{\\\"__current_case__\\\": 0, \\\"fastq_input1\\\": {\\\"__class__\\\": \\\"RuntimeValue\\\"}, \\\"fastq_input2\\\": {\\\"__class__\\\": \\\"RuntimeValue\\\"}, \\\"fastq_input_selector\\\": \\\"paired\\\", \\\"iset_stats\\\": \\\"\\\"}\", \"analysis_type\": \"{\\\"__current_case__\\\": 0, \\\"analysis_type_selector\\\": \\\"illumina\\\"}\", \"reference_source\": \"{\\\"__current_case__\\\": 0, \\\"ref_file\\\": \\\"hg19\\\", \\\"reference_source_selector\\\": \\\"cached\\\"}\"}",
+            "tool_state": "{\"__page__\": null, \"__rerun_remap_job_id__\": null, \"rg\": \"{\\\"CN\\\": \\\"\\\", \\\"DS\\\": \\\"\\\", \\\"DT\\\": \\\"\\\", \\\"FO\\\": \\\"\\\", \\\"KS\\\": \\\"\\\", \\\"PG\\\": \\\"\\\", \\\"PI\\\": \\\"\\\", \\\"PL\\\": \\\"ILLUMINA\\\", \\\"PU\\\": \\\"\\\", \\\"__current_case__\\\": 1, \\\"read_group_id_conditional\\\": {\\\"ID\\\": \\\"001\\\", \\\"__current_case__\\\": 1, \\\"do_auto_name\\\": \\\"false\\\"}, \\\"read_group_lb_conditional\\\": {\\\"LB\\\": \\\"\\\", \\\"__current_case__\\\": 1, \\\"do_auto_name\\\": \\\"false\\\"}, \\\"read_group_sm_conditional\\\": {\\\"SM\\\": \\\"father\\\", \\\"__current_case__\\\": 1, \\\"do_auto_name\\\": \\\"false\\\"}, \\\"rg_selector\\\": \\\"set\\\"}\", \"fastq_input\": \"{\\\"__current_case__\\\": 0, \\\"fastq_input1\\\": {\\\"__class__\\\": \\\"ConnectedValue\\\"}, \\\"fastq_input2\\\": {\\\"__class__\\\": \\\"ConnectedValue\\\"}, \\\"fastq_input_selector\\\": \\\"paired\\\", \\\"iset_stats\\\": \\\"\\\"}\", \"analysis_type\": \"{\\\"__current_case__\\\": 0, \\\"analysis_type_selector\\\": \\\"illumina\\\"}\", \"reference_source\": \"{\\\"__current_case__\\\": 0, \\\"ref_file\\\": \\\"hg19\\\", \\\"reference_source_selector\\\": \\\"cached\\\"}\"}",
             "id": 9,
             "tool_shed_repository": {
                 "owner": "devteam",
@@ -382,7 +340,7 @@
                 "name": "bwa",
                 "tool_shed": "toolshed.g2.bx.psu.edu"
             },
-            "uuid": "42b72ac7-b206-45c8-bb56-5db40d36e491",
+            "uuid": "408513fa-b5b4-447c-9cdb-de0c0f4322ba",
             "errors": null,
             "name": "Map with BWA-MEM",
             "post_job_actions": {
@@ -395,19 +353,10 @@
                 }
             },
             "label": null,
-            "inputs": [
-                {
-                    "name": "fastq_input",
-                    "description": "runtime parameter for tool Map with BWA-MEM"
-                },
-                {
-                    "name": "fastq_input",
-                    "description": "runtime parameter for tool Map with BWA-MEM"
-                }
-            ],
+            "inputs": [],
             "position": {
-                "top": 752.109375,
-                "left": 601.8125
+                "top": 752.1166687011719,
+                "left": 601.816650390625
             },
             "annotation": "",
             "content_id": "toolshed.g2.bx.psu.edu/repos/devteam/bwa/bwa_mem/0.7.17.1",
@@ -429,7 +378,7 @@
             "workflow_outputs": [
                 {
                     "output_name": "html_file",
-                    "uuid": "106ea76e-8ee0-481f-89e1-1248f4d5965b",
+                    "uuid": "d9875dbf-f788-4330-bd1b-46abbda5419d",
                     "label": null
                 }
             ],
@@ -447,7 +396,7 @@
                 "name": "fastqc",
                 "tool_shed": "toolshed.g2.bx.psu.edu"
             },
-            "uuid": "4594b861-669e-434e-bd8e-35a26c15d33c",
+            "uuid": "ff071d78-e15b-4280-98f6-21d7fe033736",
             "errors": null,
             "name": "FastQC",
             "post_job_actions": {
@@ -483,8 +432,8 @@
                 }
             ],
             "position": {
-                "top": 487.203125,
-                "left": 485.609375
+                "top": 487.1999969482422,
+                "left": 485.6166687011719
             },
             "annotation": "",
             "content_id": "toolshed.g2.bx.psu.edu/repos/devteam/fastqc/fastqc/0.72",
@@ -506,7 +455,7 @@
             "workflow_outputs": [
                 {
                     "output_name": "html_file",
-                    "uuid": "f305fa15-4c94-41f0-abeb-63af2d418b6f",
+                    "uuid": "81ded18c-e3ca-4e84-ad25-995cd8c6e6c1",
                     "label": null
                 }
             ],
@@ -524,7 +473,7 @@
                 "name": "fastqc",
                 "tool_shed": "toolshed.g2.bx.psu.edu"
             },
-            "uuid": "f2c55b4b-c4b3-4635-92c1-618b828589a1",
+            "uuid": "41db1eda-ff49-4d99-a51c-705bc12a228f",
             "errors": null,
             "name": "FastQC",
             "post_job_actions": {
@@ -560,8 +509,8 @@
                 }
             ],
             "position": {
-                "top": 526.4375,
-                "left": 748.796875
+                "top": 526.4333343505859,
+                "left": 748.7999877929688
             },
             "annotation": "",
             "content_id": "toolshed.g2.bx.psu.edu/repos/devteam/fastqc/fastqc/0.72",
@@ -579,7 +528,7 @@
             "workflow_outputs": [
                 {
                     "output_name": "bam_output",
-                    "uuid": "3cc69042-8c92-40c8-83f2-77c7e1ea41e8",
+                    "uuid": "74c89449-d2c2-4ff5-8f16-8c38ce312755",
                     "label": null
                 }
             ],
@@ -593,7 +542,7 @@
                     "id": 3
                 }
             },
-            "tool_state": "{\"__page__\": null, \"__rerun_remap_job_id__\": null, \"rg\": \"{\\\"CN\\\": \\\"\\\", \\\"DS\\\": \\\"\\\", \\\"DT\\\": \\\"\\\", \\\"FO\\\": \\\"\\\", \\\"KS\\\": \\\"\\\", \\\"PG\\\": \\\"\\\", \\\"PI\\\": \\\"\\\", \\\"PL\\\": \\\"ILLUMINA\\\", \\\"PU\\\": \\\"\\\", \\\"__current_case__\\\": 1, \\\"read_group_id_conditional\\\": {\\\"ID\\\": \\\"002\\\", \\\"__current_case__\\\": 1, \\\"do_auto_name\\\": \\\"false\\\"}, \\\"read_group_lb_conditional\\\": {\\\"LB\\\": \\\"\\\", \\\"__current_case__\\\": 1, \\\"do_auto_name\\\": \\\"false\\\"}, \\\"read_group_sm_conditional\\\": {\\\"SM\\\": \\\"mother\\\", \\\"__current_case__\\\": 1, \\\"do_auto_name\\\": \\\"false\\\"}, \\\"rg_selector\\\": \\\"set\\\"}\", \"fastq_input\": \"{\\\"__current_case__\\\": 0, \\\"fastq_input1\\\": {\\\"__class__\\\": \\\"RuntimeValue\\\"}, \\\"fastq_input2\\\": {\\\"__class__\\\": \\\"RuntimeValue\\\"}, \\\"fastq_input_selector\\\": \\\"paired\\\", \\\"iset_stats\\\": \\\"\\\"}\", \"analysis_type\": \"{\\\"__current_case__\\\": 0, \\\"analysis_type_selector\\\": \\\"illumina\\\"}\", \"reference_source\": \"{\\\"__current_case__\\\": 0, \\\"ref_file\\\": \\\"hg19\\\", \\\"reference_source_selector\\\": \\\"cached\\\"}\"}",
+            "tool_state": "{\"__page__\": null, \"__rerun_remap_job_id__\": null, \"rg\": \"{\\\"CN\\\": \\\"\\\", \\\"DS\\\": \\\"\\\", \\\"DT\\\": \\\"\\\", \\\"FO\\\": \\\"\\\", \\\"KS\\\": \\\"\\\", \\\"PG\\\": \\\"\\\", \\\"PI\\\": \\\"\\\", \\\"PL\\\": \\\"ILLUMINA\\\", \\\"PU\\\": \\\"\\\", \\\"__current_case__\\\": 1, \\\"read_group_id_conditional\\\": {\\\"ID\\\": \\\"002\\\", \\\"__current_case__\\\": 1, \\\"do_auto_name\\\": \\\"false\\\"}, \\\"read_group_lb_conditional\\\": {\\\"LB\\\": \\\"\\\", \\\"__current_case__\\\": 1, \\\"do_auto_name\\\": \\\"false\\\"}, \\\"read_group_sm_conditional\\\": {\\\"SM\\\": \\\"mother\\\", \\\"__current_case__\\\": 1, \\\"do_auto_name\\\": \\\"false\\\"}, \\\"rg_selector\\\": \\\"set\\\"}\", \"fastq_input\": \"{\\\"__current_case__\\\": 0, \\\"fastq_input1\\\": {\\\"__class__\\\": \\\"ConnectedValue\\\"}, \\\"fastq_input2\\\": {\\\"__class__\\\": \\\"ConnectedValue\\\"}, \\\"fastq_input_selector\\\": \\\"paired\\\", \\\"iset_stats\\\": \\\"\\\"}\", \"analysis_type\": \"{\\\"__current_case__\\\": 0, \\\"analysis_type_selector\\\": \\\"illumina\\\"}\", \"reference_source\": \"{\\\"__current_case__\\\": 0, \\\"ref_file\\\": \\\"hg19\\\", \\\"reference_source_selector\\\": \\\"cached\\\"}\"}",
             "id": 12,
             "tool_shed_repository": {
                 "owner": "devteam",
@@ -601,7 +550,7 @@
                 "name": "bwa",
                 "tool_shed": "toolshed.g2.bx.psu.edu"
             },
-            "uuid": "12e0640f-b3e2-4888-90d7-48fa9a410494",
+            "uuid": "ab11f07e-5475-46a2-947a-49452bbe3837",
             "errors": null,
             "name": "Map with BWA-MEM",
             "post_job_actions": {
@@ -614,19 +563,10 @@
                 }
             },
             "label": null,
-            "inputs": [
-                {
-                    "name": "fastq_input",
-                    "description": "runtime parameter for tool Map with BWA-MEM"
-                },
-                {
-                    "name": "fastq_input",
-                    "description": "runtime parameter for tool Map with BWA-MEM"
-                }
-            ],
+            "inputs": [],
             "position": {
-                "top": 966.671875,
-                "left": 611.125
+                "top": 966.6666717529297,
+                "left": 611.1333312988281
             },
             "annotation": "",
             "content_id": "toolshed.g2.bx.psu.edu/repos/devteam/bwa/bwa_mem/0.7.17.1",
@@ -648,7 +588,7 @@
             "workflow_outputs": [
                 {
                     "output_name": "html_file",
-                    "uuid": "d2e3f660-d20e-4848-a3b9-f8326519612b",
+                    "uuid": "efcf9897-8489-431e-9e95-6e6fe2a9a296",
                     "label": null
                 }
             ],
@@ -666,7 +606,7 @@
                 "name": "fastqc",
                 "tool_shed": "toolshed.g2.bx.psu.edu"
             },
-            "uuid": "6b5901be-20b3-4102-9ee1-861bd841f89a",
+            "uuid": "21ebf1ae-15a7-42f3-a6a6-22fc126cb497",
             "errors": null,
             "name": "FastQC",
             "post_job_actions": {
@@ -702,8 +642,8 @@
                 }
             ],
             "position": {
-                "top": 550.921875,
-                "left": 1003.84375
+                "top": 550.9166717529297,
+                "left": 1003.8499755859375
             },
             "annotation": "",
             "content_id": "toolshed.g2.bx.psu.edu/repos/devteam/fastqc/fastqc/0.72",
@@ -725,7 +665,7 @@
             "workflow_outputs": [
                 {
                     "output_name": "html_file",
-                    "uuid": "d6d35b22-4b3f-4f9a-812b-1ef58971c11d",
+                    "uuid": "a23e13a9-57b7-4cf5-907a-2ced2ea17526",
                     "label": null
                 }
             ],
@@ -743,7 +683,7 @@
                 "name": "fastqc",
                 "tool_shed": "toolshed.g2.bx.psu.edu"
             },
-            "uuid": "16c2ac6c-8e76-4968-9f2d-1a0d9ebb3565",
+            "uuid": "037d6473-11c1-49f5-a877-4e75ccc7d202",
             "errors": null,
             "name": "FastQC",
             "post_job_actions": {
@@ -779,8 +719,8 @@
                 }
             ],
             "position": {
-                "top": 427.078125,
-                "left": 1234.609375
+                "top": 427.08331298828125,
+                "left": 1234.61669921875
             },
             "annotation": "",
             "content_id": "toolshed.g2.bx.psu.edu/repos/devteam/fastqc/fastqc/0.72",
@@ -798,7 +738,7 @@
             "workflow_outputs": [
                 {
                     "output_name": "bam_output",
-                    "uuid": "c4f3d71c-63c4-4706-8017-e1893c74e652",
+                    "uuid": "f861db10-4e22-4bc1-abd6-72a95d6098c0",
                     "label": null
                 }
             ],
@@ -812,7 +752,7 @@
                     "id": 5
                 }
             },
-            "tool_state": "{\"__page__\": null, \"__rerun_remap_job_id__\": null, \"rg\": \"{\\\"CN\\\": \\\"\\\", \\\"DS\\\": \\\"\\\", \\\"DT\\\": \\\"\\\", \\\"FO\\\": \\\"\\\", \\\"KS\\\": \\\"\\\", \\\"PG\\\": \\\"\\\", \\\"PI\\\": \\\"\\\", \\\"PL\\\": \\\"ILLUMINA\\\", \\\"PU\\\": \\\"\\\", \\\"__current_case__\\\": 1, \\\"read_group_id_conditional\\\": {\\\"ID\\\": \\\"003\\\", \\\"__current_case__\\\": 1, \\\"do_auto_name\\\": \\\"false\\\"}, \\\"read_group_lb_conditional\\\": {\\\"LB\\\": \\\"\\\", \\\"__current_case__\\\": 1, \\\"do_auto_name\\\": \\\"false\\\"}, \\\"read_group_sm_conditional\\\": {\\\"SM\\\": \\\"proband\\\", \\\"__current_case__\\\": 1, \\\"do_auto_name\\\": \\\"false\\\"}, \\\"rg_selector\\\": \\\"set\\\"}\", \"fastq_input\": \"{\\\"__current_case__\\\": 0, \\\"fastq_input1\\\": {\\\"__class__\\\": \\\"RuntimeValue\\\"}, \\\"fastq_input2\\\": {\\\"__class__\\\": \\\"RuntimeValue\\\"}, \\\"fastq_input_selector\\\": \\\"paired\\\", \\\"iset_stats\\\": \\\"\\\"}\", \"analysis_type\": \"{\\\"__current_case__\\\": 0, \\\"analysis_type_selector\\\": \\\"illumina\\\"}\", \"reference_source\": \"{\\\"__current_case__\\\": 0, \\\"ref_file\\\": \\\"hg19\\\", \\\"reference_source_selector\\\": \\\"cached\\\"}\"}",
+            "tool_state": "{\"__page__\": null, \"__rerun_remap_job_id__\": null, \"rg\": \"{\\\"CN\\\": \\\"\\\", \\\"DS\\\": \\\"\\\", \\\"DT\\\": \\\"\\\", \\\"FO\\\": \\\"\\\", \\\"KS\\\": \\\"\\\", \\\"PG\\\": \\\"\\\", \\\"PI\\\": \\\"\\\", \\\"PL\\\": \\\"ILLUMINA\\\", \\\"PU\\\": \\\"\\\", \\\"__current_case__\\\": 1, \\\"read_group_id_conditional\\\": {\\\"ID\\\": \\\"003\\\", \\\"__current_case__\\\": 1, \\\"do_auto_name\\\": \\\"false\\\"}, \\\"read_group_lb_conditional\\\": {\\\"LB\\\": \\\"\\\", \\\"__current_case__\\\": 1, \\\"do_auto_name\\\": \\\"false\\\"}, \\\"read_group_sm_conditional\\\": {\\\"SM\\\": \\\"proband\\\", \\\"__current_case__\\\": 1, \\\"do_auto_name\\\": \\\"false\\\"}, \\\"rg_selector\\\": \\\"set\\\"}\", \"fastq_input\": \"{\\\"__current_case__\\\": 0, \\\"fastq_input1\\\": {\\\"__class__\\\": \\\"ConnectedValue\\\"}, \\\"fastq_input2\\\": {\\\"__class__\\\": \\\"ConnectedValue\\\"}, \\\"fastq_input_selector\\\": \\\"paired\\\", \\\"iset_stats\\\": \\\"\\\"}\", \"analysis_type\": \"{\\\"__current_case__\\\": 0, \\\"analysis_type_selector\\\": \\\"illumina\\\"}\", \"reference_source\": \"{\\\"__current_case__\\\": 0, \\\"ref_file\\\": \\\"hg19\\\", \\\"reference_source_selector\\\": \\\"cached\\\"}\"}",
             "id": 15,
             "tool_shed_repository": {
                 "owner": "devteam",
@@ -820,7 +760,7 @@
                 "name": "bwa",
                 "tool_shed": "toolshed.g2.bx.psu.edu"
             },
-            "uuid": "55bf404d-7fec-4aad-ad2d-cdaf7f123580",
+            "uuid": "005e3ed5-477e-4d10-980e-2ffbaaf17161",
             "errors": null,
             "name": "Map with BWA-MEM",
             "post_job_actions": {
@@ -833,130 +773,125 @@
                 }
             },
             "label": null,
-            "inputs": [
-                {
-                    "name": "fastq_input",
-                    "description": "runtime parameter for tool Map with BWA-MEM"
-                },
-                {
-                    "name": "fastq_input",
-                    "description": "runtime parameter for tool Map with BWA-MEM"
-                }
-            ],
+            "inputs": [],
             "position": {
-                "top": 1179.90625,
-                "left": 674.328125
+                "top": 1179.8999938964844,
+                "left": 674.3333129882812
             },
             "annotation": "",
             "content_id": "toolshed.g2.bx.psu.edu/repos/devteam/bwa/bwa_mem/0.7.17.1",
             "type": "tool"
         },
         "16": {
-            "tool_id": "toolshed.g2.bx.psu.edu/repos/devteam/bamtools_filter/bamFilter/2.4.1",
-            "tool_version": "2.4.1",
+            "tool_id": "toolshed.g2.bx.psu.edu/repos/devteam/samtool_filter2/samtool_filter2/1.8",
+            "tool_version": "1.8",
             "outputs": [
                 {
-                    "type": "txt",
-                    "name": "out_file2"
-                },
-                {
-                    "type": "bam",
-                    "name": "out_file1"
+                    "type": "sam",
+                    "name": "output1"
                 }
             ],
             "workflow_outputs": [
                 {
-                    "output_name": "out_file1",
-                    "uuid": "b930e845-5844-4938-9ad3-4f282bb16e60",
+                    "output_name": "output1",
+                    "uuid": "400d889f-92cc-4607-9397-9cea29bd51ce",
                     "label": null
                 }
             ],
             "input_connections": {
-                "input_bam": {
+                "input1": {
                     "output_name": "bam_output",
                     "id": 9
                 }
             },
-            "tool_state": "{\"__page__\": null, \"chromInfo\": \"\\\"/opt/galaxy/tool-data/shared/ucsc/chrom/hg19.len\\\"\", \"__rerun_remap_job_id__\": null, \"conditions\": \"[{\\\"__index__\\\": 0, \\\"filters\\\": [{\\\"__index__\\\": 0, \\\"bam_property\\\": {\\\"__current_case__\\\": 11, \\\"bam_property_selector\\\": \\\"isProperPair\\\", \\\"bam_property_value\\\": \\\"true\\\"}}]}]\", \"rule_configuration\": \"{\\\"__current_case__\\\": 0, \\\"rules_selector\\\": \\\"false\\\"}\", \"input_bam\": \"{\\\"__class__\\\": \\\"ConnectedValue\\\"}\"}",
+            "tool_state": "{\"__page__\": null, \"bed_file\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\", \"input1\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\", \"possibly_select_inverse\": \"\\\"false\\\"\", \"outputtype\": \"\\\"bam\\\"\", \"library\": \"\\\"\\\"\", \"regions\": \"\\\"\\\"\", \"header\": \"\\\"-h\\\"\", \"flag\": \"{\\\"__current_case__\\\": 1, \\\"filter\\\": \\\"yes\\\", \\\"reqBits\\\": null, \\\"skipBits\\\": [\\\"0x0004\\\", \\\"0x0008\\\"]}\", \"mapq\": \"\\\"0\\\"\", \"read_group\": \"\\\"\\\"\", \"__rerun_remap_job_id__\": null}",
             "id": 16,
             "tool_shed_repository": {
                 "owner": "devteam",
-                "changeset_revision": "bd735cae4ce6",
-                "name": "bamtools_filter",
+                "changeset_revision": "56c31114ad4a",
+                "name": "samtool_filter2",
                 "tool_shed": "toolshed.g2.bx.psu.edu"
             },
-            "uuid": "6b9f4734-0a26-43ea-8684-e5547111b240",
+            "uuid": "41dd9cea-a4c8-4f3f-adb6-bcbcafaac37b",
             "errors": null,
-            "name": "Filter",
+            "name": "Filter SAM or BAM, output SAM or BAM",
             "post_job_actions": {
-                "HideDatasetActionout_file2": {
-                    "output_name": "out_file2",
+                "HideDatasetActionoutput1": {
+                    "output_name": "output1",
                     "action_type": "HideDatasetAction",
                     "action_arguments": {}
                 }
             },
             "label": null,
-            "inputs": [],
+            "inputs": [
+                {
+                    "name": "bed_file",
+                    "description": "runtime parameter for tool Filter SAM or BAM, output SAM or BAM"
+                },
+                {
+                    "name": "input1",
+                    "description": "runtime parameter for tool Filter SAM or BAM, output SAM or BAM"
+                }
+            ],
             "position": {
-                "top": 767.90625,
-                "left": 853.8125
+                "top": 735.3333282470703,
+                "left": 859.3333129882812
             },
             "annotation": "",
-            "content_id": "toolshed.g2.bx.psu.edu/repos/devteam/bamtools_filter/bamFilter/2.4.1",
+            "content_id": "toolshed.g2.bx.psu.edu/repos/devteam/samtool_filter2/samtool_filter2/1.8",
             "type": "tool"
         },
         "17": {
-            "tool_id": "toolshed.g2.bx.psu.edu/repos/devteam/bamtools_filter/bamFilter/2.4.1",
-            "tool_version": "2.4.1",
+            "tool_id": "toolshed.g2.bx.psu.edu/repos/devteam/samtool_filter2/samtool_filter2/1.8",
+            "tool_version": "1.8",
             "outputs": [
                 {
-                    "type": "txt",
-                    "name": "out_file2"
-                },
-                {
-                    "type": "bam",
-                    "name": "out_file1"
+                    "type": "sam",
+                    "name": "output1"
                 }
             ],
-            "workflow_outputs": [
-                {
-                    "output_name": "out_file1",
-                    "uuid": "ae617101-2ea5-4fe2-b0a9-7544c713cfc9",
-                    "label": null
-                }
-            ],
+            "workflow_outputs": [],
             "input_connections": {
-                "input_bam": {
+                "input1": {
                     "output_name": "bam_output",
                     "id": 12
                 }
             },
-            "tool_state": "{\"__page__\": null, \"chromInfo\": \"\\\"/opt/galaxy/tool-data/shared/ucsc/chrom/hg19.len\\\"\", \"__rerun_remap_job_id__\": null, \"conditions\": \"[{\\\"__index__\\\": 0, \\\"filters\\\": [{\\\"__index__\\\": 0, \\\"bam_property\\\": {\\\"__current_case__\\\": 11, \\\"bam_property_selector\\\": \\\"isProperPair\\\", \\\"bam_property_value\\\": \\\"true\\\"}}]}]\", \"rule_configuration\": \"{\\\"__current_case__\\\": 0, \\\"rules_selector\\\": \\\"false\\\"}\", \"input_bam\": \"{\\\"__class__\\\": \\\"ConnectedValue\\\"}\"}",
+            "tool_state": "{\"__page__\": null, \"bed_file\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\", \"input1\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\", \"possibly_select_inverse\": \"\\\"false\\\"\", \"outputtype\": \"\\\"bam\\\"\", \"library\": \"\\\"\\\"\", \"regions\": \"\\\"\\\"\", \"header\": \"\\\"-h\\\"\", \"flag\": \"{\\\"__current_case__\\\": 1, \\\"filter\\\": \\\"yes\\\", \\\"reqBits\\\": null, \\\"skipBits\\\": [\\\"0x0004\\\", \\\"0x0008\\\"]}\", \"mapq\": \"\\\"0\\\"\", \"read_group\": \"\\\"\\\"\", \"__rerun_remap_job_id__\": null}",
             "id": 17,
             "tool_shed_repository": {
                 "owner": "devteam",
-                "changeset_revision": "bd735cae4ce6",
-                "name": "bamtools_filter",
+                "changeset_revision": "56c31114ad4a",
+                "name": "samtool_filter2",
                 "tool_shed": "toolshed.g2.bx.psu.edu"
             },
-            "uuid": "de082c82-bb7d-4ebf-82df-332db2287a18",
+            "uuid": "3fc497ec-11e5-412b-a79c-27ed9c975572",
             "errors": null,
-            "name": "Filter",
+            "name": "Filter SAM or BAM, output SAM or BAM",
             "post_job_actions": {
-                "HideDatasetActionout_file2": {
-                    "output_name": "out_file2",
+                "HideDatasetActionoutput1": {
+                    "output_name": "output1",
                     "action_type": "HideDatasetAction",
                     "action_arguments": {}
                 }
             },
             "label": null,
-            "inputs": [],
+            "inputs": [
+                {
+                    "name": "bed_file",
+                    "description": "runtime parameter for tool Filter SAM or BAM, output SAM or BAM"
+                },
+                {
+                    "name": "input1",
+                    "description": "runtime parameter for tool Filter SAM or BAM, output SAM or BAM"
+                }
+            ],
             "position": {
-                "top": 947.234375,
-                "left": 823.5625
+                "top": 942.3333282470703,
+                "left": 867.3333129882812
             },
             "annotation": "",
-            "content_id": "toolshed.g2.bx.psu.edu/repos/devteam/bamtools_filter/bamFilter/2.4.1",
+            "content_id": "toolshed.g2.bx.psu.edu/repos/devteam/samtool_filter2/samtool_filter2/1.8",
             "type": "tool"
         },
         "18": {
@@ -974,8 +909,13 @@
             ],
             "workflow_outputs": [
                 {
+                    "output_name": "log",
+                    "uuid": "23cd432a-7a1b-4d91-83ff-f942a4912750",
+                    "label": null
+                },
+                {
                     "output_name": "html_report",
-                    "uuid": "7145842c-e172-415c-bcc3-f1554615e42f",
+                    "uuid": "cf47af0f-3760-42d9-b93e-8b88ee65f027",
                     "label": null
                 }
             ],
@@ -1013,7 +953,7 @@
                 "name": "multiqc",
                 "tool_shed": "toolshed.g2.bx.psu.edu"
             },
-            "uuid": "0337b671-f532-49f6-85c9-f27408039266",
+            "uuid": "13fa97d1-a167-4137-a68c-f066b50908b2",
             "errors": null,
             "name": "MultiQC",
             "post_job_actions": {
@@ -1027,64 +967,63 @@
             "inputs": [],
             "position": {
                 "top": 124,
-                "left": 833.390625
+                "left": 833.38330078125
             },
             "annotation": "",
             "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/multiqc/multiqc/1.7",
             "type": "tool"
         },
         "19": {
-            "tool_id": "toolshed.g2.bx.psu.edu/repos/devteam/bamtools_filter/bamFilter/2.4.1",
-            "tool_version": "2.4.1",
+            "tool_id": "toolshed.g2.bx.psu.edu/repos/devteam/samtool_filter2/samtool_filter2/1.8",
+            "tool_version": "1.8",
             "outputs": [
                 {
-                    "type": "txt",
-                    "name": "out_file2"
-                },
-                {
-                    "type": "bam",
-                    "name": "out_file1"
+                    "type": "sam",
+                    "name": "output1"
                 }
             ],
-            "workflow_outputs": [
-                {
-                    "output_name": "out_file1",
-                    "uuid": "59549303-8d41-4750-be7e-5b8835946e56",
-                    "label": null
-                }
-            ],
+            "workflow_outputs": [],
             "input_connections": {
-                "input_bam": {
+                "input1": {
                     "output_name": "bam_output",
                     "id": 15
                 }
             },
-            "tool_state": "{\"__page__\": null, \"chromInfo\": \"\\\"/opt/galaxy/tool-data/shared/ucsc/chrom/hg19.len\\\"\", \"__rerun_remap_job_id__\": null, \"conditions\": \"[{\\\"__index__\\\": 0, \\\"filters\\\": [{\\\"__index__\\\": 0, \\\"bam_property\\\": {\\\"__current_case__\\\": 11, \\\"bam_property_selector\\\": \\\"isProperPair\\\", \\\"bam_property_value\\\": \\\"true\\\"}}]}]\", \"rule_configuration\": \"{\\\"__current_case__\\\": 0, \\\"rules_selector\\\": \\\"false\\\"}\", \"input_bam\": \"{\\\"__class__\\\": \\\"ConnectedValue\\\"}\"}",
+            "tool_state": "{\"__page__\": null, \"bed_file\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\", \"input1\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\", \"possibly_select_inverse\": \"\\\"false\\\"\", \"outputtype\": \"\\\"bam\\\"\", \"library\": \"\\\"\\\"\", \"regions\": \"\\\"\\\"\", \"header\": \"\\\"-h\\\"\", \"flag\": \"{\\\"__current_case__\\\": 1, \\\"filter\\\": \\\"yes\\\", \\\"reqBits\\\": null, \\\"skipBits\\\": [\\\"0x0004\\\", \\\"0x0008\\\"]}\", \"mapq\": \"\\\"0\\\"\", \"read_group\": \"\\\"\\\"\", \"__rerun_remap_job_id__\": null}",
             "id": 19,
             "tool_shed_repository": {
                 "owner": "devteam",
-                "changeset_revision": "bd735cae4ce6",
-                "name": "bamtools_filter",
+                "changeset_revision": "56c31114ad4a",
+                "name": "samtool_filter2",
                 "tool_shed": "toolshed.g2.bx.psu.edu"
             },
-            "uuid": "6bca121a-60e5-4da0-a9ce-32637899ebd7",
+            "uuid": "02e1145b-9f40-4a6a-bf3a-8f0b18fb3408",
             "errors": null,
-            "name": "Filter",
+            "name": "Filter SAM or BAM, output SAM or BAM",
             "post_job_actions": {
-                "HideDatasetActionout_file2": {
-                    "output_name": "out_file2",
+                "HideDatasetActionoutput1": {
+                    "output_name": "output1",
                     "action_type": "HideDatasetAction",
                     "action_arguments": {}
                 }
             },
             "label": null,
-            "inputs": [],
+            "inputs": [
+                {
+                    "name": "bed_file",
+                    "description": "runtime parameter for tool Filter SAM or BAM, output SAM or BAM"
+                },
+                {
+                    "name": "input1",
+                    "description": "runtime parameter for tool Filter SAM or BAM, output SAM or BAM"
+                }
+            ],
             "position": {
-                "top": 1172.59375,
-                "left": 899.875
+                "top": 1158.3333129882812,
+                "left": 895.3333129882812
             },
             "annotation": "",
-            "content_id": "toolshed.g2.bx.psu.edu/repos/devteam/bamtools_filter/bamFilter/2.4.1",
+            "content_id": "toolshed.g2.bx.psu.edu/repos/devteam/samtool_filter2/samtool_filter2/1.8",
             "type": "tool"
         },
         "20": {
@@ -1099,13 +1038,13 @@
             "workflow_outputs": [
                 {
                     "output_name": "output1",
-                    "uuid": "e39819f1-29d4-483d-96d2-82190e540720",
+                    "uuid": "56197be8-170d-49e5-9598-a8c206eda9ae",
                     "label": null
                 }
             ],
             "input_connections": {
                 "input1": {
-                    "output_name": "out_file1",
+                    "output_name": "output1",
                     "id": 16
                 }
             },
@@ -1117,15 +1056,15 @@
                 "name": "samtools_rmdup",
                 "tool_shed": "toolshed.g2.bx.psu.edu"
             },
-            "uuid": "62eaf803-722c-4328-a41b-147f01638803",
+            "uuid": "6c65ebf7-94bc-436f-8b90-30070137e3d0",
             "errors": null,
             "name": "RmDup",
             "post_job_actions": {},
             "label": null,
             "inputs": [],
             "position": {
-                "top": 817.90625,
-                "left": 1117.328125
+                "top": 817.8999938964844,
+                "left": 1117.3333129882812
             },
             "annotation": "",
             "content_id": "toolshed.g2.bx.psu.edu/repos/devteam/samtools_rmdup/samtools_rmdup/2.0.1",
@@ -1143,13 +1082,13 @@
             "workflow_outputs": [
                 {
                     "output_name": "output1",
-                    "uuid": "9b6b803a-ac78-4e70-b359-9e11cc2eb99e",
+                    "uuid": "8faee4cc-2c80-4823-8f46-3682ce0313b5",
                     "label": null
                 }
             ],
             "input_connections": {
                 "input1": {
-                    "output_name": "out_file1",
+                    "output_name": "output1",
                     "id": 17
                 }
             },
@@ -1161,15 +1100,15 @@
                 "name": "samtools_rmdup",
                 "tool_shed": "toolshed.g2.bx.psu.edu"
             },
-            "uuid": "2343fbda-8591-4c53-877f-48e837e40c93",
+            "uuid": "273ff2fd-4ad6-455b-a95b-11db653271bc",
             "errors": null,
             "name": "RmDup",
             "post_job_actions": {},
             "label": null,
             "inputs": [],
             "position": {
-                "top": 992.3125,
-                "left": 1023.4375
+                "top": 992.316650390625,
+                "left": 1023.433349609375
             },
             "annotation": "",
             "content_id": "toolshed.g2.bx.psu.edu/repos/devteam/samtools_rmdup/samtools_rmdup/2.0.1",
@@ -1187,13 +1126,13 @@
             "workflow_outputs": [
                 {
                     "output_name": "output1",
-                    "uuid": "69bd1c1e-2de3-4569-8202-886de8df0973",
+                    "uuid": "73074191-e2fc-43e8-8e6c-e013b036687b",
                     "label": null
                 }
             ],
             "input_connections": {
                 "input1": {
-                    "output_name": "out_file1",
+                    "output_name": "output1",
                     "id": 19
                 }
             },
@@ -1205,15 +1144,15 @@
                 "name": "samtools_rmdup",
                 "tool_shed": "toolshed.g2.bx.psu.edu"
             },
-            "uuid": "570a912a-2e14-45bc-b006-45f2327a855f",
+            "uuid": "b8b7faf0-a025-4b2a-86a5-93f2177914f9",
             "errors": null,
             "name": "RmDup",
             "post_job_actions": {},
             "label": null,
             "inputs": [],
             "position": {
-                "top": 1210.765625,
-                "left": 1127.40625
+                "top": 1210.7666625976562,
+                "left": 1127.4000244140625
             },
             "annotation": "",
             "content_id": "toolshed.g2.bx.psu.edu/repos/devteam/samtools_rmdup/samtools_rmdup/2.0.1",
@@ -1230,8 +1169,18 @@
             ],
             "workflow_outputs": [
                 {
+                    "output_name": "output_failed_alleles_bed",
+                    "uuid": "d6adcb88-46c6-4748-b7e2-5aa87e74d6c2",
+                    "label": null
+                },
+                {
+                    "output_name": "output_trace",
+                    "uuid": "2b87f36c-fe22-4fea-8eb6-f00cad71292c",
+                    "label": null
+                },
+                {
                     "output_name": "output_vcf",
-                    "uuid": "20a74e8a-3482-49d4-8863-7fbba9785f4e",
+                    "uuid": "675eea38-d81a-4c04-a480-6e4b079c7d43",
                     "label": null
                 }
             ],
@@ -1251,7 +1200,7 @@
                     }
                 ]
             },
-            "tool_state": "{\"__page__\": null, \"reference_source\": \"{\\\"__current_case__\\\": 0, \\\"batchmode\\\": {\\\"__current_case__\\\": 0, \\\"input_bams\\\": {\\\"__class__\\\": \\\"RuntimeValue\\\"}, \\\"processmode\\\": \\\"individual\\\"}, \\\"ref_file\\\": \\\"hg19\\\", \\\"reference_source_selector\\\": \\\"cached\\\"}\", \"__rerun_remap_job_id__\": null, \"options_type\": \"{\\\"__current_case__\\\": 1, \\\"options_type_selector\\\": \\\"simple\\\"}\", \"target_limit_type\": \"{\\\"__current_case__\\\": 0, \\\"target_limit_type_selector\\\": \\\"do_not_limit\\\"}\"}",
+            "tool_state": "{\"__page__\": null, \"reference_source\": \"{\\\"__current_case__\\\": 0, \\\"batchmode\\\": {\\\"__current_case__\\\": 0, \\\"input_bams\\\": {\\\"__class__\\\": \\\"ConnectedValue\\\"}, \\\"processmode\\\": \\\"merge\\\"}, \\\"ref_file\\\": \\\"hg19\\\", \\\"reference_source_selector\\\": \\\"cached\\\"}\", \"__rerun_remap_job_id__\": null, \"options_type\": \"{\\\"__current_case__\\\": 1, \\\"options_type_selector\\\": \\\"simple\\\"}\", \"target_limit_type\": \"{\\\"__current_case__\\\": 0, \\\"target_limit_type_selector\\\": \\\"do_not_limit\\\"}\"}",
             "id": 23,
             "tool_shed_repository": {
                 "owner": "devteam",
@@ -1259,15 +1208,15 @@
                 "name": "freebayes",
                 "tool_shed": "toolshed.g2.bx.psu.edu"
             },
-            "uuid": "c73a9fe2-29e6-4b95-8ad0-5f14fdf31f52",
+            "uuid": "db64c7b0-f83d-4496-ae49-b50e6f4077e6",
             "errors": null,
             "name": "FreeBayes",
             "post_job_actions": {},
             "label": null,
             "inputs": [],
             "position": {
-                "top": 1003.625,
-                "left": 1203.015625
+                "top": 1003.6333312988281,
+                "left": 1203.0166625976562
             },
             "annotation": "",
             "content_id": "toolshed.g2.bx.psu.edu/repos/devteam/freebayes/freebayes/1.1.0.46-0",
@@ -1285,7 +1234,7 @@
             "workflow_outputs": [
                 {
                     "output_name": "output_file",
-                    "uuid": "fded8e65-9976-4d0d-bb5c-0bfed953a2f6",
+                    "uuid": "97433d21-36df-496c-8e24-40998b5783d2",
                     "label": null
                 }
             ],
@@ -1295,7 +1244,7 @@
                     "id": 23
                 }
             },
-            "tool_state": "{\"__page__\": null, \"multiallelics\": \"{\\\"__current_case__\\\": 1, \\\"mode\\\": \\\"-\\\", \\\"multiallelic_types\\\": \\\"both\\\"}\", \"sec_restrict\": \"{\\\"regions\\\": {\\\"__current_case__\\\": 0, \\\"regions_src\\\": \\\"__none__\\\"}, \\\"targets\\\": {\\\"__current_case__\\\": 0, \\\"targets_src\\\": \\\"__none__\\\"}}\", \"input_file\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\", \"sec_default\": \"{\\\"site_win\\\": \\\"1000\\\"}\", \"rm_dup\": \"\\\"\\\"\", \"check_ref\": \"\\\"w\\\"\", \"normalize_indels\": \"\\\"true\\\"\", \"reference_source\": \"{\\\"__current_case__\\\": 0, \\\"fasta_ref\\\": \\\"hg19\\\", \\\"reference_source_selector\\\": \\\"cached\\\"}\", \"output_type\": \"\\\"v\\\"\", \"__rerun_remap_job_id__\": null}",
+            "tool_state": "{\"__page__\": null, \"multiallelics\": \"{\\\"__current_case__\\\": 1, \\\"mode\\\": \\\"-\\\", \\\"multiallelic_types\\\": \\\"both\\\"}\", \"sec_restrict\": \"{\\\"regions\\\": {\\\"__current_case__\\\": 0, \\\"regions_src\\\": \\\"__none__\\\"}, \\\"targets\\\": {\\\"__current_case__\\\": 0, \\\"targets_src\\\": \\\"__none__\\\"}}\", \"input_file\": \"{\\\"__class__\\\": \\\"ConnectedValue\\\"}\", \"sec_default\": \"{\\\"site_win\\\": \\\"1000\\\"}\", \"rm_dup\": \"\\\"\\\"\", \"check_ref\": \"\\\"w\\\"\", \"normalize_indels\": \"\\\"true\\\"\", \"reference_source\": \"{\\\"__current_case__\\\": 0, \\\"fasta_ref\\\": \\\"hg19\\\", \\\"reference_source_selector\\\": \\\"cached\\\"}\", \"output_type\": \"\\\"v\\\"\", \"__rerun_remap_job_id__\": null}",
             "id": 24,
             "tool_shed_repository": {
                 "owner": "iuc",
@@ -1303,20 +1252,15 @@
                 "name": "bcftools_norm",
                 "tool_shed": "toolshed.g2.bx.psu.edu"
             },
-            "uuid": "c9941598-4302-47be-ba59-5e39cbd71a9a",
+            "uuid": "0e88d202-12d2-4689-9f71-9183ad0c9ad2",
             "errors": null,
             "name": "bcftools norm",
             "post_job_actions": {},
             "label": null,
-            "inputs": [
-                {
-                    "name": "input_file",
-                    "description": "runtime parameter for tool bcftools norm"
-                }
-            ],
+            "inputs": [],
             "position": {
-                "top": 833.1875,
-                "left": 1336.40625
+                "top": 833.1833343505859,
+                "left": 1336.4000244140625
             },
             "annotation": "",
             "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/bcftools_norm/bcftools_norm/1.9+galaxy1",
@@ -1338,12 +1282,17 @@
             "workflow_outputs": [
                 {
                     "output_name": "snpeff_output",
-                    "uuid": "47f99d01-10a0-4517-ad6f-0cf7cbf30880",
+                    "uuid": "c603b7e6-cf78-4216-b876-19a4cc09dac9",
+                    "label": null
+                },
+                {
+                    "output_name": "csvFile",
+                    "uuid": "89748f1d-638b-4f53-8e6e-54bbf1855b33",
                     "label": null
                 },
                 {
                     "output_name": "statsFile",
-                    "uuid": "f8dca64b-78f0-435e-9e07-1e54b76bed4b",
+                    "uuid": "521a5411-0ae6-440b-be95-408495b08f1f",
                     "label": null
                 }
             ],
@@ -1353,7 +1302,7 @@
                     "id": 24
                 }
             },
-            "tool_state": "{\"spliceSiteSize\": \"\\\"2\\\"\", \"csvStats\": \"\\\"false\\\"\", \"filterOut\": \"null\", \"input\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\", \"inputFormat\": \"\\\"vcf\\\"\", \"__page__\": null, \"outputConditional\": \"{\\\"__current_case__\\\": 0, \\\"outputFormat\\\": \\\"vcf\\\"}\", \"__rerun_remap_job_id__\": null, \"udLength\": \"\\\"5000\\\"\", \"generate_stats\": \"\\\"true\\\"\", \"spliceRegion\": \"{\\\"__current_case__\\\": 0, \\\"setSpliceRegions\\\": \\\"no\\\"}\", \"chr\": \"\\\"\\\"\", \"intervals\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\", \"annotations\": \"null\", \"snpDb\": \"{\\\"__current_case__\\\": 0, \\\"genomeSrc\\\": \\\"cached\\\", \\\"genomeVersion\\\": \\\"hg19\\\", \\\"reg_section\\\": {\\\"regulation\\\": \\\"\\\"}}\", \"offset\": \"\\\"default\\\"\", \"noLog\": \"\\\"true\\\"\", \"transcripts\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\", \"filter\": \"{\\\"__current_case__\\\": 0, \\\"specificEffects\\\": \\\"no\\\"}\"}",
+            "tool_state": "{\"spliceSiteSize\": \"\\\"2\\\"\", \"csvStats\": \"\\\"false\\\"\", \"filterOut\": \"null\", \"input\": \"{\\\"__class__\\\": \\\"ConnectedValue\\\"}\", \"inputFormat\": \"\\\"vcf\\\"\", \"__page__\": null, \"outputConditional\": \"{\\\"__current_case__\\\": 0, \\\"outputFormat\\\": \\\"vcf\\\"}\", \"__rerun_remap_job_id__\": null, \"udLength\": \"\\\"5000\\\"\", \"generate_stats\": \"\\\"true\\\"\", \"spliceRegion\": \"{\\\"__current_case__\\\": 0, \\\"setSpliceRegions\\\": \\\"no\\\"}\", \"chr\": \"\\\"\\\"\", \"intervals\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\", \"annotations\": \"null\", \"snpDb\": \"{\\\"__current_case__\\\": 0, \\\"genomeSrc\\\": \\\"cached\\\", \\\"genomeVersion\\\": \\\"hg19\\\", \\\"reg_section\\\": {\\\"regulation\\\": \\\"\\\"}}\", \"offset\": \"\\\"default\\\"\", \"noLog\": \"\\\"true\\\"\", \"transcripts\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\", \"filter\": \"{\\\"__current_case__\\\": 0, \\\"specificEffects\\\": \\\"no\\\"}\"}",
             "id": 25,
             "tool_shed_repository": {
                 "owner": "iuc",
@@ -1361,7 +1310,7 @@
                 "name": "snpeff",
                 "tool_shed": "toolshed.g2.bx.psu.edu"
             },
-            "uuid": "c88d8707-e994-43ba-9769-cf6dec128a75",
+            "uuid": "02ce6c03-7a90-46c2-8d38-3fce5366eaab",
             "errors": null,
             "name": "SnpEff eff:",
             "post_job_actions": {},
@@ -1372,17 +1321,13 @@
                     "description": "runtime parameter for tool SnpEff eff:"
                 },
                 {
-                    "name": "input",
-                    "description": "runtime parameter for tool SnpEff eff:"
-                },
-                {
                     "name": "transcripts",
                     "description": "runtime parameter for tool SnpEff eff:"
                 }
             ],
             "position": {
-                "top": 1131.5625,
-                "left": 1402.4375
+                "top": 1131.566650390625,
+                "left": 1402.433349609375
             },
             "annotation": "",
             "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/snpeff/snpEff/4.3+T.galaxy1",
@@ -1400,7 +1345,7 @@
             "workflow_outputs": [
                 {
                     "output_name": "outfile",
-                    "uuid": "337b76b9-5b38-47d4-a8cf-364a37b24a88",
+                    "uuid": "577de18e-afea-4da1-9037-de44f8135b39",
                     "label": null
                 }
             ],
@@ -1422,15 +1367,15 @@
                 "name": "gemini_load",
                 "tool_shed": "toolshed.g2.bx.psu.edu"
             },
-            "uuid": "5f7e5403-4105-4457-bf93-96f43bd9b07a",
+            "uuid": "3810da92-8f0d-4444-b4a3-bd7aefcc7642",
             "errors": null,
             "name": "GEMINI load",
             "post_job_actions": {},
             "label": null,
             "inputs": [],
             "position": {
-                "top": 1180.296875,
-                "left": 1691.140625
+                "top": 1180.2999877929688,
+                "left": 1691.13330078125
             },
             "annotation": "",
             "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/gemini_load/gemini_load/0.20.1+galaxy1",
@@ -1448,7 +1393,7 @@
             "workflow_outputs": [
                 {
                     "output_name": "outfile",
-                    "uuid": "125a9901-867f-433b-bbd3-adadfec831a4",
+                    "uuid": "619c4e05-3d18-4038-9e2b-a030f0d59020",
                     "label": null
                 }
             ],
@@ -1466,7 +1411,7 @@
                 "name": "gemini_inheritance",
                 "tool_shed": "toolshed.g2.bx.psu.edu"
             },
-            "uuid": "2d1ea0f7-7684-4cea-bd2b-2f10c03007b0",
+            "uuid": "eecc879f-93bc-4513-840e-b56704e5ed77",
             "errors": null,
             "name": "GEMINI inheritance pattern",
             "post_job_actions": {},
@@ -1474,7 +1419,7 @@
             "inputs": [],
             "position": {
                 "top": 1025,
-                "left": 1667.40625
+                "left": 1667.4000244140625
             },
             "annotation": "",
             "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/gemini_inheritance/gemini_inheritance/0.20.1",

--- a/topics/variant-analysis/tutorials/somatic-variants/tutorial.md
+++ b/topics/variant-analysis/tutorials/somatic-variants/tutorial.md
@@ -419,23 +419,62 @@ read mappings we will do some postprocessing next.
 
 ## Filtering on mapped reads properties
 
-To produce new filtered BAM datasets with only those reads retained that
-have a minimal mapping quality of 1 and are mapped in a proper pair:
+To produce new filtered BAM datasets with only those reads retained that have
+been mapped to the reference successfully, have a minimal mapping quality of 1,
+and for which the mate read has also been mapped:
 
 > ### {% icon hands_on %} Hands-on: Filtering for mapping status and quality
 >
-> 1. **Filter SAM or BAM, output SAM or BAM** {% icon tool %} with the following
-> parameters (leaving non-mentioned ones at their defaults):
->   - {% icon param-files %} *"SAM or BAM file to filter"*: mapped reads datasets from
->     the normal *and* the tumor tissue data, outputs of **Map with BWA-MEM** {% icon tool %}
->   - *"Minimum MAPQ quality score"*: `1`
->   - *"Filter on bitwise flag"*: `yes`
->     - *"Only output alignments with all of these flag bits set"*:
->        - {% icon param-check %} *"Read is mapped in a proper pair"*
+> 1. **Filter BAM datasets on a variety of attributes** {% icon tool %} with the following parameters:
+>   - {% icon param-files %} *"BAM dataset(s) to filter"*: mapped reads
+>     datasets from the normal *and* the tumor tissue data, outputs of
+>     **Map with BWA-MEM** {% icon tool %}
+>   - In *"Condition"*:
+>     - In *"1: Condition"*:
+>       - In *"Filter"*:
+>         - In *"1: Filter"*:
+>           - *"Select BAM property to filter on"*: `mapQuality`
+>             - *"Filter on read mapping quality (phred scale)"*: `1`
+>         - In *"2: Filter"*:
+>           - *"Select BAM property to filter on"*: `isMapped`
+>             - *"Selected mapped reads"*: `Yes`
+>         - Click on *"Insert Filter"*
+>         - In *"3: Filter"*:
+>           - *"Select BAM property to filter on"*: `isMateMapped`
+>             - *"Select reads with mapped mate"*: `Yes`
+>
+>       When you configure multiple filters within one condition, reads have
+>       to pass *all* the filters to be retained in the output. The above
+>       settings, thus, retain only read pairs, for which both mates are
+>       mapped.
+>
+>       Note that filtering for a minimal mapping quality is not strictly
+>       necessary. Most variant callers (including **VarScan somatic, which we
+>       will be using later) have an option for using only reads above a
+>       certain mapping quality. In this section, however, we are going to
+>       process the retained reads further rather extensively so it pays off
+>       in terms of performance to eliminate reads we do not plan to use at an
+>       early step.
+>
+>   - *"Would you like to set rules?"*: `No`
 >
 {: .hands_on}
 
 This will result in two new datasets, one for each of the normal and tumor data.
+
+> ### {% icon details %} Tools for filtering BAM datasets
+> The related tutorial on variant detection from exome-seq data, demonstrates
+> nearly identical filtering of BAM datasets using the tool **Filter BAM
+> datasets on a variety of attributes** {% icon tool %}.
+>
+> These two tools offer very similar functionality and can often be used
+> interchangeably. Under the hood, **Filter SAM or BAM, output SAM or BAM**
+> {% icon tool %} uses the `samtools view` command line tool, while **Filter
+> BAM datasets on a variety of attributes** {% icon tool %} uses `bamtools
+> filter`. Whatever the BAM filtering task, you should be able to perform it in
+> Galaxy with one of these two tools.
+>
+{: .details}
 
 ## Removing duplicate reads
 
@@ -536,6 +575,30 @@ As before, this will generate two new datasets, one for each of the normal and t
 This will, once more, produce two new datasets, one for each of the normal
 and tumor data.
 
+## Refilter reads based on mapping quality
+
+During recalibration of read mapping qualities **CalMD** may have set some
+mapping quality scores to 255. This special value is reserved for *undefined*
+mapping qualities and is used by the tool when a recalibrated mapping quality
+would drop below zero. In other words, a value of 255 does not indicate a
+particularly good mapping score, but a really poor one.
+To remove such reads from the data:
+
+> ### {% icon hands_on %} Hands-on: Eliminating reads with undefined mapping quality
+>
+> 1. **Filter BAM datasets on a variety of attributes** {% icon tool %} with the following parameters:
+>   - {% icon param-files %} *"BAM dataset(s) to filter"*: the recalibrated
+>     datasets from the normal and the tumor tissue data; the outputs of
+>     **CalMD** {% icon tool %}
+>   - In *"Condition"*:
+>     - In *"1: Condition"*:
+>       - In *"Filter"*:
+>         - In *"1: Filter"*:
+>           - *"Select BAM property to filter on"*: `mapQuality`
+>             - *"Filter on read mapping quality (phred scale)"*: `<=254`
+>
+{: .hands_on}
+
 
 # Variant calling and classification
 
@@ -559,8 +622,8 @@ somatic variant calling that:
 >      > ### {% icon comment %} Using the imported `hg19` sequence
 >      > If you have imported the `hg19` sequence as a fasta dataset into your
 >      > history instead:
->      >   - *"Will you select a reference genome from your history or use a built-in
->      >     genome?"*: `Use a genome from the history`
+>      >   - *"Will you select a reference genome from your history or use a
+>      >     built-in genome?"*: `Use a genome from the history`
 >      >      - {% icon param-file %} *"reference genome"*: your imported `hg19` fasta dataset.
 >      {: .comment}
 >
@@ -584,9 +647,9 @@ somatic variant calling that:
 >
 >      - *"Minimum mapping quality"*: `1`
 >
->        During postprocessing, we have filtered our reads for ones with a mapping
->        quality of at least one, so requiring this quality also here does not
->        actually change the results, but it makes the requirement more explicit.
+>        During postprocessing, we have filtered our reads for ones with a
+>        mapping quality of at least one, but **CalMD** may have lowered some
+>        mapping qualities to zero afterwards.
 >
 >      Leave all other settings in this section at their default values.
 >    - *"Settings for Posterior Variant Filtering"*: `Use default values`
@@ -656,7 +719,7 @@ license.
 >    > `Homo sapiens: hg19` as a locally installed snpEff database. You can
 >    > check the **SnpEff eff** {% icon tool%} tool under **Genome source** to
 >    > see if this is the case.
->    {: .tip}
+>    {: .comment}
 >
 >    Use **SnpEff Download** {% icon tool %} to download genome annotation
 >    database `hg19`.
@@ -894,30 +957,6 @@ want to add:
 >        This recipe extracts the dbSNP *SAO* field and adds it as *rs_ss* to
 >        the GEMINI database.
 >
->      - {% icon param-repeat %} *"Insert Annotation extraction recipe"*
->      - In *"2: Annotation extraction recipe"*:
->        - *"Elements to extract from the annotation source"*: `CFL`
->        - *"Database column name to use for recording annotations"*:
->       `rs_cfl`
->        - *"What type of data are you trying to extract?"*: `Numbers with
->        decimal precision`
->        - *"If multiple annotations are found for the same variant,
->        store ..."*: `the first annotation found`
->
->        This recipe extracts the dbSNP *CFL* field and adds it as *rs_cfl* to
->        the GEMINI database.
->
->      - {% icon param-repeat %} *"Insert Annotation extraction recipe"*
->      - In *"3: Annotation extraction recipe"*:
->        - *"Elements to extract from the annotation source"*: `ASP`
->        - *"Database column name to use for recording annotations"*:
->       `rs_asp`
->        - *"What type of data are you trying to extract?"*: `Integer numbers`
->        - *"If multiple annotations are found for the same variant,
->        store ..."*: `the first annotation found`
->
->        This recipe extracts the dbSNP *ASP* field and adds it as *rs_asp* to
->        the GEMINI database.
 > 2. **GEMINI annotate** {% icon tool %} to add further annotations from **cancerhotspots**
 >    - {% icon param-file %} *"GEMINI database"*: the output of the last
 >      **GEMINI annotate** {% icon tool %} run
@@ -1099,12 +1138,10 @@ What about more sophisticated filtering?
 
 > ### {% icon hands_on %} Hands-on: More complex filter criteria
 > 1. **GEMINI query** {% icon tool %} with the exact same settings as before, but:
->    - *"Additional constraints expressed in SQL syntax"*: `somatic_status = 2 AND somatic_p <= 0.05 AND (filter IS NULL OR rs_ids IS NOT NULL) AND rs_cfl != 1 AND rs_asp != 1`
+>    - *"Additional constraints expressed in SQL syntax"*: `somatic_status = 2 AND somatic_p <= 0.05 AND filter IS NULL`
 >
 >     This translates into "variants classified as somatic with a p-value <=
->     0.05, which haven't been flagged as likely false-positives or, if so, are
->     listed in dbSNP, but in there, are not flagged as being assembly-dependent
->     or -specific".
+>     0.05, which haven't been flagged as likely false-positives".
 {: .hands_on}
 
 > ### {% icon comment %} SQL keywords
@@ -1192,8 +1229,7 @@ advanced mode for composing the query.
 >     g.synonym, g.hgnc_id, g.entrez_id, g.rvis_pct, v.clinvar_gene_phenotype
 >     FROM variants v, gene_detailed g WHERE v.chrom = g.chrom AND
 >     v.gene = g.gene AND v.somatic_status = 2 AND v.somatic_p <= 0.05 AND
->     (v.filter IS NULL OR v.rs_ids IS NOT NULL) AND v.rs_cfl != 1 and
->     v.rs_asp != 1 GROUP BY g.gene`
+>     v.filter IS NULL GROUP BY g.gene`
 >
 >     > ### {% icon comment %} Elements of the SQL query
 >     > In this full SQL query, the part between `SELECT` and `FROM` states which


### PR DESCRIPTION
Different possibilities for filtering BAM reads get explained in
detail now in the exome-seq and somatic variants tutorials.
Dysfunctional usage of gemini annotate has been eliminated from the
somatic variants tutorial.