### PR TITLE
Broken box detection

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -140,6 +140,10 @@ check-framework:
 		ruby _plugins/jekyll-notranslate.rb
 .PHONY: check-framework
 
+check-broken-boxes: build ## List tutorials containing broken boxes
+	./bin/check-broken-boxes
+.PHONY: check-broken-boxes
+
 check: check-yaml check-frontmatter check-html-internal check-html check-slides check-workflows check-references check-snippets ## run all checks
 .PHONY: check
 

--- a/bin/check-broken-boxes
+++ b/bin/check-broken-boxes
@@ -13,7 +13,7 @@ BROKEN_BOXES="$(diff \
 	grep '^>' | \
 	sed 's/^> //g;s/html$/md/')"
 
-BROKEN_TUTOS=$(echo "$BROKEN_BOXES" | wc -l)
+BROKEN_TUTOS=$(echo "$BROKEN_BOXES" | wc -c)
 
 for box in ${BROKEN_BOXES}; do
 	warning "Broken boxes in $box"

--- a/bin/check-broken-boxes
+++ b/bin/check-broken-boxes
@@ -7,9 +7,15 @@ warning() {
 	(>&2 echo "$(tput setab 2)$*$(tput sgr0)")
 }
 
+html2md() {
+	cat | sed 's|_site/training-material/||;s|html$|md|'
+}
+
+DISABLED_TUTOS="$(grep 'enable:.*false' -R topics/*/tutorials/*/tutorial.md -l)"
+
 BROKEN_BOXES="$(diff \
-	<(grep 'enable:.*false' -R topics/*/tutorials/*/tutorial.md -l | sed 's/md$/html/' ) \
-	<(grep '<blockquote>' `find _site -name 'tutorial.html' ` -l | sort -u | sed 's|_site/training-material/||' | sort -u) | \
+	<(echo "$DISABLED_TUTOS" ) \
+	<(grep '<blockquote>' $(find _site -name 'tutorial.html') -l | sort -u | html2md | sort -u) | \
 	grep '^>' | \
 	sed 's/^> //g;s/html$/md/')"
 
@@ -19,6 +25,42 @@ for box in ${BROKEN_BOXES}; do
 	warning "Broken boxes in $box"
 	html=$(echo "$box" | sed 's/md$/html/')
 	grep --color=always '<blockquote>' -A5 -B5 _site/training-material/$html
+done
+
+WRONG_BOXES="$(grep '<blockquote[^>]*' $(find _site -name 'tutorial.html') | sed 's/notranslate//g;s/\s*<[^"]*"\s*//g;s/\s*".*//g' |grep -v 'agenda' | grep -v no_toc)"
+
+for line in ${WRONG_BOXES}; do
+	file=$(echo "$line" | sed 's/:.*//g')
+	mdfile=$(echo "$file" | html2md)
+
+	# Check if tuto is disabled
+	echo "$DISABLED_TUTOS" | grep --quiet "$mdfile"
+	ec=$?
+	if (( ec == 0 )); then
+		continue
+	fi
+
+	# Otherwise compare tags to our list of expected values
+	tags=$(echo "$line" | sed 's/.*://g' | sed 's/\s*//g')
+	case $tags in
+		details         ) ;;
+		comment         ) ;;
+		hands_on        ) ;;
+		tip             ) ;;
+		question        ) ;;
+		solution        ) ;;
+		key_points      ) ;;
+		feedback        ) ;;
+		overview        ) ;;
+		warning         ) ;;
+		quote           ) ;;
+		#matrix          ) ;;
+		imgur-embed-pub ) ;;
+		*)
+			warning "Issue with $tags in $mdfile";
+			grep --color=always "{.*:.*$tags.*}" -A5 -B5 "$mdfile"
+			;;
+	esac
 done
 
 

--- a/bin/check-broken-boxes
+++ b/bin/check-broken-boxes
@@ -1,0 +1,27 @@
+#!/bin/bash
+
+# First find the disabled tutorials, we don't care if boxes are broken there
+# Then find any 'raw' blockquote (missing any classes)
+# and diff those, removing everything from the disabled list.
+warning() {
+	(>&2 echo "$(tput setab 2)$*$(tput sgr0)")
+}
+
+BROKEN_BOXES="$(diff \
+	<(grep 'enable:.*false' -R topics/*/tutorials/*/tutorial.md -l | sed 's/md$/html/' ) \
+	<(grep '<blockquote>' `find _site -name 'tutorial.html' ` -l | sort -u | sed 's|_site/training-material/||' | sort -u) | \
+	grep '^>' | \
+	sed 's/^> //g;s/html$/md/')"
+
+BROKEN_TUTOS=$(echo "$BROKEN_BOXES" | wc -l)
+
+for box in ${BROKEN_BOXES}; do
+	warning "Broken boxes in $box"
+	html=$(echo "$box" | sed 's/md$/html/')
+	grep --color=always '<blockquote>' -A5 -B5 _site/training-material/$html
+done
+
+
+if (( BROKEN_TUTOS > 0 )); then
+	exit 1;
+fi

--- a/bin/check-broken-boxes
+++ b/bin/check-broken-boxes
@@ -1,5 +1,4 @@
 #!/bin/bash
-
 # First find the disabled tutorials, we don't care if boxes are broken there
 # Then find any 'raw' blockquote (missing any classes)
 # and diff those, removing everything from the disabled list.
@@ -12,6 +11,7 @@ html2md() {
 }
 
 DISABLED_TUTOS="$(grep 'enable:.*false' -R topics/*/tutorials/*/tutorial.md -l)"
+
 
 BROKEN_BOXES="$(diff \
 	<(echo "$DISABLED_TUTOS" ) \
@@ -28,6 +28,8 @@ for box in ${BROKEN_BOXES}; do
 done
 
 WRONG_BOXES="$(grep '<blockquote[^>]*' $(find _site -name 'tutorial.html') | sed 's/notranslate//g;s/\s*<[^"]*"\s*//g;s/\s*".*//g' |grep -v 'agenda' | grep -v no_toc)"
+
+WRONG_TAG_EC=0
 
 for line in ${WRONG_BOXES}; do
 	file=$(echo "$line" | sed 's/:.*//g')
@@ -54,16 +56,23 @@ for line in ${WRONG_BOXES}; do
 		overview        ) ;;
 		warning         ) ;;
 		quote           ) ;;
-		#matrix          ) ;;
+		matrix          ) ;;
 		imgur-embed-pub ) ;;
 		*)
 			warning "Issue with $tags in $mdfile";
 			grep --color=always "{.*:.*$tags.*}" -A5 -B5 "$mdfile"
+			WRONG_TAG_EC=1
 			;;
 	esac
 done
 
 
-if (( BROKEN_TUTOS > 0 )); then
+if (( BROKEN_TUTOS > 1 )); then
 	exit 1;
 fi
+
+if (( WRONG_TAG_EC > 0 )); then
+	exit 2;
+fi
+
+exit 0

--- a/topics/computational-chemistry/tutorials/analysis-md-simulations/tutorial.md
+++ b/topics/computational-chemistry/tutorials/analysis-md-simulations/tutorial.md
@@ -99,16 +99,16 @@ RMSD, or root-mean-square deviation, is a standard measure of structural distanc
 ![Snapshot of RMSD plot]({{ site.baseurl }}{% link topics/computational-chemistry/images/RMSD_plot_33.png %} "RMSD plot for a short CBH1 simulation")
 ![Snapshot of RMSD histogram]({{ site.baseurl }}{% link topics/computational-chemistry/images/RMSD_Histogram_Plot_34.png %} "RMSD histogram for a short CBH1 simulation")
 
-> > ### {% icon question %} Question
+> ### {% icon question %} Question
+>
+> What do the features in the RMSD plot tell us?
+>
+> > ### {% icon solution %} Solution
+> > The increase in the RMSD plot with time shows the protein steadily deviates from its original conformation.
 > >
-> > What do the features in the RMSD plot tell us?
-> >
-> > > ### {% icon solution %} Solution
-> > > The increase in the RMSD plot with time shows the protein steadily deviates from its original conformation.
-> > >
-> > > The three peaks visible in the histogram suggests the presence of three main conformations which are accessed during the trajectory.
-> > {: .solution}
-> {: .question}
+> > The three peaks visible in the histogram suggests the presence of three main conformations which are accessed during the trajectory.
+> {: .solution}
+{: .question}
 
 
 ## RMSF
@@ -170,14 +170,14 @@ In summary:
 
 ![Snapshot of PCA plot]({{ site.baseurl }}{% link topics/computational-chemistry/images/PCA_plot_46.png %} "PCA plot for a short CBH1 simulation")
 
-> > ### {% icon question %} Question
-> >
-> > What do the features in the RMSD plot tell us? Do the principal coordinates have a meaning?
-> >
-> > > ### {% icon solution %} Solution
-> > > Here, PCA shows the statistically meaningful conformations in the CBH1 trajectory. The principal motions within the trajectory and the vital motions needed for conformational changes can be identified. Two distinct groupings along the PC1 plane, indicating a non-periodic conformational change, are identified. The groupings along the PC2 and PC3 planes do not completely cluster separately, implying that these global motions are periodic. The PC1 is linked to an active site motion that limits the motion to a key glycosidic bond.
-> > {: .solution}
-> {: .question}
+> ### {% icon question %} Question
+>
+> What do the features in the RMSD plot tell us? Do the principal coordinates have a meaning?
+>
+> > ### {% icon solution %} Solution
+> > Here, PCA shows the statistically meaningful conformations in the CBH1 trajectory. The principal motions within the trajectory and the vital motions needed for conformational changes can be identified. Two distinct groupings along the PC1 plane, indicating a non-periodic conformational change, are identified. The groupings along the PC2 and PC3 planes do not completely cluster separately, implying that these global motions are periodic. The PC1 is linked to an active site motion that limits the motion to a key glycosidic bond.
+> {: .solution}
+{: .question}
 
 ## Workflow vs. individual tools
 You can choose to use the tools one by one as described above, or alternatively combine into a single analysis using the workflow provided.

