### PR TITLE
Add citation to every tutorial page

### DIFF
--- a/_includes/contributor-author-list-comma.html
+++ b/_includes/contributor-author-list-comma.html
@@ -1,0 +1,6 @@
+{%- if include.contributors -%}
+{%- capture people -%}
+{% for id in include.contributors %}, {% assign name = contributors[id].name | default: id -%}{{ name -}}{%- endfor -%}
+{%- endcapture -%}
+{%- endif -%}
+{{- people | remove_first: ', ' -}}

--- a/_includes/contributor-author-list.html
+++ b/_includes/contributor-author-list.html
@@ -1,0 +1,6 @@
+{%- if include.contributors -%}
+{%- capture people -%}
+{% for id in include.contributors %} and {% assign name = contributors[id].name | default: id -%}{{ name -}}{%- endfor -%}
+{%- endcapture -%}
+{%- endif -%}
+{{- people | remove_first: ' and ' -}}

--- a/_layouts/tutorial_hands_on.html
+++ b/_layouts/tutorial_hands_on.html
@@ -225,9 +225,9 @@ layout: base
                     {% endif %}
 
                     <h1>Citing this Tutorial</h1>
-                    <p id="citation-text">
+                    <p>
                         <ol>
-                            <li>
+                            <li id="citation-text">
                             {%- include _includes/contributor-author-list-comma.html contributors=page.contributors -%}, {{ page.last_modified_at | date: "%Y" }} <b>{{ page.title }} (Galaxy Training Materials)</b>. <a href="{{ site.baseurl }}{{page.url}}">{{ site.baseurl }}{{page.url}}</a> Online; accessed TODAY
                             </li>
                             <li>

--- a/_layouts/tutorial_hands_on.html
+++ b/_layouts/tutorial_hands_on.html
@@ -98,7 +98,7 @@ layout: base
         {% endif %}
 
         <div class="contributors-line">By: {% include _includes/contributor-badge-list.html contributors=page.contributors %}</div>
-        
+
         <blockquote class="overview">
             <h3>Overview</h3>
             <strong>{% icon question %} Questions</strong>
@@ -223,6 +223,58 @@ layout: base
                     <h1 id="bibliography">References</h1>
                     {% bibliography --cited %}
                     {% endif %}
+
+                    <h1>Citing this Tutorial</h1>
+                    <p id="citation-text">
+                        <ol>
+                            <li>
+                            {%- include _includes/contributor-author-list-comma.html contributors=page.contributors -%}, {{ page.last_modified_at | date: "%Y" }} <b>{{ page.title }} (Galaxy Training Materials)</b>. <a href="{{ site.baseurl }}{{page.url}}">{{ site.baseurl }}{{page.url}}</a> Online; accessed TODAY
+                            </li>
+                            <li>
+                            Batut et al., 2018 <b>Community-Driven Data Analysis Training for Biology</b> Cell Systems <a href="https://doi.org/10.1016%2Fj.cels.2018.05.012">10.1016/j.cels.2018.05.012</a>
+                            </li>
+                        </ol>
+                    </p>
+
+
+                    <blockquote class="details">
+                      <h3><i class="fa fa-info-circle" aria-hidden="true"></i><span class="visually-hidden">details</span> BibTeX</h3>
+                      <p style="display: none;">
+
+                    <div class="highlighter-rouge"><div class="highlight"><pre class="highlight">
+<code id="citation-code">@misc{% raw %}{{% endraw %}{{topic.name}}-{{page.tutorial_name}},
+    author = "{%- include _includes/contributor-author-list.html contributors=page.contributors -%}",
+    title = "{{ page.title }} (Galaxy Training Materials)",
+    year = "{{ page.last_modified_at | date: "%Y"}}",
+    month = "{{ page.last_modified_at | date: "%m"}}",
+    day = "{{ page.last_modified_at | date: "%d" }}"
+    url = "{% raw %}\url{{% endraw %}{{ site.baseurl }}{{page.url}}{% raw %}}{% endraw %}",
+    note = "[Online; accessed TODAY]"
+}
+@article{Batut_2018,
+        doi = {10.1016/j.cels.2018.05.012},
+        url = {https://doi.org/10.1016%2Fj.cels.2018.05.012},
+        year = 2018,
+        month = {jun},
+        publisher = {Elsevier {BV}},
+        volume = {6},
+        number = {6},
+        pages = {752--758.e1},
+        author = {B{\'{e}}r{\'{e}}nice Batut and Saskia Hiltemann and Andrea Bagnacani and Dannon Baker and Vivek Bhardwaj and Clemens Blank and Anthony Bretaudeau and Loraine Brillet-Gu{\'{e}}guen and Martin {\v{C}}ech and John Chilton and Dave Clements and Olivia Doppelt-Azeroual and Anika Erxleben and Mallory Ann Freeberg and Simon Gladman and Youri Hoogstrate and Hans-Rudolf Hotz and Torsten Houwaart and Pratik Jagtap and Delphine Larivi{\`{e}}re and Gildas Le Corguill{\'{e}} and Thomas Manke and Fabien Mareuil and Fidel Ram{\'{\i}}rez and Devon Ryan and Florian Christoph Sigloch and Nicola Soranzo and Joachim Wolff and Pavankumar Videm and Markus Wolfien and Aisanjiang Wubuli and Dilmurat Yusuf and James Taylor and Rolf Backofen and Anton Nekrutenko and Björn Grüning},
+        title = {Community-Driven Data Analysis Training for Biology},
+        journal = {Cell Systems}
+}</code>
+                    </pre></div></div>
+                    </p>
+                    </blockquote>
+
+
+<script type="text/javascript">
+// update the date on load, or leave fallback of 'today'
+d = new Date();
+document.getElementById("citation-code").innerHTML = document.getElementById("citation-code").innerHTML.replace("TODAY", d.toDateString());
+document.getElementById("citation-text").innerHTML = document.getElementById("citation-text").innerHTML.replace("TODAY", d.toDateString());
+</script>
 
                 </div>
             </div>


### PR DESCRIPTION
This adds a box which helps users cite the tutorial + training material. the urls should be correct when deployed.

Hopefully it will make it easier for users to find the proper citations.

![image](https://user-images.githubusercontent.com/458683/68298158-f396d980-0098-11ea-99e1-d7b334ec39fc.png)
