### PR TITLE
Docker update

### DIFF
--- a/topics/admin/docker/Dockerfile
+++ b/topics/admin/docker/Dockerfile
@@ -7,7 +7,7 @@
 #    docker run -p "8080:80" -t <your_tag>
 #    use -d to automatically dowload the datalibraries in the container
 
-FROM bgruening/galaxy-stable:latest
+FROM bgruening/galaxy-stable:19.01
 
 MAINTAINER Galaxy Training Material
 

--- a/topics/assembly/docker/Dockerfile
+++ b/topics/assembly/docker/Dockerfile
@@ -7,7 +7,7 @@
 #    docker run -p "8080:80" -t <your_tag>
 #    use -d to automatically dowload the datalibraries in the container
 
-FROM bgruening/galaxy-stable:latest
+FROM bgruening/galaxy-stable:19.01
 
 MAINTAINER Galaxy Training Material
 

--- a/topics/computational-chemistry/docker/Dockerfile
+++ b/topics/computational-chemistry/docker/Dockerfile
@@ -1,4 +1,3 @@
-
 # Galaxy - Computational chemistry
 #
 # to build the docker image, go to root of training repo and
@@ -8,15 +7,11 @@
 #    docker run -p "8080:80" -t computational-chemistry
 #    use -d to automatically dowload the datalibraries in the container
 
-FROM bgruening/galaxy-stable
+FROM bgruening/galaxy-stable:19.01
 
 MAINTAINER Galaxy Training Material
 
 ENV GALAXY_CONFIG_BRAND "GTN: Computational chemistry"
-
-# prerequisites
-RUN pip install ephemeris -U
-ADD bin/galaxy-sleep.py /galaxy-sleep.py
 
 # copy the tutorials directory for your topic
 ADD topics/computational-chemistry/tutorials/ /tutorials/
@@ -24,4 +19,7 @@ ADD topics/computational-chemistry/tutorials/ /tutorials/
 # install everything for tutorials
 ADD bin/docker-install-tutorials.sh /setup-tutorials.sh
 ADD bin/mergeyaml.py /mergeyaml.py
+ADD bin/data_libarary_download.sh /data_libarary_download.sh
 RUN /setup-tutorials.sh
+
+ENTRYPOINT ["/data_libarary_download.sh"]

--- a/topics/contributing/docker/Dockerfile
+++ b/topics/contributing/docker/Dockerfile
@@ -7,14 +7,11 @@
 #    docker run -p "8080:80" -t <your_tag>
 #    use -d to automatically dowload the datalibraries in the container
 
-FROM bgruening/galaxy-stable:latest
+FROM bgruening/galaxy-stable:19.01
 
 MAINTAINER Galaxy Training Material
 
 ENV GALAXY_CONFIG_BRAND "GTN: Contributing"
-
-# prerequisites
-RUN pip install ephemeris -U
 
 # copy the tutorials directory for your topic
 ADD topics/contributing/tutorials/ /tutorials/

--- a/topics/dev/docker/Dockerfile
+++ b/topics/dev/docker/Dockerfile
@@ -7,7 +7,7 @@
 #    docker run -p "8080:80" -t <your_tag>
 #    use -d to automatically dowload the datalibraries in the container
 
-FROM bgruening/galaxy-stable:latest
+FROM bgruening/galaxy-stable:19.01
 
 MAINTAINER Galaxy Training Material
 

--- a/topics/ecology/docker/Dockerfile
+++ b/topics/ecology/docker/Dockerfile
@@ -1,5 +1,4 @@
 # Galaxy - ecology training material
-
 #
 # to build the docker image, go to root of training repo and
 #    docker build -t <your_tag> -f topics/<your_topic>/docker/Dockerfile .
@@ -8,7 +7,7 @@
 #    docker run -p "8080:80" -t <your_tag>
 #    use -d to automatically dowload the datalibraries in the container
 
-FROM bgruening/galaxy-stable
+FROM bgruening/galaxy-stable:19.01
 
 MAINTAINER Galaxy Training Material
 
@@ -20,4 +19,7 @@ ADD topics/ecology/tutorials/ /tutorials/
 # install everything for tutorials
 ADD bin/docker-install-tutorials.sh /setup-tutorials.sh
 ADD bin/mergeyaml.py /mergeyaml.py
+ADD bin/data_libarary_download.sh /data_libarary_download.sh
 RUN /setup-tutorials.sh
+
+ENTRYPOINT ["/data_libarary_download.sh"]

--- a/topics/epigenetics/docker/Dockerfile
+++ b/topics/epigenetics/docker/Dockerfile
@@ -7,7 +7,7 @@
 #    docker run -p "8080:80" -t <your_tag>
 #    use -d to automatically dowload the datalibraries in the container
 
-FROM bgruening/galaxy-stable:latest
+FROM bgruening/galaxy-stable:19.01
 
 MAINTAINER Galaxy Training Material
 

--- a/topics/genome-annotation/docker/Dockerfile
+++ b/topics/genome-annotation/docker/Dockerfile
@@ -7,7 +7,7 @@
 #    docker run -p "8080:80" -t <your_tag>
 #    use -d to automatically dowload the datalibraries in the container
 
