### PR TITLE
Temporarily disable GA tutorial pending updates

### DIFF
--- a/topics/genome-annotation/tutorials/genome-annotation/tutorial.md
+++ b/topics/genome-annotation/tutorials/genome-annotation/tutorial.md
@@ -6,6 +6,7 @@ zenodo_link: "https://doi.org/10.5281/zenodo.1250793"
 tags:
   - prokaryote
 questions:
+enable: false
 objectives:
 time_estimation: "2H"
 key_points:


### PR DESCRIPTION
Given [suboptimal feedback](https://github.com/galaxyproject/training-material/issues/989#issuecomment-565807493) temporarily disable until it can be updated to current standards, and potentially split into tutorials for how to use each subcomponent.