--- a/topics/computational-chemistry/tutorials/md-simulation-gromacs/tutorial.md
+++ b/topics/computational-chemistry/tutorials/md-simulation-gromacs/tutorial.md
@@ -34,10 +34,10 @@ Molecular dynamics (MD) is a method to simulate molecular motion by iterative ap
 
 Multiple packages exist for performing MD simulations. One of the most popular is the open-source GROMACS, which is the subject of this tutorial. Other MD packages which are also wrapped in Galaxy are [NAMD]({{ site.baseurl }}{% link topics/computational-chemistry/tutorials/md-simulation-namd/tutorial.md %}) and CHARMM (available in the [docker container](https://github.com/scientificomputing/BRIDGE)).
 
-This is a introductory guide to using GROMACS ({% cite abraham15 %}) in Galaxy to prepare and perform molecular dynamics on a small protein. For the tutorial, we will perform our simulations on hen egg white lysozyme. 
+This is a introductory guide to using GROMACS ({% cite abraham15 %}) in Galaxy to prepare and perform molecular dynamics on a small protein. For the tutorial, we will perform our simulations on hen egg white lysozyme.
 
 > ### {% icon comment %} More information
-> This guide is based on the GROMACS tutorial provided by Justin Lemkul [here](http://www.mdtutorials.com/gmx/lysozyme/index.html) - please consult it if you are interested in a more detailed, technical guide to GROMACS. 
+> This guide is based on the GROMACS tutorial provided by Justin Lemkul [here](http://www.mdtutorials.com/gmx/lysozyme/index.html) - please consult it if you are interested in a more detailed, technical guide to GROMACS.
 {: .comment}
 
 > ### Agenda
@@ -256,14 +256,14 @@ Note that we can continue where the last simulation left off (with new parameter
 >    - *"Generate detailed log"*: `Yes`
 {: .hands_on}
 
-> > ### {% icon question %} Question
-> >
-> > Why is the position of the protein restrained during equilibration?
-> >
-> > > ### {% icon solution %} Solution
-> > > The purpose of equilibration is to stabilize the temperature and pressure of the system; these are overwhelmingly dependent on the solvent. Structural changes in the protein are an additional complicating variable, which can more simply be removed by restraining the protein.
-> > {: .solution}
-> {: .question}
+> ### {% icon question %} Question
+>
+> Why is the position of the protein restrained during equilibration?
+>
+> > ### {% icon solution %} Solution
+> > The purpose of equilibration is to stabilize the temperature and pressure of the system; these are overwhelmingly dependent on the solvent. Structural changes in the protein are an additional complicating variable, which can more simply be removed by restraining the protein.
+> {: .solution}
+{: .question}
 
 
 # Production simulation

--- a/topics/computational-chemistry/tutorials/setting-up-molecular-systems/tutorial.md
+++ b/topics/computational-chemistry/tutorials/setting-up-molecular-systems/tutorial.md
@@ -100,9 +100,10 @@ The 7CEL [PDB](https://files.rcsb.org/download/7CEL.pdb) does not include a comp
 >    {% include snippets/create_new_history.md %}
 >
 > 2. Import the files from the Zenodo link provided.
->    >    ```
->    > https://zenodo.org/record/2600690
->    >    ```
+>
+>    ```
+>    https://zenodo.org/record/2600690
+>    ```
 >
 >    {% include snippets/import_via_link.md %}
 >    {% include snippets/import_from_data_library.md %}
@@ -119,7 +120,7 @@ It is convenient to set up the molecular system outside Galaxy using a tool such
 
 > ### {% icon tip %} Tip: Viewing figures
 > * Some of the figures are screenshots and it may be difficult to make out details
-> * Right-click on the image and choose 'Open image in new tab' to view 
+> * Right-click on the image and choose 'Open image in new tab' to view
 > * Zoom in and out as needed to see the content
 {: .tip}
 
@@ -133,7 +134,7 @@ Go to the correct section depending on which MD engine you will be using.
 [Navigate to CHARMM-GUI](http://www.charmm-gui.org/?doc=input/pdbreader) and use the Input Generator, specifically the PDB Reader tool and upload the Cellulase PDB file. Press 'Next Step: Select Model/Chain' in the bottom right corner.
 
 > ### {% icon hands_on %} Hands-on: Upload the PDB to CHARMM-GUI
-> 
+>
 > 1. Retrieve the modelled PDB structure from [Zenodo](https://doi.org/10.5281/zenodo.2600690).
 > 2. Upload the PDB and choose CHARMM format.
 > ![Snapshot of CHARMM-GUI PDB reader section]({{ site.baseurl }}{% link topics/computational-chemistry/images/charmmgui-reader.png %} "The CHARMM-GUI PDB Reader tool")
@@ -197,19 +198,17 @@ Go to the correct section depending on which MD engine you will be using.
 > ![Snapshot of CHARMM-GUI waterbox section]({{ site.baseurl }}{% link topics/computational-chemistry/images/charmmgui-waterbox.png %} "Setting up a waterbox in CHARMM-GUI")
 {: .hands_on}
 
-> > ### {% icon question %} Question
+> ### {% icon question %} Question
+>
+> Why is 10 angstrom a fair choice for the buffer?  Why choose 0.15M NaCl?
+>
+> > ### {% icon solution %} Solution
+> > Under periodic boundary conditions, we need to ensure the protein can never interact with its periodic image, otherwise artefacts are introduced. Allowing 10 angstroms between the protein and the box edge ensures the two images will always be at minimum 20 angstroms apart, which is sufficient.
 > >
-> > Why is 10 angstrom a fair choice for the buffer?  Why choose 0.15M NaCl?
-> >
-> > > ### {% icon solution %} Solution
-> > > Under periodic boundary conditions, we need to ensure the protein can never interact with its periodic image, otherwise artefacts are introduced. Allowing 10 angstroms between the protein and the box edge ensures the two images will always be at minimum 20 angstroms apart, which is sufficient.
-> > >
-> > > Some of the residues on the protein surface are charged and counter-ions need to be present nearby to neutralise them. Failure to explicitly model salt ions may destabilise the protein.
-> > {: .solution}
-> {: .question}
+> > Some of the residues on the protein surface are charged and counter-ions need to be present nearby to neutralise them. Failure to explicitly model salt ions may destabilise the protein.
+> {: .solution}
+{: .question}
 
-
-{: .details}
 
 ### Generate the FFT automatically
 

--- a/topics/contributing/tutorials/create-new-topic/tutorial.md
+++ b/topics/contributing/tutorials/create-new-topic/tutorial.md
@@ -63,7 +63,9 @@ The templates for the tutorials are different from the other pages to help users
 
 The content of each tutorial is generated with [Jekyll](https://jekyllrb.com/) from a Markdown file and some metadata (e.g. the requirements, the Zenodo link, the questions) defined inside the metadata of the related topic.
 
-Want to contribute to a tutorial? Check out [our training materials about that]({{ site.baseurl }}{% link topics/contributing/index.md %}).
+> ### {% icon comment %} Contributing
+> Want to contribute to a tutorial? Check out [our training materials about that]({{ site.baseurl }}{% link topics/contributing/index.md %}).
+{: .comment}
 
 Sometimes, an hands-on tutorial is not the most appropriate format for a tutorial and slides are better. The content must be then added in the `slides` directory.
 
@@ -133,7 +135,9 @@ Once the topic name has been chosen, we can create it.
 > 4. Check that a YAML file with your topic name has been generated in `metadata` folder
 > 5. Make sure that Jekyll is running
 >
->    Want to learn how to start Jekyll? [Check out our tutorial to serve the website locally]({{ site.baseurl }}{% link topics/contributing/tutorials/running-jekyll/tutorial.md %})
+>    > ### {% icon comment %} Jekyll
+>    > Want to learn how to start Jekyll? [Check out our tutorial to serve the website locally]({{ site.baseurl }}{% link topics/contributing/tutorials/running-jekyll/tutorial.md %})
+>    {: .comment}
 >
 > 6. Check if the topic has been correctly added at [http://localhost:4000/training-material/](http://localhost:4000/training-material/)
 >
@@ -182,7 +186,9 @@ Several metadata are defined in `metadata.yaml` file in your topic folder to :
 > 2. Fill the correct metadata of the topic
 > 3. Make sure that Jekyll is running
 >
->    Want to learn how to start Jekyll? [Check out our tutorial to serve the website locally]({{ site.baseurl }}{% link topics/contributing/tutorials/running-jekyll/tutorial.md %})
+>    > ### {% icon comment %} Jekyll
+>    > Want to learn how to start Jekyll? [Check out our tutorial to serve the website locally]({{ site.baseurl }}{% link topics/contributing/tutorials/running-jekyll/tutorial.md %})
+>    {: .comment}
 >
 > 4. Check how it changes the local website
 >

--- a/topics/contributing/tutorials/create-new-topic/tutorial.md
+++ b/topics/contributing/tutorials/create-new-topic/tutorial.md
@@ -63,7 +63,7 @@ The templates for the tutorials are different from the other pages to help users
 
 The content of each tutorial is generated with [Jekyll](https://jekyllrb.com/) from a Markdown file and some metadata (e.g. the requirements, the Zenodo link, the questions) defined inside the metadata of the related topic.
 
-> Want to contribute to a tutorial? Check out [our training materials about that]({{ site.baseurl }}{% link topics/contributing/index.md %}).
+Want to contribute to a tutorial? Check out [our training materials about that]({{ site.baseurl }}{% link topics/contributing/index.md %}).
 
 Sometimes, an hands-on tutorial is not the most appropriate format for a tutorial and slides are better. The content must be then added in the `slides` directory.
 
@@ -133,7 +133,7 @@ Once the topic name has been chosen, we can create it.
 > 4. Check that a YAML file with your topic name has been generated in `metadata` folder
 > 5. Make sure that Jekyll is running
 >
->    > Want to learn how to start Jekyll? [Check out our tutorial to serve the website locally]({{ site.baseurl }}{% link topics/contributing/tutorials/running-jekyll/tutorial.md %})
+>    Want to learn how to start Jekyll? [Check out our tutorial to serve the website locally]({{ site.baseurl }}{% link topics/contributing/tutorials/running-jekyll/tutorial.md %})
 >
 > 6. Check if the topic has been correctly added at [http://localhost:4000/training-material/](http://localhost:4000/training-material/)
 >
@@ -182,7 +182,7 @@ Several metadata are defined in `metadata.yaml` file in your topic folder to :
 > 2. Fill the correct metadata of the topic
 > 3. Make sure that Jekyll is running
 >
->    > Want to learn how to start Jekyll? [Check out our tutorial to serve the website locally]({{ site.baseurl }}{% link topics/contributing/tutorials/running-jekyll/tutorial.md %})
+>    Want to learn how to start Jekyll? [Check out our tutorial to serve the website locally]({{ site.baseurl }}{% link topics/contributing/tutorials/running-jekyll/tutorial.md %})
 >
 > 4. Check how it changes the local website
 >

--- a/topics/contributing/tutorials/create-new-tutorial/tutorial.md
+++ b/topics/contributing/tutorials/create-new-tutorial/tutorial.md
@@ -136,7 +136,7 @@ The most important file is the `tutorial.md` where the content of the tutorial i
 > 2. Check that a new directory (with your tutorial name) has been generated in the topic folder
 > 3. Make sure that Jekyll is running
 >
->    > Want to learn how to start Jekyll? [Check out our tutorial to serve the website locally]({{ site.baseurl }}{% link topics/contributing/tutorials/running-jekyll/tutorial.md %})
+>    Want to learn how to start Jekyll? [Check out our tutorial to serve the website locally]({{ site.baseurl }}{% link topics/contributing/tutorials/running-jekyll/tutorial.md %})
 >
 > 2. Check if the tutorial has been correctly added at [http://localhost:4000/training-material/](http://localhost:4000/training-material/)
 {: .hands_on}

--- a/topics/contributing/tutorials/create-new-tutorial/tutorial.md
+++ b/topics/contributing/tutorials/create-new-tutorial/tutorial.md
@@ -136,7 +136,9 @@ The most important file is the `tutorial.md` where the content of the tutorial i
 > 2. Check that a new directory (with your tutorial name) has been generated in the topic folder
 > 3. Make sure that Jekyll is running
 >
->    Want to learn how to start Jekyll? [Check out our tutorial to serve the website locally]({{ site.baseurl }}{% link topics/contributing/tutorials/running-jekyll/tutorial.md %})
+>    > ### {% icon comment %} Jekyll
+>    > Want to learn how to start Jekyll? [Check out our tutorial to serve the website locally]({{ site.baseurl }}{% link topics/contributing/tutorials/running-jekyll/tutorial.md %})
+>    {: .comment}
 >
 > 2. Check if the tutorial has been correctly added at [http://localhost:4000/training-material/](http://localhost:4000/training-material/)
 {: .hands_on}

--- a/topics/ecology/tutorials/de-novo-rad-seq/tutorial.md
+++ b/topics/ecology/tutorials/de-novo-rad-seq/tutorial.md
@@ -262,7 +262,8 @@ Run `Stacks: De novo map` Galaxy tool. This program will run ustacks, cstacks, a
 > > {: .solution }
 > {: .question}
 {: .hands_on}
-> You can now for xample filter this dataset to only keep FST'=1 loci for further analysis...
+
+You can now for example filter this dataset to only keep FST'=1 loci for further analysis...
 
 # Conclusion
 {:.no_toc}

--- a/topics/ecology/tutorials/genetic-map-rad-seq/tutorial.md
+++ b/topics/ecology/tutorials/genetic-map-rad-seq/tutorial.md
@@ -196,16 +196,17 @@ We can then see that Stack_ID 330 for female corresponds to the 39 for male:
 
 > ### {% icon hands_on %} Hands-on: Stacks: Genotypes
 > **Stacks: genotypes** {% icon tool %}: Re-Run the last step of `Stacks: De novo map` pipeline specifying more options as:
->    > 1. The genetic map type (ie F1, F2 (left figure, F1xF1), Double Haploid, Back Cross (F1xF0), Cross Pollination (right figure, F1 or F2 but resulting from the cross of pure homozygous parents))
->    >
->    >    ![The genetic map type F2](../../images/RAD2_Genetic_Map/Genetic_map_F2.png)    ![The genetic map CrossPollination](../../images/RAD2_Genetic_Map/Genetic_map_CrossPollination.png)
->    >
->    >
->    > 2. Genotyping options output file type for input in genetic mapper tools (ie JoinMap, R/qtl, ...). Observe that the R/qtl format for an F2 cross type can be an input for MapMaker or Carthagene.
->    >
->    > 3. Thresholds concerning a minimal number of progeny and/or minimum stacks depth to consider a locus
->    >
->    > 4. Make Automated Corrections to the Data. This option allows the user to have the program automatically correct some types of errors. This setting can correct errors with the homozygous tags verification in the progeny by confirming the presence or absence of the SNP. If SNP detection model can't identify a site as heterygous or homozygous, that site is temporarily tagged as homozygous to facilitate the search, by sstacks, in concordance with the loci catalog. If a second allele is detected on the catalog (ie, in parents) and is found on a progeny with a weak frequency (<10% of a stack reads number), the genotypes program can correct the genotype. Additionally, it will delete a homozygous genotype on a particular individual if locus genotype is supported by less than 5 reads. Corrected genotypes are marked uppercase.
+>
+>    1. The genetic map type (ie F1, F2 (left figure, F1xF1), Double Haploid, Back Cross (F1xF0), Cross Pollination (right figure, F1 or F2 but resulting from the cross of pure homozygous parents))
+>
+>       ![The genetic map type F2](../../images/RAD2_Genetic_Map/Genetic_map_F2.png)    ![The genetic map CrossPollination](../../images/RAD2_Genetic_Map/Genetic_map_CrossPollination.png)
+>
+>
+>    2. Genotyping options output file type for input in genetic mapper tools (ie JoinMap, R/qtl, ...). Observe that the R/qtl format for an F2 cross type can be an input for MapMaker or Carthagene.
+>
+>    3. Thresholds concerning a minimal number of progeny and/or minimum stacks depth to consider a locus
+>
+>    4. Make Automated Corrections to the Data. This option allows the user to have the program automatically correct some types of errors. This setting can correct errors with the homozygous tags verification in the progeny by confirming the presence or absence of the SNP. If SNP detection model can't identify a site as heterygous or homozygous, that site is temporarily tagged as homozygous to facilitate the search, by sstacks, in concordance with the loci catalog. If a second allele is detected on the catalog (ie, in parents) and is found on a progeny with a weak frequency (<10% of a stack reads number), the genotypes program can correct the genotype. Additionally, it will delete a homozygous genotype on a particular individual if locus genotype is supported by less than 5 reads. Corrected genotypes are marked uppercase.
 >
 >    Here is an example of a locus originally marked as homozygous before automatic correction because an allele is supported by less than 5 reads. After correction, this locus is marked as heterozygous.
 >

--- a/topics/ecology/tutorials/regionalGAM/tutorial.md
+++ b/topics/ecology/tutorials/regionalGAM/tutorial.md
@@ -417,11 +417,11 @@ We would like to know if the year has an influence on the abundance of a species
 
 > ### {% icon details %} More details about the statistics
 > The model fitted to the data is:
-> $$ Y_i = \alpha + \beta x_i + \epsilon_i $$  
-> with $$Y_i$$ = value of the dependent variable for the unit $$i$$  
-> $$\alpha$$ = intercept  
-> $$\beta$$ = slope  
-> $$x_i$$ = value of the explanatory variable for the unit $$i$$  
+> $$ Y_i = \alpha + \beta x_i + \epsilon_i $$
+> with $$Y_i$$ = value of the dependent variable for the unit $$i$$
+> $$\alpha$$ = intercept
+> $$\beta$$ = slope
+> $$x_i$$ = value of the explanatory variable for the unit $$i$$
 > $$e_i$$ = residual for the unit $$i$$
 >
 {: .details}
@@ -443,22 +443,21 @@ Details about the output from the tool
 3. The standard error of the coefficients
 4. The value of the "hypothesis test statistic"
 5. The probability value.
+
+> ### {% icon question %} Questions
 >
-> > ### {% icon question %} Questions
-> >
-> > 1. What are the estimates of the regression coefficients?
-> > 2. Can we use this model to make good predictions?
-> > 3. Is the test p-value significant?
-> >
-> > > ### {% icon solution %} Solutions
-> > >
-> > > 1. Intercept is 183.33852 and the slope (Year) is -0.08952.
-> > > 2. No, the residual standard error is high.
-> > > 3. Yes (0.0282 < 0.05).
-> > >
-> > {: .solution}
-> {: .question}
+> 1. What are the estimates of the regression coefficients?
+> 2. Can we use this model to make good predictions?
+> 3. Is the test p-value significant?
 >
+> > ### {% icon solution %} Solutions
+> >
+> > 1. Intercept is 183.33852 and the slope (Year) is -0.08952.
+> > 2. No, the residual standard error is high.
+> > 3. Yes (0.0282 < 0.05).
+> >
+> {: .solution}
+{: .question}
 
 We can also test for autocorrelation in the data.
 

--- a/topics/ecology/tutorials/species-distribution-modeling/tutorial.md
+++ b/topics/ecology/tutorials/species-distribution-modeling/tutorial.md
@@ -306,7 +306,7 @@ Wallace can use the trained model to predict possible species distributions in a
 > 1. Go to **8 Project**
 > 2. In **Project Model**
 >    - *"Modules Available"*: `Project to New Extent`
-> > 3. In the middle panel,
+> 3. In the middle panel,
 >    1. Click on the polygon icon on the map
 >    2. Draw a polygon around a part of Canada
 > 2. In **Project Model**

--- a/topics/epigenetics/tutorials/atac-seq/tutorial.md
+++ b/topics/epigenetics/tutorials/atac-seq/tutorial.md
@@ -149,16 +149,19 @@ The first step is to check the quality of the reads and the presence of the Next
 >    > > 1. There are 285247 reads.
 >    > > 2. The 3 steps below have warnings:
 >    > >
->    > > > 1) **Per base sequence content**
->    > > > > It is well known that the Tn5 has a strong sequence bias at the insertion site. You can read more about it in {% cite Green2012 %}.
+>    > >    1. **Per base sequence content**
 >    > >
->    > > > 2) **Sequence Duplication Levels**
->    > > > > The read library quite often has PCR duplicates that are introduced
->    > > > > simply by the PCR itself. We will remove these duplicates later on.
+>    > >       It is well known that the Tn5 has a strong sequence bias at the insertion site. You can read more about it in {% cite Green2012 %}.
 >    > >
->    > > > 3) **Overrepresented sequences**
->    > > > > Nextera adapter sequences are observable in the **Adapter Content** section.
->    > > 
+>    > >    2. **Sequence Duplication Levels**
+>    > >
+>    > >       The read library quite often has PCR duplicates that are introduced
+>    > >       simply by the PCR itself. We will remove these duplicates later on.
+>    > >
+>    > >    3. **Overrepresented sequences**
+>    > >
+>    > >       Nextera adapter sequences are observable in the **Adapter Content** section.
+>    > >
 >    > {: .solution}
 >    >
 >    {: .question}
@@ -245,7 +248,7 @@ The forward and reverse adapters are slightly different. We will also trim low q
 
 ## Mapping Reads to Reference Genome
 
-Next we map the trimmed reads to the human reference genome. Here we will use **Bowtie2**. We will extend the maximum fragment length (distance between read pairs) from 500 to 1000 because we know some valid read pairs are from this fragment length. We will use the `--very-sensitive` parameter to have more chance to get the best match even if it takes a bit longer to run. We will run the **end-to-end** mode because we trimmed the adapters so we expect the whole read to map, no clipping of ends is needed. 
+Next we map the trimmed reads to the human reference genome. Here we will use **Bowtie2**. We will extend the maximum fragment length (distance between read pairs) from 500 to 1000 because we know some valid read pairs are from this fragment length. We will use the `--very-sensitive` parameter to have more chance to get the best match even if it takes a bit longer to run. We will run the **end-to-end** mode because we trimmed the adapters so we expect the whole read to map, no clipping of ends is needed.
 
 > ### {% icon comment %} Dovetailing
 > We will allow dovetailing of read pairs with Bowtie2. This is because adapters are removed by Cutadapt only when at least 3 bases match the adapter sequence, so it is possible that after trimming a read can contain 1-2 bases of adapter and go beyond it's mate start site. For example, if the first mate in the read pair is: `GCTATGAAGAATAGGGCGAAGGGGCCTGCGGCGTATTCGATGTTGAAGCT` and the second mate is `CTTCAACATCGAATACGCCGCAGGCCCCTTCGCCCTATTCTTCATAGCCT`, where both contain 2 bases of adapter sequence, they will not be trimmed by Cutadapt and will map this way:
@@ -428,7 +431,7 @@ We will check the insert sizes with **Picard CollectInsertSizeMetrics**. The ins
 > ### {% icon comment %} CollectInsertSizeMetrics Results
 > This is what you get from CollectInsertSizeMetrics:
 > ![Fragment size distribution](../../images/atac-seq/Screenshot_sizeDistribution.png "Fragment size distribution")
-{: .comment} 
+{: .comment}
 
 > ### {% icon question %} Questions
 >
@@ -533,9 +536,14 @@ In order to visualise a specific region (e.g. the gene *RAC2*), we can either us
 {: .hands_on}
 
 ### Convert the Genrich peaks to BED
-At the moment, **pyGenomeTracks** does not deal with the datatype encodepeak which is a special bed. So we need to change the datatype of the output of **Genrich** from encodepeak to bed.
+At the moment, **pyGenomeTracks** does not deal with the datatype encodepeak which is a special bed.
 
-{% include snippets/change_datatype.md datatype="datatypes" %}
+> ### {% icon hands_on %} Hands-on: Change the datatype
+> 1. Change the datatype of the output of **Genrich** from encodepeak to bed.
+>
+>    {% include snippets/change_datatype.md datatype="bed" %}
+>
+{: .hands_on }
 
 ## Create heatmap of genes
 
@@ -648,7 +656,7 @@ Unfortunately, Genrich does not work very well with our small training dataset (
 
 
 > ### {% icon question %} Questions
-> In the ATAC-Seq sample in this selected region we see four peaks detected by Genrich. 
+> In the ATAC-Seq sample in this selected region we see four peaks detected by Genrich.
 >
 > 1. How many TSS are accessible in the sample in the displayed region?
 > 2. How many CTCF binding loci are accessible?

--- a/topics/galaxy-data-manipulation/tutorials/upload-rules/tutorial.md
+++ b/topics/galaxy-data-manipulation/tutorials/upload-rules/tutorial.md
@@ -66,7 +66,6 @@ This approach could be used to manipulate lists of uploads coming from many diff
 > PRJDA60709      | SAMD00016382     | DRX000480            | File 1
 >
 > Download the resulting tabular data describing the files by clicking the "TEXT" link at the top of the page. Alternatively, the resulting sample sheet can be downloaded directly [here](https://www.ebi.ac.uk/ena/data/warehouse/filereport?accession=PRJDA60709&result=read_run&fields=study_accession,sample_accession,experiment_accession,fastq_ftp&download=txt). The number and size of the files for this example are relatively small for sequencing data but larger files and larger numbers of files should work as well - Galaxy will just need more time to download and process the files.
-
 {: .hands_on}
 
 Unfortunately the ENA ftp server is not operational at this moment,

--- a/topics/galaxy-ui/tutorials/history-to-workflow/tutorial.md
+++ b/topics/galaxy-ui/tutorials/history-to-workflow/tutorial.md
@@ -197,11 +197,11 @@ Now that we have finished creating our workflow, it is time to test it.
 > 2. *Examine* the workflow run form.
 >
 >
->   This form lists all the inputs and steps in the workflow also asks if you want to run this workflow in a new history, of just add it to your existing history.
->   ![Run workflow form](../../images/workflow_run_strand_landing.png)
+>    This form lists all the inputs and steps in the workflow also asks if you want to run this workflow in a new history, of just add it to your existing history.
+>    ![Run workflow form](../../images/workflow_run_strand_landing.png)
 >
->   In this form you can also change the run-time parameters of any of the steps.  We aren't going to do that, but it can be useful when are experimenting with different parameters in different steps.
->   Let's test the workflow by running it on the same input datasets we used in the current history.  If we created the workflow correctly, we should get the same results as in the history.
+>    In this form you can also change the run-time parameters of any of the steps.  We aren't going to do that, but it can be useful when are experimenting with different parameters in different steps.
+>    Let's test the workflow by running it on the same input datasets we used in the current history.  If we created the workflow correctly, we should get the same results as in the history.
 >
 > 3. *Select* **Yes** under **Send results to a new history**.
 >    - Sometimes you'll be building analyses out of component workflows and you will want to run them all in the same history.  Here we want a new history because the results will be cleaner and easier to understand.

--- a/topics/galaxy-ui/tutorials/history-to-workflow/tutorial.md
+++ b/topics/galaxy-ui/tutorials/history-to-workflow/tutorial.md
@@ -117,8 +117,9 @@ Now that we have the history we want, let's use Galaxy to create a reusable work
 >     - If there were any missteps or dead-ends in your history, uncheck those steps here.
 >     - Don't worry if you miss one - we can drop it in a subsequent step.
 > 5. Once you have named your workflow, click the **Create Workflow** button.
->    > ![Create workflow form](../../images/workflow_strand_create.png)
->    >
+>
+>    ![Create workflow form](../../images/workflow_strand_create.png)
+>
 >    - This replaces the workflow creation form with a box that says:
 >       - Workflow *`whatever name you entered`* created from current history. You can edit or run the workflow.
 > 6. *Click* on the **edit** link in the box.
@@ -194,14 +195,14 @@ Now that we have finished creating our workflow, it is time to test it.
 >
 > 1. *Click* on the **gear icon** and this time select **Run**.
 > 2. *Examine* the workflow run form.
->   >
->   >
->   >This form lists all the inputs and steps in the workflow also asks if you want to run this workflow in a new history, of just add it to your existing history.
->   >![Run workflow form](../../images/workflow_run_strand_landing.png)
->   >
->   >In this form you can also change the run-time parameters of any of the steps.  We aren't going to do that, but it can be useful when are experimenting with different parameters in different steps.
->   >Let's test the workflow by running it on the same input datasets we used in the current history.  If we created the workflow correctly, we should get the same results as in the history.
->   >
+>
+>
+>   This form lists all the inputs and steps in the workflow also asks if you want to run this workflow in a new history, of just add it to your existing history.
+>   ![Run workflow form](../../images/workflow_run_strand_landing.png)
+>
+>   In this form you can also change the run-time parameters of any of the steps.  We aren't going to do that, but it can be useful when are experimenting with different parameters in different steps.
+>   Let's test the workflow by running it on the same input datasets we used in the current history.  If we created the workflow correctly, we should get the same results as in the history.
+>
 > 3. *Select* **Yes** under **Send results to a new history**.
 >    - Sometimes you'll be building analyses out of component workflows and you will want to run them all in the same history.  Here we want a new history because the results will be cleaner and easier to understand.
 > 4. Give the new history a meaningful name.
@@ -212,7 +213,7 @@ Now that we have finished creating our workflow, it is time to test it.
 
 And Galaxy launches the workflow, running in a new history.  It says (in a nice big green box) something like:
 
-> You can check the status of queued jobs and view the resulting data *by refreshing the History pane.* When the job has been run the status will change from 'running' to 'finished' if completed successfully or 'error' if problems were encountered.
+You can check the status of queued jobs and view the resulting data *by refreshing the History pane.* When the job has been run the status will change from 'running' to 'finished' if completed successfully or 'error' if problems were encountered.
 
 But, *that's a lie*.  In our case we sent the results to a new history, and the history panel is still showing us the old history.  To get to the new history, open the histories view (*click* the **table icon** at top of history) and then make the newly created history be the current history.
 

--- a/topics/genome-annotation/tutorials/annotation-with-maker/tutorial.md
+++ b/topics/genome-annotation/tutorials/annotation-with-maker/tutorial.md
@@ -156,7 +156,7 @@ BUSCO produces three output datasets
 - A full table: lists all the BUSCOs that were searched for, with the corresponding status (was it found in the genome? how many times? where?)
 - A table of missing BUSCOs: this is the list of all genes that were not found in the genome
 
->    ![BUSCO genome summary](../../images/busco_genome_summary.png "BUSCO short summary. Here BUSCO searched for 290 genes in a genome, and found 282 of them complete (269 in single-copy, and 13 duplicated). 5 where found but are fragmented, and 3 were not found at all.")
+![BUSCO genome summary](../../images/busco_genome_summary.png "BUSCO short summary. Here BUSCO searched for 290 genes in a genome, and found 282 of them complete (269 in single-copy, and 13 duplicated). 5 where found but are fragmented, and 3 were not found at all.")
 
 > ### {% icon question %} Questions
 >

--- a/topics/genome-annotation/tutorials/genome-annotation/tutorial.md
+++ b/topics/genome-annotation/tutorials/genome-annotation/tutorial.md
@@ -159,11 +159,11 @@ For similarity searches we use *NCBI BLAST+ blastp* to find similar proteins in 
 >
 >    <img src="../../images/selectlines.png" alt="Select lines that match an expression tool interface and parameters" width="50%">
 >
->    ### {% icon comment %} Results file
+>    > ### {% icon comment %} Results file
 >    > The result file will contain all proteins which do not have an entry in the second column and therefore have no similar protein in the SwissProt database.
 >    {: .comment}
 >
->    ### {% icon comment %} Obtaining unannotated proteins for analysis
+>    > ### {% icon comment %} Obtaining unannotated proteins for analysis
 >    > For functional description of those proteins we want to search for motifs or domains which may classify them more. To get a protein sequence FASTA file with only the not annotated proteins, use the tool **Filter sequences by ID from a tabular file** and select for *Sequence file to filter on the identifiers* [Augustus protein sequences] and for *Tabular file containing sequence identifiers* the protein file with not annotated sequences. The output file is a FASTA file with only those sequences without description.
 >    {: .comment}
 >

--- a/topics/genome-annotation/tutorials/genome-annotation/tutorial.md
+++ b/topics/genome-annotation/tutorials/genome-annotation/tutorial.md
@@ -37,19 +37,19 @@ It consists of three main steps:
 
 **FASTA**
 
-> DNA and protein sequences are written in FASTA format where you have in the first line a ">" followed by the description. In the second line the sequence starts.
+DNA and protein sequences are written in FASTA format where you have in the first line a ">" followed by the description. In the second line the sequence starts.
 
 ![FASTA file](../../images/fasta_format.png)
 
 **GFF3**
 
-> The general feature format (gene-finding format, generic feature format, GFF) is a file format used for describing genes and other features of DNA, RNA and protein sequences.
+The general feature format (gene-finding format, generic feature format, GFF) is a file format used for describing genes and other features of DNA, RNA and protein sequences.
 
 <img src="../../images/gff3_format.png" alt="GFF3 overview" width="70%">
 
 **GENBANK**
 
->The genbank sequence format is a rich format for storing sequences and associated annotations.
+The genbank sequence format is a rich format for storing sequences and associated annotations.
 
 ![genbank file](../../images/gb_full.png)
 
@@ -143,7 +143,7 @@ For similarity searches we use *NCBI BLAST+ blastp* to find similar proteins in 
 >    >
 >    > What information do you see in the BLAST output?
 >    >
-> {: .question}
+>    {: .question}
 >
 >
 > From BLAST search results we want to get only the best hit for each protein.
@@ -153,7 +153,7 @@ For similarity searches we use *NCBI BLAST+ blastp* to find similar proteins in 
 >    >
 >    > For how many proteins we do not get a BLAST hit?
 >    >
-> {: .question}
+>    {: .question}
 >
 > 5. {% icon tool %} Choose the tool **Select lines that match an expression** and enter the following information: *Select lines from* [select the BLAST top hit descriptions result file]; *that* [not matching]; *the pattern* [gi].
 >

--- a/topics/instructors/tutorials/setup-galaxy-for-training/tutorial.md
+++ b/topics/instructors/tutorials/setup-galaxy-for-training/tutorial.md
@@ -31,7 +31,9 @@ Tutorials in this repository are all supplemented with files describing the tech
   - `workflows` folder: contains one or more workflows with all steps in the tutorial
   - `tours` folder: contains one or more yaml files describing interactive tours
 
-For more information about how to create these files, please see our module on [specifying the technical requirements for your tutorial]({{ site.baseurl }}{% link topics/contributing/tutorials/create-new-tutorial-technical/tutorial.md %}).
+> ### {% icon comment %} Requirements
+> For more information about how to create these files, please see our module on [specifying the technical requirements for your tutorial]({{ site.baseurl }}{% link topics/contributing/tutorials/create-new-tutorial-technical/tutorial.md %}).
+{: .comment}
 
 For just the list of Ephemeris commands needed for installation, skip to the [Quickstart section](#quickstart) at the end of this tutorial.
 

--- a/topics/instructors/tutorials/setup-galaxy-for-training/tutorial.md
+++ b/topics/instructors/tutorials/setup-galaxy-for-training/tutorial.md
@@ -31,7 +31,7 @@ Tutorials in this repository are all supplemented with files describing the tech
   - `workflows` folder: contains one or more workflows with all steps in the tutorial
   - `tours` folder: contains one or more yaml files describing interactive tours
 
-> For more information about how to create these files, please see our module on [specifying the technical requirements for your tutorial]({{ site.baseurl }}{% link topics/contributing/tutorials/create-new-tutorial-technical/tutorial.md %}).
+For more information about how to create these files, please see our module on [specifying the technical requirements for your tutorial]({{ site.baseurl }}{% link topics/contributing/tutorials/create-new-tutorial-technical/tutorial.md %}).
 
 For just the list of Ephemeris commands needed for installation, skip to the [Quickstart section](#quickstart) at the end of this tutorial.
 

--- a/topics/introduction/tutorials/galaxy-intro-101/tutorial.md
+++ b/topics/introduction/tutorials/galaxy-intro-101/tutorial.md
@@ -263,10 +263,10 @@ This file contains only two columns. The first contains the exon IDs, and the se
 > ### {% icon question %} Question
 > How many exons are there in total in your file?
 >
->    > > ### {% icon solution %} Solution
->    > > Each line now represents a different exon, so you can see the answer to this when you expand the history item, as in the image above. The exact number you see for your dataset may be slightly different due to the updates to the exon and SNPs information in UCSC.
->    > >
->    > {: .solution }
+> > ### {% icon solution %} Solution
+> > Each line now represents a different exon, so you can see the answer to this when you expand the history item, as in the image above. The exact number you see for your dataset may be slightly different due to the updates to the exon and SNPs information in UCSC.
+> >
+> {: .solution }
 {: .question}
 
 ## Sort the exons by SNPs count

--- a/topics/introduction/tutorials/galaxy-intro-strands/tutorial.md
+++ b/topics/introduction/tutorials/galaxy-intro-strands/tutorial.md
@@ -60,17 +60,21 @@ To explore this question we need a basic understanding of *genomes, chromosomes,
 
 > ### {% icon comment %} Definitions 1
 >
-> * **Genome**
->> The genome is the collection of all DNA native to an organism. For humans, the genome is all of a person's chromosomes.
+> - **Genome**
 >
-> * **Chromosome**
->> The largest unit of DNA organization in an organism.  Humans have two copies of 23 chromosomes.  Chromosomes are *linear* in humans, and all animals and plants.  (Bacteria have *circular* chromosomes.)
+>   The genome is the collection of all DNA native to an organism. For humans, the genome is all of a person's chromosomes.
 >
-> * **Strand**
->> Chromosomes are *double-stranded*.  One is the forward strand, is typically drawn on top, and moves from left to right. The other, reverse strand, is typically drawn on the bottom and moves from right to left.  Genes can occur on either strand.  A single gene will have parts on only one stand.
+> - **Chromosome**
 >
-> * **Gene**
->> "What is a gene?" is actually a hotly debated question.  For our purposes, a gene is a section of DNA on chromosome strand that creates a molecule used by an organism.
+>   The largest unit of DNA organization in an organism.  Humans have two copies of 23 chromosomes.  Chromosomes are *linear* in humans, and all animals and plants.  (Bacteria have *circular* chromosomes.)
+>
+> - **Strand**
+>
+>   Chromosomes are *double-stranded*.  One is the forward strand, is typically drawn on top, and moves from left to right. The other, reverse strand, is typically drawn on the bottom and moves from right to left.  Genes can occur on either strand.  A single gene will have parts on only one stand.
+>
+> - **Gene**
+>
+>   "What is a gene?" is actually a hotly debated question.  For our purposes, a gene is a section of DNA on chromosome strand that creates a molecule used by an organism.
 >
 > Graphically, the human genome can be shown as the chromosomes that are in it:
 >
@@ -118,7 +122,8 @@ There are [many ways to get data into a Galaxy instance]({{ site.baseurl }}{% li
 > ### {% icon hands_on %} Hands-on: Open **Get Data** toolbox
 >
 > 1. *Click* on the **Get Data** toolbox to expand it.
->  > ![The Get Data toolbox](../../images/101_01.png)
+>
+>    ![The Get Data toolbox](../../images/101_01.png)
 >
 {: .hands_on}
 
@@ -129,7 +134,9 @@ The **Get Data** toolbox contains a list of data sources that this Galaxy instan
 > ### {% icon hands_on %} Hands-on: Go to UCSC
 >
 > 1. *Click* on the tool **UCSC Main table browser** to go to UCSC.
->  > ![Click on UCSC Main table browser](../../images/101_01.png)
+>
+>    ![Click on UCSC Main table browser](../../images/101_01.png)
+>
 {: .hands_on}
 
 This will take you to the UCSC Table Browser:
@@ -150,20 +157,23 @@ The Table Browser has a daunting number of options. Fortunately, they are all se
 
 **track** has a bewildering list of options. UCSC suggests `GENCODE v24`.  A web search leads us to the [GENCODE web site](https://www.gencodegenes.org/) which prominently states:
 
-> The GENCODE project produces high quality reference gene annotation and ...
+The GENCODE project produces high quality reference gene annotation and ...
 
 Time for a few more definitions.
 
 > ### {% icon comment %} Definitions 2
 >
-> * **Reference genome**
->> A reference genome is the *genome of a single individual* that has been thoroughly studied, to the point that we know exactly what most of that individual's DNA is.  In practice a reference genome is used as shared map by researchers working on that organism. Reference genomes are updated periodically as techniques improve.
+> - **Reference genome**
 >
-> * **Sequence**
->> A genome's sequence describes the DNA in that genome, down to the A, C, T, and G (single nucleotide) level including the exact location where each is.  Given a reference genome, you can ask questions like, "What's the DNA on chromosome 2 between positions 1,678,901 and 1.688,322?"
+>    A reference genome is the *genome of a single individual* that has been thoroughly studied, to the point that we know exactly what most of that individual's DNA is.  In practice a reference genome is used as shared map by researchers working on that organism. Reference genomes are updated periodically as techniques improve.
 >
-> * **Genome/Gene annotation**
->> The sequence tells us what DNA is where, but it doesn't tell us anything about the function of that DNA.  *Annotation* is additional information about particular regions of the genome like where genes, repeats, promotors, and centromeres are, or how active a particular gene is.
+> - **Sequence**
+>
+>   A genome's sequence describes the DNA in that genome, down to the A, C, T, and G (single nucleotide) level including the exact location where each is.  Given a reference genome, you can ask questions like, "What's the DNA on chromosome 2 between positions 1,678,901 and 1.688,322?"
+>
+> - **Genome/Gene annotation**
+>
+>   The sequence tells us what DNA is where, but it doesn't tell us anything about the function of that DNA.  *Annotation* is additional information about particular regions of the genome like where genes, repeats, promotors, and centromeres are, or how active a particular gene is.
 {: .comment}
 
 The **track** option asks us which set of annotations do we want to get?  There are so many choices because annotation is the result of analysis and interpretation, and there are many ways to do this. (And in this case, many of the options aren't even genes or gene predictions.)
@@ -175,14 +185,16 @@ So far we haven't changed *anything* from the defaults.  Lets change something. 
 > ### {% icon hands_on %} Hands-on: Limit the region and get the data.
 >
 > 1. Say that we just want chromosome 22
->   * For **region** select `position`.
->   * In the text box next to `position` enter `chr22` (case matters).
->     > ![Change the region](../../images/ucsc_tb_set_region_chr22.png)
+>    - For **region** select `position`.
+>    - In the text box next to `position` enter `chr22` (case matters).
+>
+>    ![Change the region](../../images/ucsc_tb_set_region_chr22.png)
 >
 > 2. *Click* the **get output** button.
->   * And, that doesn't actually get us the output.  It sends us to a second UCSC page that asks us exactly what we want.
-> &nbsp;
->     > ![UCSC Table Browser 2nd page](../../images/ucsc_tb_2nd_page_whole_gene.png)
+>
+>    And, that doesn't actually get us the output.  It sends us to a second UCSC page that asks us exactly what we want.
+>
+>    ![UCSC Table Browser 2nd page](../../images/ucsc_tb_2nd_page_whole_gene.png)
 >
 > 3. Under **Create one BED record per** make sure that **Whole Gene** is selected.
 >
@@ -228,9 +240,9 @@ The dataset preview is informative, but you can't see much of the actual dataset
 
 > ### {% icon hands_on %} Hands-on: Look at all the data.
 > 1. Click on the {% icon galaxy-eye %} (eye) icon to view the contents of the dataset.
->    > This displays all of the data
->      &nbsp;
->    > ![Full dataset in central panel](../../images/genes_human_chr22_dataset_view.png)
+>    This displays all of the data
+>
+>    ![Full dataset in central panel](../../images/genes_human_chr22_dataset_view.png)
 {: .hands_on}
 
 ### BED Format
@@ -310,11 +322,14 @@ It doesn't say anything about Filter being able to split a file into multiple fi
 > * The filter tool has 3 fields:
 >
 >   1. **Dataset**: This pulldown will list any dataset from your history that this tool can work on.  In your case that's probably only one dataset.  Make sure this is set to your `Genes` dataset.
->   1. **Condition**: this free text field is where we specify which records we want in the output dataset.  *Enter* `c6 == "+"` in the text box.
->   * This specifies that column 6 (the strand) must be equal to (`==` is Python for *is equal to*) a plus sign.
->   1. **Header lines to skip**: Leave this as `0`. Our dataset does not have any header lines.
+>   2. **Condition**: this free text field is where we specify which records we want in the output dataset.  *Enter* `c6 == "+"` in the text box.
+>      This specifies that column 6 (the strand) must be equal to (`==` is Python for *is equal to*) a plus sign.
+>   3. **Header lines to skip**: Leave this as `0`. Our dataset does not have any header lines.
+>
 > * Finally, *click* the **Execute** button.
->   > ![Run the Filter tool to get only the forward strand genes](../../images/filter_tool_forward_strand_genes_only.png)
+>
+>   ![Run the Filter tool to get only the forward strand genes](../../images/filter_tool_forward_strand_genes_only.png)
+>
 {: .hands_on}
 
 This adds another dataset to your history. This one should contain only genes on the forward strand.  Once the dataset is green, click the {% icon galaxy-eye %} (eye) icon to confirm this. We also recommend that you rename this dataset to something like `Genes, forward strand` (remember how?).
@@ -365,8 +380,8 @@ Genes are an example of a *genomic interval*.
 
 > ### {% icon comment %} Definitions 3
 >
-> * **Genomic interval**
->> In Galaxy, a *genomic interval* is a something that spans part of a chromosome (or some other linear frame of reference like a contig).  Genes are a common example of a genomic interval.  Even a chromosome is a genomic interval, albeit a very long one.
+> - **Genomic interval**
+>   In Galaxy, a *genomic interval* is a something that spans part of a chromosome (or some other linear frame of reference like a contig).  Genes are a common example of a genomic interval.  Even a chromosome is a genomic interval, albeit a very long one.
 {: .comment}
 
 Galaxy excels at answering questions about genomic intervals and different sets of genomic intervals relate to each other.  Lets take a look.
@@ -390,7 +405,8 @@ Of the tools in the **Operate on Genomic Intervals** toolbox, **Join** and parti
 >     - **for at least** to `1`
 >       - This will return genes with even just one position overlapping.
 >     - *Click* **Execute**.
->     > ![Run Intersect](../../images/genes_human_intersect_strands.png)
+>
+>     ![Run Intersect](../../images/genes_human_intersect_strands.png)
 >
 > 3. Now repeat the intersect, but make the first dataset be the reverse genes, and the second be the forward genes.
 >
@@ -457,12 +473,12 @@ Now, take a look at one of our results.  (Any pair of overlapping genes will do.
 > To zoom in,
 > * *Click* on the **Scale** track (the top track) just to the left of the start of the black boxes.
 > * Now *drag* the mouse across the Scale track to just to the right of the  black boxes and let go.
->    > ![Zoom by clicking and dragging on the Scale track](../../images/ucsc_gb_zoom_by_drag.png)
+>   ![Zoom by clicking and dragging on the Scale track](../../images/ucsc_gb_zoom_by_drag.png)
 > * A window pops up describing several ways to interact with the browser.  Just *click* the **Zoom In** button at the bottom.
 > * This redraws the window, this time zoomed in to what you highlighted.
 > * Continue to zoom in until you have the set of linked black boxes you picked centered on the screen.
 > * Once you are as zoomed as you want to be, click on one of the linked boxes.  This will expand the track:
->    > ![One gene, fully zoomed and expanded](../../images/ucsc_gb_zoom_to_1_gene.png)
+>   ![One gene, fully zoomed and expanded](../../images/ucsc_gb_zoom_to_1_gene.png)
 {: .hands_on}
 
 The black boxes connected by lines represent genes, and each set of connected boxes is a single gene (actually, a single transcript of a gene).  Take a close look at the top several tracks.
@@ -474,8 +490,8 @@ Um, *what's up with the boxes and the lines connecting them?*
 
 > ### {% icon comment %} Definitions 4
 >
-> * **Exon**
->> In humans (and in all plants and animals) the molecules that are built from genes are often only built from a part of the DNA in the gene. The sections of DNA that can produce the molecules are called *exons*.
+> - **Exon**
+>   In humans (and in all plants and animals) the molecules that are built from genes are often only built from a part of the DNA in the gene. The sections of DNA that can produce the molecules are called *exons*.
 {: .comment}
 
 As you may have guessed (or already knew): The black boxes are exons.  *Genes* are defined as *covering the entire area from the first black box to the last connected black box.*
@@ -515,10 +531,10 @@ We want to run the same analysis, but this time only look for overlaps that happ
 >    - In our case, we only want the `Genes` dataset.
 > 4. Under **Destination History** enter an informative history name in the **New history named:** box.
 >    - For example, `Exon overlaps on opposite strands`
->    > ![Copy only the Genes dataset to the new history](../../images/copy_datasets_to_new_history.png)
+>      ![Copy only the Genes dataset to the new history](../../images/copy_datasets_to_new_history.png)
 > 5. *Click* the **Copy History Items** button to create your new history.
 >    - This creates a new history (with the copied dataset) and throws up a green box saying:
->    >  1 dataset copied to 1 history: `name you gave your new history`.
+>      "1 dataset copied to 1 history: `name you gave your new history`."
 > 6. The history name is a link.  *Click* on it.
 {: .hands_on}
 
@@ -561,6 +577,7 @@ When you did the *History to Workflow* tutorial you created a new workflow that 
 And Galaxy launches the workflow and says (in a nice big green box) something like:
 
 > You can check the status of queued jobs and view the resulting data by refreshing the History pane.
+{: .quote}
 
 Which in this case *is the truth*.  You can refresh the history panel by either reloading the whole page, of by clicking the looping arrow icon at the top of the history panel.  What you'll see is a stack of history steps that will go from queued to running to done as you watch them.
 

--- a/topics/metabolomics/tutorials/lcms/tutorial.md
+++ b/topics/metabolomics/tutorials/lcms/tutorial.md
@@ -192,21 +192,21 @@ Note that you can either:
 > ### {% icon tip %} Optional: Generate the right template with **xcms get a sampleMetadata file** {% icon tool %}
 >
 > In the case of this tutorial, we already prepared a *sampleMetadata* file with all the necessary information. Below is an optional hands-on explaining how to get a template to fill, with the two following advantages:
->   1. You will have the exact list of the samples you used in Galaxy, with the exact identifiers (*i.e.* exact sample names)
->   2. You will have a file with the right format (tabulation-separated text file) that only needs to be filled with the information you want.
+>
+> 1. You will have the exact list of the samples you used in Galaxy, with the exact identifiers (*i.e.* exact sample names)
+> 2. You will have a file with the right format (tabulation-separated text file) that only needs to be filled with the information you want.
 >
 > > ### {% icon hands_on %} Hands-on: xcms get a sampleMetadata file
 > >
 > > 1. **xcms get a sampleMetadata file** {% icon tool %} with the following parameters:
 > >    - *"RData file"*: the `sacurine.raw.RData` collection output from **MSnbase readMSData** {% icon tool %}
-> >      {% include snippets/select_collection.md %}
 > >
 > {: .hands_on}
 >
 > An easy step for an easy sampleMetadata filling!
 >
 > From this tool, you will obtain a `tabular` file (meaning a tab-separated text file) with a first column of identifiers and a
-second column called *class* which is empty for the moment (only '.' for each sample). You can now download this file by clicking on the {% icon galaxy-save %} icon.
+> second column called *class* which is empty for the moment (only '.' for each sample). You can now download this file by clicking on the {% icon galaxy-save %} icon.
 >
 {: .tip}
 

--- a/topics/metabolomics/tutorials/lcms/tutorial.md
+++ b/topics/metabolomics/tutorials/lcms/tutorial.md
@@ -199,7 +199,7 @@ Note that you can either:
 > > ### {% icon hands_on %} Hands-on: xcms get a sampleMetadata file
 > >
 > > 1. **xcms get a sampleMetadata file** {% icon tool %} with the following parameters:
-> >    - *"RData file"*: the `sacurine.raw.RData` collection output from **MSnbase readMSData** {% icon tool %}
+> >    - {% icon param-collection %} *"RData file"*: the `sacurine.raw.RData` collection output from **MSnbase readMSData** {% icon tool %}
 > >
 > {: .hands_on}
 >

--- a/topics/statistics/tutorials/iwtomics/tutorial.md
+++ b/topics/statistics/tutorials/iwtomics/tutorial.md
@@ -54,7 +54,7 @@ The data we use in this tutorial is available at [Zenodo](https://doi.org/10.528
 
 # Step 1: Loading and pre-processing
 
-> The first tool (IWTomics Load Smooth and Plot) imports a collection of genomic region datasets, and associates to each region multiple genomic feature measurements. It allows to align the regions in multiple ways (center, left, right or scale alignment), to smooth the feature curves (possibly filling gaps in the measurements) and to create a graphical representation of the feature measurements in each region datasets (aligned curves or pointwise quantile curves).
+The first tool (IWTomics Load Smooth and Plot) imports a collection of genomic region datasets, and associates to each region multiple genomic feature measurements. It allows to align the regions in multiple ways (center, left, right or scale alignment), to smooth the feature curves (possibly filling gaps in the measurements) and to create a graphical representation of the feature measurements in each region datasets (aligned curves or pointwise quantile curves).
 
 > ### {% icon hands_on %} Hands-on: Get the data
 > 1. Create a new history for this tutorial
@@ -96,9 +96,9 @@ The data we use in this tutorial is available at [Zenodo](https://doi.org/10.528
 
 # Step 2: Performing Interval-Wise Testing
 
-> The second tool (IWTomics Test and Plot) statistically evaluates differences in genomic features between groups of regions along the genome. In particular, it implements the Interval-Wise Testing for omics data, an extended version of the Interval-Wise Testing for functional data presented in [Pini and Vantini (2017)](https://doi.org/10.1080/10485252.2017.1306627).
+The second tool (IWTomics Test and Plot) statistically evaluates differences in genomic features between groups of regions along the genome. In particular, it implements the Interval-Wise Testing for omics data, an extended version of the Interval-Wise Testing for functional data presented in [Pini and Vantini (2017)](https://doi.org/10.1080/10485252.2017.1306627).
 
-> It allows to perform multiple two sample permutation tests between pairs of region datasets, on several features. It returns the adjusted p-value curves for every test and all possible scales. Moreover, it creates a graphical representation of the Interval-Wise Testing results and a summary plot (optional) with p-values at the maximum scale. The tool IWTomics Plot with Threshold on Test Scale permits to select the scale to be used in the plots.
+It allows to perform multiple two sample permutation tests between pairs of region datasets, on several features. It returns the adjusted p-value curves for every test and all possible scales. Moreover, it creates a graphical representation of the Interval-Wise Testing results and a summary plot (optional) with p-values at the maximum scale. The tool IWTomics Plot with Threshold on Test Scale permits to select the scale to be used in the plots.
 
 > ### {% icon hands_on %} Hands-on: Test for difference between ETn and Control regions
 > **Test and Plot** {% icon tool %}: Run **Test and Plot** with:
@@ -113,7 +113,7 @@ The data we use in this tutorial is available at [Zenodo](https://doi.org/10.528
 
 # Step 3: Selecting test scale
 
-> The third tool (IWTomics Plot with Threshold on Test Scale) allows to select the scale for the Interval-Wise Testing results. In particular it returns the p-value curves for the different tests performed at the selected scale, and it creates a graphical representation of the Interval-Wise Testing results and a summary plot (optional) at the selected scale.
+The third tool (IWTomics Plot with Threshold on Test Scale) allows to select the scale for the Interval-Wise Testing results. In particular it returns the p-value curves for the different tests performed at the selected scale, and it creates a graphical representation of the Interval-Wise Testing results and a summary plot (optional) at the selected scale.
 
 > ### {% icon hands_on %} Hands-on: Change scale for test results
 > **Plot with Threshold on Test Scale** {% icon tool %}: Run **Plot with Threshold on Test Scale** with:

--- a/topics/statistics/tutorials/machinelearning/tutorial.md
+++ b/topics/statistics/tutorials/machinelearning/tutorial.md
@@ -31,19 +31,19 @@ contributors:
 
 [Machine learning](https://en.wikipedia.org/wiki/Machine_learning) uses the techniques from statistics, mathematics and computer science to make computer programs learn from data. It is one of the most popular fields of computer science and finds applications in multiple streams of data analysis like [classification](https://en.wikipedia.org/wiki/Statistical_classification), [regression](https://en.wikipedia.org/wiki/Regression_analysis), [clustering](https://en.wikipedia.org/wiki/Cluster_analysis), [dimensionality reduction](https://en.wikipedia.org/wiki/Dimensionality_reduction), [density estimation](https://en.wikipedia.org/wiki/Density_estimation) and many more. Some real-life applications are spam filtering, medical diagnosis, autonomous driving, recommendation systems, facial recognition, stock prices prediction and many more. The following image shows a basic flow of any machine learning task. A user has data and it is given to a machine learning algorithm for analysis.
 
->    ![data](images/ml_basics.png "Flow of a machine learning task.")
+![data](images/ml_basics.png "Flow of a machine learning task.")
 
 There are multiple ways in which machine learning can be used to perform data analysis. They depend on the nature of data and the kind of data analysis. The following image shows the most popular ones. In [supervised learning](https://en.wikipedia.org/wiki/Supervised_learning) techniques, the categories of data records are known beforehand. But in [unsupervised learning](https://en.wikipedia.org/wiki/Unsupervised_learning), the categories of data records are not known.
 
->    ![data](images/variants_ml.png "Different types of machine learning.")
+![data](images/variants_ml.png "Different types of machine learning.")
 
 In general, machine learning can be used in multiple real-life tasks by using applying its variants as depicted in the following image.
 
->    ![data](images/usage_ml.png "Real-life usage of machine learning.")
+![data](images/usage_ml.png "Real-life usage of machine learning.")
 
 The following image shows how a classification task is performed. The complete data is divided into training and test sets. The training set is used by a classifier to learn features. It results in a trained model and its robustness (of learning) is evaluated using the test set (unseen by the classifier during the training).
 
->    ![data](images/prediction.png "Supervised learning.")
+![data](images/prediction.png "Supervised learning.")
 
 This tutorial shows how to use a machine learning module implemented as a Galaxy tool. The data used in this tutorial is available at [Zenodo](https://zenodo.org/record/1468039#.W8zyxBRoSAo).
 

--- a/topics/transcriptomics/tutorials/clipseq/tutorial.md
+++ b/topics/transcriptomics/tutorials/clipseq/tutorial.md
@@ -213,7 +213,7 @@ In this task we are going to remove the UMI at the 5' end of the second read. We
 >   > ### {% icon comment %} Do the same thing for the input control data set.
 >   >
 >   > If you processed the RBFOX2 FASTQ dataset then do the same thing for the input control dataset or *vice verca*.
-> {: .comment}
+>   {: .comment}
 >
 >   > ### {% icon question %} Questions
 >   > 1. What is the meaning of the barcode pattern?
@@ -253,17 +253,17 @@ To determine where DNA fragments originated in the genome, the sequenced reads m
 >   > ### {% icon comment %} Note: We have switched R1 and R2 as forward and reverse reads!
 >   >
 >   > We need to do that because the eCLIP read library is organised in a way such that the first mate (R1) is in reverse and the second mate (R2) in forward orientation.
-> {: .comment}
+>   {: .comment}
 >
 >   > ### {% icon comment %} Soft-Clipping vs Hard-Clipping
 >   >
 >   > Clipping is a way to deal with low quality bases during the alignment step. In **Soft-Clipping** the bases at the 5' and 3' end of the read are not part of the alignment. In **Hard-Clipping** the bases at the 5' and 3' end of the read are not part of the alignment **and** will be completely removed from the read sequence in the BAM file.
-> {: .comment}
+>   {: .comment}
 >
 >   > ### {% icon comment %} Do the same thing for the input control data set.
 >   >
 >   > If you processed the RBFOX2 FASTQ dataset then do the same thing for the input control dataset or *vice verca*.
-> {: .comment}
+>   {: .comment}
 >
 >   > ### {% icon question %} Questions
 >   >
@@ -296,12 +296,12 @@ Lets return to the UMIs which we extracted in step three. Since we have mapped t
 >   > ### {% icon comment %} What is the purpose of the method we have chosen for the de-duplication?
 >   >
 >   > `UMI-tools deduplication` has several methods. The method we have picked is called the  **adjacency** method. For detailed information have a look at method descriptions of   [UMI-tools](https://doi.org/10.1101/gr.209601.116). For a brief explanation: the method fuses reads together when they have the same coordinates and the same UMI. However, sequencing errors can occur in the UMI. Thus, in the **adjacency** method we fuse also UMIs that differ in a maximal number of characters and where we identify a lot of copies, i.e., the method creates clusters of nodes, a node for each individual UMI, and fuses these nodes based on the [hamming distance](https://en.wikipedia.org/wiki/Hamming_distance) and read counts.
-> {: .comment}
+>   {: .comment}
 >
 >   > ### {% icon comment %} Do the same thing for the input control data set.
 >   >
 >   > If you processed the RBFOX2 bam file then do the same thing for the input control bam or *vice verca*.
-> {: .comment}
+>   {: .comment}
 >
 >   > ### {% icon question %} Questions
 >   >
@@ -357,12 +357,10 @@ In this section we check the quality of our mapped reads and see if our samples 
 > 2. View the output image.
 > ![fingerprint](../../images/clipseq_fingerprint.png "Graph of IP strength from <b>plotFingerprint</b>. The y-axis represents the fraction of the total number of reads. `plotFingerprint` randomly samples genome regions (bins) of a specified length and sums the per-base coverage that overlap with those regions. The x-axis therefore orders the bins from lowest coverage to highest coverage. The plot here is too idealistic which is because of our small data set.")
 >
->    {: .comment}
->
 >   > ### {% icon comment %} What does this graph represent, especially for CLIP-Seq data?
 >   >
 >   > It shows us how good the CLIP Signal compared to the control signal is. Now be careful, CLIP-Seq experiments involve either a total RNA control or a negative control with another protein that unspecifically binds RNA (e.g., IgG). An ideal total RNA control (input control) like ours with perfect uniform distribution of reads along the genome/transcriptome (i.e. without enrichments) and infinite sequencing coverage should generate a straighter, diagonal line. On the other hand, a very specific and strong CLIP enrichment will be indicated by a prominent and steep rise of the cumulative sum towards the highest rank. Yet, a negative control often has the same sharp slope at the end as a CLIP experiment but often depicts a straighter, diagonal line in the beginning like the input control.
-> {: .comment}
+>   {: .comment}
 >
 >   > ### {% icon question %} Questions
 >   >
@@ -444,12 +442,12 @@ calling
 >   > ### {% icon comment %} Adjusted p-value Threshold
 >   >
 >   > P-values are calculated by DESeq2. A low p-value represent a significantly enriched binding region. Since we are doing thousands of independent hypothesis testings, we have to correct for significant p-values that happen just by chance. DESeq2 uses the Benjamini-Hochberg procedure as a correction. For more information read [here](http://www.biostathandbook.com/multiplecomparisons.html).
-> {: .comment}
+>   {: .comment}
 >
 >   > ### {% icon comment %} Fold-Change Threshold
 >   >
 >   > The fold-change is calculated by DESeq2 and is actually a log2 fold-change. Because we want significantly enriched binding regions, we basically search for peaks that are at least four times higher in our CLIP experiment than in our control.
-> {: .comment}
+>   {: .comment}
 >
 >   > ### {% icon question %} Questions
 >   >
@@ -516,17 +514,17 @@ Lets first find out which sequence motifs RBFOX2 might preferentially bind to.
 >   > ### {% icon comment %} MEME and DREME
 >   >
 >   > **MEME** and **DREME** are two motif finding tools that MEME-ChIP uses. More information about theses tools can be found [here](http://meme-suite.org/).
-> {: .comment}
+>   {: .comment}
 >
 >   > ### {% icon comment %} What is the purpose of SlopBED?
 >   >
 >   > **PEAKachu** might underestimate the length of the binding regions, because the actually protein-RNA-binding concentrates on the cross linking site that is one nucleotide long. Thus, we extend the peaks from **PEAKachu** by 20 bp at each site. A true conserved binding motif will not be affected by it, if we make the region to wide.
-> {: .comment}
+>   {: .comment}
 >
 >   > ### {% icon comment %} What is the meaning of the E-value?
 >   >
 >   > The E-value represents the expected number of times we would find our sequence motif in a database (peak file), just by chance. This means, that a small E-value correspond to a very significant motif, because the expected number we would find that motif in our peak file just by chance is very low. Other sequences like repeats will have a high E-value on the other hand.
-> {: .comment}
+>   {: .comment}
 >
 >   > ### {% icon question %} Questions
 >   >

--- a/topics/transcriptomics/tutorials/clipseq/tutorial.md
+++ b/topics/transcriptomics/tutorials/clipseq/tutorial.md
@@ -649,16 +649,16 @@ In this tutorial you imported raw eCLIP data, evaluated the quality of the read 
 
 In order to use the workflow linked to this tutorial, you have to create two lists of dataset pairs; one for you control and one for your CLIP experiment.
 
->    > ### {% icon tip %} Tip: Creating a list of dataset pairs.
->    >
->    > * Click on the check box icon in the history.
->    > ![builddatasetpairs1](../../images/clipseq_build_list_data_set_pairs_1.png "Select data sets for your list of data set pairs.")
->    > * Select the data files for your experiment (or control).
->    > * Select **For all selected...** below the check box icon.
->    > * Select **Build List of Dataset Paris**
->    > * In the new window, if you see no files and a warning, then select **Clear filters**. After that, organise the files into forward-reverse pairs.
->    > ![builddatasetpairs2](../../images/clipseq_build_list_data_set_pairs_2.png "Organise the data sets into pairs.")
->    >
->    >  ![builddatasetpairs3](../../images/clipseq_build_list_data_set_pairs_3.png "Result after organising the data sets into pairs.")
->    > * Give the list a name and click on the button **Create list**.
->    {: .tip}
+> ### {% icon tip %} Tip: Creating a list of dataset pairs.
+>
+> * Click on the check box icon in the history.
+> ![builddatasetpairs1](../../images/clipseq_build_list_data_set_pairs_1.png "Select data sets for your list of data set pairs.")
+> * Select the data files for your experiment (or control).
+> * Select **For all selected...** below the check box icon.
+> * Select **Build List of Dataset Paris**
+> * In the new window, if you see no files and a warning, then select **Clear filters**. After that, organise the files into forward-reverse pairs.
+> ![builddatasetpairs2](../../images/clipseq_build_list_data_set_pairs_2.png "Organise the data sets into pairs.")
+>
+>  ![builddatasetpairs3](../../images/clipseq_build_list_data_set_pairs_3.png "Result after organising the data sets into pairs.")
+> * Give the list a name and click on the button **Create list**.
+{: .tip}

--- a/topics/transcriptomics/tutorials/goenrichment/tutorial.md
+++ b/topics/transcriptomics/tutorials/goenrichment/tutorial.md
@@ -28,9 +28,7 @@ One way to do so is to perform functional enrichment analysis. This method consi
 **What is the Gene Ontology?** <br/>
 The [Gene Ontology](http://www.geneontology.org/) (GO) is a structured, controlled vocabulary for the classification of gene function at the molecular and cellular level. It is divided in three separate sub-ontologies or GO types: biological process (e.g., signal transduction), molecular function (e.g., ATPase activity) and cellular component (e.g., ribosome). These sub-ontologies are structured as directed acyclic graphs (a hierarchy with multi-parenting) of GO terms.
 
-![GO Example](../../images/goenrichment_GOexample.png)
->
-**Figure 1** QuickGO - http://www.ebi.ac.uk/QuickGO
+![GO Example](../../images/goenrichment_GOexample.png "QuickGO - http://www.ebi.ac.uk/QuickGO")
 
 The GO Ontology, like other ontologies, are usually coded in the [OBO](http://www.geneontology.org/faq/what-obo-file-format) or the [OWL](http://www.geneontology.org/faq/what-owl-file) formats. It can be downloaded from the [Gene Ontology website](http://geneontology.org/page/download-ontology) or from the [OBO foundry](http://www.obofoundry.org/). You can also find in Galaxy tools that allow you to manipulate and extract information from OBO files, but this is outside the scope of this tutorial.
 
@@ -68,7 +66,7 @@ To perform functional enrichment analysis, we need to have:
 For each GO term, we need to count the frequency (**k**) of genes in the study set (**n**) that are associated to the term, and the frequency (**K**) of genes in the population set (**N**) that are associated to the same term. Then we test how likely would it be to obtain at least **k** genes associated to the term if **n** genes would be randomly sampled from the population, given the frequency **K** and size **N** of the population.
 
 The appropriate statistical test is the one-tailed variant of Fisher’s exact test, also known as the hypergeometric test for over-representation. When the one-tailed version is applied, this test will compute the probability of observing at least the sample frequency, given the population frequency.  The [hypergeometric distribution](https://en.wikipedia.org/wiki/Hypergeometric_distribution) measures precisely the probability of **k** successes in **n** draws, without replacement, from a finite population of size **N** that contains exactly **K** successful objects:
->
+
 ![Go Enrichment Formula](../../images/goenrichment_formula.png)
 
 For this first exercise we will use data from [Trapnell et al. 2014](https://www.ncbi.nlm.nih.gov/pubmed/22383036 "Trapnell et al. data"). In this work, the authors created an artificial dataset of gene expression in *Drosophila melanogaster*, where 300 random genes were set (insilico) to be differentially expressed between two conditions.
@@ -97,9 +95,8 @@ For this first exercise we will use data from [Trapnell et al. 2014](https://www
 >
 > 3. **Rename** the *go.obo* file to `GO` and *drosophila_gene_association.fb* file to `GO annotations Drosophila melanogaster`.
 >
->    > After you upload the files, and if you press the {% icon galaxy-eye %} (eye) icon of `trapnellPopulation.tab` it should look something like this:
->    > ![Trapnell File](../../images/goenrichment_trapnellFile.png)
-> **Figure 2** Trapnell file
+>    After you upload the files, and if you press the {% icon galaxy-eye %} (eye) icon of `trapnellPopulation.tab` it should look something like this:
+>    ![Trapnell File](../../images/goenrichment_trapnellFile.png "Trapnell file")
 >
 >
 >    > ### {% icon comment %} Comments
@@ -283,8 +280,6 @@ To test the GO slim approach, let us use the mouse dataset again. First, however
 >
 > This will generate one file called `Slim Annotations`.
 {: .hands_on}
->
->
 
 Now we will go use the GOEnrichment tool with the new Slim Annotations file and the same study set.
 

--- a/topics/transcriptomics/tutorials/rna-seq-reads-to-counts/tutorial.md
+++ b/topics/transcriptomics/tutorials/rna-seq-reads-to-counts/tutorial.md
@@ -374,8 +374,6 @@ It is also good practice to visualise the read alignments in the BAM file, for e
 
 As far as we know this data is unstranded, but as a sanity check you can check the strandness. You can use RSeQC Infer Experiment tool to "guess" the strandness, as explained in the [RNA-seq ref-based tutorial]({{ site.baseurl }}{% link topics/transcriptomics/tutorials/ref-based/tutorial.md %}). This is done through comparing the "strandness of reads" with the "strandness of transcripts". For this tool, and many of the other RSeQC tools, a reference bed file of genes (`reference genes`) is required. RSeQC provides some reference BED files for model organisms. You can import the RSeQC mm10 RefSeq BED file from the link `https://sourceforge.net/projects/rseqc/files/BED/Mouse_Mus_musculus/mm10_RefSeq.bed.gz/download` (and rename to `reference genes`) or import a file from Shared data if provided. Alternatively, you can provide your own BED file of reference genes, for example from UCSC (see the [Peaks to Genes tutorial]({{ site.baseurl }}{% link topics/introduction/tutorials/galaxy-intro-peaks2genes/tutorial.md %}). Or the **Convert GTF to BED12** tool can be used to convert a GTF into a BED file.
 
-{% include snippets/import_via_link.md %}
-
 > ### {% icon hands_on %} Hands-on: Check strandness with **Infer Experiment**
 >
 > 1. **Infer Experiment** {% icon tool %} with the following parameters:

--- a/topics/transcriptomics/tutorials/scrna-scater-qc/tutorial.md
+++ b/topics/transcriptomics/tutorials/scrna-scater-qc/tutorial.md
@@ -113,7 +113,7 @@ Next, lets take a look at the data by plotting various properties to see what ou
 >     - {% icon param-check %} *"Plot on log scale"*: `No`
 >
 > 2. If we have a large number of cells (500+), set the 'Plot on log scale' option to 'Yes'. This will make it easier to pick cut-offs when dealing with large numbers. When the tool has finished running, click on the {% icon galaxy-eye %} to view the plots. If it doesn't appear in the browser, you may have to download it and view it externally. You should be presented with plots similar to those below.
-> ![Raw data QC plots](../../images/scrna-scater-qc/raw_data.png "Raw data QC plots")
+>    ![Raw data QC plots](../../images/scrna-scater-qc/raw_data.png "Raw data QC plots")
 >
 >    > ### {% icon comment %} Comment
 >    >

--- a/topics/transcriptomics/tutorials/scrna-scater-qc/tutorial.md
+++ b/topics/transcriptomics/tutorials/scrna-scater-qc/tutorial.md
@@ -117,18 +117,18 @@ Next, lets take a look at the data by plotting various properties to see what ou
 >
 >    > ### {% icon comment %} Comment
 >    >
->    > There are four plots, two distribution bar plots and two scatter plots. 
-> > The first distribution plot is the number of reads in each library (from a single cell). 
-> > The second plot is the distribution of *feature counts* per cell. Feature counts in this case refers to the number of genes expressed in each cell. 
-> > The third plot **Scatterplot of reads vs genes** is a combination of the two barplots, in that it plots both the read count and the expressed gene count for each cell. 
-> > The final scatterplot is the **% MT genes**, which plots the number of genes expressed verses the percentage of those genes that are mitochondrial genes.
+>    > There are four plots, two distribution bar plots and two scatter plots.
+>    > The first distribution plot is the number of reads in each library (from a single cell).
+>    > The second plot is the distribution of *feature counts* per cell. Feature counts in this case refers to the number of genes expressed in each cell.
+>    > The third plot **Scatterplot of reads vs genes** is a combination of the two barplots, in that it plots both the read count and the expressed gene count for each cell.
+>    > The final scatterplot is the **% MT genes**, which plots the number of genes expressed verses the percentage of those genes that are mitochondrial genes.
 >    {: .comment}
->    > Let's look at each plot in turn and see what it tells us.
->    > - **Read counts**. You can see that there are a few cells that have less than ~200,000 reads, with other cells having up to one million reads. Although 200,000 reads is still quite a lot and we wouldn't want to get rid of so much data, we might want to think about removing cells that only contain a smaller number of reads (say, 100,000).
->    > - **Feature counts**. Similar to the read counts plot, we see a few cells that have a very low number of expressed genes (<600), then followed by a more even distribution.
->    > - **Scatterplot of reads vs genes**. This takes the information provided in the two distribution plots above and creates a scatterplot from them. The really poor-quality cells are represented by the points near the intersection of the x and y axis, being data with low read count and low gene count. These are the cells we want to remove during filtering.
->    > - **% MT genes**. You can see from the plot that there are a few cells outside the main "cloud" of datapoints. Some of these could be removed by filtering out cells with low feature counts, but others might need to be removed by mitochondrial content, such as the cell around 37.5%
-
+>
+>    Let's look at each plot in turn and see what it tells us.
+>    - **Read counts**. You can see that there are a few cells that have less than ~200,000 reads, with other cells having up to one million reads. Although 200,000 reads is still quite a lot and we wouldn't want to get rid of so much data, we might want to think about removing cells that only contain a smaller number of reads (say, 100,000).
+>    - **Feature counts**. Similar to the read counts plot, we see a few cells that have a very low number of expressed genes (<600), then followed by a more even distribution.
+>    - **Scatterplot of reads vs genes**. This takes the information provided in the two distribution plots above and creates a scatterplot from them. The really poor-quality cells are represented by the points near the intersection of the x and y axis, being data with low read count and low gene count. These are the cells we want to remove during filtering.
+>    - **% MT genes**. You can see from the plot that there are a few cells outside the main "cloud" of datapoints. Some of these could be removed by filtering out cells with low feature counts, but others might need to be removed by mitochondrial content, such as the cell around 37.5%
 >
 {: .hands_on}
 
@@ -151,12 +151,12 @@ Here, we'll use the manual filtering method.
 >
 >    > ### {% icon comment %} Comment
 >    >
->    > Let's have a look at the parameters and their value:
-    {: .comment}
+>    > Let's have a look at the parameters and their values:
 >    > 1. *"Number of reads mapped to a gene for it to be counted as expressed"*: by default, only one read needs to be mapped to a gene for it to be counted as "expressed". We can be a little bit more stringent here and increase the number of reads that need to be mapped to a gene for it to be categorised as "expressed".
 >    > 2. *"Minimum library size (mapped reads) to filter cells on"*: This value asks how many mapped reads from each cell do you require to be mapped to your genome to be included in downstream analysis. We can see from our plots that we have a few cells that have less than 200,000 reads. 200,000 can still be quite a lot of reads (depending on the experiment), but we can use a smaller number to see what the initial effect of filtering is. Initially, use 100,000 as the value here.
 >    > 3. *"Minimum number of expressed genes"*: You can see that some cells only express a few hundred genes, so we'll remove these cells also.
 >    > 4. *"Maximum % of mitochondrial genes expressed per cell"*. You can see that as well as having one obvious outlier (~37%).
+>    {: .comment}
 >
 >
 {: .hands_on}
@@ -173,10 +173,9 @@ Here, we'll use the manual filtering method.
 
 > ### {% icon comment %} Comment
 >
-> > How did the filtering go? Do you think it's done a good job? Have you removed too many cells? Too few cells? About right?
-> >
-> > Often, it's a matter of trial and error, where you would start off by being quite lenient (low parameters) and then increasing the stringency until you're happy with the results. Using the initial Calculate QC metrics file, play around with the filtering parameters and visualise the output to see the effect different paramters have.
-
+> How did the filtering go? Do you think it's done a good job? Have you removed too many cells? Too few cells? About right?
+>
+> Often, it's a matter of trial and error, where you would start off by being quite lenient (low parameters) and then increasing the stringency until you're happy with the results. Using the initial Calculate QC metrics file, play around with the filtering parameters and visualise the output to see the effect different paramters have.
 >
 {: .comment}
 

--- a/topics/variant-analysis/tutorials/exome-seq/tutorial.md
+++ b/topics/variant-analysis/tutorials/exome-seq/tutorial.md
@@ -457,7 +457,7 @@ the dedicated [Mapping tutorial]({{ site.baseurl }}{% link topics/sequence-analy
 >        - *"Read group identifier (ID)"*: `001`
 >      - *"Auto-assign"*: `No`
 >        - *"Read group sample name (SM)"*: `mother`
-> 
+>
 > 3. **Map with BWA-MEM** {% icon tool %} to map the reads from the **child** sample to the reference genome **using the same parameters as before** except
 >
 >    - *"Single or Paired-end reads"*: `Paired`
@@ -1174,22 +1174,22 @@ you think could plausibly be causative for the child's disease.
 >
 {: .hands_on}
 
-> > ### {% icon question %} Question
-> >
-> > From the GEMINI reports you generated, can you identify the most likely
-> > candidate variant responsible for the child's disease?
-> {: .question}
+> ### {% icon question %} Question
+>
+> From the GEMINI reports you generated, can you identify the most likely
+> candidate variant responsible for the child's disease?
+{: .question}
 
-> > ### {% icon details %} More GEMINI usage examples
-> >
-> > While only demonstrating command line use of GEMINI, the following tutorial
-> > slides may give you additional ideas for variant queries and filters:
-> >
-> > - [Introduction to GEMINI](https://s3.amazonaws.com/gemini-tutorials/Intro-To-Gemini.pdf)
-> > - [Identifying *de novo* mutations with GEMINI](https://s3.amazonaws.com/gemini-tutorials/Gemini-DeNovo-Tutorial.pdf)
-> > - [Identifying recessive gene candidates with GEMINI](https://s3.amazonaws.com/gemini-tutorials/Gemini-Recessive-Tutorial.pdf)
-> > - [Identifying dominant gene candidates with GEMINI](https://s3.amazonaws.com/gemini-tutorials/Gemini-Dominant-Tutorial.pdf)
-> {: .details}
+> ### {% icon details %} More GEMINI usage examples
+>
+> While only demonstrating command line use of GEMINI, the following tutorial
+> slides may give you additional ideas for variant queries and filters:
+>
+> - [Introduction to GEMINI](https://s3.amazonaws.com/gemini-tutorials/Intro-To-Gemini.pdf)
+> - [Identifying *de novo* mutations with GEMINI](https://s3.amazonaws.com/gemini-tutorials/Gemini-DeNovo-Tutorial.pdf)
+> - [Identifying recessive gene candidates with GEMINI](https://s3.amazonaws.com/gemini-tutorials/Gemini-Recessive-Tutorial.pdf)
+> - [Identifying dominant gene candidates with GEMINI](https://s3.amazonaws.com/gemini-tutorials/Gemini-Dominant-Tutorial.pdf)
+{: .details}
 
 # Conclusion
 {:.no_toc}

--- a/topics/variant-analysis/tutorials/non-dip/tutorial.md
+++ b/topics/variant-analysis/tutorials/non-dip/tutorial.md
@@ -376,7 +376,7 @@ chrM	8557	.	G	C	2590.97	.	AB=0.267066;ABP=790.051;AC=2;AF=0.5;AN=4;AO=446;CIGAR=
 ```
 # Looking at the data
 
-For visualizing VCFs Galaxy relies on the two external tools.  The first is called [VCF.IOBIO](http://vcf.iobio.io/) and is developed by [Gabor Marth's group](http://marthlab.org/) at the University of Utah. The second is called [IGV](http://software.broadinstitute.org/software/igv/) developed by Broad Institute.  
+For visualizing VCFs Galaxy relies on the two external tools.  The first is called [VCF.IOBIO](http://vcf.iobio.io/) and is developed by [Gabor Marth's group](http://marthlab.org/) at the University of Utah. The second is called [IGV](http://software.broadinstitute.org/software/igv/) developed by Broad Institute.
 
 ## VCF.IOBIO
 
@@ -471,6 +471,7 @@ To cut these columns out we will use **Text Manipulation** &#8594; **Cut**
 >8557  G   C   raw_mother-ds- 265   946
 >
 >```
+{: .hands_on}
 
 Let's look at site 4,243. At this site Mother has 841 `G`s (since `G` is an alternative allele) and 1,068-841=227 `A`s. This child has 767 `G`s and 1,558-767=791 `A`s:
 


### PR DESCRIPTION
This PR implements a makefile target which checks that in every enabled tutorial:

- There are no blockquotes without classes (commonly caused with accidental line breaks in the middle of a hands on that isn't noticed)
- There are no blockquotes with unexpected/wrong classes (e.g. typos)

This is added as a mandatory travis test. To make it more pleasant for contributors, it attempts to locate the usage of the broken box and greps for context to help users to locate the issue.

In a pretend world where the matrix class didn't exist, this will show the relevant source code and files.

![image](https://user-images.githubusercontent.com/458683/69054620-4a42d280-0a0c-11ea-858e-8246e53b5f52.png)

I've fixed many boxes in existing tutorials, and changed some usages to be more correct.

**Edit** maintainers were pinged due to changes to tutorials to bring them into compliance.