-FROM bgruening/galaxy-stable:latest
+FROM bgruening/galaxy-stable:19.01
 
 MAINTAINER Galaxy Training Material
 

--- a/topics/imaging/docker/Dockerfile
+++ b/topics/imaging/docker/Dockerfile
@@ -7,7 +7,7 @@
 #    docker run -p "8080:80" -t galaxy/imaging-training
 #    use -d to automatically dowload the datalibraries in the container
 
-FROM bgruening/galaxy-stable:latest
+FROM bgruening/galaxy-stable:19.01
 
 MAINTAINER Galaxy Training Material
 

--- a/topics/introduction/docker/Dockerfile
+++ b/topics/introduction/docker/Dockerfile
@@ -7,7 +7,7 @@
 #    docker run -p "8080:80" -t <your_tag>
 #    use -d to automatically dowload the datalibraries in the container
 
-FROM bgruening/galaxy-stable:latest
+FROM bgruening/galaxy-stable:19.01
 
 MAINTAINER Galaxy Training Material
 

--- a/topics/metabolomics/docker/Dockerfile
+++ b/topics/metabolomics/docker/Dockerfile
@@ -7,7 +7,7 @@
 #    docker run -p "8080:80" -t <your_tag>
 #    use -d to automatically dowload the datalibraries in the container
 
-FROM bgruening/galaxy-stable:latest
+FROM bgruening/galaxy-stable:19.01
 
 MAINTAINER Galaxy Training Material
 

--- a/topics/metagenomics/docker/Dockerfile
+++ b/topics/metagenomics/docker/Dockerfile
@@ -7,7 +7,7 @@
 #    docker run -p "8080:80" -t <your_tag>
 #    use -d to automatically dowload the datalibraries in the container
 
-FROM bgruening/galaxy-stable:latest
+FROM bgruening/galaxy-stable:19.01
 
 MAINTAINER Galaxy Training Material
 

--- a/topics/proteomics/docker/Dockerfile
+++ b/topics/proteomics/docker/Dockerfile
@@ -7,7 +7,7 @@
 #    docker run -p "8080:80" -t <your_tag>
 #    use -d to automatically dowload the datalibraries in the container
 
-FROM bgruening/galaxy-stable:latest
+FROM bgruening/galaxy-stable:19.01
 
 MAINTAINER Galaxy Training Material
 

--- a/topics/sequence-analysis/docker/Dockerfile
+++ b/topics/sequence-analysis/docker/Dockerfile
@@ -7,7 +7,7 @@
 #    docker run -p "8080:80" -t <your_tag>
 #    use -d to automatically dowload the datalibraries in the container
 
-FROM bgruening/galaxy-stable:latest
+FROM bgruening/galaxy-stable:19.01
 
 MAINTAINER Galaxy Training Material
 

--- a/topics/statistics/docker/Dockerfile
+++ b/topics/statistics/docker/Dockerfile
@@ -7,7 +7,7 @@
 #    docker run -p "8080:80" -t <your_tag>
 #    use -d to automatically dowload the datalibraries in the container
 
-FROM bgruening/galaxy-stable:latest
+FROM bgruening/galaxy-stable:19.01
 
 MAINTAINER Galaxy Training Material
 

--- a/topics/transcriptomics/docker/Dockerfile
+++ b/topics/transcriptomics/docker/Dockerfile
@@ -7,7 +7,7 @@
 #    docker run -p "8080:80" -t <your_tag>
 #    use -d to automatically dowload the datalibraries in the container
 
-FROM bgruening/galaxy-stable:latest
+FROM bgruening/galaxy-stable:19.01
 
 MAINTAINER Galaxy Training Material
 

--- a/topics/variant-analysis/docker/Dockerfile
+++ b/topics/variant-analysis/docker/Dockerfile
@@ -7,7 +7,7 @@
 #    docker run -p "8080:80" -t <your_tag>
 #    use -d to automatically dowload the datalibraries in the container
 
-FROM bgruening/galaxy-stable:latest
+FROM bgruening/galaxy-stable:19.01
 
 MAINTAINER Galaxy Training Material
 


### PR DESCRIPTION
I've experienced some problems with the latest galaxy container which were not present in version 19.01. For example the `galaxy-wait -g $galaxy_instance` is not available. To overcome problems like this in the future, I suggest that we increase the galaxy docker version manually after testing. Although this is maybe not feasible long term, it will decrease the amount of problems with building the containers... I am now testing all the containers one by one using docker version 19.01 :

- [ ] admin
- [ ] assembly
- [ ] computational-chemistry
- [ ] contributing
- [ ] dev
- [x] ecology
- [ ] epigenetics
- [ ] genome-annotation
- [ ] imaging
- [ ] introduction
- [ ] metabolomics
- [ ] metagenomics
- [ ] proteomics
- [ ] sequence-analysis
- [ ] statistics
- [x] transcriptomics
- [x] variant-analysis

Future plans:
Having the possibility to build the container with all the data libraries like we did in the past, but as an option with for example a -data flag. This to enable the use-case of @TKlingstrom