### PR TITLE
Fixing multiple workflows

### DIFF
--- a/topics/computational-chemistry/tutorials/cheminformatics/workflows/main_workflow.ga
+++ b/topics/computational-chemistry/tutorials/cheminformatics/workflows/main_workflow.ga
@@ -121,7 +121,13 @@
       "tool_state": "{\"__page__\": 0, \"whitelist\": \"\\\"\\\"\", \"url_paste\": \"\\\"http://www.drugbank.ca/system/downloads/current/structures/approved.sdf.zip\\\"\"}",
       "tool_version": "0.2",
       "type": "tool",
-      "user_outputs": []
+      "user_outputs": [],
+      "tool_shed_repository": {
+        "changeset_revision": "c2055dd1927b",
+        "name": "chemical_data_sources",
+        "owner": "bgruening",
+        "tool_shed": "toolshed.g2.bx.psu.edu"
+      }
     },
     "29": {
       "annotation": "",
@@ -208,7 +214,13 @@
       "tool_state": "{\"__page__\": 0, \"fp_opts\": \"{\\\"targetSize\\\": \\\"4\\\", \\\"fpSize\\\": \\\"2048\\\", \\\"fp_opts_selector\\\": \\\"--torsions\\\", \\\"__current_case__\\\": 5}\", \"infile\": \"null\"}",
       "tool_version": "0.2.0",
       "type": "tool",
-      "user_outputs": []
+      "user_outputs": [],
+      "tool_shed_repository": {
+        "changeset_revision": "43a9e7d9b24f",
+        "name": "chemfp",
+        "owner": "bgruening",
+        "tool_shed": "toolshed.g2.bx.psu.edu"
+      }
     },
     "39": {
       "annotation": "",
@@ -270,7 +282,13 @@
       "tool_state": "{\"__page__\": 0, \"fp_opts\": \"{\\\"fp_opts_selector\\\": \\\"--FP2\\\", \\\"__current_case__\\\": 0}\", \"infile\": \"null\"}",
       "tool_version": "0.2.0",
       "type": "tool",
-      "user_outputs": []
+      "user_outputs": [],
+      "tool_shed_repository": {
+        "changeset_revision": "43a9e7d9b24f",
+        "name": "chemfp",
+        "owner": "bgruening",
+        "tool_shed": "toolshed.g2.bx.psu.edu"
+      }
     },
     "44": {
       "annotation": "",

--- a/topics/contributing/tutorials/create-new-tutorial/workflows/example-workflow.ga
+++ b/topics/contributing/tutorials/create-new-tutorial/workflows/example-workflow.ga
@@ -1,368 +1,380 @@
 {
-    "a_galaxy_workflow": "true", 
-    "annotation": "", 
-    "format-version": "0.1", 
-    "name": "Find Exons with the highest number of SNPs (or other features)", 
-    "steps": {
-        "0": {
-            "annotation": "", 
-            "content_id": null, 
-            "errors": null, 
-            "id": 0, 
-            "input_connections": {}, 
-            "inputs": [
-                {
-                    "description": "", 
-                    "name": "Exons"
-                }
-            ], 
-            "label": "Exons", 
-            "name": "Input dataset", 
-            "outputs": [], 
-            "position": {
-                "left": 195.96665954589844, 
-                "top": 245.9666748046875
-            }, 
-            "tool_id": null, 
-            "tool_state": "{\"name\": \"Exons\"}", 
-            "tool_version": null, 
-            "type": "data_input", 
-            "uuid": "c52a5e18-822d-45bd-93c0-d537e607cdc6", 
-            "workflow_outputs": [
-                {
-                    "label": null, 
-                    "output_name": "output", 
-                    "uuid": "2a327882-1ffb-47af-9172-87244d4e3784"
-                }
-            ]
-        }, 
-        "1": {
-            "annotation": "", 
-            "content_id": null, 
-            "errors": null, 
-            "id": 1, 
-            "input_connections": {}, 
-            "inputs": [
-                {
-                    "description": "", 
-                    "name": "Feature"
-                }
-            ], 
-            "label": "Feature", 
-            "name": "Input dataset", 
-            "outputs": [], 
-            "position": {
-                "left": 199.9499969482422, 
-                "top": 378.9666748046875
-            }, 
-            "tool_id": null, 
-            "tool_state": "{\"name\": \"Feature\"}", 
-            "tool_version": null, 
-            "type": "data_input", 
-            "uuid": "2f684ad5-8e4e-4fb8-a2a4-645f82579a94", 
-            "workflow_outputs": [
-                {
-                    "label": null, 
-                    "output_name": "output", 
-                    "uuid": "bcd32a06-2a7c-455f-9c6d-d260060aeeb9"
-                }
-            ]
-        }, 
-        "2": {
-            "annotation": "", 
-            "content_id": "toolshed.g2.bx.psu.edu/repos/devteam/join/gops_join_1/1.0.0", 
-            "errors": null, 
-            "id": 2, 
-            "input_connections": {
-                "input1": {
-                    "id": 0, 
-                    "output_name": "output"
-                }, 
-                "input2": {
-                    "id": 1, 
-                    "output_name": "output"
-                }
-            }, 
-            "inputs": [
-                {
-                    "description": "runtime parameter for tool Join", 
-                    "name": "input2"
-                }, 
-                {
-                    "description": "runtime parameter for tool Join", 
-                    "name": "input1"
-                }
-            ], 
-            "label": null, 
-            "name": "Join", 
-            "outputs": [
-                {
-                    "name": "output", 
-                    "type": "interval"
-                }
-            ], 
-            "position": {
-                "left": 419.95001220703125, 
-                "top": 258.98333740234375
-            }, 
-            "post_job_actions": {
-                "HideDatasetActionoutput": {
-                    "action_arguments": {}, 
-                    "action_type": "HideDatasetAction", 
-                    "output_name": "output"
-                }
-            }, 
-            "tool_id": "toolshed.g2.bx.psu.edu/repos/devteam/join/gops_join_1/1.0.0", 
-            "tool_shed_repository": {
-                "changeset_revision": "de21bdbb8d28", 
-                "name": "join", 
-                "owner": "devteam", 
-                "tool_shed": "toolshed.g2.bx.psu.edu"
-            }, 
-            "tool_state": "{\"input2\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\", \"__page__\": null, \"input1\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\", \"min\": \"\\\"1\\\"\", \"__rerun_remap_job_id__\": null, \"chromInfo\": \"\\\"/data/galaxy/galaxy-dist/tool-data/shared/ucsc/chrom/hg19.len\\\"\", \"fill\": \"\\\"none\\\"\"}", 
-            "tool_version": "1.0.0", 
-            "type": "tool", 
-            "uuid": "a165c2c5-6706-4e6d-bf56-93d01c6ba5b0", 
-            "workflow_outputs": []
-        }, 
-        "3": {
-            "annotation": "", 
-            "content_id": "Grouping1", 
-            "errors": null, 
-            "id": 3, 
-            "input_connections": {
-                "input1": {
-                    "id": 2, 
-                    "output_name": "output"
-                }
-            }, 
-            "inputs": [
-                {
-                    "description": "runtime parameter for tool Group", 
-                    "name": "input1"
-                }
-            ], 
-            "label": null, 
-            "name": "Group", 
-            "outputs": [
-                {
-                    "name": "out_file1", 
-                    "type": "tabular"
-                }
-            ], 
-            "position": {
-                "left": 639.9666748046875, 
-                "top": 258.98333740234375
-            }, 
-            "post_job_actions": {
-                "HideDatasetActionout_file1": {
-                    "action_arguments": {}, 
-                    "action_type": "HideDatasetAction", 
-                    "output_name": "out_file1"
-                }
-            }, 
-            "tool_id": "Grouping1", 
-            "tool_state": "{\"operations\": \"[{\\\"opcol\\\": \\\"1\\\", \\\"__index__\\\": 0, \\\"optype\\\": \\\"length\\\", \\\"opround\\\": \\\"no\\\"}]\", \"__page__\": null, \"input1\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\", \"ignorelines\": \"null\", \"groupcol\": \"\\\"4\\\"\", \"__rerun_remap_job_id__\": null, \"ignorecase\": \"\\\"false\\\"\", \"chromInfo\": \"\\\"/data/galaxy/galaxy-dist/tool-data/shared/ucsc/chrom/hg19.len\\\"\"}", 
-            "tool_version": "2.1.1", 
-            "type": "tool", 
-            "uuid": "107623d3-77a6-450a-9f91-254ca7000f7b", 
-            "workflow_outputs": []
-        }, 
-        "4": {
-            "annotation": "", 
-            "content_id": "Grouping1", 
-            "errors": null, 
-            "id": 4, 
-            "input_connections": {
-                "input1": {
-                    "id": 2, 
-                    "output_name": "output"
-                }
-            }, 
-            "inputs": [
-                {
-                    "description": "runtime parameter for tool Group", 
-                    "name": "input1"
-                }
-            ], 
-            "label": null, 
-            "name": "Group", 
-            "outputs": [
-                {
-                    "name": "out_file1", 
-                    "type": "tabular"
-                }
-            ], 
-            "position": {
-                "left": 639.9666748046875, 
-                "top": 378.9666748046875
-            }, 
-            "post_job_actions": {
-                "HideDatasetActionout_file1": {
-                    "action_arguments": {}, 
-                    "action_type": "HideDatasetAction", 
-                    "output_name": "out_file1"
-                }
-            }, 
-            "tool_id": "Grouping1", 
-            "tool_state": "{\"operations\": \"[{\\\"opcol\\\": \\\"4\\\", \\\"__index__\\\": 0, \\\"optype\\\": \\\"length\\\", \\\"opround\\\": \\\"no\\\"}]\", \"__page__\": null, \"input1\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\", \"ignorelines\": \"null\", \"groupcol\": \"\\\"4\\\"\", \"__rerun_remap_job_id__\": null, \"ignorecase\": \"\\\"false\\\"\", \"chromInfo\": \"\\\"/data/galaxy/galaxy-dist/tool-data/shared/ucsc/chrom/hg19.len\\\"\"}", 
-            "tool_version": "2.1.1", 
-            "type": "tool", 
-            "uuid": "91bdfdbc-cb4e-47c9-9fb8-a3b8214a828a", 
-            "workflow_outputs": []
-        }, 
-        "5": {
-            "annotation": "", 
-            "content_id": "toolshed.g2.bx.psu.edu/repos/bgruening/text_processing/tp_sort_header_tool/1.1.1", 
-            "errors": null, 
-            "id": 5, 
-            "input_connections": {
-                "infile": {
-                    "id": 4, 
-                    "output_name": "out_file1"
-                }
-            }, 
-            "inputs": [
-                {
-                    "description": "runtime parameter for tool Sort", 
-                    "name": "infile"
-                }
-            ], 
-            "label": null, 
-            "name": "Sort", 
-            "outputs": [
-                {
-                    "name": "outfile", 
-                    "type": "input"
-                }
-            ], 
-            "position": {
-                "left": 861, 
-                "top": 257.5
-            }, 
-            "post_job_actions": {
-                "HideDatasetActionoutfile": {
-                    "action_arguments": {}, 
-                    "action_type": "HideDatasetAction", 
-                    "output_name": "outfile"
-                }
-            }, 
-            "tool_id": "toolshed.g2.bx.psu.edu/repos/bgruening/text_processing/tp_sort_header_tool/1.1.1", 
-            "tool_shed_repository": {
-                "changeset_revision": "74a8bef53a00", 
-                "name": "text_processing", 
-                "owner": "bgruening", 
-                "tool_shed": "toolshed.g2.bx.psu.edu"
-            }, 
-            "tool_state": "{\"sortkeys\": \"[{\\\"column\\\": \\\"2\\\", \\\"__index__\\\": 0, \\\"style\\\": \\\"g\\\", \\\"order\\\": \\\"r\\\"}]\", \"__page__\": null, \"ignore_case\": \"\\\"false\\\"\", \"__rerun_remap_job_id__\": null, \"header\": \"\\\"0\\\"\", \"unique\": \"\\\"false\\\"\", \"infile\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\"}", 
-            "tool_version": "1.1.1", 
-            "type": "tool", 
-            "uuid": "2b7ac43c-6e2b-46d0-9c38-c12c897a4310", 
-            "workflow_outputs": []
-        }, 
-        "6": {
-            "annotation": "", 
-            "content_id": "Show beginning1", 
-            "errors": null, 
-            "id": 6, 
-            "input_connections": {
-                "input": {
-                    "id": 5, 
-                    "output_name": "outfile"
-                }
-            }, 
-            "inputs": [
-                {
-                    "description": "runtime parameter for tool Select first", 
-                    "name": "input"
-                }
-            ], 
-            "label": null, 
-            "name": "Select first", 
-            "outputs": [
-                {
-                    "name": "out_file1", 
-                    "type": "input"
-                }
-            ], 
-            "position": {
-                "left": 1079.9833984375, 
-                "top": 258.98333740234375
-            }, 
-            "post_job_actions": {
-                "HideDatasetActionout_file1": {
-                    "action_arguments": {}, 
-                    "action_type": "HideDatasetAction", 
-                    "output_name": "out_file1"
-                }
-            }, 
-            "tool_id": "Show beginning1", 
-            "tool_state": "{\"__page__\": null, \"lineNum\": \"\\\"5\\\"\", \"__rerun_remap_job_id__\": null, \"chromInfo\": \"\\\"/data/galaxy/galaxy-dist/tool-data/shared/ucsc/chrom/hg19.len\\\"\", \"input\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\"}", 
-            "tool_version": "1.0.0", 
-            "type": "tool", 
-            "uuid": "ecedf93a-a895-433a-a029-458e6a3ff3ed", 
-            "workflow_outputs": []
-        }, 
-        "7": {
-            "annotation": "", 
-            "content_id": "comp1", 
-            "errors": null, 
-            "id": 7, 
-            "input_connections": {
-                "input1": {
-                    "id": 0, 
-                    "output_name": "output"
-                }, 
-                "input2": {
-                    "id": 6, 
-                    "output_name": "out_file1"
-                }
-            }, 
-            "inputs": [
-                {
-                    "description": "runtime parameter for tool Compare two Datasets", 
-                    "name": "input2"
-                }, 
-                {
-                    "description": "runtime parameter for tool Compare two Datasets", 
-                    "name": "input1"
-                }
-            ], 
-            "label": null, 
-            "name": "Compare two Datasets", 
-            "outputs": [
-                {
-                    "name": "out_file1", 
-                    "type": "input"
-                }
-            ], 
-            "position": {
-                "left": 1299.9666748046875, 
-                "top": 258.98333740234375
-            }, 
-            "post_job_actions": {
-                "RenameDatasetActionout_file1": {
-                    "action_arguments": {
-                        "newname": "Top 5 Exons"
-                    }, 
-                    "action_type": "RenameDatasetAction", 
-                    "output_name": "out_file1"
-                }
-            }, 
-            "tool_id": "comp1", 
-            "tool_state": "{\"input2\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\", \"__page__\": null, \"input1\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\", \"field2\": \"\\\"1\\\"\", \"__rerun_remap_job_id__\": null, \"field1\": \"\\\"4\\\"\", \"mode\": \"\\\"N\\\"\"}", 
-            "tool_version": "1.0.2", 
-            "type": "tool", 
-            "uuid": "1cc75a75-1dd2-466f-b3d1-2bdc03dbb005", 
-            "workflow_outputs": [
-                {
-                    "label": null, 
-                    "output_name": "out_file1", 
-                    "uuid": "97434b92-3975-4f5e-bd24-f910f60a8ab5"
-                }
-            ]
+  "a_galaxy_workflow": "true",
+  "annotation": "",
+  "format-version": "0.1",
+  "name": "Find Exons with the highest number of SNPs (or other features)",
+  "steps": {
+    "0": {
+      "annotation": "",
+      "content_id": null,
+      "errors": null,
+      "id": 0,
+      "input_connections": {},
+      "inputs": [
+        {
+          "description": "",
+          "name": "Exons"
         }
-    }, 
-    "tags": [], 
-    "uuid": "d9327bd7-417b-401c-af44-b7402db4cf16"
+      ],
+      "label": "Exons",
+      "name": "Input dataset",
+      "outputs": [],
+      "position": {
+        "left": 195.96665954589844,
+        "top": 245.9666748046875
+      },
+      "tool_id": null,
+      "tool_state": "{\"name\": \"Exons\"}",
+      "tool_version": null,
+      "type": "data_input",
+      "uuid": "c52a5e18-822d-45bd-93c0-d537e607cdc6",
+      "workflow_outputs": [
+        {
+          "label": null,
+          "output_name": "output",
+          "uuid": "2a327882-1ffb-47af-9172-87244d4e3784"
+        }
+      ]
+    },
+    "1": {
+      "annotation": "",
+      "content_id": null,
+      "errors": null,
+      "id": 1,
+      "input_connections": {},
+      "inputs": [
+        {
+          "description": "",
+          "name": "Feature"
+        }
+      ],
+      "label": "Feature",
+      "name": "Input dataset",
+      "outputs": [],
+      "position": {
+        "left": 199.9499969482422,
+        "top": 378.9666748046875
+      },
+      "tool_id": null,
+      "tool_state": "{\"name\": \"Feature\"}",
+      "tool_version": null,
+      "type": "data_input",
+      "uuid": "2f684ad5-8e4e-4fb8-a2a4-645f82579a94",
+      "workflow_outputs": [
+        {
+          "label": null,
+          "output_name": "output",
+          "uuid": "bcd32a06-2a7c-455f-9c6d-d260060aeeb9"
+        }
+      ]
+    },
+    "2": {
+      "annotation": "",
+      "content_id": "toolshed.g2.bx.psu.edu/repos/devteam/join/gops_join_1/1.0.0",
+      "errors": null,
+      "id": 2,
+      "input_connections": {
+        "input1": {
+          "id": 0,
+          "output_name": "output"
+        },
+        "input2": {
+          "id": 1,
+          "output_name": "output"
+        }
+      },
+      "inputs": [
+        {
+          "description": "runtime parameter for tool Join",
+          "name": "input2"
+        },
+        {
+          "description": "runtime parameter for tool Join",
+          "name": "input1"
+        }
+      ],
+      "label": null,
+      "name": "Join",
+      "outputs": [
+        {
+          "name": "output",
+          "type": "interval"
+        }
+      ],
+      "position": {
+        "left": 419.95001220703125,
+        "top": 258.98333740234375
+      },
+      "post_job_actions": {
+        "HideDatasetActionoutput": {
+          "action_arguments": {},
+          "action_type": "HideDatasetAction",
+          "output_name": "output"
+        }
+      },
+      "tool_id": "toolshed.g2.bx.psu.edu/repos/devteam/join/gops_join_1/1.0.0",
+      "tool_shed_repository": {
+        "changeset_revision": "de21bdbb8d28",
+        "name": "join",
+        "owner": "devteam",
+        "tool_shed": "toolshed.g2.bx.psu.edu"
+      },
+      "tool_state": "{\"input2\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\", \"__page__\": null, \"input1\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\", \"min\": \"\\\"1\\\"\", \"__rerun_remap_job_id__\": null, \"chromInfo\": \"\\\"/data/galaxy/galaxy-dist/tool-data/shared/ucsc/chrom/hg19.len\\\"\", \"fill\": \"\\\"none\\\"\"}",
+      "tool_version": "1.0.0",
+      "type": "tool",
+      "uuid": "a165c2c5-6706-4e6d-bf56-93d01c6ba5b0",
+      "workflow_outputs": []
+    },
+    "3": {
+      "annotation": "",
+      "content_id": "Grouping1",
+      "errors": null,
+      "id": 3,
+      "input_connections": {
+        "input1": {
+          "id": 2,
+          "output_name": "output"
+        }
+      },
+      "inputs": [
+        {
+          "description": "runtime parameter for tool Group",
+          "name": "input1"
+        }
+      ],
+      "label": null,
+      "name": "Group",
+      "outputs": [
+        {
+          "name": "out_file1",
+          "type": "tabular"
+        }
+      ],
+      "position": {
+        "left": 639.9666748046875,
+        "top": 258.98333740234375
+      },
+      "post_job_actions": {
+        "HideDatasetActionout_file1": {
+          "action_arguments": {},
+          "action_type": "HideDatasetAction",
+          "output_name": "out_file1"
+        }
+      },
+      "tool_id": "Grouping1",
+      "tool_state": "{\"operations\": \"[{\\\"opcol\\\": \\\"1\\\", \\\"__index__\\\": 0, \\\"optype\\\": \\\"length\\\", \\\"opround\\\": \\\"no\\\"}]\", \"__page__\": null, \"input1\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\", \"ignorelines\": \"null\", \"groupcol\": \"\\\"4\\\"\", \"__rerun_remap_job_id__\": null, \"ignorecase\": \"\\\"false\\\"\", \"chromInfo\": \"\\\"/data/galaxy/galaxy-dist/tool-data/shared/ucsc/chrom/hg19.len\\\"\"}",
+      "tool_version": "2.1.1",
+      "type": "tool",
+      "uuid": "107623d3-77a6-450a-9f91-254ca7000f7b",
+      "workflow_outputs": []
+    },
+    "4": {
+      "annotation": "",
+      "content_id": "Grouping1",
+      "errors": null,
+      "id": 4,
+      "input_connections": {
+        "input1": {
+          "id": 2,
+          "output_name": "output"
+        }
+      },
+      "inputs": [
+        {
+          "description": "runtime parameter for tool Group",
+          "name": "input1"
+        }
+      ],
+      "label": null,
+      "name": "Group",
+      "outputs": [
+        {
+          "name": "out_file1",
+          "type": "tabular"
+        }
+      ],
+      "position": {
+        "left": 639.9666748046875,
+        "top": 378.9666748046875
+      },
+      "post_job_actions": {
+        "HideDatasetActionout_file1": {
+          "action_arguments": {},
+          "action_type": "HideDatasetAction",
+          "output_name": "out_file1"
+        }
+      },
+      "tool_id": "Grouping1",
+      "tool_state": "{\"operations\": \"[{\\\"opcol\\\": \\\"4\\\", \\\"__index__\\\": 0, \\\"optype\\\": \\\"length\\\", \\\"opround\\\": \\\"no\\\"}]\", \"__page__\": null, \"input1\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\", \"ignorelines\": \"null\", \"groupcol\": \"\\\"4\\\"\", \"__rerun_remap_job_id__\": null, \"ignorecase\": \"\\\"false\\\"\", \"chromInfo\": \"\\\"/data/galaxy/galaxy-dist/tool-data/shared/ucsc/chrom/hg19.len\\\"\"}",
+      "tool_version": "2.1.1",
+      "type": "tool",
+      "uuid": "91bdfdbc-cb4e-47c9-9fb8-a3b8214a828a",
+      "workflow_outputs": []
+    },
+    "5": {
+      "annotation": "",
+      "content_id": "toolshed.g2.bx.psu.edu/repos/bgruening/text_processing/tp_sort_header_tool/1.1.1",
+      "errors": null,
+      "id": 5,
+      "input_connections": {
+        "infile": {
+          "id": 4,
+          "output_name": "out_file1"
+        }
+      },
+      "inputs": [
+        {
+          "description": "runtime parameter for tool Sort",
+          "name": "infile"
+        }
+      ],
+      "label": null,
+      "name": "Sort",
+      "outputs": [
+        {
+          "name": "outfile",
+          "type": "input"
+        }
+      ],
+      "position": {
+        "left": 861,
+        "top": 257.5
+      },
+      "post_job_actions": {
+        "HideDatasetActionoutfile": {
+          "action_arguments": {},
+          "action_type": "HideDatasetAction",
+          "output_name": "outfile"
+        }
+      },
+      "tool_id": "toolshed.g2.bx.psu.edu/repos/bgruening/text_processing/tp_sort_header_tool/1.1.1",
+      "tool_shed_repository": {
+        "changeset_revision": "74a8bef53a00",
+        "name": "text_processing",
+        "owner": "bgruening",
+        "tool_shed": "toolshed.g2.bx.psu.edu"
+      },
+      "tool_state": "{\"sortkeys\": \"[{\\\"column\\\": \\\"2\\\", \\\"__index__\\\": 0, \\\"style\\\": \\\"g\\\", \\\"order\\\": \\\"r\\\"}]\", \"__page__\": null, \"ignore_case\": \"\\\"false\\\"\", \"__rerun_remap_job_id__\": null, \"header\": \"\\\"0\\\"\", \"unique\": \"\\\"false\\\"\", \"infile\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\"}",
+      "tool_version": "1.1.1",
+      "type": "tool",
+      "uuid": "2b7ac43c-6e2b-46d0-9c38-c12c897a4310",
+      "workflow_outputs": []
+    },
+    "6": {
+      "annotation": "",
+      "content_id": "Show beginning1",
+      "errors": null,
+      "id": 6,
+      "input_connections": {
+        "input": {
+          "id": 5,
+          "output_name": "outfile"
+        }
+      },
+      "inputs": [
+        {
+          "description": "runtime parameter for tool Select first",
+          "name": "input"
+        }
+      ],
+      "label": null,
+      "name": "Select first",
+      "outputs": [
+        {
+          "name": "out_file1",
+          "type": "input"
+        }
+      ],
+      "position": {
+        "left": 1079.9833984375,
+        "top": 258.98333740234375
+      },
+      "post_job_actions": {
+        "HideDatasetActionout_file1": {
+          "action_arguments": {},
+          "action_type": "HideDatasetAction",
+          "output_name": "out_file1"
+        }
+      },
+      "tool_id": "Show beginning1",
+      "tool_state": "{\"__page__\": null, \"lineNum\": \"\\\"5\\\"\", \"__rerun_remap_job_id__\": null, \"chromInfo\": \"\\\"/data/galaxy/galaxy-dist/tool-data/shared/ucsc/chrom/hg19.len\\\"\", \"input\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\"}",
+      "tool_version": "1.0.0",
+      "type": "tool",
+      "uuid": "ecedf93a-a895-433a-a029-458e6a3ff3ed",
+      "workflow_outputs": [],
+      "tool_shed_repository": {
+        "changeset_revision": "b5af46a99f6e",
+        "name": "show_beginning",
+        "owner": "devteam",
+        "tool_shed": "toolshed.g2.bx.psu.edu"
+      }
+    },
+    "7": {
+      "annotation": "",
+      "content_id": "comp1",
+      "errors": null,
+      "id": 7,
+      "input_connections": {
+        "input1": {
+          "id": 0,
+          "output_name": "output"
+        },
+        "input2": {
+          "id": 6,
+          "output_name": "out_file1"
+        }
+      },
+      "inputs": [
+        {
+          "description": "runtime parameter for tool Compare two Datasets",
+          "name": "input2"
+        },
+        {
+          "description": "runtime parameter for tool Compare two Datasets",
+          "name": "input1"
+        }
+      ],
+      "label": null,
+      "name": "Compare two Datasets",
+      "outputs": [
+        {
+          "name": "out_file1",
+          "type": "input"
+        }
+      ],
+      "position": {
+        "left": 1299.9666748046875,
+        "top": 258.98333740234375
+      },
+      "post_job_actions": {
+        "RenameDatasetActionout_file1": {
+          "action_arguments": {
+            "newname": "Top 5 Exons"
+          },
+          "action_type": "RenameDatasetAction",
+          "output_name": "out_file1"
+        }
+      },
+      "tool_id": "comp1",
+      "tool_state": "{\"input2\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\", \"__page__\": null, \"input1\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\", \"field2\": \"\\\"1\\\"\", \"__rerun_remap_job_id__\": null, \"field1\": \"\\\"4\\\"\", \"mode\": \"\\\"N\\\"\"}",
+      "tool_version": "1.0.2",
+      "type": "tool",
+      "uuid": "1cc75a75-1dd2-466f-b3d1-2bdc03dbb005",
+      "workflow_outputs": [
+        {
+          "label": null,
+          "output_name": "out_file1",
+          "uuid": "97434b92-3975-4f5e-bd24-f910f60a8ab5"
+        }
+      ],
+      "tool_shed_repository": {
+        "changeset_revision": "c2a356708570",
+        "name": "sharplabtool",
+        "owner": "xuebing",
+        "tool_shed": "toolshed.g2.bx.psu.edu"
+      }
+    }
+  },
+  "tags": [],
+  "uuid": "d9327bd7-417b-401c-af44-b7402db4cf16"
 }

--- a/topics/epigenetics/tutorials/estrogen-receptor-binding-site-identification/workflows/chip_seq.ga
+++ b/topics/epigenetics/tutorials/estrogen-receptor-binding-site-identification/workflows/chip_seq.ga
@@ -2,7 +2,7 @@
     "a_galaxy_workflow": "true", 
     "annotation": "", 
     "format-version": "0.1", 
-    "name": "Identification of the binding sites of the Estrogen receptor", 
+    "name": "Identification of the binding sites of the Estrogen receptor - chip-seq", 
     "steps": {
         "0": {
             "annotation": "", 

--- a/topics/epigenetics/tutorials/estrogen-receptor-binding-site-identification/workflows/qc_mapping.ga
+++ b/topics/epigenetics/tutorials/estrogen-receptor-binding-site-identification/workflows/qc_mapping.ga
@@ -2,7 +2,7 @@
     "a_galaxy_workflow": "true", 
     "annotation": "", 
     "format-version": "0.1", 
-    "name": "Identification of the binding sites of the Estrogen receptor", 
+    "name": "Identification of the binding sites of the Estrogen receptor - qc mapping", 
     "steps": {
         "0": {
             "annotation": "", 

--- a/topics/epigenetics/tutorials/ewas-suite/tours/tour.yaml
+++ b/topics/epigenetics/tutorials/ewas-suite/tours/tour.yaml
@@ -1,5 +1,0 @@
----
-id: ewas-suite
-name: ewas-suite
-description: Epigenome-wide association studies (EWAS) analyse genome-wide activity of epigenetic marks in  cohorts of different individuals to find associations between epigenetic variation and phenotype
-title_default: "EWAS data analysis"

--- a/topics/epigenetics/tutorials/formation_of_super-structures_on_xi/workflows/formation_of_super_structures_on_xi.ga
+++ b/topics/epigenetics/tutorials/formation_of_super-structures_on_xi/workflows/formation_of_super_structures_on_xi.ga
@@ -2923,7 +2923,7 @@
     },
     "50": {
       "annotation": "",
-      "content_id": "datamash_ops",
+      "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/datamash_ops/datamash_ops/1.0.6",
       "errors": null,
       "id": 50,
       "input_connections": {
@@ -2957,7 +2957,7 @@
           "output_name": "out_file"
         }
       },
-      "tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/datamash_ops/datamash_ops/datamash_ops/1.0.6",
+      "tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/datamash_ops/datamash_ops/1.0.6",
       "tool_shed_repository": {
         "changeset_revision": "2f3c6f2dcf39",
         "name": "datamash_ops",
@@ -2972,7 +2972,7 @@
     },
     "51": {
       "annotation": "",
-      "content_id": "datamash_ops",
+      "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/datamash_ops/datamash_ops/1.0.6",
       "errors": null,
       "id": 51,
       "input_connections": {
@@ -3006,7 +3006,7 @@
           "output_name": "out_file"
         }
       },
-      "tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/datamash_ops/datamash_ops/datamash_ops/1.0.6",
+      "tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/datamash_ops/datamash_ops/1.0.6",
       "tool_shed_repository": {
         "changeset_revision": "2f3c6f2dcf39",
         "name": "datamash_ops",

--- a/topics/epigenetics/tutorials/formation_of_super-structures_on_xi/workflows/formation_of_super_structures_on_xi.ga
+++ b/topics/epigenetics/tutorials/formation_of_super-structures_on_xi/workflows/formation_of_super_structures_on_xi.ga
@@ -2923,7 +2923,7 @@
     },
     "50": {
       "annotation": "",
-      "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/datamash_ops/datamash_ops/datamash_ops/1.0.6",
+      "content_id": "datamash_ops",
       "errors": null,
       "id": 50,
       "input_connections": {
@@ -2972,7 +2972,7 @@
     },
     "51": {
       "annotation": "",
-      "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/datamash_ops/datamash_ops/datamash_ops/1.0.6",
+      "content_id": "datamash_ops",
       "errors": null,
       "id": 51,
       "input_connections": {

--- a/topics/introduction/tutorials/galaxy-intro-101-everyone/workflows/main_workflow.ga
+++ b/topics/introduction/tutorials/galaxy-intro-101-everyone/workflows/main_workflow.ga
@@ -32,8 +32,8 @@
       "type": "data_input"
     },
     "1": {
-      "tool_id": "csv_to_tabular",
-      "tool_version": "1.0.0",
+      "tool_id": "csv2tab_R",
+      "tool_version": "0.1",
       "outputs": [
         {
           "type": "tabular",
@@ -61,7 +61,13 @@
       },
       "annotation": "",
       "content_id": "csv_to_tabular",
-      "type": "tool"
+      "type": "tool",
+      "tool_shed_repository": {
+        "changeset_revision": "b735ac78702b",
+        "name": "csv_to_tabular",
+        "owner": "mnhn65mo",
+        "tool_shed": "toolshed.g2.bx.psu.edu"
+      }
     },
     "2": {
       "tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/datamash_ops/datamash_ops/1.1.0",

--- a/topics/introduction/tutorials/galaxy-intro-101-everyone/workflows/main_workflow.ga
+++ b/topics/introduction/tutorials/galaxy-intro-101-everyone/workflows/main_workflow.ga
@@ -32,8 +32,8 @@
       "type": "data_input"
     },
     "1": {
-      "tool_id": "csv2tab_R",
-      "tool_version": "0.1",
+      "tool_id": "csv_to_tabular",
+      "tool_version": "1.0.0",
       "outputs": [
         {
           "type": "tabular",
@@ -61,13 +61,7 @@
       },
       "annotation": "",
       "content_id": "csv_to_tabular",
-      "type": "tool",
-      "tool_shed_repository": {
-        "changeset_revision": "b735ac78702b",
-        "name": "csv_to_tabular",
-        "owner": "mnhn65mo",
-        "tool_shed": "toolshed.g2.bx.psu.edu"
-      }
+      "type": "tool"
     },
     "2": {
       "tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/datamash_ops/datamash_ops/1.1.0",

--- a/topics/proteomics/tutorials/database-handling/workflows/wf_database-handling.ga
+++ b/topics/proteomics/tutorials/database-handling/workflows/wf_database-handling.ga
@@ -1,372 +1,378 @@
 {
-    "a_galaxy_workflow": "true", 
-    "annotation": "", 
-    "format-version": "0.1", 
-    "name": "Database Handling Tutorial Workflow", 
-    "steps": {
-        "0": {
-            "annotation": "", 
-            "content_id": "toolshed.g2.bx.psu.edu/repos/galaxyp/dbbuilder/dbbuilder/0.2.0", 
-            "id": 0, 
-            "input_connections": {}, 
-            "inputs": [], 
-            "label": null, 
-            "name": "Protein Database Downloader", 
-            "outputs": [
-                {
-                    "name": "output_database", 
-                    "type": "fasta"
-                }
-            ], 
-            "position": {
-                "left": 221, 
-                "top": 372
-            }, 
-            "post_job_actions": {
-                "HideDatasetActionoutput_database": {
-                    "action_arguments": {}, 
-                    "action_type": "HideDatasetAction", 
-                    "output_name": "output_database"
-                }, 
-                "RenameDatasetActionoutput_database": {
-                    "action_arguments": {
-                        "newname": "Main database"
-                    }, 
-                    "action_type": "RenameDatasetAction", 
-                    "output_name": "output_database"
-                }
-            }, 
-            "tool_errors": null, 
-            "tool_id": "toolshed.g2.bx.psu.edu/repos/galaxyp/dbbuilder/dbbuilder/0.2.0", 
-            "tool_shed_repository": {
-                "changeset_revision": "b39347891609", 
-                "name": "dbbuilder", 
-                "owner": "galaxyp", 
-                "tool_shed": "toolshed.g2.bx.psu.edu"
-            }, 
-            "tool_state": "{\"source\": \"{\\\"set\\\": \\\"+keyword%3a1185\\\", \\\"from\\\": \\\"uniprot\\\", \\\"taxon\\\": \\\"9606\\\", \\\"reviewed\\\": \\\"+reviewed%3Ayes\\\", \\\"__current_case__\\\": 0, \\\"include_isoform\\\": \\\"false\\\"}\", \"__rerun_remap_job_id__\": null, \"__page__\": 0}", 
-            "tool_version": "0.2.0", 
-            "type": "tool", 
-            "uuid": "7f5ca5fe-79b5-4e25-9121-0e4349c2185a", 
-            "workflow_outputs": []
-        }, 
-        "1": {
-            "annotation": "", 
-            "content_id": "toolshed.g2.bx.psu.edu/repos/galaxyp/dbbuilder/dbbuilder/0.2.0", 
-            "id": 1, 
-            "input_connections": {}, 
-            "inputs": [], 
-            "label": null, 
-            "name": "Protein Database Downloader", 
-            "outputs": [
-                {
-                    "name": "output_database", 
-                    "type": "fasta"
-                }
-            ], 
-            "position": {
-                "left": 221, 
-                "top": 492
-            }, 
-            "post_job_actions": {
-                "HideDatasetActionoutput_database": {
-                    "action_arguments": {}, 
-                    "action_type": "HideDatasetAction", 
-                    "output_name": "output_database"
-                }, 
-                "RenameDatasetActionoutput_database": {
-                    "action_arguments": {
-                        "newname": "cRAP database"
-                    }, 
-                    "action_type": "RenameDatasetAction", 
-                    "output_name": "output_database"
-                }
-            }, 
-            "tool_errors": null, 
-            "tool_id": "toolshed.g2.bx.psu.edu/repos/galaxyp/dbbuilder/dbbuilder/0.2.0", 
-            "tool_shed_repository": {
-                "changeset_revision": "b39347891609", 
-                "name": "dbbuilder", 
-                "owner": "galaxyp", 
-                "tool_shed": "toolshed.g2.bx.psu.edu"
-            }, 
-            "tool_state": "{\"source\": \"{\\\"from\\\": \\\"cRAP\\\", \\\"__current_case__\\\": 1}\", \"__rerun_remap_job_id__\": null, \"__page__\": 0}", 
-            "tool_version": "0.2.0", 
-            "type": "tool", 
-            "uuid": "defc442e-f1e5-40da-b702-4e55e1a9107e", 
-            "workflow_outputs": []
-        }, 
-        "2": {
-            "annotation": "", 
-            "content_id": "toolshed.g2.bx.psu.edu/repos/devteam/fasta_to_tabular/fasta2tab/1.1.0", 
-            "id": 2, 
-            "input_connections": {
-                "input": {
-                    "id": 1, 
-                    "output_name": "output_database"
-                }
-            }, 
-            "inputs": [
-                {
-                    "description": "runtime parameter for tool FASTA-to-Tabular", 
-                    "name": "input"
-                }
-            ], 
-            "label": null, 
-            "name": "FASTA-to-Tabular", 
-            "outputs": [
-                {
-                    "name": "output", 
-                    "type": "tabular"
-                }
-            ], 
-            "position": {
-                "left": 508, 
-                "top": 443
-            }, 
-            "post_job_actions": {
-                "DeleteIntermediatesActionoutput": {
-                    "action_arguments": {}, 
-                    "action_type": "DeleteIntermediatesAction", 
-                    "output_name": "output"
-                }, 
-                "HideDatasetActionoutput": {
-                    "action_arguments": {}, 
-                    "action_type": "HideDatasetAction", 
-                    "output_name": "output"
-                }
-            }, 
-            "tool_errors": null, 
-            "tool_id": "toolshed.g2.bx.psu.edu/repos/devteam/fasta_to_tabular/fasta2tab/1.1.0", 
-            "tool_shed_repository": {
-                "changeset_revision": "7e801ab2b70e", 
-                "name": "fasta_to_tabular", 
-                "owner": "devteam", 
-                "tool_shed": "toolshed.g2.bx.psu.edu"
-            }, 
-            "tool_state": "{\"input\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\", \"keep_first\": \"\\\"0\\\"\", \"__rerun_remap_job_id__\": null, \"descr_columns\": \"\\\"1\\\"\", \"__page__\": 0}", 
-            "tool_version": "1.1.0", 
-            "type": "tool", 
-            "uuid": "911f4ecd-57cf-4d2d-8d1f-40597493b75a", 
-            "workflow_outputs": []
-        }, 
-        "3": {
-            "annotation": "", 
-            "content_id": "toolshed.g2.bx.psu.edu/repos/devteam/add_value/addValue/1.0.0", 
-            "id": 3, 
-            "input_connections": {
-                "input": {
-                    "id": 2, 
-                    "output_name": "output"
-                }
-            }, 
-            "inputs": [
-                {
-                    "description": "runtime parameter for tool Add column", 
-                    "name": "input"
-                }
-            ], 
-            "label": null, 
-            "name": "Add column", 
-            "outputs": [
-                {
-                    "name": "out_file1", 
-                    "type": "input"
-                }
-            ], 
-            "position": {
-                "left": 728, 
-                "top": 477
-            }, 
-            "post_job_actions": {
-                "DeleteIntermediatesActionout_file1": {
-                    "action_arguments": {}, 
-                    "action_type": "DeleteIntermediatesAction", 
-                    "output_name": "out_file1"
-                }, 
-                "HideDatasetActionout_file1": {
-                    "action_arguments": {}, 
-                    "action_type": "HideDatasetAction", 
-                    "output_name": "out_file1"
-                }
-            }, 
-            "tool_errors": null, 
-            "tool_id": "toolshed.g2.bx.psu.edu/repos/devteam/add_value/addValue/1.0.0", 
-            "tool_shed_repository": {
-                "changeset_revision": "745871c0b055", 
-                "name": "add_value", 
-                "owner": "devteam", 
-                "tool_shed": "toolshed.g2.bx.psu.edu"
-            }, 
-            "tool_state": "{\"__page__\": 0, \"input\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\", \"__rerun_remap_job_id__\": null, \"exp\": \"\\\"CONTAMINANT\\\"\", \"iterate\": \"\\\"no\\\"\"}", 
-            "tool_version": "1.0.0", 
-            "type": "tool", 
-            "uuid": "1fe09bbb-ba83-448f-8dfd-1b7270441c42", 
-            "workflow_outputs": []
-        }, 
-        "4": {
-            "annotation": "", 
-            "content_id": "toolshed.g2.bx.psu.edu/repos/devteam/tabular_to_fasta/tab2fasta/1.1.0", 
-            "id": 4, 
-            "input_connections": {
-                "input": {
-                    "id": 3, 
-                    "output_name": "out_file1"
-                }
-            }, 
-            "inputs": [
-                {
-                    "description": "runtime parameter for tool Tabular-to-FASTA", 
-                    "name": "input"
-                }
-            ], 
-            "label": null, 
-            "name": "Tabular-to-FASTA", 
-            "outputs": [
-                {
-                    "name": "output", 
-                    "type": "fasta"
-                }
-            ], 
-            "position": {
-                "left": 912, 
-                "top": 507
-            }, 
-            "post_job_actions": {
-                "HideDatasetActionoutput": {
-                    "action_arguments": {}, 
-                    "action_type": "HideDatasetAction", 
-                    "output_name": "output"
-                }, 
-                "RenameDatasetActionoutput": {
-                    "action_arguments": {
-                        "newname": "tagged cRAP database"
-                    }, 
-                    "action_type": "RenameDatasetAction", 
-                    "output_name": "output"
-                }
-            }, 
-            "tool_errors": null, 
-            "tool_id": "toolshed.g2.bx.psu.edu/repos/devteam/tabular_to_fasta/tab2fasta/1.1.0", 
-            "tool_shed_repository": {
-                "changeset_revision": "0b4e36026794", 
-                "name": "tabular_to_fasta", 
-                "owner": "devteam", 
-                "tool_shed": "toolshed.g2.bx.psu.edu"
-            }, 
-            "tool_state": "{\"title_col\": \"[\\\"1\\\", \\\"3\\\"]\", \"input\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\", \"__page__\": 0, \"__rerun_remap_job_id__\": null, \"seq_col\": \"\\\"2\\\"\"}", 
-            "tool_version": "1.1.0", 
-            "type": "tool", 
-            "uuid": "1bd7f1b9-4974-4cd5-b9a1-91787e503ecf", 
-            "workflow_outputs": []
-        }, 
-        "5": {
-            "annotation": "", 
-            "content_id": "toolshed.g2.bx.psu.edu/repos/galaxyp/fasta_merge_files_and_filter_unique_sequences/fasta_merge_files_and_filter_unique_sequences/1.0", 
-            "id": 5, 
-            "input_connections": {
-                "inputs_0|input": {
-                    "id": 0, 
-                    "output_name": "output_database"
-                }, 
-                "inputs_1|input": {
-                    "id": 4, 
-                    "output_name": "output"
-                }
-            }, 
-            "inputs": [], 
-            "label": null, 
-            "name": "FASTA Merge Files and Filter Unique Sequences", 
-            "outputs": [
-                {
-                    "name": "output", 
-                    "type": "fasta"
-                }
-            ], 
-            "position": {
-                "left": 1131, 
-                "top": 333
-            }, 
-            "post_job_actions": {
-                "RenameDatasetActionoutput": {
-                    "action_arguments": {
-                        "newname": "Main database (cRAP added)"
-                    }, 
-                    "action_type": "RenameDatasetAction", 
-                    "output_name": "output"
-                }
-            }, 
-            "tool_errors": null, 
-            "tool_id": "toolshed.g2.bx.psu.edu/repos/galaxyp/fasta_merge_files_and_filter_unique_sequences/fasta_merge_files_and_filter_unique_sequences/1.0", 
-            "tool_shed_repository": {
-                "changeset_revision": "2904d46167da", 
-                "name": "fasta_merge_files_and_filter_unique_sequences", 
-                "owner": "galaxyp", 
-                "tool_shed": "toolshed.g2.bx.psu.edu"
-            }, 
-            "tool_state": "{\"inputs\": \"[{\\\"__index__\\\": 0, \\\"input\\\": {\\\"__class__\\\": \\\"RuntimeValue\\\"}}, {\\\"__index__\\\": 1, \\\"input\\\": {\\\"__class__\\\": \\\"RuntimeValue\\\"}}]\", \"__rerun_remap_job_id__\": null, \"__page__\": 0}", 
-            "tool_version": "1.0", 
-            "type": "tool", 
-            "uuid": "6fbc2008-7b04-49af-af2f-01c55ff09e59", 
-            "workflow_outputs": [
-                {
-                    "label": "", 
-                    "output_name": "output", 
-                    "uuid": "bb1f67d0-6e5e-462e-9802-f354706a1531"
-                }
-            ]
-        }, 
-        "6": {
-            "annotation": "", 
-            "content_id": "DecoyDatabase", 
-            "id": 6, 
-            "input_connections": {
-                "param_in": {
-                    "id": 5, 
-                    "output_name": "output"
-                }
-            }, 
-            "inputs": [
-                {
-                    "description": "runtime parameter for tool DecoyDatabase", 
-                    "name": "param_in"
-                }
-            ], 
-            "label": null, 
-            "name": "DecoyDatabase", 
-            "outputs": [
-                {
-                    "name": "param_out", 
-                    "type": "fasta"
-                }
-            ], 
-            "position": {
-                "left": 1438, 
-                "top": 355.5
-            }, 
-            "post_job_actions": {
-                "RenameDatasetActionparam_out": {
-                    "action_arguments": {
-                        "newname": "Main database with decoys (cRAP added)"
-                    }, 
-                    "action_type": "RenameDatasetAction", 
-                    "output_name": "param_out"
-                }
-            }, 
-            "tool_errors": null, 
-            "tool_id": "DecoyDatabase", 
-            "tool_state": "{\"__page__\": 0, \"param_append\": \"\\\"true\\\"\", \"adv_opts\": \"{\\\"adv_opts_selector\\\": \\\"basic\\\", \\\"__current_case__\\\": 0}\", \"__rerun_remap_job_id__\": null, \"param_method\": \"\\\"reverse\\\"\", \"param_decoy_string\": \"\\\"DECOY_\\\"\", \"param_decoy_string_position\": \"\\\"prefix\\\"\", \"param_in\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\"}", 
-            "tool_version": "2.1.0", 
-            "type": "tool", 
-            "uuid": "a96cde43-cd29-4683-8f32-fe8603b2e682", 
-            "workflow_outputs": [
-                {
-                    "label": null, 
-                    "output_name": "param_out", 
-                    "uuid": "9f464e59-daa0-4013-b266-4b7eae387507"
-                }
-            ]
+  "a_galaxy_workflow": "true",
+  "annotation": "",
+  "format-version": "0.1",
+  "name": "Database Handling Tutorial Workflow",
+  "steps": {
+    "0": {
+      "annotation": "",
+      "content_id": "toolshed.g2.bx.psu.edu/repos/galaxyp/dbbuilder/dbbuilder/0.2.0",
+      "id": 0,
+      "input_connections": {},
+      "inputs": [],
+      "label": null,
+      "name": "Protein Database Downloader",
+      "outputs": [
+        {
+          "name": "output_database",
+          "type": "fasta"
         }
-    }, 
-    "uuid": "4226528a-b119-4086-88d2-ec3d211d3e84"
+      ],
+      "position": {
+        "left": 221,
+        "top": 372
+      },
+      "post_job_actions": {
+        "HideDatasetActionoutput_database": {
+          "action_arguments": {},
+          "action_type": "HideDatasetAction",
+          "output_name": "output_database"
+        },
+        "RenameDatasetActionoutput_database": {
+          "action_arguments": {
+            "newname": "Main database"
+          },
+          "action_type": "RenameDatasetAction",
+          "output_name": "output_database"
+        }
+      },
+      "tool_errors": null,
+      "tool_id": "toolshed.g2.bx.psu.edu/repos/galaxyp/dbbuilder/dbbuilder/0.2.0",
+      "tool_shed_repository": {
+        "changeset_revision": "b39347891609",
+        "name": "dbbuilder",
+        "owner": "galaxyp",
+        "tool_shed": "toolshed.g2.bx.psu.edu"
+      },
+      "tool_state": "{\"source\": \"{\\\"set\\\": \\\"+keyword%3a1185\\\", \\\"from\\\": \\\"uniprot\\\", \\\"taxon\\\": \\\"9606\\\", \\\"reviewed\\\": \\\"+reviewed%3Ayes\\\", \\\"__current_case__\\\": 0, \\\"include_isoform\\\": \\\"false\\\"}\", \"__rerun_remap_job_id__\": null, \"__page__\": 0}",
+      "tool_version": "0.2.0",
+      "type": "tool",
+      "uuid": "7f5ca5fe-79b5-4e25-9121-0e4349c2185a",
+      "workflow_outputs": []
+    },
+    "1": {
+      "annotation": "",
+      "content_id": "toolshed.g2.bx.psu.edu/repos/galaxyp/dbbuilder/dbbuilder/0.2.0",
+      "id": 1,
+      "input_connections": {},
+      "inputs": [],
+      "label": null,
+      "name": "Protein Database Downloader",
+      "outputs": [
+        {
+          "name": "output_database",
+          "type": "fasta"
+        }
+      ],
+      "position": {
+        "left": 221,
+        "top": 492
+      },
+      "post_job_actions": {
+        "HideDatasetActionoutput_database": {
+          "action_arguments": {},
+          "action_type": "HideDatasetAction",
+          "output_name": "output_database"
+        },
+        "RenameDatasetActionoutput_database": {
+          "action_arguments": {
+            "newname": "cRAP database"
+          },
+          "action_type": "RenameDatasetAction",
+          "output_name": "output_database"
+        }
+      },
+      "tool_errors": null,
+      "tool_id": "toolshed.g2.bx.psu.edu/repos/galaxyp/dbbuilder/dbbuilder/0.2.0",
+      "tool_shed_repository": {
+        "changeset_revision": "b39347891609",
+        "name": "dbbuilder",
+        "owner": "galaxyp",
+        "tool_shed": "toolshed.g2.bx.psu.edu"
+      },
+      "tool_state": "{\"source\": \"{\\\"from\\\": \\\"cRAP\\\", \\\"__current_case__\\\": 1}\", \"__rerun_remap_job_id__\": null, \"__page__\": 0}",
+      "tool_version": "0.2.0",
+      "type": "tool",
+      "uuid": "defc442e-f1e5-40da-b702-4e55e1a9107e",
+      "workflow_outputs": []
+    },
+    "2": {
+      "annotation": "",
+      "content_id": "toolshed.g2.bx.psu.edu/repos/devteam/fasta_to_tabular/fasta2tab/1.1.0",
+      "id": 2,
+      "input_connections": {
+        "input": {
+          "id": 1,
+          "output_name": "output_database"
+        }
+      },
+      "inputs": [
+        {
+          "description": "runtime parameter for tool FASTA-to-Tabular",
+          "name": "input"
+        }
+      ],
+      "label": null,
+      "name": "FASTA-to-Tabular",
+      "outputs": [
+        {
+          "name": "output",
+          "type": "tabular"
+        }
+      ],
+      "position": {
+        "left": 508,
+        "top": 443
+      },
+      "post_job_actions": {
+        "DeleteIntermediatesActionoutput": {
+          "action_arguments": {},
+          "action_type": "DeleteIntermediatesAction",
+          "output_name": "output"
+        },
+        "HideDatasetActionoutput": {
+          "action_arguments": {},
+          "action_type": "HideDatasetAction",
+          "output_name": "output"
+        }
+      },
+      "tool_errors": null,
+      "tool_id": "toolshed.g2.bx.psu.edu/repos/devteam/fasta_to_tabular/fasta2tab/1.1.0",
+      "tool_shed_repository": {
+        "changeset_revision": "7e801ab2b70e",
+        "name": "fasta_to_tabular",
+        "owner": "devteam",
+        "tool_shed": "toolshed.g2.bx.psu.edu"
+      },
+      "tool_state": "{\"input\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\", \"keep_first\": \"\\\"0\\\"\", \"__rerun_remap_job_id__\": null, \"descr_columns\": \"\\\"1\\\"\", \"__page__\": 0}",
+      "tool_version": "1.1.0",
+      "type": "tool",
+      "uuid": "911f4ecd-57cf-4d2d-8d1f-40597493b75a",
+      "workflow_outputs": []
+    },
+    "3": {
+      "annotation": "",
+      "content_id": "toolshed.g2.bx.psu.edu/repos/devteam/add_value/addValue/1.0.0",
+      "id": 3,
+      "input_connections": {
+        "input": {
+          "id": 2,
+          "output_name": "output"
+        }
+      },
+      "inputs": [
+        {
+          "description": "runtime parameter for tool Add column",
+          "name": "input"
+        }
+      ],
+      "label": null,
+      "name": "Add column",
+      "outputs": [
+        {
+          "name": "out_file1",
+          "type": "input"
+        }
+      ],
+      "position": {
+        "left": 728,
+        "top": 477
+      },
+      "post_job_actions": {
+        "DeleteIntermediatesActionout_file1": {
+          "action_arguments": {},
+          "action_type": "DeleteIntermediatesAction",
+          "output_name": "out_file1"
+        },
+        "HideDatasetActionout_file1": {
+          "action_arguments": {},
+          "action_type": "HideDatasetAction",
+          "output_name": "out_file1"
+        }
+      },
+      "tool_errors": null,
+      "tool_id": "toolshed.g2.bx.psu.edu/repos/devteam/add_value/addValue/1.0.0",
+      "tool_shed_repository": {
+        "changeset_revision": "745871c0b055",
+        "name": "add_value",
+        "owner": "devteam",
+        "tool_shed": "toolshed.g2.bx.psu.edu"
+      },
+      "tool_state": "{\"__page__\": 0, \"input\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\", \"__rerun_remap_job_id__\": null, \"exp\": \"\\\"CONTAMINANT\\\"\", \"iterate\": \"\\\"no\\\"\"}",
+      "tool_version": "1.0.0",
+      "type": "tool",
+      "uuid": "1fe09bbb-ba83-448f-8dfd-1b7270441c42",
+      "workflow_outputs": []
+    },
+    "4": {
+      "annotation": "",
+      "content_id": "toolshed.g2.bx.psu.edu/repos/devteam/tabular_to_fasta/tab2fasta/1.1.0",
+      "id": 4,
+      "input_connections": {
+        "input": {
+          "id": 3,
+          "output_name": "out_file1"
+        }
+      },
+      "inputs": [
+        {
+          "description": "runtime parameter for tool Tabular-to-FASTA",
+          "name": "input"
+        }
+      ],
+      "label": null,
+      "name": "Tabular-to-FASTA",
+      "outputs": [
+        {
+          "name": "output",
+          "type": "fasta"
+        }
+      ],
+      "position": {
+        "left": 912,
+        "top": 507
+      },
+      "post_job_actions": {
+        "HideDatasetActionoutput": {
+          "action_arguments": {},
+          "action_type": "HideDatasetAction",
+          "output_name": "output"
+        },
+        "RenameDatasetActionoutput": {
+          "action_arguments": {
+            "newname": "tagged cRAP database"
+          },
+          "action_type": "RenameDatasetAction",
+          "output_name": "output"
+        }
+      },
+      "tool_errors": null,
+      "tool_id": "toolshed.g2.bx.psu.edu/repos/devteam/tabular_to_fasta/tab2fasta/1.1.0",
+      "tool_shed_repository": {
+        "changeset_revision": "0b4e36026794",
+        "name": "tabular_to_fasta",
+        "owner": "devteam",
+        "tool_shed": "toolshed.g2.bx.psu.edu"
+      },
+      "tool_state": "{\"title_col\": \"[\\\"1\\\", \\\"3\\\"]\", \"input\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\", \"__page__\": 0, \"__rerun_remap_job_id__\": null, \"seq_col\": \"\\\"2\\\"\"}",
+      "tool_version": "1.1.0",
+      "type": "tool",
+      "uuid": "1bd7f1b9-4974-4cd5-b9a1-91787e503ecf",
+      "workflow_outputs": []
+    },
+    "5": {
+      "annotation": "",
+      "content_id": "toolshed.g2.bx.psu.edu/repos/galaxyp/fasta_merge_files_and_filter_unique_sequences/fasta_merge_files_and_filter_unique_sequences/1.0",
+      "id": 5,
+      "input_connections": {
+        "inputs_0|input": {
+          "id": 0,
+          "output_name": "output_database"
+        },
+        "inputs_1|input": {
+          "id": 4,
+          "output_name": "output"
+        }
+      },
+      "inputs": [],
+      "label": null,
+      "name": "FASTA Merge Files and Filter Unique Sequences",
+      "outputs": [
+        {
+          "name": "output",
+          "type": "fasta"
+        }
+      ],
+      "position": {
+        "left": 1131,
+        "top": 333
+      },
+      "post_job_actions": {
+        "RenameDatasetActionoutput": {
+          "action_arguments": {
+            "newname": "Main database (cRAP added)"
+          },
+          "action_type": "RenameDatasetAction",
+          "output_name": "output"
+        }
+      },
+      "tool_errors": null,
+      "tool_id": "toolshed.g2.bx.psu.edu/repos/galaxyp/fasta_merge_files_and_filter_unique_sequences/fasta_merge_files_and_filter_unique_sequences/1.0",
+      "tool_shed_repository": {
+        "changeset_revision": "2904d46167da",
+        "name": "fasta_merge_files_and_filter_unique_sequences",
+        "owner": "galaxyp",
+        "tool_shed": "toolshed.g2.bx.psu.edu"
+      },
+      "tool_state": "{\"inputs\": \"[{\\\"__index__\\\": 0, \\\"input\\\": {\\\"__class__\\\": \\\"RuntimeValue\\\"}}, {\\\"__index__\\\": 1, \\\"input\\\": {\\\"__class__\\\": \\\"RuntimeValue\\\"}}]\", \"__rerun_remap_job_id__\": null, \"__page__\": 0}",
+      "tool_version": "1.0",
+      "type": "tool",
+      "uuid": "6fbc2008-7b04-49af-af2f-01c55ff09e59",
+      "workflow_outputs": [
+        {
+          "label": "",
+          "output_name": "output",
+          "uuid": "bb1f67d0-6e5e-462e-9802-f354706a1531"
+        }
+      ]
+    },
+    "6": {
+      "annotation": "",
+      "content_id": "DecoyDatabase",
+      "id": 6,
+      "input_connections": {
+        "param_in": {
+          "id": 5,
+          "output_name": "output"
+        }
+      },
+      "inputs": [
+        {
+          "description": "runtime parameter for tool DecoyDatabase",
+          "name": "param_in"
+        }
+      ],
+      "label": null,
+      "name": "DecoyDatabase",
+      "outputs": [
+        {
+          "name": "param_out",
+          "type": "fasta"
+        }
+      ],
+      "position": {
+        "left": 1438,
+        "top": 355.5
+      },
+      "post_job_actions": {
+        "RenameDatasetActionparam_out": {
+          "action_arguments": {
+            "newname": "Main database with decoys (cRAP added)"
+          },
+          "action_type": "RenameDatasetAction",
+          "output_name": "param_out"
+        }
+      },
+      "tool_errors": null,
+      "tool_id": "DecoyDatabase",
+      "tool_state": "{\"__page__\": 0, \"param_append\": \"\\\"true\\\"\", \"adv_opts\": \"{\\\"adv_opts_selector\\\": \\\"basic\\\", \\\"__current_case__\\\": 0}\", \"__rerun_remap_job_id__\": null, \"param_method\": \"\\\"reverse\\\"\", \"param_decoy_string\": \"\\\"DECOY_\\\"\", \"param_decoy_string_position\": \"\\\"prefix\\\"\", \"param_in\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\"}",
+      "tool_version": "2.1.0",
+      "type": "tool",
+      "uuid": "a96cde43-cd29-4683-8f32-fe8603b2e682",
+      "workflow_outputs": [
+        {
+          "label": null,
+          "output_name": "param_out",
+          "uuid": "9f464e59-daa0-4013-b266-4b7eae387507"
+        }
+      ],
+      "tool_shed_repository": {
+        "changeset_revision": "8ced1ef014ae",
+        "name": "openms_decoydatabase",
+        "owner": "galaxyp",
+        "tool_shed": "toolshed.g2.bx.psu.edu"
+      }
+    }
+  },
+  "uuid": "4226528a-b119-4086-88d2-ec3d211d3e84"
 }

--- a/topics/proteomics/tutorials/database-handling/workflows/wf_database-handling_mycoplasma.ga
+++ b/topics/proteomics/tutorials/database-handling/workflows/wf_database-handling_mycoplasma.ga
@@ -1,726 +1,732 @@
 {
-    "a_galaxy_workflow": "true", 
-    "annotation": "", 
-    "format-version": "0.1", 
-    "name": "Database Handling Tutorial Workflow2 including Mycoplasma", 
-    "steps": {
-        "0": {
-            "annotation": "", 
-            "content_id": "toolshed.g2.bx.psu.edu/repos/galaxyp/dbbuilder/dbbuilder/0.2.0", 
-            "id": 0, 
-            "input_connections": {}, 
-            "inputs": [], 
-            "label": null, 
-            "name": "Protein Database Downloader", 
-            "outputs": [
-                {
-                    "name": "output_database", 
-                    "type": "fasta"
-                }
-            ], 
-            "position": {
-                "left": 245, 
-                "top": 250
-            }, 
-            "post_job_actions": {
-                "HideDatasetActionoutput_database": {
-                    "action_arguments": {}, 
-                    "action_type": "HideDatasetAction", 
-                    "output_name": "output_database"
-                }, 
-                "RenameDatasetActionoutput_database": {
-                    "action_arguments": {
-                        "newname": "Main database"
-                    }, 
-                    "action_type": "RenameDatasetAction", 
-                    "output_name": "output_database"
-                }
-            }, 
-            "tool_errors": null, 
-            "tool_id": "toolshed.g2.bx.psu.edu/repos/galaxyp/dbbuilder/dbbuilder/0.2.0", 
-            "tool_shed_repository": {
-                "changeset_revision": "b39347891609", 
-                "name": "dbbuilder", 
-                "owner": "galaxyp", 
-                "tool_shed": "toolshed.g2.bx.psu.edu"
-            }, 
-            "tool_state": "{\"source\": \"{\\\"set\\\": \\\"+keyword%3a1185\\\", \\\"from\\\": \\\"uniprot\\\", \\\"taxon\\\": \\\"9606\\\", \\\"reviewed\\\": \\\"+reviewed%3Ayes\\\", \\\"__current_case__\\\": 0, \\\"include_isoform\\\": \\\"false\\\"}\", \"__rerun_remap_job_id__\": null, \"__page__\": 0}", 
-            "tool_version": "0.2.0", 
-            "type": "tool", 
-            "uuid": "7f5ca5fe-79b5-4e25-9121-0e4349c2185a", 
-            "workflow_outputs": []
-        }, 
-        "1": {
-            "annotation": "", 
-            "content_id": "toolshed.g2.bx.psu.edu/repos/galaxyp/dbbuilder/dbbuilder/0.2.0", 
-            "id": 1, 
-            "input_connections": {}, 
-            "inputs": [], 
-            "label": null, 
-            "name": "Protein Database Downloader", 
-            "outputs": [
-                {
-                    "name": "output_database", 
-                    "type": "fasta"
-                }
-            ], 
-            "position": {
-                "left": 245, 
-                "top": 370
-            }, 
-            "post_job_actions": {
-                "HideDatasetActionoutput_database": {
-                    "action_arguments": {}, 
-                    "action_type": "HideDatasetAction", 
-                    "output_name": "output_database"
-                }, 
-                "RenameDatasetActionoutput_database": {
-                    "action_arguments": {
-                        "newname": "cRAP database"
-                    }, 
-                    "action_type": "RenameDatasetAction", 
-                    "output_name": "output_database"
-                }
-            }, 
-            "tool_errors": null, 
-            "tool_id": "toolshed.g2.bx.psu.edu/repos/galaxyp/dbbuilder/dbbuilder/0.2.0", 
-            "tool_shed_repository": {
-                "changeset_revision": "b39347891609", 
-                "name": "dbbuilder", 
-                "owner": "galaxyp", 
-                "tool_shed": "toolshed.g2.bx.psu.edu"
-            }, 
-            "tool_state": "{\"source\": \"{\\\"from\\\": \\\"cRAP\\\", \\\"__current_case__\\\": 1}\", \"__rerun_remap_job_id__\": null, \"__page__\": 0}", 
-            "tool_version": "0.2.0", 
-            "type": "tool", 
-            "uuid": "defc442e-f1e5-40da-b702-4e55e1a9107e", 
-            "workflow_outputs": []
-        }, 
-        "2": {
-            "annotation": "", 
-            "content_id": "toolshed.g2.bx.psu.edu/repos/galaxyp/dbbuilder/dbbuilder/0.2.0", 
-            "id": 2, 
-            "input_connections": {}, 
-            "inputs": [], 
-            "label": null, 
-            "name": "Protein Database Downloader", 
-            "outputs": [
-                {
-                    "name": "output_database", 
-                    "type": "fasta"
-                }
-            ], 
-            "position": {
-                "left": 247, 
-                "top": 463
-            }, 
-            "post_job_actions": {
-                "HideDatasetActionoutput_database": {
-                    "action_arguments": {}, 
-                    "action_type": "HideDatasetAction", 
-                    "output_name": "output_database"
-                }
-            }, 
-            "tool_errors": null, 
-            "tool_id": "toolshed.g2.bx.psu.edu/repos/galaxyp/dbbuilder/dbbuilder/0.2.0", 
-            "tool_shed_repository": {
-                "changeset_revision": "b39347891609", 
-                "name": "dbbuilder", 
-                "owner": "galaxyp", 
-                "tool_shed": "toolshed.g2.bx.psu.edu"
-            }, 
-            "tool_state": "{\"source\": \"{\\\"set\\\": \\\"+keyword%3a1185\\\", \\\"from\\\": \\\"uniprot\\\", \\\"taxon\\\": \\\"2148\\\", \\\"reviewed\\\": \\\"+\\\", \\\"__current_case__\\\": 0, \\\"include_isoform\\\": \\\"false\\\"}\", \"__rerun_remap_job_id__\": null, \"__page__\": 0}", 
-            "tool_version": "0.2.0", 
-            "type": "tool", 
-            "uuid": "76fb49c2-27b4-40c1-b709-deb192380898", 
-            "workflow_outputs": []
-        }, 
-        "3": {
-            "annotation": "January 2017: no reference proteome set available", 
-            "content_id": "toolshed.g2.bx.psu.edu/repos/galaxyp/dbbuilder/dbbuilder/0.2.0", 
-            "id": 3, 
-            "input_connections": {}, 
-            "inputs": [], 
-            "label": null, 
-            "name": "Protein Database Downloader", 
-            "outputs": [
-                {
-                    "name": "output_database", 
-                    "type": "fasta"
-                }
-            ], 
-            "position": {
-                "left": 247, 
-                "top": 532
-            }, 
-            "post_job_actions": {
-                "HideDatasetActionoutput_database": {
-                    "action_arguments": {}, 
-                    "action_type": "HideDatasetAction", 
-                    "output_name": "output_database"
-                }
-            }, 
-            "tool_errors": null, 
-            "tool_id": "toolshed.g2.bx.psu.edu/repos/galaxyp/dbbuilder/dbbuilder/0.2.0", 
-            "tool_shed_repository": {
-                "changeset_revision": "b39347891609", 
-                "name": "dbbuilder", 
-                "owner": "galaxyp", 
-                "tool_shed": "toolshed.g2.bx.psu.edu"
-            }, 
-            "tool_state": "{\"source\": \"{\\\"set\\\": \\\"+keyword%3a181\\\", \\\"from\\\": \\\"uniprot\\\", \\\"taxon\\\": \\\"2094\\\", \\\"reviewed\\\": \\\"+\\\", \\\"__current_case__\\\": 0, \\\"include_isoform\\\": \\\"false\\\"}\", \"__rerun_remap_job_id__\": null, \"__page__\": 0}", 
-            "tool_version": "0.2.0", 
-            "type": "tool", 
-            "uuid": "87768b6b-6835-4fb7-a89b-5fc94a5ae50e", 
-            "workflow_outputs": []
-        }, 
-        "4": {
-            "annotation": "", 
-            "content_id": "toolshed.g2.bx.psu.edu/repos/galaxyp/dbbuilder/dbbuilder/0.2.0", 
-            "id": 4, 
-            "input_connections": {}, 
-            "inputs": [], 
-            "label": null, 
-            "name": "Protein Database Downloader", 
-            "outputs": [
-                {
-                    "name": "output_database", 
-                    "type": "fasta"
-                }
-            ], 
-            "position": {
-                "left": 249, 
-                "top": 600
-            }, 
-            "post_job_actions": {
-                "HideDatasetActionoutput_database": {
-                    "action_arguments": {}, 
-                    "action_type": "HideDatasetAction", 
-                    "output_name": "output_database"
-                }
-            }, 
-            "tool_errors": null, 
-            "tool_id": "toolshed.g2.bx.psu.edu/repos/galaxyp/dbbuilder/dbbuilder/0.2.0", 
-            "tool_shed_repository": {
-                "changeset_revision": "b39347891609", 
-                "name": "dbbuilder", 
-                "owner": "galaxyp", 
-                "tool_shed": "toolshed.g2.bx.psu.edu"
-            }, 
-            "tool_state": "{\"source\": \"{\\\"set\\\": \\\"+keyword%3a1185\\\", \\\"from\\\": \\\"uniprot\\\", \\\"taxon\\\": \\\"2115\\\", \\\"reviewed\\\": \\\"+\\\", \\\"__current_case__\\\": 0, \\\"include_isoform\\\": \\\"false\\\"}\", \"__rerun_remap_job_id__\": null, \"__page__\": 0}", 
-            "tool_version": "0.2.0", 
-            "type": "tool", 
-            "uuid": "21a46cc0-4dc0-4200-81fc-ac9616db4018", 
-            "workflow_outputs": []
-        }, 
-        "5": {
-            "annotation": "", 
-            "content_id": "toolshed.g2.bx.psu.edu/repos/galaxyp/dbbuilder/dbbuilder/0.2.0", 
-            "id": 5, 
-            "input_connections": {}, 
-            "inputs": [], 
-            "label": null, 
-            "name": "Protein Database Downloader", 
-            "outputs": [
-                {
-                    "name": "output_database", 
-                    "type": "fasta"
-                }
-            ], 
-            "position": {
-                "left": 250, 
-                "top": 668
-            }, 
-            "post_job_actions": {
-                "HideDatasetActionoutput_database": {
-                    "action_arguments": {}, 
-                    "action_type": "HideDatasetAction", 
-                    "output_name": "output_database"
-                }
-            }, 
-            "tool_errors": null, 
-            "tool_id": "toolshed.g2.bx.psu.edu/repos/galaxyp/dbbuilder/dbbuilder/0.2.0", 
-            "tool_shed_repository": {
-                "changeset_revision": "b39347891609", 
-                "name": "dbbuilder", 
-                "owner": "galaxyp", 
-                "tool_shed": "toolshed.g2.bx.psu.edu"
-            }, 
-            "tool_state": "{\"source\": \"{\\\"set\\\": \\\"+keyword%3a1185\\\", \\\"from\\\": \\\"uniprot\\\", \\\"taxon\\\": \\\"2098\\\", \\\"reviewed\\\": \\\"+\\\", \\\"__current_case__\\\": 0, \\\"include_isoform\\\": \\\"false\\\"}\", \"__rerun_remap_job_id__\": null, \"__page__\": 0}", 
-            "tool_version": "0.2.0", 
-            "type": "tool", 
-            "uuid": "9225047b-794a-42cf-bb8b-bd7b4657d7c9", 
-            "workflow_outputs": []
-        }, 
-        "6": {
-            "annotation": "", 
-            "content_id": "toolshed.g2.bx.psu.edu/repos/galaxyp/dbbuilder/dbbuilder/0.2.0", 
-            "id": 6, 
-            "input_connections": {}, 
-            "inputs": [], 
-            "label": null, 
-            "name": "Protein Database Downloader", 
-            "outputs": [
-                {
-                    "name": "output_database", 
-                    "type": "fasta"
-                }
-            ], 
-            "position": {
-                "left": 248, 
-                "top": 734
-            }, 
-            "post_job_actions": {
-                "HideDatasetActionoutput_database": {
-                    "action_arguments": {}, 
-                    "action_type": "HideDatasetAction", 
-                    "output_name": "output_database"
-                }
-            }, 
-            "tool_errors": null, 
-            "tool_id": "toolshed.g2.bx.psu.edu/repos/galaxyp/dbbuilder/dbbuilder/0.2.0", 
-            "tool_shed_repository": {
-                "changeset_revision": "b39347891609", 
-                "name": "dbbuilder", 
-                "owner": "galaxyp", 
-                "tool_shed": "toolshed.g2.bx.psu.edu"
-            }, 
-            "tool_state": "{\"source\": \"{\\\"set\\\": \\\"+keyword%3a1185\\\", \\\"from\\\": \\\"uniprot\\\", \\\"taxon\\\": \\\"2100\\\", \\\"reviewed\\\": \\\"+\\\", \\\"__current_case__\\\": 0, \\\"include_isoform\\\": \\\"false\\\"}\", \"__rerun_remap_job_id__\": null, \"__page__\": 0}", 
-            "tool_version": "0.2.0", 
-            "type": "tool", 
-            "uuid": "08b53705-b35f-43f0-8796-ab3f80f21299", 
-            "workflow_outputs": []
-        }, 
-        "7": {
-            "annotation": "January 2017: Does not download any proteins, but may do so, when UniProt is updated.", 
-            "content_id": "toolshed.g2.bx.psu.edu/repos/galaxyp/dbbuilder/dbbuilder/0.2.0", 
-            "id": 7, 
-            "input_connections": {}, 
-            "inputs": [], 
-            "label": null, 
-            "name": "Protein Database Downloader", 
-            "outputs": [
-                {
-                    "name": "output_database", 
-                    "type": "fasta"
-                }
-            ], 
-            "position": {
-                "left": 248, 
-                "top": 802
-            }, 
-            "post_job_actions": {
-                "HideDatasetActionoutput_database": {
-                    "action_arguments": {}, 
-                    "action_type": "HideDatasetAction", 
-                    "output_name": "output_database"
-                }
-            }, 
-            "tool_errors": null, 
-            "tool_id": "toolshed.g2.bx.psu.edu/repos/galaxyp/dbbuilder/dbbuilder/0.2.0", 
-            "tool_shed_repository": {
-                "changeset_revision": "b39347891609", 
-                "name": "dbbuilder", 
-                "owner": "galaxyp", 
-                "tool_shed": "toolshed.g2.bx.psu.edu"
-            }, 
-            "tool_state": "{\"source\": \"{\\\"set\\\": \\\"+keyword%3a181\\\", \\\"from\\\": \\\"uniprot\\\", \\\"taxon\\\": \\\"2121\\\", \\\"reviewed\\\": \\\"+reviewed%3Ano\\\", \\\"__current_case__\\\": 0, \\\"include_isoform\\\": \\\"false\\\"}\", \"__rerun_remap_job_id__\": null, \"__page__\": 0}", 
-            "tool_version": "0.2.0", 
-            "type": "tool", 
-            "uuid": "576a9247-a52a-4a61-8207-7478d7576a7b", 
-            "workflow_outputs": []
-        }, 
-        "8": {
-            "annotation": "", 
-            "content_id": "toolshed.g2.bx.psu.edu/repos/devteam/fasta_to_tabular/fasta2tab/1.1.0", 
-            "id": 8, 
-            "input_connections": {
-                "input": {
-                    "id": 1, 
-                    "output_name": "output_database"
-                }
-            }, 
-            "inputs": [
-                {
-                    "description": "runtime parameter for tool FASTA-to-Tabular", 
-                    "name": "input"
-                }
-            ], 
-            "label": null, 
-            "name": "FASTA-to-Tabular", 
-            "outputs": [
-                {
-                    "name": "output", 
-                    "type": "tabular"
-                }
-            ], 
-            "position": {
-                "left": 532, 
-                "top": 321
-            }, 
-            "post_job_actions": {
-                "DeleteIntermediatesActionoutput": {
-                    "action_arguments": {}, 
-                    "action_type": "DeleteIntermediatesAction", 
-                    "output_name": "output"
-                }, 
-                "HideDatasetActionoutput": {
-                    "action_arguments": {}, 
-                    "action_type": "HideDatasetAction", 
-                    "output_name": "output"
-                }
-            }, 
-            "tool_errors": null, 
-            "tool_id": "toolshed.g2.bx.psu.edu/repos/devteam/fasta_to_tabular/fasta2tab/1.1.0", 
-            "tool_shed_repository": {
-                "changeset_revision": "7e801ab2b70e", 
-                "name": "fasta_to_tabular", 
-                "owner": "devteam", 
-                "tool_shed": "toolshed.g2.bx.psu.edu"
-            }, 
-            "tool_state": "{\"input\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\", \"keep_first\": \"\\\"0\\\"\", \"__rerun_remap_job_id__\": null, \"descr_columns\": \"\\\"1\\\"\", \"__page__\": 0}", 
-            "tool_version": "1.1.0", 
-            "type": "tool", 
-            "uuid": "911f4ecd-57cf-4d2d-8d1f-40597493b75a", 
-            "workflow_outputs": []
-        }, 
-        "9": {
-            "annotation": "Merges all mycoplasma databases.", 
-            "content_id": "toolshed.g2.bx.psu.edu/repos/galaxyp/fasta_merge_files_and_filter_unique_sequences/fasta_merge_files_and_filter_unique_sequences/1.0", 
-            "id": 9, 
-            "input_connections": {
-                "inputs_0|input": {
-                    "id": 2, 
-                    "output_name": "output_database"
-                }, 
-                "inputs_1|input": {
-                    "id": 3, 
-                    "output_name": "output_database"
-                }, 
-                "inputs_2|input": {
-                    "id": 4, 
-                    "output_name": "output_database"
-                }, 
-                "inputs_3|input": {
-                    "id": 5, 
-                    "output_name": "output_database"
-                }, 
-                "inputs_4|input": {
-                    "id": 6, 
-                    "output_name": "output_database"
-                }, 
-                "inputs_5|input": {
-                    "id": 7, 
-                    "output_name": "output_database"
-                }
-            }, 
-            "inputs": [], 
-            "label": null, 
-            "name": "FASTA Merge Files and Filter Unique Sequences", 
-            "outputs": [
-                {
-                    "name": "output", 
-                    "type": "fasta"
-                }
-            ], 
-            "position": {
-                "left": 728, 
-                "top": 542
-            }, 
-            "post_job_actions": {
-                "RenameDatasetActionoutput": {
-                    "action_arguments": {
-                        "newname": "complete Mycoplasma database"
-                    }, 
-                    "action_type": "RenameDatasetAction", 
-                    "output_name": "output"
-                }
-            }, 
-            "tool_errors": null, 
-            "tool_id": "toolshed.g2.bx.psu.edu/repos/galaxyp/fasta_merge_files_and_filter_unique_sequences/fasta_merge_files_and_filter_unique_sequences/1.0", 
-            "tool_shed_repository": {
-                "changeset_revision": "2904d46167da", 
-                "name": "fasta_merge_files_and_filter_unique_sequences", 
-                "owner": "galaxyp", 
-                "tool_shed": "toolshed.g2.bx.psu.edu"
-            }, 
-            "tool_state": "{\"inputs\": \"[{\\\"__index__\\\": 0, \\\"input\\\": {\\\"__class__\\\": \\\"RuntimeValue\\\"}}, {\\\"__index__\\\": 1, \\\"input\\\": {\\\"__class__\\\": \\\"RuntimeValue\\\"}}, {\\\"__index__\\\": 2, \\\"input\\\": {\\\"__class__\\\": \\\"RuntimeValue\\\"}}, {\\\"__index__\\\": 3, \\\"input\\\": {\\\"__class__\\\": \\\"RuntimeValue\\\"}}, {\\\"__index__\\\": 4, \\\"input\\\": {\\\"__class__\\\": \\\"RuntimeValue\\\"}}, {\\\"__index__\\\": 5, \\\"input\\\": {\\\"__class__\\\": \\\"RuntimeValue\\\"}}]\", \"__rerun_remap_job_id__\": null, \"__page__\": 0}", 
-            "tool_version": "1.0", 
-            "type": "tool", 
-            "uuid": "548d8464-53ce-449c-b7ca-cfbbef6138ef", 
-            "workflow_outputs": [
-                {
-                    "label": null, 
-                    "output_name": "output", 
-                    "uuid": "acec9eca-63b1-462b-95e8-6c5ecfe36f4a"
-                }
-            ]
-        }, 
-        "10": {
-            "annotation": "", 
-            "content_id": "toolshed.g2.bx.psu.edu/repos/devteam/add_value/addValue/1.0.0", 
-            "id": 10, 
-            "input_connections": {
-                "input": {
-                    "id": 8, 
-                    "output_name": "output"
-                }
-            }, 
-            "inputs": [
-                {
-                    "description": "runtime parameter for tool Add column", 
-                    "name": "input"
-                }
-            ], 
-            "label": null, 
-            "name": "Add column", 
-            "outputs": [
-                {
-                    "name": "out_file1", 
-                    "type": "input"
-                }
-            ], 
-            "position": {
-                "left": 752, 
-                "top": 355
-            }, 
-            "post_job_actions": {
-                "DeleteIntermediatesActionout_file1": {
-                    "action_arguments": {}, 
-                    "action_type": "DeleteIntermediatesAction", 
-                    "output_name": "out_file1"
-                }, 
-                "HideDatasetActionout_file1": {
-                    "action_arguments": {}, 
-                    "action_type": "HideDatasetAction", 
-                    "output_name": "out_file1"
-                }
-            }, 
-            "tool_errors": null, 
-            "tool_id": "toolshed.g2.bx.psu.edu/repos/devteam/add_value/addValue/1.0.0", 
-            "tool_shed_repository": {
-                "changeset_revision": "745871c0b055", 
-                "name": "add_value", 
-                "owner": "devteam", 
-                "tool_shed": "toolshed.g2.bx.psu.edu"
-            }, 
-            "tool_state": "{\"__page__\": 0, \"input\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\", \"__rerun_remap_job_id__\": null, \"exp\": \"\\\"CONTAMINANT\\\"\", \"iterate\": \"\\\"no\\\"\"}", 
-            "tool_version": "1.0.0", 
-            "type": "tool", 
-            "uuid": "1fe09bbb-ba83-448f-8dfd-1b7270441c42", 
-            "workflow_outputs": []
-        }, 
-        "11": {
-            "annotation": "", 
-            "content_id": "toolshed.g2.bx.psu.edu/repos/devteam/tabular_to_fasta/tab2fasta/1.1.0", 
-            "id": 11, 
-            "input_connections": {
-                "input": {
-                    "id": 10, 
-                    "output_name": "out_file1"
-                }
-            }, 
-            "inputs": [
-                {
-                    "description": "runtime parameter for tool Tabular-to-FASTA", 
-                    "name": "input"
-                }
-            ], 
-            "label": null, 
-            "name": "Tabular-to-FASTA", 
-            "outputs": [
-                {
-                    "name": "output", 
-                    "type": "fasta"
-                }
-            ], 
-            "position": {
-                "left": 936, 
-                "top": 385
-            }, 
-            "post_job_actions": {
-                "HideDatasetActionoutput": {
-                    "action_arguments": {}, 
-                    "action_type": "HideDatasetAction", 
-                    "output_name": "output"
-                }, 
-                "RenameDatasetActionoutput": {
-                    "action_arguments": {
-                        "newname": "tagged cRAP database"
-                    }, 
-                    "action_type": "RenameDatasetAction", 
-                    "output_name": "output"
-                }
-            }, 
-            "tool_errors": null, 
-            "tool_id": "toolshed.g2.bx.psu.edu/repos/devteam/tabular_to_fasta/tab2fasta/1.1.0", 
-            "tool_shed_repository": {
-                "changeset_revision": "0b4e36026794", 
-                "name": "tabular_to_fasta", 
-                "owner": "devteam", 
-                "tool_shed": "toolshed.g2.bx.psu.edu"
-            }, 
-            "tool_state": "{\"title_col\": \"[\\\"1\\\", \\\"3\\\"]\", \"input\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\", \"__page__\": 0, \"__rerun_remap_job_id__\": null, \"seq_col\": \"\\\"2\\\"\"}", 
-            "tool_version": "1.1.0", 
-            "type": "tool", 
-            "uuid": "1bd7f1b9-4974-4cd5-b9a1-91787e503ecf", 
-            "workflow_outputs": []
-        }, 
-        "12": {
-            "annotation": "", 
-            "content_id": "toolshed.g2.bx.psu.edu/repos/galaxyp/fasta_merge_files_and_filter_unique_sequences/fasta_merge_files_and_filter_unique_sequences/1.0", 
-            "id": 12, 
-            "input_connections": {
-                "inputs_0|input": {
-                    "id": 0, 
-                    "output_name": "output_database"
-                }, 
-                "inputs_1|input": {
-                    "id": 11, 
-                    "output_name": "output"
-                }
-            }, 
-            "inputs": [], 
-            "label": null, 
-            "name": "FASTA Merge Files and Filter Unique Sequences", 
-            "outputs": [
-                {
-                    "name": "output", 
-                    "type": "fasta"
-                }
-            ], 
-            "position": {
-                "left": 1155, 
-                "top": 211
-            }, 
-            "post_job_actions": {}, 
-            "tool_errors": null, 
-            "tool_id": "toolshed.g2.bx.psu.edu/repos/galaxyp/fasta_merge_files_and_filter_unique_sequences/fasta_merge_files_and_filter_unique_sequences/1.0", 
-            "tool_shed_repository": {
-                "changeset_revision": "2904d46167da", 
-                "name": "fasta_merge_files_and_filter_unique_sequences", 
-                "owner": "galaxyp", 
-                "tool_shed": "toolshed.g2.bx.psu.edu"
-            }, 
-            "tool_state": "{\"inputs\": \"[{\\\"__index__\\\": 0, \\\"input\\\": {\\\"__class__\\\": \\\"RuntimeValue\\\"}}, {\\\"__index__\\\": 1, \\\"input\\\": {\\\"__class__\\\": \\\"RuntimeValue\\\"}}]\", \"__rerun_remap_job_id__\": null, \"chromInfo\": \"\\\"/usr/local/galaxy/galaxy-dist/tool-data/shared/ucsc/chrom/?.len\\\"\", \"__page__\": 0}", 
-            "tool_version": "1.0", 
-            "type": "tool", 
-            "uuid": "6fbc2008-7b04-49af-af2f-01c55ff09e59", 
-            "workflow_outputs": [
-                {
-                    "label": "Main database (cRAP added)", 
-                    "output_name": "output", 
-                    "uuid": "bb1f67d0-6e5e-462e-9802-f354706a1531"
-                }
-            ]
-        }, 
-        "13": {
-            "annotation": "", 
-            "content_id": "toolshed.g2.bx.psu.edu/repos/galaxyp/fasta_merge_files_and_filter_unique_sequences/fasta_merge_files_and_filter_unique_sequences/1.0", 
-            "id": 13, 
-            "input_connections": {
-                "inputs_0|input": {
-                    "id": 9, 
-                    "output_name": "output"
-                }, 
-                "inputs_1|input": {
-                    "id": 12, 
-                    "output_name": "output"
-                }
-            }, 
-            "inputs": [], 
-            "label": null, 
-            "name": "FASTA Merge Files and Filter Unique Sequences", 
-            "outputs": [
-                {
-                    "name": "output", 
-                    "type": "fasta"
-                }
-            ], 
-            "position": {
-                "left": 1212, 
-                "top": 496
-            }, 
-            "post_job_actions": {
-                "RenameDatasetActionoutput": {
-                    "action_arguments": {
-                        "newname": "Main database (cRAP and mycoplasma added)"
-                    }, 
-                    "action_type": "RenameDatasetAction", 
-                    "output_name": "output"
-                }
-            }, 
-            "tool_errors": null, 
-            "tool_id": "toolshed.g2.bx.psu.edu/repos/galaxyp/fasta_merge_files_and_filter_unique_sequences/fasta_merge_files_and_filter_unique_sequences/1.0", 
-            "tool_shed_repository": {
-                "changeset_revision": "2904d46167da", 
-                "name": "fasta_merge_files_and_filter_unique_sequences", 
-                "owner": "galaxyp", 
-                "tool_shed": "toolshed.g2.bx.psu.edu"
-            }, 
-            "tool_state": "{\"inputs\": \"[{\\\"__index__\\\": 0, \\\"input\\\": {\\\"__class__\\\": \\\"RuntimeValue\\\"}}, {\\\"__index__\\\": 1, \\\"input\\\": {\\\"__class__\\\": \\\"RuntimeValue\\\"}}]\", \"__rerun_remap_job_id__\": null, \"__page__\": 0}", 
-            "tool_version": "1.0", 
-            "type": "tool", 
-            "uuid": "5b5e98bd-ed99-4269-9c11-cd98254ac9cd", 
-            "workflow_outputs": [
-                {
-                    "label": null, 
-                    "output_name": "output", 
-                    "uuid": "efd2b73c-ef07-41dd-9a28-48251913dbc1"
-                }
-            ]
-        }, 
-        "14": {
-            "annotation": "", 
-            "content_id": "DecoyDatabase", 
-            "id": 14, 
-            "input_connections": {
-                "param_in": {
-                    "id": 13, 
-                    "output_name": "output"
-                }
-            }, 
-            "inputs": [
-                {
-                    "description": "runtime parameter for tool DecoyDatabase", 
-                    "name": "param_in"
-                }
-            ], 
-            "label": null, 
-            "name": "DecoyDatabase", 
-            "outputs": [
-                {
-                    "name": "param_out", 
-                    "type": "fasta"
-                }
-            ], 
-            "position": {
-                "left": 1513, 
-                "top": 583.5
-            }, 
-            "post_job_actions": {
-                "RenameDatasetActionparam_out": {
-                    "action_arguments": {
-                        "newname": "Main database with decoys (cRAP and Mycoplasma added)"
-                    }, 
-                    "action_type": "RenameDatasetAction", 
-                    "output_name": "param_out"
-                }
-            }, 
-            "tool_errors": null, 
-            "tool_id": "DecoyDatabase", 
-            "tool_state": "{\"__page__\": 0, \"param_append\": \"\\\"true\\\"\", \"adv_opts\": \"{\\\"adv_opts_selector\\\": \\\"basic\\\", \\\"__current_case__\\\": 0}\", \"__rerun_remap_job_id__\": null, \"param_method\": \"\\\"reverse\\\"\", \"param_decoy_string\": \"\\\"DECOY_\\\"\", \"param_decoy_string_position\": \"\\\"prefix\\\"\", \"param_in\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\"}", 
-            "tool_version": "2.1.0", 
-            "type": "tool", 
-            "uuid": "a96cde43-cd29-4683-8f32-fe8603b2e682", 
-            "workflow_outputs": [
-                {
-                    "label": null, 
-                    "output_name": "param_out", 
-                    "uuid": "9f464e59-daa0-4013-b266-4b7eae387507"
-                }
-            ]
+  "a_galaxy_workflow": "true",
+  "annotation": "",
+  "format-version": "0.1",
+  "name": "Database Handling Tutorial Workflow2 including Mycoplasma",
+  "steps": {
+    "0": {
+      "annotation": "",
+      "content_id": "toolshed.g2.bx.psu.edu/repos/galaxyp/dbbuilder/dbbuilder/0.2.0",
+      "id": 0,
+      "input_connections": {},
+      "inputs": [],
+      "label": null,
+      "name": "Protein Database Downloader",
+      "outputs": [
+        {
+          "name": "output_database",
+          "type": "fasta"
         }
-    }, 
-    "uuid": "66bcd057-5032-4693-a0ba-c41d061cb0ff"
+      ],
+      "position": {
+        "left": 245,
+        "top": 250
+      },
+      "post_job_actions": {
+        "HideDatasetActionoutput_database": {
+          "action_arguments": {},
+          "action_type": "HideDatasetAction",
+          "output_name": "output_database"
+        },
+        "RenameDatasetActionoutput_database": {
+          "action_arguments": {
+            "newname": "Main database"
+          },
+          "action_type": "RenameDatasetAction",
+          "output_name": "output_database"
+        }
+      },
+      "tool_errors": null,
+      "tool_id": "toolshed.g2.bx.psu.edu/repos/galaxyp/dbbuilder/dbbuilder/0.2.0",
+      "tool_shed_repository": {
+        "changeset_revision": "b39347891609",
+        "name": "dbbuilder",
+        "owner": "galaxyp",
+        "tool_shed": "toolshed.g2.bx.psu.edu"
+      },
+      "tool_state": "{\"source\": \"{\\\"set\\\": \\\"+keyword%3a1185\\\", \\\"from\\\": \\\"uniprot\\\", \\\"taxon\\\": \\\"9606\\\", \\\"reviewed\\\": \\\"+reviewed%3Ayes\\\", \\\"__current_case__\\\": 0, \\\"include_isoform\\\": \\\"false\\\"}\", \"__rerun_remap_job_id__\": null, \"__page__\": 0}",
+      "tool_version": "0.2.0",
+      "type": "tool",
+      "uuid": "7f5ca5fe-79b5-4e25-9121-0e4349c2185a",
+      "workflow_outputs": []
+    },
+    "1": {
+      "annotation": "",
+      "content_id": "toolshed.g2.bx.psu.edu/repos/galaxyp/dbbuilder/dbbuilder/0.2.0",
+      "id": 1,
+      "input_connections": {},
+      "inputs": [],
+      "label": null,
+      "name": "Protein Database Downloader",
+      "outputs": [
+        {
+          "name": "output_database",
+          "type": "fasta"
+        }
+      ],
+      "position": {
+        "left": 245,
+        "top": 370
+      },
+      "post_job_actions": {
+        "HideDatasetActionoutput_database": {
+          "action_arguments": {},
+          "action_type": "HideDatasetAction",
+          "output_name": "output_database"
+        },
+        "RenameDatasetActionoutput_database": {
+          "action_arguments": {
+            "newname": "cRAP database"
+          },
+          "action_type": "RenameDatasetAction",
+          "output_name": "output_database"
+        }
+      },
+      "tool_errors": null,
+      "tool_id": "toolshed.g2.bx.psu.edu/repos/galaxyp/dbbuilder/dbbuilder/0.2.0",
+      "tool_shed_repository": {
+        "changeset_revision": "b39347891609",
+        "name": "dbbuilder",
+        "owner": "galaxyp",
+        "tool_shed": "toolshed.g2.bx.psu.edu"
+      },
+      "tool_state": "{\"source\": \"{\\\"from\\\": \\\"cRAP\\\", \\\"__current_case__\\\": 1}\", \"__rerun_remap_job_id__\": null, \"__page__\": 0}",
+      "tool_version": "0.2.0",
+      "type": "tool",
+      "uuid": "defc442e-f1e5-40da-b702-4e55e1a9107e",
+      "workflow_outputs": []
+    },
+    "2": {
+      "annotation": "",
+      "content_id": "toolshed.g2.bx.psu.edu/repos/galaxyp/dbbuilder/dbbuilder/0.2.0",
+      "id": 2,
+      "input_connections": {},
+      "inputs": [],
+      "label": null,
+      "name": "Protein Database Downloader",
+      "outputs": [
+        {
+          "name": "output_database",
+          "type": "fasta"
+        }
+      ],
+      "position": {
+        "left": 247,
+        "top": 463
+      },
+      "post_job_actions": {
+        "HideDatasetActionoutput_database": {
+          "action_arguments": {},
+          "action_type": "HideDatasetAction",
+          "output_name": "output_database"
+        }
+      },
+      "tool_errors": null,
+      "tool_id": "toolshed.g2.bx.psu.edu/repos/galaxyp/dbbuilder/dbbuilder/0.2.0",
+      "tool_shed_repository": {
+        "changeset_revision": "b39347891609",
+        "name": "dbbuilder",
+        "owner": "galaxyp",
+        "tool_shed": "toolshed.g2.bx.psu.edu"
+      },
+      "tool_state": "{\"source\": \"{\\\"set\\\": \\\"+keyword%3a1185\\\", \\\"from\\\": \\\"uniprot\\\", \\\"taxon\\\": \\\"2148\\\", \\\"reviewed\\\": \\\"+\\\", \\\"__current_case__\\\": 0, \\\"include_isoform\\\": \\\"false\\\"}\", \"__rerun_remap_job_id__\": null, \"__page__\": 0}",
+      "tool_version": "0.2.0",
+      "type": "tool",
+      "uuid": "76fb49c2-27b4-40c1-b709-deb192380898",
+      "workflow_outputs": []
+    },
+    "3": {
+      "annotation": "January 2017: no reference proteome set available",
+      "content_id": "toolshed.g2.bx.psu.edu/repos/galaxyp/dbbuilder/dbbuilder/0.2.0",
+      "id": 3,
+      "input_connections": {},
+      "inputs": [],
+      "label": null,
+      "name": "Protein Database Downloader",
+      "outputs": [
+        {
+          "name": "output_database",
+          "type": "fasta"
+        }
+      ],
+      "position": {
+        "left": 247,
+        "top": 532
+      },
+      "post_job_actions": {
+        "HideDatasetActionoutput_database": {
+          "action_arguments": {},
+          "action_type": "HideDatasetAction",
+          "output_name": "output_database"
+        }
+      },
+      "tool_errors": null,
+      "tool_id": "toolshed.g2.bx.psu.edu/repos/galaxyp/dbbuilder/dbbuilder/0.2.0",
+      "tool_shed_repository": {
+        "changeset_revision": "b39347891609",
+        "name": "dbbuilder",
+        "owner": "galaxyp",
+        "tool_shed": "toolshed.g2.bx.psu.edu"
+      },
+      "tool_state": "{\"source\": \"{\\\"set\\\": \\\"+keyword%3a181\\\", \\\"from\\\": \\\"uniprot\\\", \\\"taxon\\\": \\\"2094\\\", \\\"reviewed\\\": \\\"+\\\", \\\"__current_case__\\\": 0, \\\"include_isoform\\\": \\\"false\\\"}\", \"__rerun_remap_job_id__\": null, \"__page__\": 0}",
+      "tool_version": "0.2.0",
+      "type": "tool",
+      "uuid": "87768b6b-6835-4fb7-a89b-5fc94a5ae50e",
+      "workflow_outputs": []
+    },
+    "4": {
+      "annotation": "",
+      "content_id": "toolshed.g2.bx.psu.edu/repos/galaxyp/dbbuilder/dbbuilder/0.2.0",
+      "id": 4,
+      "input_connections": {},
+      "inputs": [],
+      "label": null,
+      "name": "Protein Database Downloader",
+      "outputs": [
+        {
+          "name": "output_database",
+          "type": "fasta"
+        }
+      ],
+      "position": {
+        "left": 249,
+        "top": 600
+      },
+      "post_job_actions": {
+        "HideDatasetActionoutput_database": {
+          "action_arguments": {},
+          "action_type": "HideDatasetAction",
+          "output_name": "output_database"
+        }
+      },
+      "tool_errors": null,
+      "tool_id": "toolshed.g2.bx.psu.edu/repos/galaxyp/dbbuilder/dbbuilder/0.2.0",
+      "tool_shed_repository": {
+        "changeset_revision": "b39347891609",
+        "name": "dbbuilder",
+        "owner": "galaxyp",
+        "tool_shed": "toolshed.g2.bx.psu.edu"
+      },
+      "tool_state": "{\"source\": \"{\\\"set\\\": \\\"+keyword%3a1185\\\", \\\"from\\\": \\\"uniprot\\\", \\\"taxon\\\": \\\"2115\\\", \\\"reviewed\\\": \\\"+\\\", \\\"__current_case__\\\": 0, \\\"include_isoform\\\": \\\"false\\\"}\", \"__rerun_remap_job_id__\": null, \"__page__\": 0}",
+      "tool_version": "0.2.0",
+      "type": "tool",
+      "uuid": "21a46cc0-4dc0-4200-81fc-ac9616db4018",
+      "workflow_outputs": []
+    },
+    "5": {
+      "annotation": "",
+      "content_id": "toolshed.g2.bx.psu.edu/repos/galaxyp/dbbuilder/dbbuilder/0.2.0",
+      "id": 5,
+      "input_connections": {},
+      "inputs": [],
+      "label": null,
+      "name": "Protein Database Downloader",
+      "outputs": [
+        {
+          "name": "output_database",
+          "type": "fasta"
+        }
+      ],
+      "position": {
+        "left": 250,
+        "top": 668
+      },
+      "post_job_actions": {
+        "HideDatasetActionoutput_database": {
+          "action_arguments": {},
+          "action_type": "HideDatasetAction",
+          "output_name": "output_database"
+        }
+      },
+      "tool_errors": null,
+      "tool_id": "toolshed.g2.bx.psu.edu/repos/galaxyp/dbbuilder/dbbuilder/0.2.0",
+      "tool_shed_repository": {
+        "changeset_revision": "b39347891609",
+        "name": "dbbuilder",
+        "owner": "galaxyp",
+        "tool_shed": "toolshed.g2.bx.psu.edu"
+      },
+      "tool_state": "{\"source\": \"{\\\"set\\\": \\\"+keyword%3a1185\\\", \\\"from\\\": \\\"uniprot\\\", \\\"taxon\\\": \\\"2098\\\", \\\"reviewed\\\": \\\"+\\\", \\\"__current_case__\\\": 0, \\\"include_isoform\\\": \\\"false\\\"}\", \"__rerun_remap_job_id__\": null, \"__page__\": 0}",
+      "tool_version": "0.2.0",
+      "type": "tool",
+      "uuid": "9225047b-794a-42cf-bb8b-bd7b4657d7c9",
+      "workflow_outputs": []
+    },
+    "6": {
+      "annotation": "",
+      "content_id": "toolshed.g2.bx.psu.edu/repos/galaxyp/dbbuilder/dbbuilder/0.2.0",
+      "id": 6,
+      "input_connections": {},
+      "inputs": [],
+      "label": null,
+      "name": "Protein Database Downloader",
+      "outputs": [
+        {
+          "name": "output_database",
+          "type": "fasta"
+        }
+      ],
+      "position": {
+        "left": 248,
+        "top": 734
+      },
+      "post_job_actions": {
+        "HideDatasetActionoutput_database": {
+          "action_arguments": {},
+          "action_type": "HideDatasetAction",
+          "output_name": "output_database"
+        }
+      },
+      "tool_errors": null,
+      "tool_id": "toolshed.g2.bx.psu.edu/repos/galaxyp/dbbuilder/dbbuilder/0.2.0",
+      "tool_shed_repository": {
+        "changeset_revision": "b39347891609",
+        "name": "dbbuilder",
+        "owner": "galaxyp",
+        "tool_shed": "toolshed.g2.bx.psu.edu"
+      },
+      "tool_state": "{\"source\": \"{\\\"set\\\": \\\"+keyword%3a1185\\\", \\\"from\\\": \\\"uniprot\\\", \\\"taxon\\\": \\\"2100\\\", \\\"reviewed\\\": \\\"+\\\", \\\"__current_case__\\\": 0, \\\"include_isoform\\\": \\\"false\\\"}\", \"__rerun_remap_job_id__\": null, \"__page__\": 0}",
+      "tool_version": "0.2.0",
+      "type": "tool",
+      "uuid": "08b53705-b35f-43f0-8796-ab3f80f21299",
+      "workflow_outputs": []
+    },
+    "7": {
+      "annotation": "January 2017: Does not download any proteins, but may do so, when UniProt is updated.",
+      "content_id": "toolshed.g2.bx.psu.edu/repos/galaxyp/dbbuilder/dbbuilder/0.2.0",
+      "id": 7,
+      "input_connections": {},
+      "inputs": [],
+      "label": null,
+      "name": "Protein Database Downloader",
+      "outputs": [
+        {
+          "name": "output_database",
+          "type": "fasta"
+        }
+      ],
+      "position": {
+        "left": 248,
+        "top": 802
+      },
+      "post_job_actions": {
+        "HideDatasetActionoutput_database": {
+          "action_arguments": {},
+          "action_type": "HideDatasetAction",
+          "output_name": "output_database"
+        }
+      },
+      "tool_errors": null,
+      "tool_id": "toolshed.g2.bx.psu.edu/repos/galaxyp/dbbuilder/dbbuilder/0.2.0",
+      "tool_shed_repository": {
+        "changeset_revision": "b39347891609",
+        "name": "dbbuilder",
+        "owner": "galaxyp",
+        "tool_shed": "toolshed.g2.bx.psu.edu"
+      },
+      "tool_state": "{\"source\": \"{\\\"set\\\": \\\"+keyword%3a181\\\", \\\"from\\\": \\\"uniprot\\\", \\\"taxon\\\": \\\"2121\\\", \\\"reviewed\\\": \\\"+reviewed%3Ano\\\", \\\"__current_case__\\\": 0, \\\"include_isoform\\\": \\\"false\\\"}\", \"__rerun_remap_job_id__\": null, \"__page__\": 0}",
+      "tool_version": "0.2.0",
+      "type": "tool",
+      "uuid": "576a9247-a52a-4a61-8207-7478d7576a7b",
+      "workflow_outputs": []
+    },
+    "8": {
+      "annotation": "",
+      "content_id": "toolshed.g2.bx.psu.edu/repos/devteam/fasta_to_tabular/fasta2tab/1.1.0",
+      "id": 8,
+      "input_connections": {
+        "input": {
+          "id": 1,
+          "output_name": "output_database"
+        }
+      },
+      "inputs": [
+        {
+          "description": "runtime parameter for tool FASTA-to-Tabular",
+          "name": "input"
+        }
+      ],
+      "label": null,
+      "name": "FASTA-to-Tabular",
+      "outputs": [
+        {
+          "name": "output",
+          "type": "tabular"
+        }
+      ],
+      "position": {
+        "left": 532,
+        "top": 321
+      },
+      "post_job_actions": {
+        "DeleteIntermediatesActionoutput": {
+          "action_arguments": {},
+          "action_type": "DeleteIntermediatesAction",
+          "output_name": "output"
+        },
+        "HideDatasetActionoutput": {
+          "action_arguments": {},
+          "action_type": "HideDatasetAction",
+          "output_name": "output"
+        }
+      },
+      "tool_errors": null,
+      "tool_id": "toolshed.g2.bx.psu.edu/repos/devteam/fasta_to_tabular/fasta2tab/1.1.0",
+      "tool_shed_repository": {
+        "changeset_revision": "7e801ab2b70e",
+        "name": "fasta_to_tabular",
+        "owner": "devteam",
+        "tool_shed": "toolshed.g2.bx.psu.edu"
+      },
+      "tool_state": "{\"input\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\", \"keep_first\": \"\\\"0\\\"\", \"__rerun_remap_job_id__\": null, \"descr_columns\": \"\\\"1\\\"\", \"__page__\": 0}",
+      "tool_version": "1.1.0",
+      "type": "tool",
+      "uuid": "911f4ecd-57cf-4d2d-8d1f-40597493b75a",
+      "workflow_outputs": []
+    },
+    "9": {
+      "annotation": "Merges all mycoplasma databases.",
+      "content_id": "toolshed.g2.bx.psu.edu/repos/galaxyp/fasta_merge_files_and_filter_unique_sequences/fasta_merge_files_and_filter_unique_sequences/1.0",
+      "id": 9,
+      "input_connections": {
+        "inputs_0|input": {
+          "id": 2,
+          "output_name": "output_database"
+        },
+        "inputs_1|input": {
+          "id": 3,
+          "output_name": "output_database"
+        },
+        "inputs_2|input": {
+          "id": 4,
+          "output_name": "output_database"
+        },
+        "inputs_3|input": {
+          "id": 5,
+          "output_name": "output_database"
+        },
+        "inputs_4|input": {
+          "id": 6,
+          "output_name": "output_database"
+        },
+        "inputs_5|input": {
+          "id": 7,
+          "output_name": "output_database"
+        }
+      },
+      "inputs": [],
+      "label": null,
+      "name": "FASTA Merge Files and Filter Unique Sequences",
+      "outputs": [
+        {
+          "name": "output",
+          "type": "fasta"
+        }
+      ],
+      "position": {
+        "left": 728,
+        "top": 542
+      },
+      "post_job_actions": {
+        "RenameDatasetActionoutput": {
+          "action_arguments": {
+            "newname": "complete Mycoplasma database"
+          },
+          "action_type": "RenameDatasetAction",
+          "output_name": "output"
+        }
+      },
+      "tool_errors": null,
+      "tool_id": "toolshed.g2.bx.psu.edu/repos/galaxyp/fasta_merge_files_and_filter_unique_sequences/fasta_merge_files_and_filter_unique_sequences/1.0",
+      "tool_shed_repository": {
+        "changeset_revision": "2904d46167da",
+        "name": "fasta_merge_files_and_filter_unique_sequences",
+        "owner": "galaxyp",
+        "tool_shed": "toolshed.g2.bx.psu.edu"
+      },
+      "tool_state": "{\"inputs\": \"[{\\\"__index__\\\": 0, \\\"input\\\": {\\\"__class__\\\": \\\"RuntimeValue\\\"}}, {\\\"__index__\\\": 1, \\\"input\\\": {\\\"__class__\\\": \\\"RuntimeValue\\\"}}, {\\\"__index__\\\": 2, \\\"input\\\": {\\\"__class__\\\": \\\"RuntimeValue\\\"}}, {\\\"__index__\\\": 3, \\\"input\\\": {\\\"__class__\\\": \\\"RuntimeValue\\\"}}, {\\\"__index__\\\": 4, \\\"input\\\": {\\\"__class__\\\": \\\"RuntimeValue\\\"}}, {\\\"__index__\\\": 5, \\\"input\\\": {\\\"__class__\\\": \\\"RuntimeValue\\\"}}]\", \"__rerun_remap_job_id__\": null, \"__page__\": 0}",
+      "tool_version": "1.0",
+      "type": "tool",
+      "uuid": "548d8464-53ce-449c-b7ca-cfbbef6138ef",
+      "workflow_outputs": [
+        {
+          "label": null,
+          "output_name": "output",
+          "uuid": "acec9eca-63b1-462b-95e8-6c5ecfe36f4a"
+        }
+      ]
+    },
+    "10": {
+      "annotation": "",
+      "content_id": "toolshed.g2.bx.psu.edu/repos/devteam/add_value/addValue/1.0.0",
+      "id": 10,
+      "input_connections": {
+        "input": {
+          "id": 8,
+          "output_name": "output"
+        }
+      },
+      "inputs": [
+        {
+          "description": "runtime parameter for tool Add column",
+          "name": "input"
+        }
+      ],
+      "label": null,
+      "name": "Add column",
+      "outputs": [
+        {
+          "name": "out_file1",
+          "type": "input"
+        }
+      ],
+      "position": {
+        "left": 752,
+        "top": 355
+      },
+      "post_job_actions": {
+        "DeleteIntermediatesActionout_file1": {
+          "action_arguments": {},
+          "action_type": "DeleteIntermediatesAction",
+          "output_name": "out_file1"
+        },
+        "HideDatasetActionout_file1": {
+          "action_arguments": {},
+          "action_type": "HideDatasetAction",
+          "output_name": "out_file1"
+        }
+      },
+      "tool_errors": null,
+      "tool_id": "toolshed.g2.bx.psu.edu/repos/devteam/add_value/addValue/1.0.0",
+      "tool_shed_repository": {
+        "changeset_revision": "745871c0b055",
+        "name": "add_value",
+        "owner": "devteam",
+        "tool_shed": "toolshed.g2.bx.psu.edu"
+      },
+      "tool_state": "{\"__page__\": 0, \"input\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\", \"__rerun_remap_job_id__\": null, \"exp\": \"\\\"CONTAMINANT\\\"\", \"iterate\": \"\\\"no\\\"\"}",
+      "tool_version": "1.0.0",
+      "type": "tool",
+      "uuid": "1fe09bbb-ba83-448f-8dfd-1b7270441c42",
+      "workflow_outputs": []
+    },
+    "11": {
+      "annotation": "",
+      "content_id": "toolshed.g2.bx.psu.edu/repos/devteam/tabular_to_fasta/tab2fasta/1.1.0",
+      "id": 11,
+      "input_connections": {
+        "input": {
+          "id": 10,
+          "output_name": "out_file1"
+        }
+      },
+      "inputs": [
+        {
+          "description": "runtime parameter for tool Tabular-to-FASTA",
+          "name": "input"
+        }
+      ],
+      "label": null,
+      "name": "Tabular-to-FASTA",
+      "outputs": [
+        {
+          "name": "output",
+          "type": "fasta"
+        }
+      ],
+      "position": {
+        "left": 936,
+        "top": 385
+      },
+      "post_job_actions": {
+        "HideDatasetActionoutput": {
+          "action_arguments": {},
+          "action_type": "HideDatasetAction",
+          "output_name": "output"
+        },
+        "RenameDatasetActionoutput": {
+          "action_arguments": {
+            "newname": "tagged cRAP database"
+          },
+          "action_type": "RenameDatasetAction",
+          "output_name": "output"
+        }
+      },
+      "tool_errors": null,
+      "tool_id": "toolshed.g2.bx.psu.edu/repos/devteam/tabular_to_fasta/tab2fasta/1.1.0",
+      "tool_shed_repository": {
+        "changeset_revision": "0b4e36026794",
+        "name": "tabular_to_fasta",
+        "owner": "devteam",
+        "tool_shed": "toolshed.g2.bx.psu.edu"
+      },
+      "tool_state": "{\"title_col\": \"[\\\"1\\\", \\\"3\\\"]\", \"input\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\", \"__page__\": 0, \"__rerun_remap_job_id__\": null, \"seq_col\": \"\\\"2\\\"\"}",
+      "tool_version": "1.1.0",
+      "type": "tool",
+      "uuid": "1bd7f1b9-4974-4cd5-b9a1-91787e503ecf",
+      "workflow_outputs": []
+    },
+    "12": {
+      "annotation": "",
+      "content_id": "toolshed.g2.bx.psu.edu/repos/galaxyp/fasta_merge_files_and_filter_unique_sequences/fasta_merge_files_and_filter_unique_sequences/1.0",
+      "id": 12,
+      "input_connections": {
+        "inputs_0|input": {
+          "id": 0,
+          "output_name": "output_database"
+        },
+        "inputs_1|input": {
+          "id": 11,
+          "output_name": "output"
+        }
+      },
+      "inputs": [],
+      "label": null,
+      "name": "FASTA Merge Files and Filter Unique Sequences",
+      "outputs": [
+        {
+          "name": "output",
+          "type": "fasta"
+        }
+      ],
+      "position": {
+        "left": 1155,
+        "top": 211
+      },
+      "post_job_actions": {},
+      "tool_errors": null,
+      "tool_id": "toolshed.g2.bx.psu.edu/repos/galaxyp/fasta_merge_files_and_filter_unique_sequences/fasta_merge_files_and_filter_unique_sequences/1.0",
+      "tool_shed_repository": {
+        "changeset_revision": "2904d46167da",
+        "name": "fasta_merge_files_and_filter_unique_sequences",
+        "owner": "galaxyp",
+        "tool_shed": "toolshed.g2.bx.psu.edu"
+      },
+      "tool_state": "{\"inputs\": \"[{\\\"__index__\\\": 0, \\\"input\\\": {\\\"__class__\\\": \\\"RuntimeValue\\\"}}, {\\\"__index__\\\": 1, \\\"input\\\": {\\\"__class__\\\": \\\"RuntimeValue\\\"}}]\", \"__rerun_remap_job_id__\": null, \"chromInfo\": \"\\\"/usr/local/galaxy/galaxy-dist/tool-data/shared/ucsc/chrom/?.len\\\"\", \"__page__\": 0}",
+      "tool_version": "1.0",
+      "type": "tool",
+      "uuid": "6fbc2008-7b04-49af-af2f-01c55ff09e59",
+      "workflow_outputs": [
+        {
+          "label": "Main database (cRAP added)",
+          "output_name": "output",
+          "uuid": "bb1f67d0-6e5e-462e-9802-f354706a1531"
+        }
+      ]
+    },
+    "13": {
+      "annotation": "",
+      "content_id": "toolshed.g2.bx.psu.edu/repos/galaxyp/fasta_merge_files_and_filter_unique_sequences/fasta_merge_files_and_filter_unique_sequences/1.0",
+      "id": 13,
+      "input_connections": {
+        "inputs_0|input": {
+          "id": 9,
+          "output_name": "output"
+        },
+        "inputs_1|input": {
+          "id": 12,
+          "output_name": "output"
+        }
+      },
+      "inputs": [],
+      "label": null,
+      "name": "FASTA Merge Files and Filter Unique Sequences",
+      "outputs": [
+        {
+          "name": "output",
+          "type": "fasta"
+        }
+      ],
+      "position": {
+        "left": 1212,
+        "top": 496
+      },
+      "post_job_actions": {
+        "RenameDatasetActionoutput": {
+          "action_arguments": {
+            "newname": "Main database (cRAP and mycoplasma added)"
+          },
+          "action_type": "RenameDatasetAction",
+          "output_name": "output"
+        }
+      },
+      "tool_errors": null,
+      "tool_id": "toolshed.g2.bx.psu.edu/repos/galaxyp/fasta_merge_files_and_filter_unique_sequences/fasta_merge_files_and_filter_unique_sequences/1.0",
+      "tool_shed_repository": {
+        "changeset_revision": "2904d46167da",
+        "name": "fasta_merge_files_and_filter_unique_sequences",
+        "owner": "galaxyp",
+        "tool_shed": "toolshed.g2.bx.psu.edu"
+      },
+      "tool_state": "{\"inputs\": \"[{\\\"__index__\\\": 0, \\\"input\\\": {\\\"__class__\\\": \\\"RuntimeValue\\\"}}, {\\\"__index__\\\": 1, \\\"input\\\": {\\\"__class__\\\": \\\"RuntimeValue\\\"}}]\", \"__rerun_remap_job_id__\": null, \"__page__\": 0}",
+      "tool_version": "1.0",
+      "type": "tool",
+      "uuid": "5b5e98bd-ed99-4269-9c11-cd98254ac9cd",
+      "workflow_outputs": [
+        {
+          "label": null,
+          "output_name": "output",
+          "uuid": "efd2b73c-ef07-41dd-9a28-48251913dbc1"
+        }
+      ]
+    },
+    "14": {
+      "annotation": "",
+      "content_id": "DecoyDatabase",
+      "id": 14,
+      "input_connections": {
+        "param_in": {
+          "id": 13,
+          "output_name": "output"
+        }
+      },
+      "inputs": [
+        {
+          "description": "runtime parameter for tool DecoyDatabase",
+          "name": "param_in"
+        }
+      ],
+      "label": null,
+      "name": "DecoyDatabase",
+      "outputs": [
+        {
+          "name": "param_out",
+          "type": "fasta"
+        }
+      ],
+      "position": {
+        "left": 1513,
+        "top": 583.5
+      },
+      "post_job_actions": {
+        "RenameDatasetActionparam_out": {
+          "action_arguments": {
+            "newname": "Main database with decoys (cRAP and Mycoplasma added)"
+          },
+          "action_type": "RenameDatasetAction",
+          "output_name": "param_out"
+        }
+      },
+      "tool_errors": null,
+      "tool_id": "DecoyDatabase",
+      "tool_state": "{\"__page__\": 0, \"param_append\": \"\\\"true\\\"\", \"adv_opts\": \"{\\\"adv_opts_selector\\\": \\\"basic\\\", \\\"__current_case__\\\": 0}\", \"__rerun_remap_job_id__\": null, \"param_method\": \"\\\"reverse\\\"\", \"param_decoy_string\": \"\\\"DECOY_\\\"\", \"param_decoy_string_position\": \"\\\"prefix\\\"\", \"param_in\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\"}",
+      "tool_version": "2.1.0",
+      "type": "tool",
+      "uuid": "a96cde43-cd29-4683-8f32-fe8603b2e682",
+      "workflow_outputs": [
+        {
+          "label": null,
+          "output_name": "param_out",
+          "uuid": "9f464e59-daa0-4013-b266-4b7eae387507"
+        }
+      ],
+      "tool_shed_repository": {
+        "changeset_revision": "8ced1ef014ae",
+        "name": "openms_decoydatabase",
+        "owner": "galaxyp",
+        "tool_shed": "toolshed.g2.bx.psu.edu"
+      }
+    }
+  },
+  "uuid": "66bcd057-5032-4693-a0ba-c41d061cb0ff"
 }

--- a/topics/proteomics/tutorials/ntails/workflows/WF_ntails.ga
+++ b/topics/proteomics/tutorials/ntails/workflows/WF_ntails.ga
@@ -1,1036 +1,1144 @@
 {
-    "a_galaxy_workflow": "true", 
-    "annotation": "", 
-    "format-version": "0.1", 
-    "name": "tails triple dimethyl OpenMS2.1", 
-    "steps": {
-        "0": {
-            "annotation": "", 
-            "content_id": null, 
-            "id": 0, 
-            "input_connections": {}, 
-            "inputs": [
-                {
-                    "description": "", 
-                    "name": "Input Dataset Collection (mzML files)"
-                }
-            ], 
-            "label": null, 
-            "name": "Input dataset collection", 
-            "outputs": [], 
-            "position": {
-                "left": 199.9666748046875, 
-                "top": 435.20001220703125
-            }, 
-            "tool_errors": null, 
-            "tool_id": null, 
-            "tool_state": "{\"collection_type\": \"list\", \"name\": \"Input Dataset Collection (mzML files)\"}", 
-            "tool_version": null, 
-            "type": "data_collection_input", 
-            "uuid": "7bf13771-4620-4563-b972-efaf74887ce5", 
-            "workflow_outputs": [
-                {
-                    "label": null, 
-                    "output_name": "output", 
-                    "uuid": "11ba0e33-3924-43e2-a8f9-85e0e6c12cfe"
-                }
-            ]
-        }, 
-        "1": {
-            "annotation": "", 
-            "content_id": null, 
-            "id": 1, 
-            "input_connections": {}, 
-            "inputs": [
-                {
-                    "description": "", 
-                    "name": "UniProt database (FASTA file)"
-                }
-            ], 
-            "label": null, 
-            "name": "Input dataset", 
-            "outputs": [], 
-            "position": {
-                "left": 241, 
-                "top": 603.2166748046875
-            }, 
-            "tool_errors": null, 
-            "tool_id": null, 
-            "tool_state": "{\"name\": \"UniProt database (FASTA file)\"}", 
-            "tool_version": null, 
-            "type": "data_input", 
-            "uuid": "05f5cbd8-8459-47a0-8faf-95c0821f25fc", 
-            "workflow_outputs": [
-                {
-                    "label": null, 
-                    "output_name": "output", 
-                    "uuid": "3d25e478-d053-4d4e-9c7f-92fec2d6b09c"
-                }
-            ]
-        }, 
-        "2": {
-            "annotation": "", 
-            "content_id": "FeatureFinderMultiplex", 
-            "id": 2, 
-            "input_connections": {
-                "param_in": {
-                    "id": 0, 
-                    "output_name": "output"
-                }
-            }, 
-            "inputs": [
-                {
-                    "description": "runtime parameter for tool FeatureFinderMultiplex", 
-                    "name": "param_in"
-                }
-            ], 
-            "label": null, 
-            "name": "FeatureFinderMultiplex", 
-            "outputs": [
-                {
-                    "name": "param_out", 
-                    "type": "consensusxml"
-                }, 
-                {
-                    "name": "param_out_features", 
-                    "type": "featurexml"
-                }, 
-                {
-                    "name": "param_out_mzq", 
-                    "type": "mzq"
-                }
-            ], 
-            "position": {
-                "left": 1228.9666748046875, 
-                "top": 1174.88330078125
-            }, 
-            "post_job_actions": {
-                "HideDatasetActionparam_out_mzq": {
-                    "action_arguments": {}, 
-                    "action_type": "HideDatasetAction", 
-                    "output_name": "param_out_mzq"
-                }
-            }, 
-            "tool_errors": null, 
-            "tool_id": "FeatureFinderMultiplex", 
-            "tool_state": "{\"param_algorithm_averagine_similarity\": \"\\\"0.6\\\"\", \"param_algorithm_rt_min\": \"\\\"3.0\\\"\", \"__page__\": 0, \"param_algorithm_missed_cleavages\": \"\\\"2\\\"\", \"param_algorithm_peptide_similarity\": \"\\\"0.7\\\"\", \"adv_opts\": \"{\\\"param_algorithm_knock_out\\\": \\\"true\\\", \\\"param_labels_Dimethyl4\\\": \\\"32.056407\\\", \\\"param_algorithm_isotopes_per_peptide\\\": \\\"3:6\\\", \\\"param_labels_Lys4\\\": \\\"4.0251069836\\\", \\\"param_labels_Dimethyl0\\\": \\\"28.0313\\\", \\\"param_labels_Lys8\\\": \\\"8.0141988132\\\", \\\"param_labels_ICPL10\\\": \\\"115.0667\\\", \\\"param_labels_Lys6\\\": \\\"6.0201290268\\\", \\\"param_labels_Arg10\\\": \\\"10.0082686\\\", \\\"param_labels_Dimethyl8\\\": \\\"36.07567\\\", \\\"adv_opts_selector\\\": \\\"advanced\\\", \\\"param_labels_ICPL6\\\": \\\"111.041593\\\", \\\"param_force\\\": \\\"false\\\", \\\"param_labels_Dimethyl6\\\": \\\"34.063117\\\", \\\"param_labels_Arg6\\\": \\\"6.0201290268\\\", \\\"__current_case__\\\": 1, \\\"param_algorithm_averagine_type\\\": \\\"peptide\\\", \\\"param_labels_ICPL0\\\": \\\"105.021464\\\", \\\"param_labels_Leu3\\\": \\\"3.01883\\\", \\\"param_labels_ICPL4\\\": \\\"109.046571\\\", \\\"param_algorithm_averagine_similarity_scaling\\\": \\\"0.6\\\"}\", \"param_algorithm_mz_tolerance\": \"\\\"15.0\\\"\", \"param_algorithm_charge\": \"\\\"1:5\\\"\", \"param_algorithm_mz_unit\": \"\\\"ppm\\\"\", \"param_algorithm_labels\": \"\\\"[Dimethyl0][Dimethyl4][Dimethyl8]\\\"\", \"param_algorithm_intensity_cutoff\": \"\\\"10.0\\\"\", \"param_algorithm_rt_typical\": \"\\\"50.0\\\"\", \"__rerun_remap_job_id__\": null, \"param_in\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\"}", 
-            "tool_version": "2.1.0", 
-            "type": "tool", 
-            "uuid": "627672fc-feef-4e31-9208-182a27df2533", 
-            "workflow_outputs": [
-                {
-                    "label": null, 
-                    "output_name": "param_out", 
-                    "uuid": "6e1e9231-52a0-4d05-9491-31f4b162d405"
-                }, 
-                {
-                    "label": null, 
-                    "output_name": "param_out_features", 
-                    "uuid": "a8b8b589-661b-49ca-9832-556069bf98bc"
-                }
-            ]
-        }, 
-        "3": {
-            "annotation": "", 
-            "content_id": "HighResPrecursorMassCorrector", 
-            "id": 3, 
-            "input_connections": {
-                "param_feature_in": {
-                    "id": 2, 
-                    "output_name": "param_out_features"
-                }, 
-                "param_in": {
-                    "id": 0, 
-                    "output_name": "output"
-                }
-            }, 
-            "inputs": [
-                {
-                    "description": "runtime parameter for tool HighResPrecursorMassCorrector", 
-                    "name": "param_feature_in"
-                }, 
-                {
-                    "description": "runtime parameter for tool HighResPrecursorMassCorrector", 
-                    "name": "param_in"
-                }
-            ], 
-            "label": null, 
-            "name": "HighResPrecursorMassCorrector", 
-            "outputs": [
-                {
-                    "name": "param_out", 
-                    "type": "mzml"
-                }, 
-                {
-                    "name": "param_out_csv", 
-                    "type": "tabular"
-                }
-            ], 
-            "position": {
-                "left": 484.54998779296875, 
-                "top": 151.1999969482422
-            }, 
-            "post_job_actions": {
-                "HideDatasetActionparam_out_csv": {
-                    "action_arguments": {}, 
-                    "action_type": "HideDatasetAction", 
-                    "output_name": "param_out_csv"
-                }, 
-                "RenameDatasetActionparam_out": {
-                    "action_arguments": {
-                        "newname": "HighRes_out"
-                    }, 
-                    "action_type": "RenameDatasetAction", 
-                    "output_name": "param_out"
-                }
-            }, 
-            "tool_errors": null, 
-            "tool_id": "HighResPrecursorMassCorrector", 
-            "tool_state": "{\"__page__\": 0, \"adv_opts\": \"{\\\"adv_opts_selector\\\": \\\"basic\\\", \\\"__current_case__\\\": 0}\", \"__rerun_remap_job_id__\": null, \"param_in\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\", \"param_feature_in\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\", \"param_feature_rt_tolerance\": \"\\\"15.0\\\"\", \"param_nearest_peak_mz_tolerance_unit\": \"\\\"ppm\\\"\", \"param_feature_mz_tolerance_unit\": \"\\\"ppm\\\"\", \"param_feature_mz_tolerance\": \"\\\"40.0\\\"\", \"param_feature_keep_original\": \"\\\"false\\\"\", \"param_feature_assign_all_matching\": \"\\\"false\\\"\", \"param_feature_believe_charge\": \"\\\"false\\\"\", \"param_nearest_peak_mz_tolerance\": \"\\\"0.0\\\"\"}", 
-            "tool_version": "2.1.0", 
-            "type": "tool", 
-            "uuid": "3d7f4c8b-1896-4365-b41a-77b152ec84b4", 
-            "workflow_outputs": [
-                {
-                    "label": null, 
-                    "output_name": "param_out", 
-                    "uuid": "be0344fb-dccf-4d28-a45e-9d1aded44e41"
-                }
-            ]
-        }, 
-        "4": {
-            "annotation": "", 
-            "content_id": "MSGFPlusAdapter", 
-            "id": 4, 
-            "input_connections": {
-                "param_database": {
-                    "id": 1, 
-                    "output_name": "output"
-                }, 
-                "param_in": {
-                    "id": 3, 
-                    "output_name": "param_out"
-                }
-            }, 
-            "inputs": [
-                {
-                    "description": "runtime parameter for tool MSGFPlusAdapter", 
-                    "name": "param_in"
-                }, 
-                {
-                    "description": "runtime parameter for tool MSGFPlusAdapter", 
-                    "name": "param_database"
-                }
-            ], 
-            "label": null, 
-            "name": "MSGFPlusAdapter", 
-            "outputs": [
-                {
-                    "name": "param_out", 
-                    "type": "idxml"
-                }, 
-                {
-                    "name": "param_mzid_out", 
-                    "type": "mzid"
-                }
-            ], 
-            "position": {
-                "left": 849.0500030517578, 
-                "top": 186.21665954589844
-            }, 
-            "post_job_actions": {
-                "HideDatasetActionparam_mzid_out": {
-                    "action_arguments": {}, 
-                    "action_type": "HideDatasetAction", 
-                    "output_name": "param_mzid_out"
-                }
-            }, 
-            "tool_errors": null, 
-            "tool_id": "MSGFPlusAdapter", 
-            "tool_state": "{\"param_java_executable\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\", \"param_max_precursor_charge\": \"\\\"4\\\"\", \"param_min_precursor_charge\": \"\\\"2\\\"\", \"param_min_peptide_length\": \"\\\"7\\\"\", \"param_precursor_error_units\": \"\\\"ppm\\\"\", \"param_protocol\": \"\\\"none\\\"\", \"__page__\": 0, \"__rerun_remap_job_id__\": null, \"param_tryptic\": \"\\\"semi\\\"\", \"param_max_mods\": \"\\\"3\\\"\", \"rep_param_fixed_modifications\": \"[{\\\"__index__\\\": 0, \\\"param_fixed_modifications\\\": \\\"Carbamidomethyl (C)\\\"}, {\\\"__index__\\\": 1, \\\"param_fixed_modifications\\\": \\\"Dimethyl (K)\\\"}, {\\\"__index__\\\": 2, \\\"param_fixed_modifications\\\": \\\"Dimethyl (N-term)\\\"}]\", \"param_in\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\", \"param_add_decoys\": \"\\\"false\\\"\", \"param_matches_per_spec\": \"\\\"1\\\"\", \"param_max_peptide_length\": \"\\\"40\\\"\", \"param_instrument\": \"\\\"Q_Exactive\\\"\", \"param_precursor_mass_tolerance\": \"\\\"20.0\\\"\", \"rep_param_variable_modifications\": \"[]\", \"param_add_features\": \"\\\"true\\\"\", \"param_enzyme\": \"\\\"ArgC\\\"\", \"param_database\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\", \"param_fragment_method\": \"\\\"from_spectrum\\\"\", \"adv_opts\": \"{\\\"adv_opts_selector\\\": \\\"basic\\\", \\\"__current_case__\\\": 0}\", \"param_java_memory\": \"\\\"3500\\\"\", \"param_isotope_error_range\": \"\\\"0,0\\\"\"}", 
-            "tool_version": "2.1.0", 
-            "type": "tool", 
-            "uuid": "cc98863a-5f1a-42ef-bd30-a7c6002f3efa", 
-            "workflow_outputs": [
-                {
-                    "label": null, 
-                    "output_name": "param_out", 
-                    "uuid": "7066dfd9-e896-462b-8877-68580da0cc08"
-                }
-            ]
-        }, 
-        "5": {
-            "annotation": "", 
-            "content_id": "MSGFPlusAdapter", 
-            "id": 5, 
-            "input_connections": {
-                "param_database": {
-                    "id": 1, 
-                    "output_name": "output"
-                }, 
-                "param_in": {
-                    "id": 3, 
-                    "output_name": "param_out"
-                }
-            }, 
-            "inputs": [
-                {
-                    "description": "runtime parameter for tool MSGFPlusAdapter", 
-                    "name": "param_in"
-                }, 
-                {
-                    "description": "runtime parameter for tool MSGFPlusAdapter", 
-                    "name": "param_database"
-                }
-            ], 
-            "label": null, 
-            "name": "MSGFPlusAdapter", 
-            "outputs": [
-                {
-                    "name": "param_out", 
-                    "type": "idxml"
-                }, 
-                {
-                    "name": "param_mzid_out", 
-                    "type": "mzid"
-                }
-            ], 
-            "position": {
-                "left": 887, 
-                "top": 394.20001220703125
-            }, 
-            "post_job_actions": {
-                "HideDatasetActionparam_mzid_out": {
-                    "action_arguments": {}, 
-                    "action_type": "HideDatasetAction", 
-                    "output_name": "param_mzid_out"
-                }
-            }, 
-            "tool_errors": null, 
-            "tool_id": "MSGFPlusAdapter", 
-            "tool_state": "{\"param_java_executable\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\", \"param_max_precursor_charge\": \"\\\"4\\\"\", \"param_min_precursor_charge\": \"\\\"2\\\"\", \"param_min_peptide_length\": \"\\\"7\\\"\", \"param_precursor_error_units\": \"\\\"ppm\\\"\", \"param_protocol\": \"\\\"none\\\"\", \"__page__\": 0, \"__rerun_remap_job_id__\": null, \"param_tryptic\": \"\\\"semi\\\"\", \"param_max_mods\": \"\\\"3\\\"\", \"rep_param_fixed_modifications\": \"[{\\\"__index__\\\": 0, \\\"param_fixed_modifications\\\": \\\"Carbamidomethyl (C)\\\"}, {\\\"__index__\\\": 1, \\\"param_fixed_modifications\\\": \\\"Dimethyl:2H(4) (K)\\\"}, {\\\"__index__\\\": 2, \\\"param_fixed_modifications\\\": \\\"Dimethyl:2H(4) (N-term)\\\"}]\", \"param_in\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\", \"param_add_decoys\": \"\\\"false\\\"\", \"param_matches_per_spec\": \"\\\"1\\\"\", \"param_max_peptide_length\": \"\\\"40\\\"\", \"param_instrument\": \"\\\"Q_Exactive\\\"\", \"param_precursor_mass_tolerance\": \"\\\"20.0\\\"\", \"rep_param_variable_modifications\": \"[]\", \"param_add_features\": \"\\\"true\\\"\", \"param_enzyme\": \"\\\"ArgC\\\"\", \"param_database\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\", \"param_fragment_method\": \"\\\"from_spectrum\\\"\", \"adv_opts\": \"{\\\"adv_opts_selector\\\": \\\"basic\\\", \\\"__current_case__\\\": 0}\", \"param_java_memory\": \"\\\"3500\\\"\", \"param_isotope_error_range\": \"\\\"0,0\\\"\"}", 
-            "tool_version": "2.1.0", 
-            "type": "tool", 
-            "uuid": "3a2ce94c-c7c0-43e8-a95a-29773f41ff83", 
-            "workflow_outputs": [
-                {
-                    "label": null, 
-                    "output_name": "param_out", 
-                    "uuid": "7d1226d5-80ff-4f81-b2f8-1298517f98f8"
-                }
-            ]
-        }, 
-        "6": {
-            "annotation": "", 
-            "content_id": "MSGFPlusAdapter", 
-            "id": 6, 
-            "input_connections": {
-                "param_in": {
-                    "id": 3, 
-                    "output_name": "param_out"
-                }
-            }, 
-            "inputs": [
-                {
-                    "description": "runtime parameter for tool MSGFPlusAdapter", 
-                    "name": "param_in"
-                }, 
-                {
-                    "description": "runtime parameter for tool MSGFPlusAdapter", 
-                    "name": "param_database"
-                }
-            ], 
-            "label": null, 
-            "name": "MSGFPlusAdapter", 
-            "outputs": [
-                {
-                    "name": "param_out", 
-                    "type": "idxml"
-                }, 
-                {
-                    "name": "param_mzid_out", 
-                    "type": "mzid"
-                }
-            ], 
-            "position": {
-                "left": 892.5, 
-                "top": 590
-            }, 
-            "post_job_actions": {
-                "HideDatasetActionparam_mzid_out": {
-                    "action_arguments": {}, 
-                    "action_type": "HideDatasetAction", 
-                    "output_name": "param_mzid_out"
-                }
-            }, 
-            "tool_errors": null, 
-            "tool_id": "MSGFPlusAdapter", 
-            "tool_state": "{\"param_java_executable\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\", \"param_max_precursor_charge\": \"\\\"4\\\"\", \"param_min_precursor_charge\": \"\\\"2\\\"\", \"param_min_peptide_length\": \"\\\"7\\\"\", \"param_precursor_error_units\": \"\\\"ppm\\\"\", \"param_protocol\": \"\\\"none\\\"\", \"__page__\": 0, \"__rerun_remap_job_id__\": null, \"param_tryptic\": \"\\\"semi\\\"\", \"param_max_mods\": \"\\\"3\\\"\", \"rep_param_fixed_modifications\": \"[{\\\"__index__\\\": 0, \\\"param_fixed_modifications\\\": \\\"Carbamidomethyl (C)\\\"}, {\\\"__index__\\\": 1, \\\"param_fixed_modifications\\\": \\\"Dimethyl:2H(6)13C(2) (K)\\\"}, {\\\"__index__\\\": 2, \\\"param_fixed_modifications\\\": \\\"Dimethyl:2H(6)13C(2) (N-term)\\\"}]\", \"param_in\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\", \"param_add_decoys\": \"\\\"false\\\"\", \"param_matches_per_spec\": \"\\\"1\\\"\", \"param_max_peptide_length\": \"\\\"40\\\"\", \"param_instrument\": \"\\\"Q_Exactive\\\"\", \"param_precursor_mass_tolerance\": \"\\\"20.0\\\"\", \"rep_param_variable_modifications\": \"[]\", \"param_add_features\": \"\\\"true\\\"\", \"param_enzyme\": \"\\\"ArgC\\\"\", \"param_database\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\", \"param_fragment_method\": \"\\\"from_spectrum\\\"\", \"adv_opts\": \"{\\\"adv_opts_selector\\\": \\\"basic\\\", \\\"__current_case__\\\": 0}\", \"param_java_memory\": \"\\\"3500\\\"\", \"param_isotope_error_range\": \"\\\"0,0\\\"\"}", 
-            "tool_version": "2.1.0", 
-            "type": "tool", 
-            "uuid": "05593ca7-2056-4201-9ce7-60b4abc82ff5", 
-            "workflow_outputs": [
-                {
-                    "label": null, 
-                    "output_name": "param_out", 
-                    "uuid": "22b3fa5a-a162-4ce1-8c07-8c3f84fc0551"
-                }
-            ]
-        }, 
-        "7": {
-            "annotation": "", 
-            "content_id": "PeptideIndexer", 
-            "id": 7, 
-            "input_connections": {
-                "param_fasta": {
-                    "id": 1, 
-                    "output_name": "output"
-                }, 
-                "param_in": {
-                    "id": 4, 
-                    "output_name": "param_out"
-                }
-            }, 
-            "inputs": [
-                {
-                    "description": "runtime parameter for tool PeptideIndexer", 
-                    "name": "param_fasta"
-                }, 
-                {
-                    "description": "runtime parameter for tool PeptideIndexer", 
-                    "name": "param_in"
-                }
-            ], 
-            "label": null, 
-            "name": "PeptideIndexer", 
-            "outputs": [
-                {
-                    "name": "param_out", 
-                    "type": "idxml"
-                }
-            ], 
-            "position": {
-                "left": 1191, 
-                "top": 181.1999969482422
-            }, 
-            "post_job_actions": {}, 
-            "tool_errors": null, 
-            "tool_id": "PeptideIndexer", 
-            "tool_state": "{\"param_write_protein_sequence\": \"\\\"true\\\"\", \"param_missing_decoy_action\": \"\\\"error\\\"\", \"param_filter_aaa_proteins\": \"\\\"false\\\"\", \"param_prefix\": \"\\\"true\\\"\", \"param_keep_unreferenced_proteins\": \"\\\"false\\\"\", \"adv_opts\": \"{\\\"adv_opts_selector\\\": \\\"basic\\\", \\\"__current_case__\\\": 0}\", \"__page__\": 0, \"param_allow_unmatched\": \"\\\"true\\\"\", \"param_decoy_string_position\": \"\\\"prefix\\\"\", \"param_mismatches_max\": \"\\\"0\\\"\", \"param_enzyme_name\": \"\\\"Trypsin/P\\\"\", \"param_enzyme_specificity\": \"\\\"semi\\\"\", \"param_decoy_string\": \"\\\"dec_\\\"\", \"__rerun_remap_job_id__\": null, \"param_write_protein_description\": \"\\\"true\\\"\", \"param_full_tolerant_search\": \"\\\"false\\\"\", \"param_fasta\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\", \"param_aaa_max\": \"\\\"4\\\"\", \"param_annotate_proteins\": \"\\\"True\\\"\", \"param_IL_equivalent\": \"\\\"false\\\"\", \"param_in\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\"}", 
-            "tool_version": "2.1.0", 
-            "type": "tool", 
-            "uuid": "6d75c013-51d3-49f5-8b26-876a8b1c06d5", 
-            "workflow_outputs": [
-                {
-                    "label": null, 
-                    "output_name": "param_out", 
-                    "uuid": "92afc5d3-a20f-4f89-8b80-f6618ba430d0"
-                }
-            ]
-        }, 
-        "8": {
-            "annotation": "", 
-            "content_id": "PeptideIndexer", 
-            "id": 8, 
-            "input_connections": {
-                "param_fasta": {
-                    "id": 1, 
-                    "output_name": "output"
-                }, 
-                "param_in": {
-                    "id": 5, 
-                    "output_name": "param_out"
-                }
-            }, 
-            "inputs": [
-                {
-                    "description": "runtime parameter for tool PeptideIndexer", 
-                    "name": "param_fasta"
-                }, 
-                {
-                    "description": "runtime parameter for tool PeptideIndexer", 
-                    "name": "param_in"
-                }
-            ], 
-            "label": null, 
-            "name": "PeptideIndexer", 
-            "outputs": [
-                {
-                    "name": "param_out", 
-                    "type": "idxml"
-                }
-            ], 
-            "position": {
-                "left": 1155, 
-                "top": 398.2166748046875
-            }, 
-            "post_job_actions": {}, 
-            "tool_errors": null, 
-            "tool_id": "PeptideIndexer", 
-            "tool_state": "{\"param_write_protein_sequence\": \"\\\"true\\\"\", \"param_missing_decoy_action\": \"\\\"error\\\"\", \"param_filter_aaa_proteins\": \"\\\"false\\\"\", \"param_prefix\": \"\\\"true\\\"\", \"param_keep_unreferenced_proteins\": \"\\\"false\\\"\", \"adv_opts\": \"{\\\"adv_opts_selector\\\": \\\"basic\\\", \\\"__current_case__\\\": 0}\", \"__page__\": 0, \"param_allow_unmatched\": \"\\\"true\\\"\", \"param_decoy_string_position\": \"\\\"prefix\\\"\", \"param_mismatches_max\": \"\\\"0\\\"\", \"param_enzyme_name\": \"\\\"Trypsin/P\\\"\", \"param_enzyme_specificity\": \"\\\"semi\\\"\", \"param_decoy_string\": \"\\\"dec_\\\"\", \"__rerun_remap_job_id__\": null, \"param_write_protein_description\": \"\\\"true\\\"\", \"param_full_tolerant_search\": \"\\\"false\\\"\", \"param_fasta\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\", \"param_aaa_max\": \"\\\"4\\\"\", \"param_annotate_proteins\": \"\\\"True\\\"\", \"param_IL_equivalent\": \"\\\"false\\\"\", \"param_in\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\"}", 
-            "tool_version": "2.1.0", 
-            "type": "tool", 
-            "uuid": "8cd335cb-9d51-4c04-99b3-38fed4f3c3b6", 
-            "workflow_outputs": [
-                {
-                    "label": null, 
-                    "output_name": "param_out", 
-                    "uuid": "9774a600-1f91-4927-932a-b887a1b6f73a"
-                }
-            ]
-        }, 
-        "9": {
-            "annotation": "", 
-            "content_id": "PeptideIndexer", 
-            "id": 9, 
-            "input_connections": {
-                "param_fasta": {
-                    "id": 1, 
-                    "output_name": "output"
-                }, 
-                "param_in": {
-                    "id": 6, 
-                    "output_name": "param_out"
-                }
-            }, 
-            "inputs": [
-                {
-                    "description": "runtime parameter for tool PeptideIndexer", 
-                    "name": "param_fasta"
-                }, 
-                {
-                    "description": "runtime parameter for tool PeptideIndexer", 
-                    "name": "param_in"
-                }
-            ], 
-            "label": null, 
-            "name": "PeptideIndexer", 
-            "outputs": [
-                {
-                    "name": "param_out", 
-                    "type": "idxml"
-                }
-            ], 
-            "position": {
-                "left": 1180.5, 
-                "top": 569
-            }, 
-            "post_job_actions": {
-                "HideDatasetActionparam_out": {
-                    "action_arguments": {}, 
-                    "action_type": "HideDatasetAction", 
-                    "output_name": "param_out"
-                }
-            }, 
-            "tool_errors": null, 
-            "tool_id": "PeptideIndexer", 
-            "tool_state": "{\"param_write_protein_sequence\": \"\\\"true\\\"\", \"param_missing_decoy_action\": \"\\\"error\\\"\", \"param_filter_aaa_proteins\": \"\\\"false\\\"\", \"param_prefix\": \"\\\"true\\\"\", \"param_keep_unreferenced_proteins\": \"\\\"false\\\"\", \"adv_opts\": \"{\\\"adv_opts_selector\\\": \\\"basic\\\", \\\"__current_case__\\\": 0}\", \"__page__\": 0, \"param_allow_unmatched\": \"\\\"true\\\"\", \"param_decoy_string_position\": \"\\\"prefix\\\"\", \"param_mismatches_max\": \"\\\"0\\\"\", \"param_enzyme_name\": \"\\\"Trypsin/P\\\"\", \"param_enzyme_specificity\": \"\\\"semi\\\"\", \"param_decoy_string\": \"\\\"dec_\\\"\", \"__rerun_remap_job_id__\": null, \"param_write_protein_description\": \"\\\"true\\\"\", \"param_full_tolerant_search\": \"\\\"false\\\"\", \"param_fasta\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\", \"param_aaa_max\": \"\\\"4\\\"\", \"param_annotate_proteins\": \"\\\"True\\\"\", \"param_IL_equivalent\": \"\\\"false\\\"\", \"param_in\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\"}", 
-            "tool_version": "2.1.0", 
-            "type": "tool", 
-            "uuid": "9361c7be-0416-4ae2-94f6-1722124be507", 
-            "workflow_outputs": []
-        }, 
-        "10": {
-            "annotation": "", 
-            "content_id": "IDMerger", 
-            "id": 10, 
-            "input_connections": {
-                "param_in": [
-                    {
-                        "id": 7, 
-                        "output_name": "param_out"
-                    }, 
-                    {
-                        "id": 8, 
-                        "output_name": "param_out"
-                    }, 
-                    {
-                        "id": 9, 
-                        "output_name": "param_out"
-                    }
-                ]
-            }, 
-            "inputs": [
-                {
-                    "description": "runtime parameter for tool IDMerger", 
-                    "name": "param_add_to"
-                }, 
-                {
-                    "description": "runtime parameter for tool IDMerger", 
-                    "name": "param_in"
-                }
-            ], 
-            "label": null, 
-            "name": "IDMerger", 
-            "outputs": [
-                {
-                    "name": "param_out", 
-                    "type": "idxml"
-                }
-            ], 
-            "position": {
-                "left": 1441, 
-                "top": 352.20001220703125
-            }, 
-            "post_job_actions": {}, 
-            "tool_errors": null, 
-            "tool_id": "IDMerger", 
-            "tool_state": "{\"inputs\": \"[{\\\"__index__\\\": 0, \\\"param_in\\\": {\\\"__class__\\\": \\\"RuntimeValue\\\"}}, {\\\"__index__\\\": 1, \\\"param_in\\\": {\\\"__class__\\\": \\\"RuntimeValue\\\"}}]\", \"__page__\": 0, \"adv_opts\": \"{\\\"adv_opts_selector\\\": \\\"basic\\\", \\\"__current_case__\\\": 0}\", \"__rerun_remap_job_id__\": null, \"param_annotate_file_origin\": \"\\\"false\\\"\", \"param_pepxml_protxml\": \"\\\"false\\\"\", \"param_add_to\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\", \"param_in1\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\", \"param_in\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\"}", 
-            "tool_version": "2.1.0", 
-            "type": "tool", 
-            "uuid": "3616471f-09c7-4c6a-8118-e92619874f09", 
-            "workflow_outputs": [
-                {
-                    "label": null, 
-                    "output_name": "param_out", 
-                    "uuid": "f78b508e-7e25-4d72-a870-9f12371c95ea"
-                }
-            ]
-        }, 
-        "11": {
-            "annotation": "", 
-            "content_id": "ConsensusID", 
-            "id": 11, 
-            "input_connections": {
-                "param_in": {
-                    "id": 10, 
-                    "output_name": "param_out"
-                }
-            }, 
-            "inputs": [
-                {
-                    "description": "runtime parameter for tool ConsensusID", 
-                    "name": "param_in"
-                }
-            ], 
-            "label": null, 
-            "name": "ConsensusID", 
-            "outputs": [
-                {
-                    "name": "param_out", 
-                    "type": "input"
-                }
-            ], 
-            "position": {
-                "left": 1609, 
-                "top": 470.20001220703125
-            }, 
-            "post_job_actions": {}, 
-            "tool_errors": null, 
-            "tool_id": "ConsensusID", 
-            "tool_state": "{\"__page__\": 0, \"param_algorithm\": \"\\\"best\\\"\", \"param_filter_considered_hits\": \"\\\"0\\\"\", \"adv_opts\": \"{\\\"adv_opts_selector\\\": \\\"basic\\\", \\\"__current_case__\\\": 0}\", \"__rerun_remap_job_id__\": null, \"param_filter_count_empty\": \"\\\"false\\\"\", \"param_PEPIons_mass_tolerance\": \"\\\"0.5\\\"\", \"param_PEPIons_min_shared\": \"\\\"2\\\"\", \"param_PEPMatrix_penalty\": \"\\\"5\\\"\", \"param_filter_min_support\": \"\\\"0.0\\\"\", \"param_rt_delta\": \"\\\"0.1\\\"\", \"param_PEPMatrix_matrix\": \"\\\"identity\\\"\", \"param_mz_delta\": \"\\\"0.1\\\"\", \"param_in\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\"}", 
-            "tool_version": "2.1.0", 
-            "type": "tool", 
-            "uuid": "a397db69-017e-4988-9f94-7ecbc119e3f3", 
-            "workflow_outputs": [
-                {
-                    "label": null, 
-                    "output_name": "param_out", 
-                    "uuid": "b05c7e3e-e094-4366-9163-e0c1984974b9"
-                }
-            ]
-        }, 
-        "12": {
-            "annotation": "", 
-            "content_id": "PeptideIndexer", 
-            "id": 12, 
-            "input_connections": {
-                "param_fasta": {
-                    "id": 1, 
-                    "output_name": "output"
-                }, 
-                "param_in": {
-                    "id": 11, 
-                    "output_name": "param_out"
-                }
-            }, 
-            "inputs": [
-                {
-                    "description": "runtime parameter for tool PeptideIndexer", 
-                    "name": "param_fasta"
-                }, 
-                {
-                    "description": "runtime parameter for tool PeptideIndexer", 
-                    "name": "param_in"
-                }
-            ], 
-            "label": null, 
-            "name": "PeptideIndexer", 
-            "outputs": [
-                {
-                    "name": "param_out", 
-                    "type": "idxml"
-                }
-            ], 
-            "position": {
-                "left": 1003, 
-                "top": 820.2000122070312
-            }, 
-            "post_job_actions": {}, 
-            "tool_errors": null, 
-            "tool_id": "PeptideIndexer", 
-            "tool_state": "{\"param_write_protein_sequence\": \"\\\"true\\\"\", \"param_missing_decoy_action\": \"\\\"error\\\"\", \"param_filter_aaa_proteins\": \"\\\"false\\\"\", \"param_prefix\": \"\\\"true\\\"\", \"param_keep_unreferenced_proteins\": \"\\\"false\\\"\", \"adv_opts\": \"{\\\"adv_opts_selector\\\": \\\"basic\\\", \\\"__current_case__\\\": 0}\", \"__page__\": 0, \"param_allow_unmatched\": \"\\\"true\\\"\", \"param_decoy_string_position\": \"\\\"prefix\\\"\", \"param_mismatches_max\": \"\\\"0\\\"\", \"param_enzyme_name\": \"\\\"Trypsin/P\\\"\", \"param_enzyme_specificity\": \"\\\"none\\\"\", \"param_decoy_string\": \"\\\"dec_\\\"\", \"__rerun_remap_job_id__\": null, \"param_write_protein_description\": \"\\\"true\\\"\", \"param_full_tolerant_search\": \"\\\"false\\\"\", \"param_fasta\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\", \"param_aaa_max\": \"\\\"4\\\"\", \"param_annotate_proteins\": \"\\\"True\\\"\", \"param_IL_equivalent\": \"\\\"false\\\"\", \"param_in\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\"}", 
-            "tool_version": "2.1.0", 
-            "type": "tool", 
-            "uuid": "868442d2-bb81-4d9a-b783-448377dce6d7", 
-            "workflow_outputs": [
-                {
-                    "label": null, 
-                    "output_name": "param_out", 
-                    "uuid": "f026ce76-91ea-40df-99bb-00ae4bacf3f6"
-                }
-            ]
-        }, 
-        "13": {
-            "annotation": "", 
-            "content_id": "FalseDiscoveryRate", 
-            "id": 13, 
-            "input_connections": {
-                "param_in": {
-                    "id": 12, 
-                    "output_name": "param_out"
-                }
-            }, 
-            "inputs": [
-                {
-                    "description": "runtime parameter for tool FalseDiscoveryRate", 
-                    "name": "param_in"
-                }, 
-                {
-                    "description": "runtime parameter for tool FalseDiscoveryRate", 
-                    "name": "param_in_target"
-                }, 
-                {
-                    "description": "runtime parameter for tool FalseDiscoveryRate", 
-                    "name": "param_in_decoy"
-                }
-            ], 
-            "label": null, 
-            "name": "FalseDiscoveryRate", 
-            "outputs": [
-                {
-                    "name": "param_out", 
-                    "type": "idxml"
-                }
-            ], 
-            "position": {
-                "left": 1334.11669921875, 
-                "top": 802.61669921875
-            }, 
-            "post_job_actions": {
-                "HideDatasetActionparam_out": {
-                    "action_arguments": {}, 
-                    "action_type": "HideDatasetAction", 
-                    "output_name": "param_out"
-                }
-            }, 
-            "tool_errors": null, 
-            "tool_id": "FalseDiscoveryRate", 
-            "tool_state": "{\"__page__\": 0, \"param_algorithm_use_all_hits\": \"\\\"false\\\"\", \"param_algorithm_add_decoy_peptides\": \"\\\"false\\\"\", \"adv_opts\": \"{\\\"adv_opts_selector\\\": \\\"basic\\\", \\\"__current_case__\\\": 0}\", \"param_peptides_only\": \"\\\"false\\\"\", \"param_algorithm_split_charge_variants\": \"\\\"false\\\"\", \"param_algorithm_no_qvalues\": \"\\\"false\\\"\", \"param_proteins_only\": \"\\\"false\\\"\", \"param_in_target\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\", \"param_algorithm_treat_runs_separately\": \"\\\"false\\\"\", \"param_in_decoy\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\", \"__rerun_remap_job_id__\": null, \"param_in\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\"}", 
-            "tool_version": "2.1.0", 
-            "type": "tool", 
-            "uuid": "fa96e1f0-5c85-42b4-8afc-7dbd4f0e798a", 
-            "workflow_outputs": []
-        }, 
-        "14": {
-            "annotation": "", 
-            "content_id": "IDFilter", 
-            "id": 14, 
-            "input_connections": {
-                "param_in": {
-                    "id": 13, 
-                    "output_name": "param_out"
-                }
-            }, 
-            "inputs": [
-                {
-                    "description": "runtime parameter for tool IDFilter", 
-                    "name": "param_whitelist_peptides"
-                }, 
-                {
-                    "description": "runtime parameter for tool IDFilter", 
-                    "name": "param_whitelist_proteins"
-                }, 
-                {
-                    "description": "runtime parameter for tool IDFilter", 
-                    "name": "param_blacklist_proteins"
-                }, 
-                {
-                    "description": "runtime parameter for tool IDFilter", 
-                    "name": "param_in"
-                }, 
-                {
-                    "description": "runtime parameter for tool IDFilter", 
-                    "name": "param_blacklist_peptides"
-                }
-            ], 
-            "label": null, 
-            "name": "IDFilter", 
-            "outputs": [
-                {
-                    "name": "param_out", 
-                    "type": "idxml"
-                }
-            ], 
-            "position": {
-                "left": 1647.9666748046875, 
-                "top": 808.88330078125
-            }, 
-            "post_job_actions": {}, 
-            "tool_errors": null, 
-            "tool_id": "IDFilter", 
-            "tool_state": "{\"param_whitelist_peptides\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\", \"param_length\": \"\\\":\\\"\", \"param_keep_unreferenced_protein_hits\": \"\\\"false\\\"\", \"param_unique\": \"\\\"false\\\"\", \"param_whitelist_proteins\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\", \"param_unique_per_protein\": \"\\\"false\\\"\", \"param_remove_decoys\": \"\\\"false\\\"\", \"param_score_prot\": \"\\\"0.0\\\"\", \"param_rt_p_value_1st_dim\": \"\\\"0.0\\\"\", \"param_best_n_protein_hits\": \"\\\"0\\\"\", \"param_min_length\": \"\\\"0\\\"\", \"__rerun_remap_job_id__\": null, \"param_precursor_mz\": \"\\\":\\\"\", \"param_mz_error\": \"\\\"-1.0\\\"\", \"rep_param_blacklist_modifications\": \"[]\", \"param_precursor_allow_missing\": \"\\\"false\\\"\", \"param_blacklist_proteins\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\", \"param_delete_unreferenced_peptide_hits\": \"\\\"false\\\"\", \"param_precursor_rt\": \"\\\":\\\"\", \"param_in\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\", \"__page__\": 0, \"param_charge\": \"\\\":\\\"\", \"param_var_mods\": \"\\\"false\\\"\", \"param_max_length\": \"\\\"0\\\"\", \"param_best_strict\": \"\\\"false\\\"\", \"rep_param_whitelist_protein_accessions\": \"[]\", \"rep_param_whitelist_modifications\": \"[]\", \"param_thresh_pep\": \"\\\"0.0\\\"\", \"param_mz_unit\": \"\\\"ppm\\\"\", \"param_best_n_peptide_hits\": \"\\\"0\\\"\", \"param_whitelist_by_seq_only\": \"\\\"false\\\"\", \"param_blacklist_peptides\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\", \"adv_opts\": \"{\\\"adv_opts_selector\\\": \\\"basic\\\", \\\"__current_case__\\\": 0}\", \"param_score_pep\": \"\\\"0.05\\\"\", \"param_rt_p_value\": \"\\\"0.0\\\"\", \"param_min_charge\": \"\\\"1\\\"\", \"param_blacklist_ignore_modifications\": \"\\\"false\\\"\", \"rep_param_blacklist_protein_accessions\": \"[]\", \"param_whitelist_ignore_modifications\": \"\\\"false\\\"\", \"param_thresh_prot\": \"\\\"0.0\\\"\"}", 
-            "tool_version": "2.1.0", 
-            "type": "tool", 
-            "uuid": "458f5b98-62dd-4650-86dc-f3fc3da4584e", 
-            "workflow_outputs": [
-                {
-                    "label": null, 
-                    "output_name": "param_out", 
-                    "uuid": "ac38c879-b0a6-4260-a659-32bc6f531232"
-                }
-            ]
-        }, 
-        "15": {
-            "annotation": "", 
-            "content_id": "IDMapper", 
-            "id": 15, 
-            "input_connections": {
-                "param_id": {
-                    "id": 14, 
-                    "output_name": "param_out"
-                }, 
-                "param_in": {
-                    "id": 2, 
-                    "output_name": "param_out"
-                }
-            }, 
-            "inputs": [
-                {
-                    "description": "runtime parameter for tool IDMapper", 
-                    "name": "param_id"
-                }, 
-                {
-                    "description": "runtime parameter for tool IDMapper", 
-                    "name": "param_in"
-                }
-            ], 
-            "label": null, 
-            "name": "IDMapper", 
-            "outputs": [
-                {
-                    "name": "param_out", 
-                    "type": "input"
-                }
-            ], 
-            "position": {
-                "left": 1979.9666748046875, 
-                "top": 843.88330078125
-            }, 
-            "post_job_actions": {}, 
-            "tool_errors": null, 
-            "tool_id": "IDMapper", 
-            "tool_state": "{\"param_mz_tolerance\": \"\\\"30.0\\\"\", \"param_ignore_charge\": \"\\\"true\\\"\", \"param_feature_use_centroid_rt\": \"\\\"false\\\"\", \"__page__\": 0, \"adv_opts\": \"{\\\"adv_opts_selector\\\": \\\"basic\\\", \\\"__current_case__\\\": 0}\", \"__rerun_remap_job_id__\": null, \"param_mz_measure\": \"\\\"ppm\\\"\", \"param_mz_reference\": \"\\\"precursor\\\"\", \"param_id\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\", \"param_rt_tolerance\": \"\\\"50.0\\\"\", \"param_consensus_use_subelements\": \"\\\"true\\\"\", \"param_feature_use_centroid_mz\": \"\\\"false\\\"\", \"param_in\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\"}", 
-            "tool_version": "2.1.0", 
-            "type": "tool", 
-            "uuid": "f199e8c6-c243-4fce-8dac-a62d504c9cdd", 
-            "workflow_outputs": [
-                {
-                    "label": null, 
-                    "output_name": "param_out", 
-                    "uuid": "84923098-0cc0-4c3b-ac19-aa12ef6a5244"
-                }
-            ]
-        }, 
-        "16": {
-            "annotation": "", 
-            "content_id": "IDConflictResolver", 
-            "id": 16, 
-            "input_connections": {
-                "param_in": {
-                    "id": 15, 
-                    "output_name": "param_out"
-                }
-            }, 
-            "inputs": [
-                {
-                    "description": "runtime parameter for tool IDConflictResolver", 
-                    "name": "param_in"
-                }
-            ], 
-            "label": null, 
-            "name": "IDConflictResolver", 
-            "outputs": [
-                {
-                    "name": "param_out", 
-                    "type": "input"
-                }
-            ], 
-            "position": {
-                "left": 2220.449951171875, 
-                "top": 881.88330078125
-            }, 
-            "post_job_actions": {}, 
-            "tool_errors": null, 
-            "tool_id": "IDConflictResolver", 
-            "tool_state": "{\"adv_opts\": \"{\\\"param_force\\\": \\\"false\\\", \\\"adv_opts_selector\\\": \\\"advanced\\\", \\\"__current_case__\\\": 1}\", \"__page__\": 0, \"__rerun_remap_job_id__\": null, \"param_in\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\"}", 
-            "tool_version": "2.1.0", 
-            "type": "tool", 
-            "uuid": "6f4dc17d-b0fd-4b66-9487-3fda71316199", 
-            "workflow_outputs": [
-                {
-                    "label": null, 
-                    "output_name": "param_out", 
-                    "uuid": "485d4684-835d-4ff0-9ca5-3400a0b8fa22"
-                }
-            ]
-        }, 
-        "17": {
-            "annotation": "", 
-            "content_id": "FileFilter", 
-            "id": 17, 
-            "input_connections": {
-                "param_in": {
-                    "id": 16, 
-                    "output_name": "param_out"
-                }
-            }, 
-            "inputs": [
-                {
-                    "description": "runtime parameter for tool FileFilter", 
-                    "name": "param_in"
-                }, 
-                {
-                    "description": "runtime parameter for tool FileFilter", 
-                    "name": "param_id_blacklist"
-                }, 
-                {
-                    "description": "runtime parameter for tool FileFilter", 
-                    "name": "param_consensus_blackorwhitelist_file"
-                }
-            ], 
-            "label": null, 
-            "name": "FileFilter", 
-            "outputs": [
-                {
-                    "name": "param_out", 
-                    "type": "input"
-                }
-            ], 
-            "position": {
-                "left": 2531, 
-                "top": 786.88330078125
-            }, 
-            "post_job_actions": {}, 
-            "tool_errors": null, 
-            "tool_id": "FileFilter", 
-            "tool_state": "{\"rep_param_id_sequences_whitelist\": \"[]\", \"param_algorithm_SignalToNoise_win_len\": \"\\\"200.0\\\"\", \"param_algorithm_SignalToNoise_bin_count\": \"\\\"30\\\"\", \"param_peak_options_sn\": \"\\\"0.0\\\"\", \"param_id_mz\": \"\\\"0.001\\\"\", \"param_spectra_select_polarity\": \"null\", \"param_spectra_remove_collision_energy\": \"\\\":\\\"\", \"param_id_blacklist_imperfect\": \"\\\"false\\\"\", \"param_mz\": \"\\\":\\\"\", \"param_int\": \"\\\":\\\"\", \"param_spectra_select_isolation_window_width\": \"\\\":\\\"\", \"param_peak_options_indexed_file\": \"\\\"false\\\"\", \"param_spectra_select_activation\": \"null\", \"param_id_remove_annotated_features\": \"\\\"false\\\"\", \"__page__\": 0, \"param_peak_options_no_chromatograms\": \"\\\"false\\\"\", \"rep_param_peak_options_pc_mz_list\": \"[]\", \"param_peak_options_numpress_masstime\": \"\\\"none\\\"\", \"param_peak_options_remove_chromatograms\": \"\\\"false\\\"\", \"rep_param_consensus_map\": \"[]\", \"param_peak_options_numpress_intensity\": \"\\\"none\\\"\", \"param_pc_mz\": \"\\\":\\\"\", \"__rerun_remap_job_id__\": null, \"param_spectra_select_mode\": \"null\", \"param_rt\": \"\\\":\\\"\", \"param_algorithm_SignalToNoise_write_log_messages\": \"\\\"true\\\"\", \"param_consensus_blackorwhitelist_use_ppm_tolerance\": \"\\\"false\\\"\", \"param_in\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\", \"param_id_remove_unannotated_features\": \"\\\"true\\\"\", \"param_peak_options_sort_peaks\": \"\\\"false\\\"\", \"param_peak_options_int_precision\": \"\\\"32\\\"\", \"rep_param_id_accessions_whitelist\": \"[]\", \"param_peak_options_pc_mz_range\": \"\\\":\\\"\", \"param_out_type\": \"\\\"consensusXML\\\"\", \"param_spectra_remove_mode\": \"null\", \"param_consensus_blackorwhitelist_blacklist\": \"\\\"true\\\"\", \"rep_param_peak_options_level\": \"[{\\\"__index__\\\": 0, \\\"param_peak_options_level\\\": \\\"1 2 3\\\"}]\", \"rep_param_f_and_c_remove_meta\": \"[]\", \"param_f_and_c_size\": \"\\\":\\\"\", \"param_id_remove_unassigned_ids\": \"\\\"true\\\"\", \"param_spectra_remove_zoom\": \"\\\"false\\\"\", \"param_peak_options_mz_precision\": \"\\\"64\\\"\", \"param_sort\": \"\\\"false\\\"\", \"param_algorithm_SignalToNoise_min_required_elements\": \"\\\"10\\\"\", \"param_consensus_blackorwhitelist_rt\": \"\\\"60.0\\\"\", \"rep_param_peak_options_rm_pc_charge\": \"[]\", \"param_peak_options_numpress_intensity_error\": \"\\\"0.0001\\\"\", \"param_id_rt\": \"\\\"0.1\\\"\", \"param_id_keep_best_score_id\": \"\\\"false\\\"\", \"param_id_blacklist\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\", \"param_spectra_select_collision_energy\": \"\\\":\\\"\", \"param_feature_q\": \"\\\":\\\"\", \"adv_opts\": \"{\\\"adv_opts_selector\\\": \\\"basic\\\", \\\"__current_case__\\\": 0}\", \"param_f_and_c_charge\": \"\\\":\\\"\", \"param_consensus_map_and\": \"\\\"false\\\"\", \"param_spectra_select_zoom\": \"\\\"false\\\"\", \"param_consensus_blackorwhitelist_mz\": \"\\\"0.01\\\"\", \"param_consensus_blackorwhitelist_file\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\", \"rep_param_consensus_blackorwhitelist_maps\": \"[]\", \"param_spectra_remove_activation\": \"null\", \"param_peak_options_numpress_masstime_error\": \"\\\"0.0001\\\"\", \"param_spectra_remove_isolation_window_width\": \"\\\":\\\"\"}", 
-            "tool_version": "2.1.0", 
-            "type": "tool", 
-            "uuid": "77e6a295-f6e2-4d72-a7e3-94f682d916a7", 
-            "workflow_outputs": [
-                {
-                    "label": null, 
-                    "output_name": "param_out", 
-                    "uuid": "55dc6d2b-f473-4496-abaf-86630ad0151b"
-                }
-            ]
-        }, 
-        "18": {
-            "annotation": "", 
-            "content_id": "FileMerger", 
-            "id": 18, 
-            "input_connections": {
-                "param_in": {
-                    "id": 17, 
-                    "output_name": "param_out"
-                }
-            }, 
-            "inputs": [
-                {
-                    "description": "runtime parameter for tool FileMerger", 
-                    "name": "param_in"
-                }
-            ], 
-            "label": null, 
-            "name": "FileMerger", 
-            "outputs": [
-                {
-                    "name": "param_out", 
-                    "type": "featurexml"
-                }, 
-                {
-                    "name": "param_rt_concat_trafo_out", 
-                    "type": "trafoxml"
-                }
-            ], 
-            "position": {
-                "left": 2832.966552734375, 
-                "top": 1062.9000244140625
-            }, 
-            "post_job_actions": {}, 
-            "tool_errors": null, 
-            "tool_id": "FileMerger", 
-            "tool_state": "{\"param_raw_user_ms_level\": \"\\\"False\\\"\", \"param_raw_rt_auto\": \"\\\"false\\\"\", \"__page__\": 0, \"adv_opts\": \"{\\\"adv_opts_selector\\\": \\\"basic\\\", \\\"__current_case__\\\": 0}\", \"param_raw_rt_filename\": \"\\\"false\\\"\", \"param_rt_concat_gap\": \"\\\"0.0\\\"\", \"param_annotate_file_origin\": \"\\\"false\\\"\", \"__rerun_remap_job_id__\": null, \"param_raw_ms_level\": \"\\\"2\\\"\", \"rep_param_raw_rt_custom\": \"[]\", \"param_in\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\"}", 
-            "tool_version": "2.1.0", 
-            "type": "tool", 
-            "uuid": "d82505c8-6f1c-43a9-a9c7-c572ad2aa3c8", 
-            "workflow_outputs": [
-                {
-                    "label": null, 
-                    "output_name": "param_out", 
-                    "uuid": "db9ffdb1-ef2f-4d53-9808-bef6de3d85b4"
-                }, 
-                {
-                    "label": null, 
-                    "output_name": "param_rt_concat_trafo_out", 
-                    "uuid": "47af80c0-5efb-43b3-a830-c3df9fc0528d"
-                }
-            ]
-        }, 
-        "19": {
-            "annotation": "", 
-            "content_id": "MzTabExporter", 
-            "id": 19, 
-            "input_connections": {
-                "param_in": {
-                    "id": 18, 
-                    "output_name": "param_out"
-                }
-            }, 
-            "inputs": [
-                {
-                    "description": "runtime parameter for tool MzTabExporter", 
-                    "name": "param_in"
-                }
-            ], 
-            "label": null, 
-            "name": "MzTabExporter", 
-            "outputs": [
-                {
-                    "name": "param_out", 
-                    "type": "tabular"
-                }
-            ], 
-            "position": {
-                "left": 3076.5, 
-                "top": 1061.88330078125
-            }, 
-            "post_job_actions": {}, 
-            "tool_errors": null, 
-            "tool_id": "MzTabExporter", 
-            "tool_state": "{\"adv_opts\": \"{\\\"adv_opts_selector\\\": \\\"basic\\\", \\\"__current_case__\\\": 0}\", \"__page__\": 0, \"__rerun_remap_job_id__\": null, \"param_in\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\"}", 
-            "tool_version": "2.1.0", 
-            "type": "tool", 
-            "uuid": "3f6cb69e-8629-4fea-ab74-dec388ed0fd4", 
-            "workflow_outputs": [
-                {
-                    "label": null, 
-                    "output_name": "param_out", 
-                    "uuid": "a6361de3-6865-4c6b-9920-d7a8c6a27645"
-                }
-            ]
+  "a_galaxy_workflow": "true",
+  "annotation": "",
+  "format-version": "0.1",
+  "name": "tails triple dimethyl OpenMS2.1",
+  "steps": {
+    "0": {
+      "annotation": "",
+      "content_id": null,
+      "id": 0,
+      "input_connections": {},
+      "inputs": [
+        {
+          "description": "",
+          "name": "Input Dataset Collection (mzML files)"
         }
-    }, 
-    "uuid": "6300a4b9-cb1d-42a5-af00-a2bbc76fa200"
+      ],
+      "label": null,
+      "name": "Input dataset collection",
+      "outputs": [],
+      "position": {
+        "left": 199.9666748046875,
+        "top": 435.20001220703125
+      },
+      "tool_errors": null,
+      "tool_id": null,
+      "tool_state": "{\"collection_type\": \"list\", \"name\": \"Input Dataset Collection (mzML files)\"}",
+      "tool_version": null,
+      "type": "data_collection_input",
+      "uuid": "7bf13771-4620-4563-b972-efaf74887ce5",
+      "workflow_outputs": [
+        {
+          "label": null,
+          "output_name": "output",
+          "uuid": "11ba0e33-3924-43e2-a8f9-85e0e6c12cfe"
+        }
+      ]
+    },
+    "1": {
+      "annotation": "",
+      "content_id": null,
+      "id": 1,
+      "input_connections": {},
+      "inputs": [
+        {
+          "description": "",
+          "name": "UniProt database (FASTA file)"
+        }
+      ],
+      "label": null,
+      "name": "Input dataset",
+      "outputs": [],
+      "position": {
+        "left": 241,
+        "top": 603.2166748046875
+      },
+      "tool_errors": null,
+      "tool_id": null,
+      "tool_state": "{\"name\": \"UniProt database (FASTA file)\"}",
+      "tool_version": null,
+      "type": "data_input",
+      "uuid": "05f5cbd8-8459-47a0-8faf-95c0821f25fc",
+      "workflow_outputs": [
+        {
+          "label": null,
+          "output_name": "output",
+          "uuid": "3d25e478-d053-4d4e-9c7f-92fec2d6b09c"
+        }
+      ]
+    },
+    "2": {
+      "annotation": "",
+      "content_id": "FeatureFinderMultiplex",
+      "id": 2,
+      "input_connections": {
+        "param_in": {
+          "id": 0,
+          "output_name": "output"
+        }
+      },
+      "inputs": [
+        {
+          "description": "runtime parameter for tool FeatureFinderMultiplex",
+          "name": "param_in"
+        }
+      ],
+      "label": null,
+      "name": "FeatureFinderMultiplex",
+      "outputs": [
+        {
+          "name": "param_out",
+          "type": "consensusxml"
+        },
+        {
+          "name": "param_out_features",
+          "type": "featurexml"
+        },
+        {
+          "name": "param_out_mzq",
+          "type": "mzq"
+        }
+      ],
+      "position": {
+        "left": 1228.9666748046875,
+        "top": 1174.88330078125
+      },
+      "post_job_actions": {
+        "HideDatasetActionparam_out_mzq": {
+          "action_arguments": {},
+          "action_type": "HideDatasetAction",
+          "output_name": "param_out_mzq"
+        }
+      },
+      "tool_errors": null,
+      "tool_id": "FeatureFinderMultiplex",
+      "tool_state": "{\"param_algorithm_averagine_similarity\": \"\\\"0.6\\\"\", \"param_algorithm_rt_min\": \"\\\"3.0\\\"\", \"__page__\": 0, \"param_algorithm_missed_cleavages\": \"\\\"2\\\"\", \"param_algorithm_peptide_similarity\": \"\\\"0.7\\\"\", \"adv_opts\": \"{\\\"param_algorithm_knock_out\\\": \\\"true\\\", \\\"param_labels_Dimethyl4\\\": \\\"32.056407\\\", \\\"param_algorithm_isotopes_per_peptide\\\": \\\"3:6\\\", \\\"param_labels_Lys4\\\": \\\"4.0251069836\\\", \\\"param_labels_Dimethyl0\\\": \\\"28.0313\\\", \\\"param_labels_Lys8\\\": \\\"8.0141988132\\\", \\\"param_labels_ICPL10\\\": \\\"115.0667\\\", \\\"param_labels_Lys6\\\": \\\"6.0201290268\\\", \\\"param_labels_Arg10\\\": \\\"10.0082686\\\", \\\"param_labels_Dimethyl8\\\": \\\"36.07567\\\", \\\"adv_opts_selector\\\": \\\"advanced\\\", \\\"param_labels_ICPL6\\\": \\\"111.041593\\\", \\\"param_force\\\": \\\"false\\\", \\\"param_labels_Dimethyl6\\\": \\\"34.063117\\\", \\\"param_labels_Arg6\\\": \\\"6.0201290268\\\", \\\"__current_case__\\\": 1, \\\"param_algorithm_averagine_type\\\": \\\"peptide\\\", \\\"param_labels_ICPL0\\\": \\\"105.021464\\\", \\\"param_labels_Leu3\\\": \\\"3.01883\\\", \\\"param_labels_ICPL4\\\": \\\"109.046571\\\", \\\"param_algorithm_averagine_similarity_scaling\\\": \\\"0.6\\\"}\", \"param_algorithm_mz_tolerance\": \"\\\"15.0\\\"\", \"param_algorithm_charge\": \"\\\"1:5\\\"\", \"param_algorithm_mz_unit\": \"\\\"ppm\\\"\", \"param_algorithm_labels\": \"\\\"[Dimethyl0][Dimethyl4][Dimethyl8]\\\"\", \"param_algorithm_intensity_cutoff\": \"\\\"10.0\\\"\", \"param_algorithm_rt_typical\": \"\\\"50.0\\\"\", \"__rerun_remap_job_id__\": null, \"param_in\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\"}",
+      "tool_version": "2.1.0",
+      "type": "tool",
+      "uuid": "627672fc-feef-4e31-9208-182a27df2533",
+      "workflow_outputs": [
+        {
+          "label": null,
+          "output_name": "param_out",
+          "uuid": "6e1e9231-52a0-4d05-9491-31f4b162d405"
+        },
+        {
+          "label": null,
+          "output_name": "param_out_features",
+          "uuid": "a8b8b589-661b-49ca-9832-556069bf98bc"
+        }
+      ],
+      "tool_shed_repository": {
+        "changeset_revision": "ca88bd28f116",
+        "name": "openms_featurefindermultiplex",
+        "owner": "galaxyp",
+        "tool_shed": "toolshed.g2.bx.psu.edu"
+      }
+    },
+    "3": {
+      "annotation": "",
+      "content_id": "HighResPrecursorMassCorrector",
+      "id": 3,
+      "input_connections": {
+        "param_feature_in": {
+          "id": 2,
+          "output_name": "param_out_features"
+        },
+        "param_in": {
+          "id": 0,
+          "output_name": "output"
+        }
+      },
+      "inputs": [
+        {
+          "description": "runtime parameter for tool HighResPrecursorMassCorrector",
+          "name": "param_feature_in"
+        },
+        {
+          "description": "runtime parameter for tool HighResPrecursorMassCorrector",
+          "name": "param_in"
+        }
+      ],
+      "label": null,
+      "name": "HighResPrecursorMassCorrector",
+      "outputs": [
+        {
+          "name": "param_out",
+          "type": "mzml"
+        },
+        {
+          "name": "param_out_csv",
+          "type": "tabular"
+        }
+      ],
+      "position": {
+        "left": 484.54998779296875,
+        "top": 151.1999969482422
+      },
+      "post_job_actions": {
+        "HideDatasetActionparam_out_csv": {
+          "action_arguments": {},
+          "action_type": "HideDatasetAction",
+          "output_name": "param_out_csv"
+        },
+        "RenameDatasetActionparam_out": {
+          "action_arguments": {
+            "newname": "HighRes_out"
+          },
+          "action_type": "RenameDatasetAction",
+          "output_name": "param_out"
+        }
+      },
+      "tool_errors": null,
+      "tool_id": "HighResPrecursorMassCorrector",
+      "tool_state": "{\"__page__\": 0, \"adv_opts\": \"{\\\"adv_opts_selector\\\": \\\"basic\\\", \\\"__current_case__\\\": 0}\", \"__rerun_remap_job_id__\": null, \"param_in\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\", \"param_feature_in\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\", \"param_feature_rt_tolerance\": \"\\\"15.0\\\"\", \"param_nearest_peak_mz_tolerance_unit\": \"\\\"ppm\\\"\", \"param_feature_mz_tolerance_unit\": \"\\\"ppm\\\"\", \"param_feature_mz_tolerance\": \"\\\"40.0\\\"\", \"param_feature_keep_original\": \"\\\"false\\\"\", \"param_feature_assign_all_matching\": \"\\\"false\\\"\", \"param_feature_believe_charge\": \"\\\"false\\\"\", \"param_nearest_peak_mz_tolerance\": \"\\\"0.0\\\"\"}",
+      "tool_version": "2.1.0",
+      "type": "tool",
+      "uuid": "3d7f4c8b-1896-4365-b41a-77b152ec84b4",
+      "workflow_outputs": [
+        {
+          "label": null,
+          "output_name": "param_out",
+          "uuid": "be0344fb-dccf-4d28-a45e-9d1aded44e41"
+        }
+      ],
+      "tool_shed_repository": {
+        "changeset_revision": "9e26f5c770f8",
+        "name": "openms_highresprecursormasscorrector",
+        "owner": "galaxyp",
+        "tool_shed": "toolshed.g2.bx.psu.edu"
+      }
+    },
+    "4": {
+      "annotation": "",
+      "content_id": "MSGFPlusAdapter",
+      "id": 4,
+      "input_connections": {
+        "param_database": {
+          "id": 1,
+          "output_name": "output"
+        },
+        "param_in": {
+          "id": 3,
+          "output_name": "param_out"
+        }
+      },
+      "inputs": [
+        {
+          "description": "runtime parameter for tool MSGFPlusAdapter",
+          "name": "param_in"
+        },
+        {
+          "description": "runtime parameter for tool MSGFPlusAdapter",
+          "name": "param_database"
+        }
+      ],
+      "label": null,
+      "name": "MSGFPlusAdapter",
+      "outputs": [
+        {
+          "name": "param_out",
+          "type": "idxml"
+        },
+        {
+          "name": "param_mzid_out",
+          "type": "mzid"
+        }
+      ],
+      "position": {
+        "left": 849.0500030517578,
+        "top": 186.21665954589844
+      },
+      "post_job_actions": {
+        "HideDatasetActionparam_mzid_out": {
+          "action_arguments": {},
+          "action_type": "HideDatasetAction",
+          "output_name": "param_mzid_out"
+        }
+      },
+      "tool_errors": null,
+      "tool_id": "MSGFPlusAdapter",
+      "tool_state": "{\"param_java_executable\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\", \"param_max_precursor_charge\": \"\\\"4\\\"\", \"param_min_precursor_charge\": \"\\\"2\\\"\", \"param_min_peptide_length\": \"\\\"7\\\"\", \"param_precursor_error_units\": \"\\\"ppm\\\"\", \"param_protocol\": \"\\\"none\\\"\", \"__page__\": 0, \"__rerun_remap_job_id__\": null, \"param_tryptic\": \"\\\"semi\\\"\", \"param_max_mods\": \"\\\"3\\\"\", \"rep_param_fixed_modifications\": \"[{\\\"__index__\\\": 0, \\\"param_fixed_modifications\\\": \\\"Carbamidomethyl (C)\\\"}, {\\\"__index__\\\": 1, \\\"param_fixed_modifications\\\": \\\"Dimethyl (K)\\\"}, {\\\"__index__\\\": 2, \\\"param_fixed_modifications\\\": \\\"Dimethyl (N-term)\\\"}]\", \"param_in\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\", \"param_add_decoys\": \"\\\"false\\\"\", \"param_matches_per_spec\": \"\\\"1\\\"\", \"param_max_peptide_length\": \"\\\"40\\\"\", \"param_instrument\": \"\\\"Q_Exactive\\\"\", \"param_precursor_mass_tolerance\": \"\\\"20.0\\\"\", \"rep_param_variable_modifications\": \"[]\", \"param_add_features\": \"\\\"true\\\"\", \"param_enzyme\": \"\\\"ArgC\\\"\", \"param_database\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\", \"param_fragment_method\": \"\\\"from_spectrum\\\"\", \"adv_opts\": \"{\\\"adv_opts_selector\\\": \\\"basic\\\", \\\"__current_case__\\\": 0}\", \"param_java_memory\": \"\\\"3500\\\"\", \"param_isotope_error_range\": \"\\\"0,0\\\"\"}",
+      "tool_version": "2.1.0",
+      "type": "tool",
+      "uuid": "cc98863a-5f1a-42ef-bd30-a7c6002f3efa",
+      "workflow_outputs": [
+        {
+          "label": null,
+          "output_name": "param_out",
+          "uuid": "7066dfd9-e896-462b-8877-68580da0cc08"
+        }
+      ],
+      "tool_shed_repository": {
+        "changeset_revision": "2b2a7551a857",
+        "name": "openms_msgfplusadapter",
+        "owner": "galaxyp",
+        "tool_shed": "toolshed.g2.bx.psu.edu"
+      }
+    },
+    "5": {
+      "annotation": "",
+      "content_id": "MSGFPlusAdapter",
+      "id": 5,
+      "input_connections": {
+        "param_database": {
+          "id": 1,
+          "output_name": "output"
+        },
+        "param_in": {
+          "id": 3,
+          "output_name": "param_out"
+        }
+      },
+      "inputs": [
+        {
+          "description": "runtime parameter for tool MSGFPlusAdapter",
+          "name": "param_in"
+        },
+        {
+          "description": "runtime parameter for tool MSGFPlusAdapter",
+          "name": "param_database"
+        }
+      ],
+      "label": null,
+      "name": "MSGFPlusAdapter",
+      "outputs": [
+        {
+          "name": "param_out",
+          "type": "idxml"
+        },
+        {
+          "name": "param_mzid_out",
+          "type": "mzid"
+        }
+      ],
+      "position": {
+        "left": 887,
+        "top": 394.20001220703125
+      },
+      "post_job_actions": {
+        "HideDatasetActionparam_mzid_out": {
+          "action_arguments": {},
+          "action_type": "HideDatasetAction",
+          "output_name": "param_mzid_out"
+        }
+      },
+      "tool_errors": null,
+      "tool_id": "MSGFPlusAdapter",
+      "tool_state": "{\"param_java_executable\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\", \"param_max_precursor_charge\": \"\\\"4\\\"\", \"param_min_precursor_charge\": \"\\\"2\\\"\", \"param_min_peptide_length\": \"\\\"7\\\"\", \"param_precursor_error_units\": \"\\\"ppm\\\"\", \"param_protocol\": \"\\\"none\\\"\", \"__page__\": 0, \"__rerun_remap_job_id__\": null, \"param_tryptic\": \"\\\"semi\\\"\", \"param_max_mods\": \"\\\"3\\\"\", \"rep_param_fixed_modifications\": \"[{\\\"__index__\\\": 0, \\\"param_fixed_modifications\\\": \\\"Carbamidomethyl (C)\\\"}, {\\\"__index__\\\": 1, \\\"param_fixed_modifications\\\": \\\"Dimethyl:2H(4) (K)\\\"}, {\\\"__index__\\\": 2, \\\"param_fixed_modifications\\\": \\\"Dimethyl:2H(4) (N-term)\\\"}]\", \"param_in\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\", \"param_add_decoys\": \"\\\"false\\\"\", \"param_matches_per_spec\": \"\\\"1\\\"\", \"param_max_peptide_length\": \"\\\"40\\\"\", \"param_instrument\": \"\\\"Q_Exactive\\\"\", \"param_precursor_mass_tolerance\": \"\\\"20.0\\\"\", \"rep_param_variable_modifications\": \"[]\", \"param_add_features\": \"\\\"true\\\"\", \"param_enzyme\": \"\\\"ArgC\\\"\", \"param_database\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\", \"param_fragment_method\": \"\\\"from_spectrum\\\"\", \"adv_opts\": \"{\\\"adv_opts_selector\\\": \\\"basic\\\", \\\"__current_case__\\\": 0}\", \"param_java_memory\": \"\\\"3500\\\"\", \"param_isotope_error_range\": \"\\\"0,0\\\"\"}",
+      "tool_version": "2.1.0",
+      "type": "tool",
+      "uuid": "3a2ce94c-c7c0-43e8-a95a-29773f41ff83",
+      "workflow_outputs": [
+        {
+          "label": null,
+          "output_name": "param_out",
+          "uuid": "7d1226d5-80ff-4f81-b2f8-1298517f98f8"
+        }
+      ],
+      "tool_shed_repository": {
+        "changeset_revision": "2b2a7551a857",
+        "name": "openms_msgfplusadapter",
+        "owner": "galaxyp",
+        "tool_shed": "toolshed.g2.bx.psu.edu"
+      }
+    },
+    "6": {
+      "annotation": "",
+      "content_id": "MSGFPlusAdapter",
+      "id": 6,
+      "input_connections": {
+        "param_in": {
+          "id": 3,
+          "output_name": "param_out"
+        }
+      },
+      "inputs": [
+        {
+          "description": "runtime parameter for tool MSGFPlusAdapter",
+          "name": "param_in"
+        },
+        {
+          "description": "runtime parameter for tool MSGFPlusAdapter",
+          "name": "param_database"
+        }
+      ],
+      "label": null,
+      "name": "MSGFPlusAdapter",
+      "outputs": [
+        {
+          "name": "param_out",
+          "type": "idxml"
+        },
+        {
+          "name": "param_mzid_out",
+          "type": "mzid"
+        }
+      ],
+      "position": {
+        "left": 892.5,
+        "top": 590
+      },
+      "post_job_actions": {
+        "HideDatasetActionparam_mzid_out": {
+          "action_arguments": {},
+          "action_type": "HideDatasetAction",
+          "output_name": "param_mzid_out"
+        }
+      },
+      "tool_errors": null,
+      "tool_id": "MSGFPlusAdapter",
+      "tool_state": "{\"param_java_executable\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\", \"param_max_precursor_charge\": \"\\\"4\\\"\", \"param_min_precursor_charge\": \"\\\"2\\\"\", \"param_min_peptide_length\": \"\\\"7\\\"\", \"param_precursor_error_units\": \"\\\"ppm\\\"\", \"param_protocol\": \"\\\"none\\\"\", \"__page__\": 0, \"__rerun_remap_job_id__\": null, \"param_tryptic\": \"\\\"semi\\\"\", \"param_max_mods\": \"\\\"3\\\"\", \"rep_param_fixed_modifications\": \"[{\\\"__index__\\\": 0, \\\"param_fixed_modifications\\\": \\\"Carbamidomethyl (C)\\\"}, {\\\"__index__\\\": 1, \\\"param_fixed_modifications\\\": \\\"Dimethyl:2H(6)13C(2) (K)\\\"}, {\\\"__index__\\\": 2, \\\"param_fixed_modifications\\\": \\\"Dimethyl:2H(6)13C(2) (N-term)\\\"}]\", \"param_in\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\", \"param_add_decoys\": \"\\\"false\\\"\", \"param_matches_per_spec\": \"\\\"1\\\"\", \"param_max_peptide_length\": \"\\\"40\\\"\", \"param_instrument\": \"\\\"Q_Exactive\\\"\", \"param_precursor_mass_tolerance\": \"\\\"20.0\\\"\", \"rep_param_variable_modifications\": \"[]\", \"param_add_features\": \"\\\"true\\\"\", \"param_enzyme\": \"\\\"ArgC\\\"\", \"param_database\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\", \"param_fragment_method\": \"\\\"from_spectrum\\\"\", \"adv_opts\": \"{\\\"adv_opts_selector\\\": \\\"basic\\\", \\\"__current_case__\\\": 0}\", \"param_java_memory\": \"\\\"3500\\\"\", \"param_isotope_error_range\": \"\\\"0,0\\\"\"}",
+      "tool_version": "2.1.0",
+      "type": "tool",
+      "uuid": "05593ca7-2056-4201-9ce7-60b4abc82ff5",
+      "workflow_outputs": [
+        {
+          "label": null,
+          "output_name": "param_out",
+          "uuid": "22b3fa5a-a162-4ce1-8c07-8c3f84fc0551"
+        }
+      ],
+      "tool_shed_repository": {
+        "changeset_revision": "2b2a7551a857",
+        "name": "openms_msgfplusadapter",
+        "owner": "galaxyp",
+        "tool_shed": "toolshed.g2.bx.psu.edu"
+      }
+    },
+    "7": {
+      "annotation": "",
+      "content_id": "PeptideIndexer",
+      "id": 7,
+      "input_connections": {
+        "param_fasta": {
+          "id": 1,
+          "output_name": "output"
+        },
+        "param_in": {
+          "id": 4,
+          "output_name": "param_out"
+        }
+      },
+      "inputs": [
+        {
+          "description": "runtime parameter for tool PeptideIndexer",
+          "name": "param_fasta"
+        },
+        {
+          "description": "runtime parameter for tool PeptideIndexer",
+          "name": "param_in"
+        }
+      ],
+      "label": null,
+      "name": "PeptideIndexer",
+      "outputs": [
+        {
+          "name": "param_out",
+          "type": "idxml"
+        }
+      ],
+      "position": {
+        "left": 1191,
+        "top": 181.1999969482422
+      },
+      "post_job_actions": {},
+      "tool_errors": null,
+      "tool_id": "PeptideIndexer",
+      "tool_state": "{\"param_write_protein_sequence\": \"\\\"true\\\"\", \"param_missing_decoy_action\": \"\\\"error\\\"\", \"param_filter_aaa_proteins\": \"\\\"false\\\"\", \"param_prefix\": \"\\\"true\\\"\", \"param_keep_unreferenced_proteins\": \"\\\"false\\\"\", \"adv_opts\": \"{\\\"adv_opts_selector\\\": \\\"basic\\\", \\\"__current_case__\\\": 0}\", \"__page__\": 0, \"param_allow_unmatched\": \"\\\"true\\\"\", \"param_decoy_string_position\": \"\\\"prefix\\\"\", \"param_mismatches_max\": \"\\\"0\\\"\", \"param_enzyme_name\": \"\\\"Trypsin/P\\\"\", \"param_enzyme_specificity\": \"\\\"semi\\\"\", \"param_decoy_string\": \"\\\"dec_\\\"\", \"__rerun_remap_job_id__\": null, \"param_write_protein_description\": \"\\\"true\\\"\", \"param_full_tolerant_search\": \"\\\"false\\\"\", \"param_fasta\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\", \"param_aaa_max\": \"\\\"4\\\"\", \"param_annotate_proteins\": \"\\\"True\\\"\", \"param_IL_equivalent\": \"\\\"false\\\"\", \"param_in\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\"}",
+      "tool_version": "2.1.0",
+      "type": "tool",
+      "uuid": "6d75c013-51d3-49f5-8b26-876a8b1c06d5",
+      "workflow_outputs": [
+        {
+          "label": null,
+          "output_name": "param_out",
+          "uuid": "92afc5d3-a20f-4f89-8b80-f6618ba430d0"
+        }
+      ],
+      "tool_shed_repository": {
+        "changeset_revision": "539a3a4dcc9e",
+        "name": "openms_peptideindexer",
+        "owner": "galaxyp",
+        "tool_shed": "toolshed.g2.bx.psu.edu"
+      }
+    },
+    "8": {
+      "annotation": "",
+      "content_id": "PeptideIndexer",
+      "id": 8,
+      "input_connections": {
+        "param_fasta": {
+          "id": 1,
+          "output_name": "output"
+        },
+        "param_in": {
+          "id": 5,
+          "output_name": "param_out"
+        }
+      },
+      "inputs": [
+        {
+          "description": "runtime parameter for tool PeptideIndexer",
+          "name": "param_fasta"
+        },
+        {
+          "description": "runtime parameter for tool PeptideIndexer",
+          "name": "param_in"
+        }
+      ],
+      "label": null,
+      "name": "PeptideIndexer",
+      "outputs": [
+        {
+          "name": "param_out",
+          "type": "idxml"
+        }
+      ],
+      "position": {
+        "left": 1155,
+        "top": 398.2166748046875
+      },
+      "post_job_actions": {},
+      "tool_errors": null,
+      "tool_id": "PeptideIndexer",
+      "tool_state": "{\"param_write_protein_sequence\": \"\\\"true\\\"\", \"param_missing_decoy_action\": \"\\\"error\\\"\", \"param_filter_aaa_proteins\": \"\\\"false\\\"\", \"param_prefix\": \"\\\"true\\\"\", \"param_keep_unreferenced_proteins\": \"\\\"false\\\"\", \"adv_opts\": \"{\\\"adv_opts_selector\\\": \\\"basic\\\", \\\"__current_case__\\\": 0}\", \"__page__\": 0, \"param_allow_unmatched\": \"\\\"true\\\"\", \"param_decoy_string_position\": \"\\\"prefix\\\"\", \"param_mismatches_max\": \"\\\"0\\\"\", \"param_enzyme_name\": \"\\\"Trypsin/P\\\"\", \"param_enzyme_specificity\": \"\\\"semi\\\"\", \"param_decoy_string\": \"\\\"dec_\\\"\", \"__rerun_remap_job_id__\": null, \"param_write_protein_description\": \"\\\"true\\\"\", \"param_full_tolerant_search\": \"\\\"false\\\"\", \"param_fasta\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\", \"param_aaa_max\": \"\\\"4\\\"\", \"param_annotate_proteins\": \"\\\"True\\\"\", \"param_IL_equivalent\": \"\\\"false\\\"\", \"param_in\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\"}",
+      "tool_version": "2.1.0",
+      "type": "tool",
+      "uuid": "8cd335cb-9d51-4c04-99b3-38fed4f3c3b6",
+      "workflow_outputs": [
+        {
+          "label": null,
+          "output_name": "param_out",
+          "uuid": "9774a600-1f91-4927-932a-b887a1b6f73a"
+        }
+      ],
+      "tool_shed_repository": {
+        "changeset_revision": "539a3a4dcc9e",
+        "name": "openms_peptideindexer",
+        "owner": "galaxyp",
+        "tool_shed": "toolshed.g2.bx.psu.edu"
+      }
+    },
+    "9": {
+      "annotation": "",
+      "content_id": "PeptideIndexer",
+      "id": 9,
+      "input_connections": {
+        "param_fasta": {
+          "id": 1,
+          "output_name": "output"
+        },
+        "param_in": {
+          "id": 6,
+          "output_name": "param_out"
+        }
+      },
+      "inputs": [
+        {
+          "description": "runtime parameter for tool PeptideIndexer",
+          "name": "param_fasta"
+        },
+        {
+          "description": "runtime parameter for tool PeptideIndexer",
+          "name": "param_in"
+        }
+      ],
+      "label": null,
+      "name": "PeptideIndexer",
+      "outputs": [
+        {
+          "name": "param_out",
+          "type": "idxml"
+        }
+      ],
+      "position": {
+        "left": 1180.5,
+        "top": 569
+      },
+      "post_job_actions": {
+        "HideDatasetActionparam_out": {
+          "action_arguments": {},
+          "action_type": "HideDatasetAction",
+          "output_name": "param_out"
+        }
+      },
+      "tool_errors": null,
+      "tool_id": "PeptideIndexer",
+      "tool_state": "{\"param_write_protein_sequence\": \"\\\"true\\\"\", \"param_missing_decoy_action\": \"\\\"error\\\"\", \"param_filter_aaa_proteins\": \"\\\"false\\\"\", \"param_prefix\": \"\\\"true\\\"\", \"param_keep_unreferenced_proteins\": \"\\\"false\\\"\", \"adv_opts\": \"{\\\"adv_opts_selector\\\": \\\"basic\\\", \\\"__current_case__\\\": 0}\", \"__page__\": 0, \"param_allow_unmatched\": \"\\\"true\\\"\", \"param_decoy_string_position\": \"\\\"prefix\\\"\", \"param_mismatches_max\": \"\\\"0\\\"\", \"param_enzyme_name\": \"\\\"Trypsin/P\\\"\", \"param_enzyme_specificity\": \"\\\"semi\\\"\", \"param_decoy_string\": \"\\\"dec_\\\"\", \"__rerun_remap_job_id__\": null, \"param_write_protein_description\": \"\\\"true\\\"\", \"param_full_tolerant_search\": \"\\\"false\\\"\", \"param_fasta\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\", \"param_aaa_max\": \"\\\"4\\\"\", \"param_annotate_proteins\": \"\\\"True\\\"\", \"param_IL_equivalent\": \"\\\"false\\\"\", \"param_in\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\"}",
+      "tool_version": "2.1.0",
+      "type": "tool",
+      "uuid": "9361c7be-0416-4ae2-94f6-1722124be507",
+      "workflow_outputs": [],
+      "tool_shed_repository": {
+        "changeset_revision": "539a3a4dcc9e",
+        "name": "openms_peptideindexer",
+        "owner": "galaxyp",
+        "tool_shed": "toolshed.g2.bx.psu.edu"
+      }
+    },
+    "10": {
+      "annotation": "",
+      "content_id": "IDMerger",
+      "id": 10,
+      "input_connections": {
+        "param_in": [
+          {
+            "id": 7,
+            "output_name": "param_out"
+          },
+          {
+            "id": 8,
+            "output_name": "param_out"
+          },
+          {
+            "id": 9,
+            "output_name": "param_out"
+          }
+        ]
+      },
+      "inputs": [
+        {
+          "description": "runtime parameter for tool IDMerger",
+          "name": "param_add_to"
+        },
+        {
+          "description": "runtime parameter for tool IDMerger",
+          "name": "param_in"
+        }
+      ],
+      "label": null,
+      "name": "IDMerger",
+      "outputs": [
+        {
+          "name": "param_out",
+          "type": "idxml"
+        }
+      ],
+      "position": {
+        "left": 1441,
+        "top": 352.20001220703125
+      },
+      "post_job_actions": {},
+      "tool_errors": null,
+      "tool_id": "IDMerger",
+      "tool_state": "{\"inputs\": \"[{\\\"__index__\\\": 0, \\\"param_in\\\": {\\\"__class__\\\": \\\"RuntimeValue\\\"}}, {\\\"__index__\\\": 1, \\\"param_in\\\": {\\\"__class__\\\": \\\"RuntimeValue\\\"}}]\", \"__page__\": 0, \"adv_opts\": \"{\\\"adv_opts_selector\\\": \\\"basic\\\", \\\"__current_case__\\\": 0}\", \"__rerun_remap_job_id__\": null, \"param_annotate_file_origin\": \"\\\"false\\\"\", \"param_pepxml_protxml\": \"\\\"false\\\"\", \"param_add_to\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\", \"param_in1\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\", \"param_in\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\"}",
+      "tool_version": "2.1.0",
+      "type": "tool",
+      "uuid": "3616471f-09c7-4c6a-8118-e92619874f09",
+      "workflow_outputs": [
+        {
+          "label": null,
+          "output_name": "param_out",
+          "uuid": "f78b508e-7e25-4d72-a870-9f12371c95ea"
+        }
+      ],
+      "tool_shed_repository": {
+        "changeset_revision": "18f93351f8b6",
+        "name": "openms_idmerger",
+        "owner": "galaxyp",
+        "tool_shed": "toolshed.g2.bx.psu.edu"
+      }
+    },
+    "11": {
+      "annotation": "",
+      "content_id": "ConsensusID",
+      "id": 11,
+      "input_connections": {
+        "param_in": {
+          "id": 10,
+          "output_name": "param_out"
+        }
+      },
+      "inputs": [
+        {
+          "description": "runtime parameter for tool ConsensusID",
+          "name": "param_in"
+        }
+      ],
+      "label": null,
+      "name": "ConsensusID",
+      "outputs": [
+        {
+          "name": "param_out",
+          "type": "input"
+        }
+      ],
+      "position": {
+        "left": 1609,
+        "top": 470.20001220703125
+      },
+      "post_job_actions": {},
+      "tool_errors": null,
+      "tool_id": "ConsensusID",
+      "tool_state": "{\"__page__\": 0, \"param_algorithm\": \"\\\"best\\\"\", \"param_filter_considered_hits\": \"\\\"0\\\"\", \"adv_opts\": \"{\\\"adv_opts_selector\\\": \\\"basic\\\", \\\"__current_case__\\\": 0}\", \"__rerun_remap_job_id__\": null, \"param_filter_count_empty\": \"\\\"false\\\"\", \"param_PEPIons_mass_tolerance\": \"\\\"0.5\\\"\", \"param_PEPIons_min_shared\": \"\\\"2\\\"\", \"param_PEPMatrix_penalty\": \"\\\"5\\\"\", \"param_filter_min_support\": \"\\\"0.0\\\"\", \"param_rt_delta\": \"\\\"0.1\\\"\", \"param_PEPMatrix_matrix\": \"\\\"identity\\\"\", \"param_mz_delta\": \"\\\"0.1\\\"\", \"param_in\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\"}",
+      "tool_version": "2.1.0",
+      "type": "tool",
+      "uuid": "a397db69-017e-4988-9f94-7ecbc119e3f3",
+      "workflow_outputs": [
+        {
+          "label": null,
+          "output_name": "param_out",
+          "uuid": "b05c7e3e-e094-4366-9163-e0c1984974b9"
+        }
+      ],
+      "tool_shed_repository": {
+        "changeset_revision": "8960fb791701",
+        "name": "openms_consensusid",
+        "owner": "galaxyp",
+        "tool_shed": "toolshed.g2.bx.psu.edu"
+      }
+    },
+    "12": {
+      "annotation": "",
+      "content_id": "PeptideIndexer",
+      "id": 12,
+      "input_connections": {
+        "param_fasta": {
+          "id": 1,
+          "output_name": "output"
+        },
+        "param_in": {
+          "id": 11,
+          "output_name": "param_out"
+        }
+      },
+      "inputs": [
+        {
+          "description": "runtime parameter for tool PeptideIndexer",
+          "name": "param_fasta"
+        },
+        {
+          "description": "runtime parameter for tool PeptideIndexer",
+          "name": "param_in"
+        }
+      ],
+      "label": null,
+      "name": "PeptideIndexer",
+      "outputs": [
+        {
+          "name": "param_out",
+          "type": "idxml"
+        }
+      ],
+      "position": {
+        "left": 1003,
+        "top": 820.2000122070312
+      },
+      "post_job_actions": {},
+      "tool_errors": null,
+      "tool_id": "PeptideIndexer",
+      "tool_state": "{\"param_write_protein_sequence\": \"\\\"true\\\"\", \"param_missing_decoy_action\": \"\\\"error\\\"\", \"param_filter_aaa_proteins\": \"\\\"false\\\"\", \"param_prefix\": \"\\\"true\\\"\", \"param_keep_unreferenced_proteins\": \"\\\"false\\\"\", \"adv_opts\": \"{\\\"adv_opts_selector\\\": \\\"basic\\\", \\\"__current_case__\\\": 0}\", \"__page__\": 0, \"param_allow_unmatched\": \"\\\"true\\\"\", \"param_decoy_string_position\": \"\\\"prefix\\\"\", \"param_mismatches_max\": \"\\\"0\\\"\", \"param_enzyme_name\": \"\\\"Trypsin/P\\\"\", \"param_enzyme_specificity\": \"\\\"none\\\"\", \"param_decoy_string\": \"\\\"dec_\\\"\", \"__rerun_remap_job_id__\": null, \"param_write_protein_description\": \"\\\"true\\\"\", \"param_full_tolerant_search\": \"\\\"false\\\"\", \"param_fasta\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\", \"param_aaa_max\": \"\\\"4\\\"\", \"param_annotate_proteins\": \"\\\"True\\\"\", \"param_IL_equivalent\": \"\\\"false\\\"\", \"param_in\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\"}",
+      "tool_version": "2.1.0",
+      "type": "tool",
+      "uuid": "868442d2-bb81-4d9a-b783-448377dce6d7",
+      "workflow_outputs": [
+        {
+          "label": null,
+          "output_name": "param_out",
+          "uuid": "f026ce76-91ea-40df-99bb-00ae4bacf3f6"
+        }
+      ],
+      "tool_shed_repository": {
+        "changeset_revision": "539a3a4dcc9e",
+        "name": "openms_peptideindexer",
+        "owner": "galaxyp",
+        "tool_shed": "toolshed.g2.bx.psu.edu"
+      }
+    },
+    "13": {
+      "annotation": "",
+      "content_id": "FalseDiscoveryRate",
+      "id": 13,
+      "input_connections": {
+        "param_in": {
+          "id": 12,
+          "output_name": "param_out"
+        }
+      },
+      "inputs": [
+        {
+          "description": "runtime parameter for tool FalseDiscoveryRate",
+          "name": "param_in"
+        },
+        {
+          "description": "runtime parameter for tool FalseDiscoveryRate",
+          "name": "param_in_target"
+        },
+        {
+          "description": "runtime parameter for tool FalseDiscoveryRate",
+          "name": "param_in_decoy"
+        }
+      ],
+      "label": null,
+      "name": "FalseDiscoveryRate",
+      "outputs": [
+        {
+          "name": "param_out",
+          "type": "idxml"
+        }
+      ],
+      "position": {
+        "left": 1334.11669921875,
+        "top": 802.61669921875
+      },
+      "post_job_actions": {
+        "HideDatasetActionparam_out": {
+          "action_arguments": {},
+          "action_type": "HideDatasetAction",
+          "output_name": "param_out"
+        }
+      },
+      "tool_errors": null,
+      "tool_id": "FalseDiscoveryRate",
+      "tool_state": "{\"__page__\": 0, \"param_algorithm_use_all_hits\": \"\\\"false\\\"\", \"param_algorithm_add_decoy_peptides\": \"\\\"false\\\"\", \"adv_opts\": \"{\\\"adv_opts_selector\\\": \\\"basic\\\", \\\"__current_case__\\\": 0}\", \"param_peptides_only\": \"\\\"false\\\"\", \"param_algorithm_split_charge_variants\": \"\\\"false\\\"\", \"param_algorithm_no_qvalues\": \"\\\"false\\\"\", \"param_proteins_only\": \"\\\"false\\\"\", \"param_in_target\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\", \"param_algorithm_treat_runs_separately\": \"\\\"false\\\"\", \"param_in_decoy\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\", \"__rerun_remap_job_id__\": null, \"param_in\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\"}",
+      "tool_version": "2.1.0",
+      "type": "tool",
+      "uuid": "fa96e1f0-5c85-42b4-8afc-7dbd4f0e798a",
+      "workflow_outputs": [],
+      "tool_shed_repository": {
+        "changeset_revision": "518b1730cf2a",
+        "name": "openms_falsediscoveryrate",
+        "owner": "galaxyp",
+        "tool_shed": "toolshed.g2.bx.psu.edu"
+      }
+    },
+    "14": {
+      "annotation": "",
+      "content_id": "IDFilter",
+      "id": 14,
+      "input_connections": {
+        "param_in": {
+          "id": 13,
+          "output_name": "param_out"
+        }
+      },
+      "inputs": [
+        {
+          "description": "runtime parameter for tool IDFilter",
+          "name": "param_whitelist_peptides"
+        },
+        {
+          "description": "runtime parameter for tool IDFilter",
+          "name": "param_whitelist_proteins"
+        },
+        {
+          "description": "runtime parameter for tool IDFilter",
+          "name": "param_blacklist_proteins"
+        },
+        {
+          "description": "runtime parameter for tool IDFilter",
+          "name": "param_in"
+        },
+        {
+          "description": "runtime parameter for tool IDFilter",
+          "name": "param_blacklist_peptides"
+        }
+      ],
+      "label": null,
+      "name": "IDFilter",
+      "outputs": [
+        {
+          "name": "param_out",
+          "type": "idxml"
+        }
+      ],
+      "position": {
+        "left": 1647.9666748046875,
+        "top": 808.88330078125
+      },
+      "post_job_actions": {},
+      "tool_errors": null,
+      "tool_id": "IDFilter",
+      "tool_state": "{\"param_whitelist_peptides\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\", \"param_length\": \"\\\":\\\"\", \"param_keep_unreferenced_protein_hits\": \"\\\"false\\\"\", \"param_unique\": \"\\\"false\\\"\", \"param_whitelist_proteins\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\", \"param_unique_per_protein\": \"\\\"false\\\"\", \"param_remove_decoys\": \"\\\"false\\\"\", \"param_score_prot\": \"\\\"0.0\\\"\", \"param_rt_p_value_1st_dim\": \"\\\"0.0\\\"\", \"param_best_n_protein_hits\": \"\\\"0\\\"\", \"param_min_length\": \"\\\"0\\\"\", \"__rerun_remap_job_id__\": null, \"param_precursor_mz\": \"\\\":\\\"\", \"param_mz_error\": \"\\\"-1.0\\\"\", \"rep_param_blacklist_modifications\": \"[]\", \"param_precursor_allow_missing\": \"\\\"false\\\"\", \"param_blacklist_proteins\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\", \"param_delete_unreferenced_peptide_hits\": \"\\\"false\\\"\", \"param_precursor_rt\": \"\\\":\\\"\", \"param_in\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\", \"__page__\": 0, \"param_charge\": \"\\\":\\\"\", \"param_var_mods\": \"\\\"false\\\"\", \"param_max_length\": \"\\\"0\\\"\", \"param_best_strict\": \"\\\"false\\\"\", \"rep_param_whitelist_protein_accessions\": \"[]\", \"rep_param_whitelist_modifications\": \"[]\", \"param_thresh_pep\": \"\\\"0.0\\\"\", \"param_mz_unit\": \"\\\"ppm\\\"\", \"param_best_n_peptide_hits\": \"\\\"0\\\"\", \"param_whitelist_by_seq_only\": \"\\\"false\\\"\", \"param_blacklist_peptides\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\", \"adv_opts\": \"{\\\"adv_opts_selector\\\": \\\"basic\\\", \\\"__current_case__\\\": 0}\", \"param_score_pep\": \"\\\"0.05\\\"\", \"param_rt_p_value\": \"\\\"0.0\\\"\", \"param_min_charge\": \"\\\"1\\\"\", \"param_blacklist_ignore_modifications\": \"\\\"false\\\"\", \"rep_param_blacklist_protein_accessions\": \"[]\", \"param_whitelist_ignore_modifications\": \"\\\"false\\\"\", \"param_thresh_prot\": \"\\\"0.0\\\"\"}",
+      "tool_version": "2.1.0",
+      "type": "tool",
+      "uuid": "458f5b98-62dd-4650-86dc-f3fc3da4584e",
+      "workflow_outputs": [
+        {
+          "label": null,
+          "output_name": "param_out",
+          "uuid": "ac38c879-b0a6-4260-a659-32bc6f531232"
+        }
+      ],
+      "tool_shed_repository": {
+        "changeset_revision": "c427a8628cbe",
+        "name": "openms_idfilter",
+        "owner": "galaxyp",
+        "tool_shed": "toolshed.g2.bx.psu.edu"
+      }
+    },
+    "15": {
+      "annotation": "",
+      "content_id": "IDMapper",
+      "id": 15,
+      "input_connections": {
+        "param_id": {
+          "id": 14,
+          "output_name": "param_out"
+        },
+        "param_in": {
+          "id": 2,
+          "output_name": "param_out"
+        }
+      },
+      "inputs": [
+        {
+          "description": "runtime parameter for tool IDMapper",
+          "name": "param_id"
+        },
+        {
+          "description": "runtime parameter for tool IDMapper",
+          "name": "param_in"
+        }
+      ],
+      "label": null,
+      "name": "IDMapper",
+      "outputs": [
+        {
+          "name": "param_out",
+          "type": "input"
+        }
+      ],
+      "position": {
+        "left": 1979.9666748046875,
+        "top": 843.88330078125
+      },
+      "post_job_actions": {},
+      "tool_errors": null,
+      "tool_id": "IDMapper",
+      "tool_state": "{\"param_mz_tolerance\": \"\\\"30.0\\\"\", \"param_ignore_charge\": \"\\\"true\\\"\", \"param_feature_use_centroid_rt\": \"\\\"false\\\"\", \"__page__\": 0, \"adv_opts\": \"{\\\"adv_opts_selector\\\": \\\"basic\\\", \\\"__current_case__\\\": 0}\", \"__rerun_remap_job_id__\": null, \"param_mz_measure\": \"\\\"ppm\\\"\", \"param_mz_reference\": \"\\\"precursor\\\"\", \"param_id\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\", \"param_rt_tolerance\": \"\\\"50.0\\\"\", \"param_consensus_use_subelements\": \"\\\"true\\\"\", \"param_feature_use_centroid_mz\": \"\\\"false\\\"\", \"param_in\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\"}",
+      "tool_version": "2.1.0",
+      "type": "tool",
+      "uuid": "f199e8c6-c243-4fce-8dac-a62d504c9cdd",
+      "workflow_outputs": [
+        {
+          "label": null,
+          "output_name": "param_out",
+          "uuid": "84923098-0cc0-4c3b-ac19-aa12ef6a5244"
+        }
+      ],
+      "tool_shed_repository": {
+        "changeset_revision": "b5d0905419da",
+        "name": "openms_idmapper",
+        "owner": "galaxyp",
+        "tool_shed": "toolshed.g2.bx.psu.edu"
+      }
+    },
+    "16": {
+      "annotation": "",
+      "content_id": "IDConflictResolver",
+      "id": 16,
+      "input_connections": {
+        "param_in": {
+          "id": 15,
+          "output_name": "param_out"
+        }
+      },
+      "inputs": [
+        {
+          "description": "runtime parameter for tool IDConflictResolver",
+          "name": "param_in"
+        }
+      ],
+      "label": null,
+      "name": "IDConflictResolver",
+      "outputs": [
+        {
+          "name": "param_out",
+          "type": "input"
+        }
+      ],
+      "position": {
+        "left": 2220.449951171875,
+        "top": 881.88330078125
+      },
+      "post_job_actions": {},
+      "tool_errors": null,
+      "tool_id": "IDConflictResolver",
+      "tool_state": "{\"adv_opts\": \"{\\\"param_force\\\": \\\"false\\\", \\\"adv_opts_selector\\\": \\\"advanced\\\", \\\"__current_case__\\\": 1}\", \"__page__\": 0, \"__rerun_remap_job_id__\": null, \"param_in\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\"}",
+      "tool_version": "2.1.0",
+      "type": "tool",
+      "uuid": "6f4dc17d-b0fd-4b66-9487-3fda71316199",
+      "workflow_outputs": [
+        {
+          "label": null,
+          "output_name": "param_out",
+          "uuid": "485d4684-835d-4ff0-9ca5-3400a0b8fa22"
+        }
+      ],
+      "tool_shed_repository": {
+        "changeset_revision": "8a04ed1c1d1b",
+        "name": "openms_idconflictresolver",
+        "owner": "galaxyp",
+        "tool_shed": "toolshed.g2.bx.psu.edu"
+      }
+    },
+    "17": {
+      "annotation": "",
+      "content_id": "FileFilter",
+      "id": 17,
+      "input_connections": {
+        "param_in": {
+          "id": 16,
+          "output_name": "param_out"
+        }
+      },
+      "inputs": [
+        {
+          "description": "runtime parameter for tool FileFilter",
+          "name": "param_in"
+        },
+        {
+          "description": "runtime parameter for tool FileFilter",
+          "name": "param_id_blacklist"
+        },
+        {
+          "description": "runtime parameter for tool FileFilter",
+          "name": "param_consensus_blackorwhitelist_file"
+        }
+      ],
+      "label": null,
+      "name": "FileFilter",
+      "outputs": [
+        {
+          "name": "param_out",
+          "type": "input"
+        }
+      ],
+      "position": {
+        "left": 2531,
+        "top": 786.88330078125
+      },
+      "post_job_actions": {},
+      "tool_errors": null,
+      "tool_id": "FileFilter",
+      "tool_state": "{\"rep_param_id_sequences_whitelist\": \"[]\", \"param_algorithm_SignalToNoise_win_len\": \"\\\"200.0\\\"\", \"param_algorithm_SignalToNoise_bin_count\": \"\\\"30\\\"\", \"param_peak_options_sn\": \"\\\"0.0\\\"\", \"param_id_mz\": \"\\\"0.001\\\"\", \"param_spectra_select_polarity\": \"null\", \"param_spectra_remove_collision_energy\": \"\\\":\\\"\", \"param_id_blacklist_imperfect\": \"\\\"false\\\"\", \"param_mz\": \"\\\":\\\"\", \"param_int\": \"\\\":\\\"\", \"param_spectra_select_isolation_window_width\": \"\\\":\\\"\", \"param_peak_options_indexed_file\": \"\\\"false\\\"\", \"param_spectra_select_activation\": \"null\", \"param_id_remove_annotated_features\": \"\\\"false\\\"\", \"__page__\": 0, \"param_peak_options_no_chromatograms\": \"\\\"false\\\"\", \"rep_param_peak_options_pc_mz_list\": \"[]\", \"param_peak_options_numpress_masstime\": \"\\\"none\\\"\", \"param_peak_options_remove_chromatograms\": \"\\\"false\\\"\", \"rep_param_consensus_map\": \"[]\", \"param_peak_options_numpress_intensity\": \"\\\"none\\\"\", \"param_pc_mz\": \"\\\":\\\"\", \"__rerun_remap_job_id__\": null, \"param_spectra_select_mode\": \"null\", \"param_rt\": \"\\\":\\\"\", \"param_algorithm_SignalToNoise_write_log_messages\": \"\\\"true\\\"\", \"param_consensus_blackorwhitelist_use_ppm_tolerance\": \"\\\"false\\\"\", \"param_in\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\", \"param_id_remove_unannotated_features\": \"\\\"true\\\"\", \"param_peak_options_sort_peaks\": \"\\\"false\\\"\", \"param_peak_options_int_precision\": \"\\\"32\\\"\", \"rep_param_id_accessions_whitelist\": \"[]\", \"param_peak_options_pc_mz_range\": \"\\\":\\\"\", \"param_out_type\": \"\\\"consensusXML\\\"\", \"param_spectra_remove_mode\": \"null\", \"param_consensus_blackorwhitelist_blacklist\": \"\\\"true\\\"\", \"rep_param_peak_options_level\": \"[{\\\"__index__\\\": 0, \\\"param_peak_options_level\\\": \\\"1 2 3\\\"}]\", \"rep_param_f_and_c_remove_meta\": \"[]\", \"param_f_and_c_size\": \"\\\":\\\"\", \"param_id_remove_unassigned_ids\": \"\\\"true\\\"\", \"param_spectra_remove_zoom\": \"\\\"false\\\"\", \"param_peak_options_mz_precision\": \"\\\"64\\\"\", \"param_sort\": \"\\\"false\\\"\", \"param_algorithm_SignalToNoise_min_required_elements\": \"\\\"10\\\"\", \"param_consensus_blackorwhitelist_rt\": \"\\\"60.0\\\"\", \"rep_param_peak_options_rm_pc_charge\": \"[]\", \"param_peak_options_numpress_intensity_error\": \"\\\"0.0001\\\"\", \"param_id_rt\": \"\\\"0.1\\\"\", \"param_id_keep_best_score_id\": \"\\\"false\\\"\", \"param_id_blacklist\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\", \"param_spectra_select_collision_energy\": \"\\\":\\\"\", \"param_feature_q\": \"\\\":\\\"\", \"adv_opts\": \"{\\\"adv_opts_selector\\\": \\\"basic\\\", \\\"__current_case__\\\": 0}\", \"param_f_and_c_charge\": \"\\\":\\\"\", \"param_consensus_map_and\": \"\\\"false\\\"\", \"param_spectra_select_zoom\": \"\\\"false\\\"\", \"param_consensus_blackorwhitelist_mz\": \"\\\"0.01\\\"\", \"param_consensus_blackorwhitelist_file\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\", \"rep_param_consensus_blackorwhitelist_maps\": \"[]\", \"param_spectra_remove_activation\": \"null\", \"param_peak_options_numpress_masstime_error\": \"\\\"0.0001\\\"\", \"param_spectra_remove_isolation_window_width\": \"\\\":\\\"\"}",
+      "tool_version": "2.1.0",
+      "type": "tool",
+      "uuid": "77e6a295-f6e2-4d72-a7e3-94f682d916a7",
+      "workflow_outputs": [
+        {
+          "label": null,
+          "output_name": "param_out",
+          "uuid": "55dc6d2b-f473-4496-abaf-86630ad0151b"
+        }
+      ],
+      "tool_shed_repository": {
+        "changeset_revision": "d6878d27f051",
+        "name": "openms_filefilter",
+        "owner": "galaxyp",
+        "tool_shed": "toolshed.g2.bx.psu.edu"
+      }
+    },
+    "18": {
+      "annotation": "",
+      "content_id": "FileMerger",
+      "id": 18,
+      "input_connections": {
+        "param_in": {
+          "id": 17,
+          "output_name": "param_out"
+        }
+      },
+      "inputs": [
+        {
+          "description": "runtime parameter for tool FileMerger",
+          "name": "param_in"
+        }
+      ],
+      "label": null,
+      "name": "FileMerger",
+      "outputs": [
+        {
+          "name": "param_out",
+          "type": "featurexml"
+        },
+        {
+          "name": "param_rt_concat_trafo_out",
+          "type": "trafoxml"
+        }
+      ],
+      "position": {
+        "left": 2832.966552734375,
+        "top": 1062.9000244140625
+      },
+      "post_job_actions": {},
+      "tool_errors": null,
+      "tool_id": "FileMerger",
+      "tool_state": "{\"param_raw_user_ms_level\": \"\\\"False\\\"\", \"param_raw_rt_auto\": \"\\\"false\\\"\", \"__page__\": 0, \"adv_opts\": \"{\\\"adv_opts_selector\\\": \\\"basic\\\", \\\"__current_case__\\\": 0}\", \"param_raw_rt_filename\": \"\\\"false\\\"\", \"param_rt_concat_gap\": \"\\\"0.0\\\"\", \"param_annotate_file_origin\": \"\\\"false\\\"\", \"__rerun_remap_job_id__\": null, \"param_raw_ms_level\": \"\\\"2\\\"\", \"rep_param_raw_rt_custom\": \"[]\", \"param_in\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\"}",
+      "tool_version": "2.1.0",
+      "type": "tool",
+      "uuid": "d82505c8-6f1c-43a9-a9c7-c572ad2aa3c8",
+      "workflow_outputs": [
+        {
+          "label": null,
+          "output_name": "param_out",
+          "uuid": "db9ffdb1-ef2f-4d53-9808-bef6de3d85b4"
+        },
+        {
+          "label": null,
+          "output_name": "param_rt_concat_trafo_out",
+          "uuid": "47af80c0-5efb-43b3-a830-c3df9fc0528d"
+        }
+      ],
+      "tool_shed_repository": {
+        "changeset_revision": "39e8fde08881",
+        "name": "openms_filemerger",
+        "owner": "galaxyp",
+        "tool_shed": "toolshed.g2.bx.psu.edu"
+      }
+    },
+    "19": {
+      "annotation": "",
+      "content_id": "MzTabExporter",
+      "id": 19,
+      "input_connections": {
+        "param_in": {
+          "id": 18,
+          "output_name": "param_out"
+        }
+      },
+      "inputs": [
+        {
+          "description": "runtime parameter for tool MzTabExporter",
+          "name": "param_in"
+        }
+      ],
+      "label": null,
+      "name": "MzTabExporter",
+      "outputs": [
+        {
+          "name": "param_out",
+          "type": "tabular"
+        }
+      ],
+      "position": {
+        "left": 3076.5,
+        "top": 1061.88330078125
+      },
+      "post_job_actions": {},
+      "tool_errors": null,
+      "tool_id": "MzTabExporter",
+      "tool_state": "{\"adv_opts\": \"{\\\"adv_opts_selector\\\": \\\"basic\\\", \\\"__current_case__\\\": 0}\", \"__page__\": 0, \"__rerun_remap_job_id__\": null, \"param_in\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\"}",
+      "tool_version": "2.1.0",
+      "type": "tool",
+      "uuid": "3f6cb69e-8629-4fea-ab74-dec388ed0fd4",
+      "workflow_outputs": [
+        {
+          "label": null,
+          "output_name": "param_out",
+          "uuid": "a6361de3-6865-4c6b-9920-d7a8c6a27645"
+        }
+      ],
+      "tool_shed_repository": {
+        "changeset_revision": "bf32e0bcf554",
+        "name": "openms_mztabexporter",
+        "owner": "galaxyp",
+        "tool_shed": "toolshed.g2.bx.psu.edu"
+      }
+    }
+  },
+  "uuid": "6300a4b9-cb1d-42a5-af00-a2bbc76fa200"
 }

--- a/topics/proteomics/tutorials/protein-id-sg-ps/workflows/wf_proteinID_SG_PS.ga
+++ b/topics/proteomics/tutorials/protein-id-sg-ps/workflows/wf_proteinID_SG_PS.ga
@@ -1,509 +1,521 @@
 {
-    "a_galaxy_workflow": "true", 
-    "annotation": "", 
-    "format-version": "0.1", 
-    "name": "Peptide and Protein ID Tutorial", 
-    "steps": {
-        "0": {
-            "annotation": "", 
-            "content_id": null, 
-            "id": 0, 
-            "input_connections": {}, 
-            "inputs": [
-                {
-                    "description": "", 
-                    "name": "Input: Protein Database"
-                }
-            ], 
-            "label": "Input: Protein Database", 
-            "name": "Input dataset", 
-            "outputs": [], 
-            "position": {
-                "left": 174.5, 
-                "top": 159.5
-            }, 
-            "tool_errors": null, 
-            "tool_id": null, 
-            "tool_state": "{\"name\": \"Input: Protein Database\"}", 
-            "tool_version": null, 
-            "type": "data_input", 
-            "uuid": "430f7bca-2c95-4bc0-89a8-3ac797ca3363", 
-            "workflow_outputs": [
-                {
-                    "label": null, 
-                    "output_name": "output", 
-                    "uuid": "0636ac0b-9003-4371-a1d0-81d325a00496"
-                }
-            ]
-        }, 
-        "1": {
-            "annotation": "", 
-            "content_id": null, 
-            "id": 1, 
-            "input_connections": {}, 
-            "inputs": [
-                {
-                    "description": "", 
-                    "name": "Input: mzML file"
-                }
-            ], 
-            "label": "Input: mzML file", 
-            "name": "Input dataset", 
-            "outputs": [], 
-            "position": {
-                "left": 183, 
-                "top": 286
-            }, 
-            "tool_errors": null, 
-            "tool_id": null, 
-            "tool_state": "{\"name\": \"Input: mzML file\"}", 
-            "tool_version": null, 
-            "type": "data_input", 
-            "uuid": "4e937c9c-582e-4064-8b2f-515979f22cf8", 
-            "workflow_outputs": [
-                {
-                    "label": null, 
-                    "output_name": "output", 
-                    "uuid": "0b857aa4-2008-4af6-aca4-7a949c012e84"
-                }
-            ]
-        }, 
-        "2": {
-            "annotation": "", 
-            "content_id": "PeakPickerHiRes", 
-            "id": 2, 
-            "input_connections": {
-                "param_in": {
-                    "id": 1, 
-                    "output_name": "output"
-                }
-            }, 
-            "inputs": [
-                {
-                    "description": "runtime parameter for tool PeakPickerHiRes", 
-                    "name": "param_in"
-                }
-            ], 
-            "label": null, 
-            "name": "PeakPickerHiRes", 
-            "outputs": [
-                {
-                    "name": "param_out", 
-                    "type": "mzml"
-                }
-            ], 
-            "position": {
-                "left": 395, 
-                "top": 270.5
-            }, 
-            "post_job_actions": {
-                "HideDatasetActionparam_out": {
-                    "action_arguments": {}, 
-                    "action_type": "HideDatasetAction", 
-                    "output_name": "param_out"
-                }
-            }, 
-            "tool_errors": null, 
-            "tool_id": "PeakPickerHiRes", 
-            "tool_state": "{\"__page__\": 0, \"rep_param_algorithm_ms_levels\": \"[]\", \"param_algorithm_SignalToNoise_win_len\": \"\\\"200.0\\\"\", \"adv_opts\": \"{\\\"param_algorithm_spacing_difference\\\": \\\"1.5\\\", \\\"param_algorithm_SignalToNoise_max_intensity\\\": \\\"-1\\\", \\\"param_algorithm_SignalToNoise_auto_mode\\\": \\\"0\\\", \\\"param_algorithm_SignalToNoise_auto_max_stdev_factor\\\": \\\"3.0\\\", \\\"adv_opts_selector\\\": \\\"advanced\\\", \\\"param_force\\\": \\\"false\\\", \\\"param_algorithm_SignalToNoise_auto_max_percentile\\\": \\\"95\\\", \\\"param_processOption\\\": \\\"inmemory\\\", \\\"__current_case__\\\": 1, \\\"param_algorithm_SignalToNoise_noise_for_empty_window\\\": \\\"1e+20\\\", \\\"param_algorithm_spacing_difference_gap\\\": \\\"4.0\\\", \\\"param_algorithm_missing\\\": \\\"1\\\"}\", \"param_algorithm_report_FWHM\": \"\\\"false\\\"\", \"param_algorithm_report_FWHM_unit\": \"\\\"relative(ppm)\\\"\", \"__rerun_remap_job_id__\": null, \"param_algorithm_signal_to_noise\": \"\\\"1.0\\\"\", \"param_algorithm_SignalToNoise_min_required_elements\": \"\\\"10\\\"\", \"param_algorithm_SignalToNoise_write_log_messages\": \"\\\"true\\\"\", \"param_algorithm_SignalToNoise_bin_count\": \"\\\"30\\\"\", \"param_in\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\"}", 
-            "tool_version": "2.1.0", 
-            "type": "tool", 
-            "uuid": "d718d7dd-442e-43d0-ad0c-cfe1f21e9aef", 
-            "workflow_outputs": []
-        }, 
-        "3": {
-            "annotation": "", 
-            "content_id": "FileConverter", 
-            "id": 3, 
-            "input_connections": {
-                "param_in": {
-                    "id": 2, 
-                    "output_name": "param_out"
-                }
-            }, 
-            "inputs": [
-                {
-                    "description": "runtime parameter for tool FileConverter", 
-                    "name": "param_in"
-                }
-            ], 
-            "label": null, 
-            "name": "FileConverter", 
-            "outputs": [
-                {
-                    "name": "param_out", 
-                    "type": "_sniff_"
-                }
-            ], 
-            "position": {
-                "left": 609, 
-                "top": 265
-            }, 
-            "post_job_actions": {
-                "HideDatasetActionparam_out": {
-                    "action_arguments": {}, 
-                    "action_type": "HideDatasetAction", 
-                    "output_name": "param_out"
-                }
-            }, 
-            "tool_errors": null, 
-            "tool_id": "FileConverter", 
-            "tool_state": "{\"__page__\": 0, \"param_out_type\": \"\\\"mgf\\\"\", \"adv_opts\": \"{\\\"adv_opts_selector\\\": \\\"basic\\\", \\\"__current_case__\\\": 0}\", \"__rerun_remap_job_id__\": null, \"param_UID_postprocessing\": \"\\\"ensure\\\"\", \"param_write_mzML_index\": \"\\\"false\\\"\", \"chromInfo\": \"\\\"/usr/local/galaxy/galaxy-dist/tool-data/shared/ucsc/chrom/?.len\\\"\", \"param_in\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\"}", 
-            "tool_version": "2.1.0", 
-            "type": "tool", 
-            "uuid": "9a7bbb7f-4159-4d53-9157-e5ffefe48ff7", 
-            "workflow_outputs": []
-        }, 
-        "4": {
-            "annotation": "", 
-            "content_id": "toolshed.g2.bx.psu.edu/repos/galaxyp/peptideshaker/search_gui/2.9.0", 
-            "id": 4, 
-            "input_connections": {
-                "input_database": {
-                    "id": 0, 
-                    "output_name": "output"
-                }, 
-                "peak_lists": {
-                    "id": 3, 
-                    "output_name": "param_out"
-                }
-            }, 
-            "inputs": [
-                {
-                    "description": "runtime parameter for tool Search GUI", 
-                    "name": "peak_lists"
-                }, 
-                {
-                    "description": "runtime parameter for tool Search GUI", 
-                    "name": "input_database"
-                }
-            ], 
-            "label": null, 
-            "name": "Search GUI", 
-            "outputs": [
-                {
-                    "name": "searchgui_results", 
-                    "type": "searchgui_archive"
-                }
-            ], 
-            "position": {
-                "left": 829, 
-                "top": 202
-            }, 
-            "post_job_actions": {
-                "HideDatasetActionsearchgui_results": {
-                    "action_arguments": {}, 
-                    "action_type": "HideDatasetAction", 
-                    "output_name": "searchgui_results"
-                }
-            }, 
-            "tool_errors": null, 
-            "tool_id": "toolshed.g2.bx.psu.edu/repos/galaxyp/peptideshaker/search_gui/2.9.0", 
-            "tool_shed_repository": {
-                "changeset_revision": "78fad25eff17", 
-                "name": "peptideshaker", 
-                "owner": "galaxyp", 
-                "tool_shed": "toolshed.g2.bx.psu.edu"
-            }, 
-            "tool_state": "{\"msgf\": \"{\\\"msgf_advanced\\\": \\\"no\\\", \\\"__current_case__\\\": 0}\", \"use_gene_mapping\": \"\\\"false\\\"\", \"min_charge\": \"\\\"2\\\"\", \"__page__\": 0, \"peak_lists\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\", \"engines\": \"[\\\"X!Tandem\\\", \\\"MSGF\\\"]\", \"__rerun_remap_job_id__\": null, \"create_decoy\": \"\\\"true\\\"\", \"enzyme\": \"\\\"Trypsin\\\"\", \"precursor_ion_tol_units\": \"\\\"1\\\"\", \"omssa\": \"{\\\"omssa_advanced\\\": \\\"no\\\", \\\"__current_case__\\\": 0}\", \"precursor_ion_tol\": \"\\\"10.0\\\"\", \"variable_modifications\": \"[\\\"Oxidation of M\\\"]\", \"input_database\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\", \"fragment_tol\": \"\\\"0.5\\\"\", \"reverse_ion\": \"\\\"y\\\"\", \"forward_ion\": \"\\\"b\\\"\", \"searchgui_advanced\": \"{\\\"searchgui_advanced_selector\\\": \\\"basic\\\", \\\"__current_case__\\\": 0}\", \"xtandem\": \"{\\\"__current_case__\\\": 0, \\\"xtandem_advanced\\\": \\\"no\\\"}\", \"max_charge\": \"\\\"4\\\"\", \"fixed_modifications\": \"[\\\"Carbamidomethylation of C\\\"]\", \"comet\": \"{\\\"comet_advanced\\\": \\\"no\\\", \\\"__current_case__\\\": 0}\", \"missed_cleavages\": \"\\\"2\\\"\"}", 
-            "tool_version": "2.9.0", 
-            "type": "tool", 
-            "uuid": "b9624104-36b1-42d8-a8d5-4dda4465bdc4", 
-            "workflow_outputs": []
-        }, 
-        "5": {
-            "annotation": "", 
-            "content_id": "toolshed.g2.bx.psu.edu/repos/galaxyp/peptideshaker/peptide_shaker/1.11.0", 
-            "id": 5, 
-            "input_connections": {
-                "searchgui_input": {
-                    "id": 4, 
-                    "output_name": "searchgui_results"
-                }
-            }, 
-            "inputs": [
-                {
-                    "description": "runtime parameter for tool Peptide Shaker", 
-                    "name": "searchgui_input"
-                }
-            ], 
-            "label": null, 
-            "name": "Peptide Shaker", 
-            "outputs": [
-                {
-                    "name": "mzidentML", 
-                    "type": "mzid"
-                }, 
-                {
-                    "name": "output_cps", 
-                    "type": "peptideshaker_archive"
-                }, 
-                {
-                    "name": "output_zip", 
-                    "type": "zip"
-                }, 
-                {
-                    "name": "output_certificate", 
-                    "type": "txt"
-                }, 
-                {
-                    "name": "output_hierarchical", 
-                    "type": "tabular"
-                }, 
-                {
-                    "name": "output_psm_phosphorylation", 
-                    "type": "tabular"
-                }, 
-                {
-                    "name": "output_psm", 
-                    "type": "tabular"
-                }, 
-                {
-                    "name": "output_peptides_phosphorylation", 
-                    "type": "tabular"
-                }, 
-                {
-                    "name": "output_peptides", 
-                    "type": "tabular"
-                }, 
-                {
-                    "name": "output_proteins_phosphorylation", 
-                    "type": "tabular"
-                }, 
-                {
-                    "name": "output_proteins", 
-                    "type": "tabular"
-                }
-            ], 
-            "position": {
-                "left": 825, 
-                "top": 397
-            }, 
-            "post_job_actions": {
-                "HideDatasetActionoutput_certificate": {
-                    "action_arguments": {}, 
-                    "action_type": "HideDatasetAction", 
-                    "output_name": "output_certificate"
-                }, 
-                "HideDatasetActionoutput_cps": {
-                    "action_arguments": {}, 
-                    "action_type": "HideDatasetAction", 
-                    "output_name": "output_cps"
-                }, 
-                "HideDatasetActionoutput_hierarchical": {
-                    "action_arguments": {}, 
-                    "action_type": "HideDatasetAction", 
-                    "output_name": "output_hierarchical"
-                }, 
-                "HideDatasetActionoutput_peptides_phosphorylation": {
-                    "action_arguments": {}, 
-                    "action_type": "HideDatasetAction", 
-                    "output_name": "output_peptides_phosphorylation"
-                }, 
-                "HideDatasetActionoutput_proteins_phosphorylation": {
-                    "action_arguments": {}, 
-                    "action_type": "HideDatasetAction", 
-                    "output_name": "output_proteins_phosphorylation"
-                }, 
-                "HideDatasetActionoutput_psm_phosphorylation": {
-                    "action_arguments": {}, 
-                    "action_type": "HideDatasetAction", 
-                    "output_name": "output_psm_phosphorylation"
-                }
-            }, 
-            "tool_errors": null, 
-            "tool_id": "toolshed.g2.bx.psu.edu/repos/galaxyp/peptideshaker/peptide_shaker/1.11.0", 
-            "tool_shed_repository": {
-                "changeset_revision": "78fad25eff17", 
-                "name": "peptideshaker", 
-                "owner": "galaxyp", 
-                "tool_shed": "toolshed.g2.bx.psu.edu"
-            }, 
-            "tool_state": "{\"__page__\": 0, \"outputs\": \"[\\\"mzidentML\\\", \\\"7\\\"]\", \"__rerun_remap_job_id__\": null, \"filtering_options\": \"{\\\"max_precursor_error_type\\\": \\\"1\\\", \\\"filtering_options_selector\\\": \\\"yes\\\", \\\"__current_case__\\\": 1, \\\"max_precursor_error\\\": \\\"10.0\\\", \\\"exclude_unknown_ptms\\\": \\\"true\\\", \\\"max_peptide_length\\\": \\\"30\\\", \\\"min_peptide_length\\\": \\\"6\\\"}\", \"searchgui_input\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\", \"processing_options\": \"{\\\"peptide_fdr\\\": \\\"1.0\\\", \\\"protein_fdr\\\": \\\"1.0\\\", \\\"protein_fraction_mw_confidence\\\": \\\"95.0\\\", \\\"ptm_score\\\": {\\\"ptm_score_selector\\\": \\\"0\\\", \\\"__current_case__\\\": 0}, \\\"ptm_alignment\\\": \\\"true\\\", \\\"__current_case__\\\": 1, \\\"processing_options_selector\\\": \\\"yes\\\", \\\"psm_fdr\\\": \\\"1.0\\\"}\"}", 
-            "tool_version": "1.11.0", 
-            "type": "tool", 
-            "uuid": "7840a984-7e8e-44fa-b8bb-a14c1eae2809", 
-            "workflow_outputs": [
-                {
-                    "label": null, 
-                    "output_name": "output_proteins", 
-                    "uuid": "14017ead-5d4e-4313-81c1-9bd854a3b22b"
-                }, 
-                {
-                    "label": null, 
-                    "output_name": "mzidentML", 
-                    "uuid": "f40142a4-f928-44e7-8feb-6524b63d3b58"
-                }, 
-                {
-                    "label": null, 
-                    "output_name": "output_psm", 
-                    "uuid": "f4d84abd-8329-430f-9762-4e1503a6a5c4"
-                }, 
-                {
-                    "label": null, 
-                    "output_name": "output_zip", 
-                    "uuid": "b5133d31-7d96-43bb-b7ee-55dc79e2719c"
-                }, 
-                {
-                    "label": null, 
-                    "output_name": "output_peptides", 
-                    "uuid": "f53dd653-c534-42a5-a86f-cc83a4d9331b"
-                }
-            ]
-        }, 
-        "6": {
-            "annotation": "Output: all identified contaminants.", 
-            "content_id": "Grep1", 
-            "id": 6, 
-            "input_connections": {
-                "input": {
-                    "id": 5, 
-                    "output_name": "output_proteins"
-                }
-            }, 
-            "inputs": [
-                {
-                    "description": "runtime parameter for tool Select", 
-                    "name": "input"
-                }
-            ], 
-            "label": null, 
-            "name": "Select", 
-            "outputs": [
-                {
-                    "name": "out_file1", 
-                    "type": "input"
-                }
-            ], 
-            "position": {
-                "left": 1149.5, 
-                "top": 738.5
-            }, 
-            "post_job_actions": {
-                "RenameDatasetActionout_file1": {
-                    "action_arguments": {
-                        "newname": "contaminant_proteins"
-                    }, 
-                    "action_type": "RenameDatasetAction", 
-                    "output_name": "out_file1"
-                }
-            }, 
-            "tool_errors": null, 
-            "tool_id": "Grep1", 
-            "tool_state": "{\"__page__\": 0, \"input\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\", \"invert\": \"\\\"false\\\"\", \"__rerun_remap_job_id__\": null, \"pattern\": \"\\\"CONTAMINANT\\\"\"}", 
-            "tool_version": "1.0.1", 
-            "type": "tool", 
-            "uuid": "913cd910-6e9a-4961-b1d6-9de03e7a5be0", 
-            "workflow_outputs": [
-                {
-                    "label": null, 
-                    "output_name": "out_file1", 
-                    "uuid": "71acf765-a1a8-449f-8e75-0f0e9cd7e97d"
-                }
-            ]
-        }, 
-        "7": {
-            "annotation": "Output: all identified proteins without common contaminants. CAVE: some proteins may be both!", 
-            "content_id": "Grep1", 
-            "id": 7, 
-            "input_connections": {
-                "input": {
-                    "id": 5, 
-                    "output_name": "output_proteins"
-                }
-            }, 
-            "inputs": [
-                {
-                    "description": "runtime parameter for tool Select", 
-                    "name": "input"
-                }
-            ], 
-            "label": null, 
-            "name": "Select", 
-            "outputs": [
-                {
-                    "name": "out_file1", 
-                    "type": "input"
-                }
-            ], 
-            "position": {
-                "left": 1152.5, 
-                "top": 842.5
-            }, 
-            "post_job_actions": {
-                "RenameDatasetActionout_file1": {
-                    "action_arguments": {
-                        "newname": "non-contaminant_proteins"
-                    }, 
-                    "action_type": "RenameDatasetAction", 
-                    "output_name": "out_file1"
-                }
-            }, 
-            "tool_errors": null, 
-            "tool_id": "Grep1", 
-            "tool_state": "{\"__page__\": 0, \"input\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\", \"invert\": \"\\\"true\\\"\", \"__rerun_remap_job_id__\": null, \"pattern\": \"\\\"CONTAMINANT\\\"\"}", 
-            "tool_version": "1.0.1", 
-            "type": "tool", 
-            "uuid": "b4c96aea-4f92-4eff-a322-9e4f7935db9d", 
-            "workflow_outputs": [
-                {
-                    "label": null, 
-                    "output_name": "out_file1", 
-                    "uuid": "a935e7bb-b5aa-43db-aa3a-2e6de6420ac5"
-                }
-            ]
-        }, 
-        "8": {
-            "annotation": "Output: only those non-contaminant proteins not evaluated to be \"Doubtful\".", 
-            "content_id": "Grep1", 
-            "id": 8, 
-            "input_connections": {
-                "input": {
-                    "id": 7, 
-                    "output_name": "out_file1"
-                }
-            }, 
-            "inputs": [
-                {
-                    "description": "runtime parameter for tool Select", 
-                    "name": "input"
-                }
-            ], 
-            "label": null, 
-            "name": "Select", 
-            "outputs": [
-                {
-                    "name": "out_file1", 
-                    "type": "input"
-                }
-            ], 
-            "position": {
-                "left": 1361.5, 
-                "top": 803.5
-            }, 
-            "post_job_actions": {
-                "RenameDatasetActionout_file1": {
-                    "action_arguments": {
-                        "newname": "confident_non-contaminant_proteins"
-                    }, 
-                    "action_type": "RenameDatasetAction", 
-                    "output_name": "out_file1"
-                }
-            }, 
-            "tool_errors": null, 
-            "tool_id": "Grep1", 
-            "tool_state": "{\"__page__\": 0, \"input\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\", \"invert\": \"\\\"true\\\"\", \"__rerun_remap_job_id__\": null, \"pattern\": \"\\\"Doubtful\\\"\"}", 
-            "tool_version": "1.0.1", 
-            "type": "tool", 
-            "uuid": "02ee5bf0-89d2-4598-a4ae-fdc44c35e954", 
-            "workflow_outputs": [
-                {
-                    "label": null, 
-                    "output_name": "out_file1", 
-                    "uuid": "5a0a1a89-a613-44cb-9b7f-ea055b9cfdaf"
-                }
-            ]
+  "a_galaxy_workflow": "true",
+  "annotation": "",
+  "format-version": "0.1",
+  "name": "Peptide and Protein ID Tutorial",
+  "steps": {
+    "0": {
+      "annotation": "",
+      "content_id": null,
+      "id": 0,
+      "input_connections": {},
+      "inputs": [
+        {
+          "description": "",
+          "name": "Input: Protein Database"
         }
-    }, 
-    "uuid": "70102704-6596-4bcf-ac9c-234ce3837f2c"
+      ],
+      "label": "Input: Protein Database",
+      "name": "Input dataset",
+      "outputs": [],
+      "position": {
+        "left": 174.5,
+        "top": 159.5
+      },
+      "tool_errors": null,
+      "tool_id": null,
+      "tool_state": "{\"name\": \"Input: Protein Database\"}",
+      "tool_version": null,
+      "type": "data_input",
+      "uuid": "430f7bca-2c95-4bc0-89a8-3ac797ca3363",
+      "workflow_outputs": [
+        {
+          "label": null,
+          "output_name": "output",
+          "uuid": "0636ac0b-9003-4371-a1d0-81d325a00496"
+        }
+      ]
+    },
+    "1": {
+      "annotation": "",
+      "content_id": null,
+      "id": 1,
+      "input_connections": {},
+      "inputs": [
+        {
+          "description": "",
+          "name": "Input: mzML file"
+        }
+      ],
+      "label": "Input: mzML file",
+      "name": "Input dataset",
+      "outputs": [],
+      "position": {
+        "left": 183,
+        "top": 286
+      },
+      "tool_errors": null,
+      "tool_id": null,
+      "tool_state": "{\"name\": \"Input: mzML file\"}",
+      "tool_version": null,
+      "type": "data_input",
+      "uuid": "4e937c9c-582e-4064-8b2f-515979f22cf8",
+      "workflow_outputs": [
+        {
+          "label": null,
+          "output_name": "output",
+          "uuid": "0b857aa4-2008-4af6-aca4-7a949c012e84"
+        }
+      ]
+    },
+    "2": {
+      "annotation": "",
+      "content_id": "PeakPickerHiRes",
+      "id": 2,
+      "input_connections": {
+        "param_in": {
+          "id": 1,
+          "output_name": "output"
+        }
+      },
+      "inputs": [
+        {
+          "description": "runtime parameter for tool PeakPickerHiRes",
+          "name": "param_in"
+        }
+      ],
+      "label": null,
+      "name": "PeakPickerHiRes",
+      "outputs": [
+        {
+          "name": "param_out",
+          "type": "mzml"
+        }
+      ],
+      "position": {
+        "left": 395,
+        "top": 270.5
+      },
+      "post_job_actions": {
+        "HideDatasetActionparam_out": {
+          "action_arguments": {},
+          "action_type": "HideDatasetAction",
+          "output_name": "param_out"
+        }
+      },
+      "tool_errors": null,
+      "tool_id": "PeakPickerHiRes",
+      "tool_state": "{\"__page__\": 0, \"rep_param_algorithm_ms_levels\": \"[]\", \"param_algorithm_SignalToNoise_win_len\": \"\\\"200.0\\\"\", \"adv_opts\": \"{\\\"param_algorithm_spacing_difference\\\": \\\"1.5\\\", \\\"param_algorithm_SignalToNoise_max_intensity\\\": \\\"-1\\\", \\\"param_algorithm_SignalToNoise_auto_mode\\\": \\\"0\\\", \\\"param_algorithm_SignalToNoise_auto_max_stdev_factor\\\": \\\"3.0\\\", \\\"adv_opts_selector\\\": \\\"advanced\\\", \\\"param_force\\\": \\\"false\\\", \\\"param_algorithm_SignalToNoise_auto_max_percentile\\\": \\\"95\\\", \\\"param_processOption\\\": \\\"inmemory\\\", \\\"__current_case__\\\": 1, \\\"param_algorithm_SignalToNoise_noise_for_empty_window\\\": \\\"1e+20\\\", \\\"param_algorithm_spacing_difference_gap\\\": \\\"4.0\\\", \\\"param_algorithm_missing\\\": \\\"1\\\"}\", \"param_algorithm_report_FWHM\": \"\\\"false\\\"\", \"param_algorithm_report_FWHM_unit\": \"\\\"relative(ppm)\\\"\", \"__rerun_remap_job_id__\": null, \"param_algorithm_signal_to_noise\": \"\\\"1.0\\\"\", \"param_algorithm_SignalToNoise_min_required_elements\": \"\\\"10\\\"\", \"param_algorithm_SignalToNoise_write_log_messages\": \"\\\"true\\\"\", \"param_algorithm_SignalToNoise_bin_count\": \"\\\"30\\\"\", \"param_in\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\"}",
+      "tool_version": "2.1.0",
+      "type": "tool",
+      "uuid": "d718d7dd-442e-43d0-ad0c-cfe1f21e9aef",
+      "workflow_outputs": [],
+      "tool_shed_repository": {
+        "changeset_revision": "5ae104d0da6e",
+        "name": "openms_peakpickerhires",
+        "owner": "galaxyp",
+        "tool_shed": "toolshed.g2.bx.psu.edu"
+      }
+    },
+    "3": {
+      "annotation": "",
+      "content_id": "FileConverter",
+      "id": 3,
+      "input_connections": {
+        "param_in": {
+          "id": 2,
+          "output_name": "param_out"
+        }
+      },
+      "inputs": [
+        {
+          "description": "runtime parameter for tool FileConverter",
+          "name": "param_in"
+        }
+      ],
+      "label": null,
+      "name": "FileConverter",
+      "outputs": [
+        {
+          "name": "param_out",
+          "type": "_sniff_"
+        }
+      ],
+      "position": {
+        "left": 609,
+        "top": 265
+      },
+      "post_job_actions": {
+        "HideDatasetActionparam_out": {
+          "action_arguments": {},
+          "action_type": "HideDatasetAction",
+          "output_name": "param_out"
+        }
+      },
+      "tool_errors": null,
+      "tool_id": "FileConverter",
+      "tool_state": "{\"__page__\": 0, \"param_out_type\": \"\\\"mgf\\\"\", \"adv_opts\": \"{\\\"adv_opts_selector\\\": \\\"basic\\\", \\\"__current_case__\\\": 0}\", \"__rerun_remap_job_id__\": null, \"param_UID_postprocessing\": \"\\\"ensure\\\"\", \"param_write_mzML_index\": \"\\\"false\\\"\", \"chromInfo\": \"\\\"/usr/local/galaxy/galaxy-dist/tool-data/shared/ucsc/chrom/?.len\\\"\", \"param_in\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\"}",
+      "tool_version": "2.1.0",
+      "type": "tool",
+      "uuid": "9a7bbb7f-4159-4d53-9157-e5ffefe48ff7",
+      "workflow_outputs": [],
+      "tool_shed_repository": {
+        "changeset_revision": "6634cad7d797",
+        "name": "openms_fileconverter",
+        "owner": "galaxyp",
+        "tool_shed": "toolshed.g2.bx.psu.edu"
+      }
+    },
+    "4": {
+      "annotation": "",
+      "content_id": "toolshed.g2.bx.psu.edu/repos/galaxyp/peptideshaker/search_gui/2.9.0",
+      "id": 4,
+      "input_connections": {
+        "input_database": {
+          "id": 0,
+          "output_name": "output"
+        },
+        "peak_lists": {
+          "id": 3,
+          "output_name": "param_out"
+        }
+      },
+      "inputs": [
+        {
+          "description": "runtime parameter for tool Search GUI",
+          "name": "peak_lists"
+        },
+        {
+          "description": "runtime parameter for tool Search GUI",
+          "name": "input_database"
+        }
+      ],
+      "label": null,
+      "name": "Search GUI",
+      "outputs": [
+        {
+          "name": "searchgui_results",
+          "type": "searchgui_archive"
+        }
+      ],
+      "position": {
+        "left": 829,
+        "top": 202
+      },
+      "post_job_actions": {
+        "HideDatasetActionsearchgui_results": {
+          "action_arguments": {},
+          "action_type": "HideDatasetAction",
+          "output_name": "searchgui_results"
+        }
+      },
+      "tool_errors": null,
+      "tool_id": "toolshed.g2.bx.psu.edu/repos/galaxyp/peptideshaker/search_gui/2.9.0",
+      "tool_shed_repository": {
+        "changeset_revision": "78fad25eff17",
+        "name": "peptideshaker",
+        "owner": "galaxyp",
+        "tool_shed": "toolshed.g2.bx.psu.edu"
+      },
+      "tool_state": "{\"msgf\": \"{\\\"msgf_advanced\\\": \\\"no\\\", \\\"__current_case__\\\": 0}\", \"use_gene_mapping\": \"\\\"false\\\"\", \"min_charge\": \"\\\"2\\\"\", \"__page__\": 0, \"peak_lists\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\", \"engines\": \"[\\\"X!Tandem\\\", \\\"MSGF\\\"]\", \"__rerun_remap_job_id__\": null, \"create_decoy\": \"\\\"true\\\"\", \"enzyme\": \"\\\"Trypsin\\\"\", \"precursor_ion_tol_units\": \"\\\"1\\\"\", \"omssa\": \"{\\\"omssa_advanced\\\": \\\"no\\\", \\\"__current_case__\\\": 0}\", \"precursor_ion_tol\": \"\\\"10.0\\\"\", \"variable_modifications\": \"[\\\"Oxidation of M\\\"]\", \"input_database\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\", \"fragment_tol\": \"\\\"0.5\\\"\", \"reverse_ion\": \"\\\"y\\\"\", \"forward_ion\": \"\\\"b\\\"\", \"searchgui_advanced\": \"{\\\"searchgui_advanced_selector\\\": \\\"basic\\\", \\\"__current_case__\\\": 0}\", \"xtandem\": \"{\\\"__current_case__\\\": 0, \\\"xtandem_advanced\\\": \\\"no\\\"}\", \"max_charge\": \"\\\"4\\\"\", \"fixed_modifications\": \"[\\\"Carbamidomethylation of C\\\"]\", \"comet\": \"{\\\"comet_advanced\\\": \\\"no\\\", \\\"__current_case__\\\": 0}\", \"missed_cleavages\": \"\\\"2\\\"\"}",
+      "tool_version": "2.9.0",
+      "type": "tool",
+      "uuid": "b9624104-36b1-42d8-a8d5-4dda4465bdc4",
+      "workflow_outputs": []
+    },
+    "5": {
+      "annotation": "",
+      "content_id": "toolshed.g2.bx.psu.edu/repos/galaxyp/peptideshaker/peptide_shaker/1.11.0",
+      "id": 5,
+      "input_connections": {
+        "searchgui_input": {
+          "id": 4,
+          "output_name": "searchgui_results"
+        }
+      },
+      "inputs": [
+        {
+          "description": "runtime parameter for tool Peptide Shaker",
+          "name": "searchgui_input"
+        }
+      ],
+      "label": null,
+      "name": "Peptide Shaker",
+      "outputs": [
+        {
+          "name": "mzidentML",
+          "type": "mzid"
+        },
+        {
+          "name": "output_cps",
+          "type": "peptideshaker_archive"
+        },
+        {
+          "name": "output_zip",
+          "type": "zip"
+        },
+        {
+          "name": "output_certificate",
+          "type": "txt"
+        },
+        {
+          "name": "output_hierarchical",
+          "type": "tabular"
+        },
+        {
+          "name": "output_psm_phosphorylation",
+          "type": "tabular"
+        },
+        {
+          "name": "output_psm",
+          "type": "tabular"
+        },
+        {
+          "name": "output_peptides_phosphorylation",
+          "type": "tabular"
+        },
+        {
+          "name": "output_peptides",
+          "type": "tabular"
+        },
+        {
+          "name": "output_proteins_phosphorylation",
+          "type": "tabular"
+        },
+        {
+          "name": "output_proteins",
+          "type": "tabular"
+        }
+      ],
+      "position": {
+        "left": 825,
+        "top": 397
+      },
+      "post_job_actions": {
+        "HideDatasetActionoutput_certificate": {
+          "action_arguments": {},
+          "action_type": "HideDatasetAction",
+          "output_name": "output_certificate"
+        },
+        "HideDatasetActionoutput_cps": {
+          "action_arguments": {},
+          "action_type": "HideDatasetAction",
+          "output_name": "output_cps"
+        },
+        "HideDatasetActionoutput_hierarchical": {
+          "action_arguments": {},
+          "action_type": "HideDatasetAction",
+          "output_name": "output_hierarchical"
+        },
+        "HideDatasetActionoutput_peptides_phosphorylation": {
+          "action_arguments": {},
+          "action_type": "HideDatasetAction",
+          "output_name": "output_peptides_phosphorylation"
+        },
+        "HideDatasetActionoutput_proteins_phosphorylation": {
+          "action_arguments": {},
+          "action_type": "HideDatasetAction",
+          "output_name": "output_proteins_phosphorylation"
+        },
+        "HideDatasetActionoutput_psm_phosphorylation": {
+          "action_arguments": {},
+          "action_type": "HideDatasetAction",
+          "output_name": "output_psm_phosphorylation"
+        }
+      },
+      "tool_errors": null,
+      "tool_id": "toolshed.g2.bx.psu.edu/repos/galaxyp/peptideshaker/peptide_shaker/1.11.0",
+      "tool_shed_repository": {
+        "changeset_revision": "78fad25eff17",
+        "name": "peptideshaker",
+        "owner": "galaxyp",
+        "tool_shed": "toolshed.g2.bx.psu.edu"
+      },
+      "tool_state": "{\"__page__\": 0, \"outputs\": \"[\\\"mzidentML\\\", \\\"7\\\"]\", \"__rerun_remap_job_id__\": null, \"filtering_options\": \"{\\\"max_precursor_error_type\\\": \\\"1\\\", \\\"filtering_options_selector\\\": \\\"yes\\\", \\\"__current_case__\\\": 1, \\\"max_precursor_error\\\": \\\"10.0\\\", \\\"exclude_unknown_ptms\\\": \\\"true\\\", \\\"max_peptide_length\\\": \\\"30\\\", \\\"min_peptide_length\\\": \\\"6\\\"}\", \"searchgui_input\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\", \"processing_options\": \"{\\\"peptide_fdr\\\": \\\"1.0\\\", \\\"protein_fdr\\\": \\\"1.0\\\", \\\"protein_fraction_mw_confidence\\\": \\\"95.0\\\", \\\"ptm_score\\\": {\\\"ptm_score_selector\\\": \\\"0\\\", \\\"__current_case__\\\": 0}, \\\"ptm_alignment\\\": \\\"true\\\", \\\"__current_case__\\\": 1, \\\"processing_options_selector\\\": \\\"yes\\\", \\\"psm_fdr\\\": \\\"1.0\\\"}\"}",
+      "tool_version": "1.11.0",
+      "type": "tool",
+      "uuid": "7840a984-7e8e-44fa-b8bb-a14c1eae2809",
+      "workflow_outputs": [
+        {
+          "label": null,
+          "output_name": "output_proteins",
+          "uuid": "14017ead-5d4e-4313-81c1-9bd854a3b22b"
+        },
+        {
+          "label": null,
+          "output_name": "mzidentML",
+          "uuid": "f40142a4-f928-44e7-8feb-6524b63d3b58"
+        },
+        {
+          "label": null,
+          "output_name": "output_psm",
+          "uuid": "f4d84abd-8329-430f-9762-4e1503a6a5c4"
+        },
+        {
+          "label": null,
+          "output_name": "output_zip",
+          "uuid": "b5133d31-7d96-43bb-b7ee-55dc79e2719c"
+        },
+        {
+          "label": null,
+          "output_name": "output_peptides",
+          "uuid": "f53dd653-c534-42a5-a86f-cc83a4d9331b"
+        }
+      ]
+    },
+    "6": {
+      "annotation": "Output: all identified contaminants.",
+      "content_id": "Grep1",
+      "id": 6,
+      "input_connections": {
+        "input": {
+          "id": 5,
+          "output_name": "output_proteins"
+        }
+      },
+      "inputs": [
+        {
+          "description": "runtime parameter for tool Select",
+          "name": "input"
+        }
+      ],
+      "label": null,
+      "name": "Select",
+      "outputs": [
+        {
+          "name": "out_file1",
+          "type": "input"
+        }
+      ],
+      "position": {
+        "left": 1149.5,
+        "top": 738.5
+      },
+      "post_job_actions": {
+        "RenameDatasetActionout_file1": {
+          "action_arguments": {
+            "newname": "contaminant_proteins"
+          },
+          "action_type": "RenameDatasetAction",
+          "output_name": "out_file1"
+        }
+      },
+      "tool_errors": null,
+      "tool_id": "Grep1",
+      "tool_state": "{\"__page__\": 0, \"input\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\", \"invert\": \"\\\"false\\\"\", \"__rerun_remap_job_id__\": null, \"pattern\": \"\\\"CONTAMINANT\\\"\"}",
+      "tool_version": "1.0.1",
+      "type": "tool",
+      "uuid": "913cd910-6e9a-4961-b1d6-9de03e7a5be0",
+      "workflow_outputs": [
+        {
+          "label": null,
+          "output_name": "out_file1",
+          "uuid": "71acf765-a1a8-449f-8e75-0f0e9cd7e97d"
+        }
+      ]
+    },
+    "7": {
+      "annotation": "Output: all identified proteins without common contaminants. CAVE: some proteins may be both!",
+      "content_id": "Grep1",
+      "id": 7,
+      "input_connections": {
+        "input": {
+          "id": 5,
+          "output_name": "output_proteins"
+        }
+      },
+      "inputs": [
+        {
+          "description": "runtime parameter for tool Select",
+          "name": "input"
+        }
+      ],
+      "label": null,
+      "name": "Select",
+      "outputs": [
+        {
+          "name": "out_file1",
+          "type": "input"
+        }
+      ],
+      "position": {
+        "left": 1152.5,
+        "top": 842.5
+      },
+      "post_job_actions": {
+        "RenameDatasetActionout_file1": {
+          "action_arguments": {
+            "newname": "non-contaminant_proteins"
+          },
+          "action_type": "RenameDatasetAction",
+          "output_name": "out_file1"
+        }
+      },
+      "tool_errors": null,
+      "tool_id": "Grep1",
+      "tool_state": "{\"__page__\": 0, \"input\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\", \"invert\": \"\\\"true\\\"\", \"__rerun_remap_job_id__\": null, \"pattern\": \"\\\"CONTAMINANT\\\"\"}",
+      "tool_version": "1.0.1",
+      "type": "tool",
+      "uuid": "b4c96aea-4f92-4eff-a322-9e4f7935db9d",
+      "workflow_outputs": [
+        {
+          "label": null,
+          "output_name": "out_file1",
+          "uuid": "a935e7bb-b5aa-43db-aa3a-2e6de6420ac5"
+        }
+      ]
+    },
+    "8": {
+      "annotation": "Output: only those non-contaminant proteins not evaluated to be \"Doubtful\".",
+      "content_id": "Grep1",
+      "id": 8,
+      "input_connections": {
+        "input": {
+          "id": 7,
+          "output_name": "out_file1"
+        }
+      },
+      "inputs": [
+        {
+          "description": "runtime parameter for tool Select",
+          "name": "input"
+        }
+      ],
+      "label": null,
+      "name": "Select",
+      "outputs": [
+        {
+          "name": "out_file1",
+          "type": "input"
+        }
+      ],
+      "position": {
+        "left": 1361.5,
+        "top": 803.5
+      },
+      "post_job_actions": {
+        "RenameDatasetActionout_file1": {
+          "action_arguments": {
+            "newname": "confident_non-contaminant_proteins"
+          },
+          "action_type": "RenameDatasetAction",
+          "output_name": "out_file1"
+        }
+      },
+      "tool_errors": null,
+      "tool_id": "Grep1",
+      "tool_state": "{\"__page__\": 0, \"input\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\", \"invert\": \"\\\"true\\\"\", \"__rerun_remap_job_id__\": null, \"pattern\": \"\\\"Doubtful\\\"\"}",
+      "tool_version": "1.0.1",
+      "type": "tool",
+      "uuid": "02ee5bf0-89d2-4598-a4ae-fdc44c35e954",
+      "workflow_outputs": [
+        {
+          "label": null,
+          "output_name": "out_file1",
+          "uuid": "5a0a1a89-a613-44cb-9b7f-ea055b9cfdaf"
+        }
+      ]
+    }
+  },
+  "uuid": "70102704-6596-4bcf-ac9c-234ce3837f2c"
 }

--- a/topics/proteomics/tutorials/protein-id-sg-ps/workflows/wf_proteinID_SG_PS_multipleFiles.ga
+++ b/topics/proteomics/tutorials/protein-id-sg-ps/workflows/wf_proteinID_SG_PS_multipleFiles.ga
@@ -1,473 +1,485 @@
 {
-    "a_galaxy_workflow": "true", 
-    "annotation": "", 
-    "format-version": "0.1", 
-    "name": "ProteinID_SG_PS_Tutorial_WF_datasetCollection", 
-    "steps": {
-        "0": {
-            "annotation": "Proteome Fasta database of organism of interest. Do not include decoys.", 
-            "content_id": null, 
-            "id": 0, 
-            "input_connections": {}, 
-            "inputs": [
-                {
-                    "description": "Proteome Fasta database of organism of interest. Do not include decoys.", 
-                    "name": "Input protein FASTA database"
-                }
-            ], 
-            "label": null, 
-            "name": "Input dataset", 
-            "outputs": [], 
-            "position": {
-                "left": 216.5, 
-                "top": 205.5
-            }, 
-            "tool_errors": null, 
-            "tool_id": null, 
-            "tool_state": "{\"name\": \"Input protein FASTA database\"}", 
-            "tool_version": null, 
-            "type": "data_input", 
-            "uuid": "74015737-98ed-47e3-8cda-3f6cf7f97078", 
-            "workflow_outputs": []
-        }, 
-        "1": {
-            "annotation": "Add all input files into a \"List of files\" first.", 
-            "content_id": null, 
-            "id": 1, 
-            "input_connections": {}, 
-            "inputs": [
-                {
-                    "description": "Add all input files into a \"List of files\" first.", 
-                    "name": "Input: List of mzML files"
-                }
-            ], 
-            "label": null, 
-            "name": "Input dataset collection", 
-            "outputs": [], 
-            "position": {
-                "left": 165, 
-                "top": 300
-            }, 
-            "tool_errors": null, 
-            "tool_id": null, 
-            "tool_state": "{\"collection_type\": \"list\", \"name\": \"Input: List of mzML files\"}", 
-            "tool_version": null, 
-            "type": "data_collection_input", 
-            "uuid": "1b360056-d424-4942-af3b-064d22841df8", 
-            "workflow_outputs": []
-        }, 
-        "2": {
-            "annotation": "", 
-            "content_id": "PeakPickerHiRes", 
-            "id": 2, 
-            "input_connections": {
-                "param_in": {
-                    "id": 1, 
-                    "output_name": "output"
-                }
-            }, 
-            "inputs": [
-                {
-                    "description": "runtime parameter for tool PeakPickerHiRes", 
-                    "name": "param_in"
-                }
-            ], 
-            "label": null, 
-            "name": "PeakPickerHiRes", 
-            "outputs": [
-                {
-                    "name": "param_out", 
-                    "type": "mzml"
-                }
-            ], 
-            "position": {
-                "left": 410, 
-                "top": 291
-            }, 
-            "post_job_actions": {
-                "HideDatasetActionparam_out": {
-                    "action_arguments": {}, 
-                    "action_type": "HideDatasetAction", 
-                    "output_name": "param_out"
-                }
-            }, 
-            "tool_errors": null, 
-            "tool_id": "PeakPickerHiRes", 
-            "tool_state": "{\"__page__\": 0, \"rep_param_algorithm_ms_levels\": \"[]\", \"param_algorithm_SignalToNoise_win_len\": \"\\\"200.0\\\"\", \"adv_opts\": \"{\\\"adv_opts_selector\\\": \\\"basic\\\", \\\"__current_case__\\\": 0}\", \"param_algorithm_SignalToNoise_bin_count\": \"\\\"30\\\"\", \"param_algorithm_report_FWHM_unit\": \"\\\"relative(ppm)\\\"\", \"param_in|__identifier__\": \"\\\"ST903.mzML centroided\\\"\", \"__rerun_remap_job_id__\": null, \"param_algorithm_signal_to_noise\": \"\\\"1.0\\\"\", \"param_algorithm_SignalToNoise_min_required_elements\": \"\\\"10\\\"\", \"param_algorithm_SignalToNoise_write_log_messages\": \"\\\"false\\\"\", \"chromInfo\": \"\\\"/usr/local/galaxy/galaxy-dist/tool-data/shared/ucsc/chrom/?.len\\\"\", \"param_algorithm_report_FWHM\": \"\\\"false\\\"\", \"param_in\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\"}", 
-            "tool_version": "2.1.0", 
-            "type": "tool", 
-            "uuid": "ed6dbbc6-7166-4681-9cb1-6071977ec9f7", 
-            "workflow_outputs": []
-        }, 
-        "3": {
-            "annotation": "", 
-            "content_id": "FileConverter", 
-            "id": 3, 
-            "input_connections": {
-                "param_in": {
-                    "id": 2, 
-                    "output_name": "param_out"
-                }
-            }, 
-            "inputs": [
-                {
-                    "description": "runtime parameter for tool FileConverter", 
-                    "name": "param_in"
-                }
-            ], 
-            "label": null, 
-            "name": "FileConverter", 
-            "outputs": [
-                {
-                    "name": "param_out", 
-                    "type": "_sniff_"
-                }
-            ], 
-            "position": {
-                "left": 594, 
-                "top": 339
-            }, 
-            "post_job_actions": {
-                "HideDatasetActionparam_out": {
-                    "action_arguments": {}, 
-                    "action_type": "HideDatasetAction", 
-                    "output_name": "param_out"
-                }
-            }, 
-            "tool_errors": null, 
-            "tool_id": "FileConverter", 
-            "tool_state": "{\"__page__\": 0, \"param_out_type\": \"\\\"mgf\\\"\", \"adv_opts\": \"{\\\"param_process_lowmemory\\\": \\\"false\\\", \\\"param_MGF_compact\\\": \\\"false\\\", \\\"adv_opts_selector\\\": \\\"advanced\\\", \\\"param_force\\\": \\\"false\\\", \\\"__current_case__\\\": 1, \\\"param_TIC_DTA2D\\\": \\\"false\\\"}\", \"__rerun_remap_job_id__\": null, \"param_in|__identifier__\": \"\\\"ST903.mzML centroided\\\"\", \"param_UID_postprocessing\": \"\\\"ensure\\\"\", \"param_write_mzML_index\": \"\\\"false\\\"\", \"chromInfo\": \"\\\"/usr/local/galaxy/galaxy-dist/tool-data/shared/ucsc/chrom/?.len\\\"\", \"param_in\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\"}", 
-            "tool_version": "2.1.0", 
-            "type": "tool", 
-            "uuid": "94853922-971c-4f02-8fa1-9cb8f3b10bc5", 
-            "workflow_outputs": []
-        }, 
-        "4": {
-            "annotation": "", 
-            "content_id": "toolshed.g2.bx.psu.edu/repos/galaxyp/peptideshaker/search_gui/2.9.0", 
-            "id": 4, 
-            "input_connections": {
-                "input_database": {
-                    "id": 0, 
-                    "output_name": "output"
-                }, 
-                "peak_lists": {
-                    "id": 3, 
-                    "output_name": "param_out"
-                }
-            }, 
-            "inputs": [
-                {
-                    "description": "runtime parameter for tool Search GUI", 
-                    "name": "peak_lists"
-                }, 
-                {
-                    "description": "runtime parameter for tool Search GUI", 
-                    "name": "input_database"
-                }
-            ], 
-            "label": null, 
-            "name": "Search GUI", 
-            "outputs": [
-                {
-                    "name": "searchgui_results", 
-                    "type": "searchgui_archive"
-                }
-            ], 
-            "position": {
-                "left": 768, 
-                "top": 207
-            }, 
-            "post_job_actions": {
-                "HideDatasetActionsearchgui_results": {
-                    "action_arguments": {}, 
-                    "action_type": "HideDatasetAction", 
-                    "output_name": "searchgui_results"
-                }
-            }, 
-            "tool_errors": null, 
-            "tool_id": "toolshed.g2.bx.psu.edu/repos/galaxyp/peptideshaker/search_gui/2.9.0", 
-            "tool_shed_repository": {
-                "changeset_revision": "78fad25eff17", 
-                "name": "peptideshaker", 
-                "owner": "galaxyp", 
-                "tool_shed": "toolshed.g2.bx.psu.edu"
-            }, 
-            "tool_state": "{\"msgf\": \"{\\\"msgf_advanced\\\": \\\"no\\\", \\\"__current_case__\\\": 0}\", \"use_gene_mapping\": \"\\\"false\\\"\", \"min_charge\": \"\\\"2\\\"\", \"__page__\": 0, \"peak_lists\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\", \"engines\": \"[\\\"X!Tandem\\\", \\\"MSGF\\\"]\", \"__rerun_remap_job_id__\": null, \"create_decoy\": \"\\\"true\\\"\", \"enzyme\": \"\\\"Trypsin\\\"\", \"precursor_ion_tol_units\": \"\\\"1\\\"\", \"omssa\": \"{\\\"omssa_advanced\\\": \\\"no\\\", \\\"__current_case__\\\": 0}\", \"precursor_ion_tol\": \"\\\"10.0\\\"\", \"variable_modifications\": \"[\\\"Oxidation of M\\\"]\", \"input_database\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\", \"fragment_tol\": \"\\\"0.5\\\"\", \"reverse_ion\": \"\\\"y\\\"\", \"forward_ion\": \"\\\"b\\\"\", \"searchgui_advanced\": \"{\\\"searchgui_advanced_selector\\\": \\\"basic\\\", \\\"__current_case__\\\": 0}\", \"xtandem\": \"{\\\"__current_case__\\\": 0, \\\"xtandem_advanced\\\": \\\"no\\\"}\", \"max_charge\": \"\\\"4\\\"\", \"fixed_modifications\": \"[\\\"Carbamidomethylation of C\\\"]\", \"comet\": \"{\\\"comet_advanced\\\": \\\"no\\\", \\\"__current_case__\\\": 0}\", \"chromInfo\": \"\\\"/usr/local/galaxy/galaxy-dist/tool-data/shared/ucsc/chrom/?.len\\\"\", \"missed_cleavages\": \"\\\"2\\\"\"}", 
-            "tool_version": "2.9.0", 
-            "type": "tool", 
-            "uuid": "d27ca46d-7f81-491d-9a4a-ef835fa5a3a8", 
-            "workflow_outputs": []
-        }, 
-        "5": {
-            "annotation": "", 
-            "content_id": "toolshed.g2.bx.psu.edu/repos/galaxyp/peptideshaker/peptide_shaker/1.11.0", 
-            "id": 5, 
-            "input_connections": {
-                "searchgui_input": {
-                    "id": 4, 
-                    "output_name": "searchgui_results"
-                }
-            }, 
-            "inputs": [
-                {
-                    "description": "runtime parameter for tool Peptide Shaker", 
-                    "name": "searchgui_input"
-                }
-            ], 
-            "label": null, 
-            "name": "Peptide Shaker", 
-            "outputs": [
-                {
-                    "name": "mzidentML", 
-                    "type": "mzid"
-                }, 
-                {
-                    "name": "output_cps", 
-                    "type": "peptideshaker_archive"
-                }, 
-                {
-                    "name": "output_zip", 
-                    "type": "zip"
-                }, 
-                {
-                    "name": "output_certificate", 
-                    "type": "txt"
-                }, 
-                {
-                    "name": "output_hierarchical", 
-                    "type": "tabular"
-                }, 
-                {
-                    "name": "output_psm_phosphorylation", 
-                    "type": "tabular"
-                }, 
-                {
-                    "name": "output_psm", 
-                    "type": "tabular"
-                }, 
-                {
-                    "name": "output_peptides_phosphorylation", 
-                    "type": "tabular"
-                }, 
-                {
-                    "name": "output_peptides", 
-                    "type": "tabular"
-                }, 
-                {
-                    "name": "output_proteins_phosphorylation", 
-                    "type": "tabular"
-                }, 
-                {
-                    "name": "output_proteins", 
-                    "type": "tabular"
-                }
-            ], 
-            "position": {
-                "left": 1056, 
-                "top": 210
-            }, 
-            "post_job_actions": {
-                "HideDatasetActionmzidentML": {
-                    "action_arguments": {}, 
-                    "action_type": "HideDatasetAction", 
-                    "output_name": "mzidentML"
-                }, 
-                "HideDatasetActionoutput_certificate": {
-                    "action_arguments": {}, 
-                    "action_type": "HideDatasetAction", 
-                    "output_name": "output_certificate"
-                }, 
-                "HideDatasetActionoutput_cps": {
-                    "action_arguments": {}, 
-                    "action_type": "HideDatasetAction", 
-                    "output_name": "output_cps"
-                }, 
-                "HideDatasetActionoutput_hierarchical": {
-                    "action_arguments": {}, 
-                    "action_type": "HideDatasetAction", 
-                    "output_name": "output_hierarchical"
-                }, 
-                "HideDatasetActionoutput_peptides_phosphorylation": {
-                    "action_arguments": {}, 
-                    "action_type": "HideDatasetAction", 
-                    "output_name": "output_peptides_phosphorylation"
-                }, 
-                "HideDatasetActionoutput_proteins_phosphorylation": {
-                    "action_arguments": {}, 
-                    "action_type": "HideDatasetAction", 
-                    "output_name": "output_proteins_phosphorylation"
-                }, 
-                "HideDatasetActionoutput_psm": {
-                    "action_arguments": {}, 
-                    "action_type": "HideDatasetAction", 
-                    "output_name": "output_psm"
-                }, 
-                "HideDatasetActionoutput_psm_phosphorylation": {
-                    "action_arguments": {}, 
-                    "action_type": "HideDatasetAction", 
-                    "output_name": "output_psm_phosphorylation"
-                }, 
-                "HideDatasetActionoutput_zip": {
-                    "action_arguments": {}, 
-                    "action_type": "HideDatasetAction", 
-                    "output_name": "output_zip"
-                }
-            }, 
-            "tool_errors": null, 
-            "tool_id": "toolshed.g2.bx.psu.edu/repos/galaxyp/peptideshaker/peptide_shaker/1.11.0", 
-            "tool_shed_repository": {
-                "changeset_revision": "78fad25eff17", 
-                "name": "peptideshaker", 
-                "owner": "galaxyp", 
-                "tool_shed": "toolshed.g2.bx.psu.edu"
-            }, 
-            "tool_state": "{\"__page__\": 0, \"processing_options\": \"{\\\"processing_options_selector\\\": \\\"no\\\", \\\"__current_case__\\\": 0}\", \"__rerun_remap_job_id__\": null, \"filtering_options\": \"{\\\"filtering_options_selector\\\": \\\"no\\\", \\\"__current_case__\\\": 0}\", \"searchgui_input\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\", \"outputs\": \"[\\\"zip\\\", \\\"mzidentML\\\", \\\"3\\\", \\\"5\\\", \\\"7\\\"]\", \"chromInfo\": \"\\\"/usr/local/galaxy/galaxy-dist/tool-data/shared/ucsc/chrom/?.len\\\"\"}", 
-            "tool_version": "1.11.0", 
-            "type": "tool", 
-            "uuid": "814dcbd4-945f-496b-906d-58e7ad93ac8e", 
-            "workflow_outputs": [
-                {
-                    "label": null, 
-                    "output_name": "output_proteins", 
-                    "uuid": "56f3da79-09c0-4ac8-8636-386de367f71e"
-                }, 
-                {
-                    "label": null, 
-                    "output_name": "output_peptides", 
-                    "uuid": "a5766292-49b9-4340-888b-6b8d4a7d773d"
-                }
-            ]
-        }, 
-        "6": {
-            "annotation": "Output: all identified contaminant proteins", 
-            "content_id": "Grep1", 
-            "id": 6, 
-            "input_connections": {
-                "input": {
-                    "id": 5, 
-                    "output_name": "output_proteins"
-                }
-            }, 
-            "inputs": [
-                {
-                    "description": "runtime parameter for tool Select", 
-                    "name": "input"
-                }
-            ], 
-            "label": null, 
-            "name": "Select", 
-            "outputs": [
-                {
-                    "name": "out_file1", 
-                    "type": "input"
-                }
-            ], 
-            "position": {
-                "left": 1351, 
-                "top": 424
-            }, 
-            "post_job_actions": {
-                "HideDatasetActionout_file1": {
-                    "action_arguments": {}, 
-                    "action_type": "HideDatasetAction", 
-                    "output_name": "out_file1"
-                }
-            }, 
-            "tool_errors": null, 
-            "tool_id": "Grep1", 
-            "tool_state": "{\"__page__\": 0, \"input\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\", \"invert\": \"\\\"false\\\"\", \"__rerun_remap_job_id__\": null, \"pattern\": \"\\\"CONTAMINANT\\\"\"}", 
-            "tool_version": "1.0.1", 
-            "type": "tool", 
-            "uuid": "9270a579-e526-4386-807b-86a3fd7c4609", 
-            "workflow_outputs": []
-        }, 
-        "7": {
-            "annotation": "Output: all identified non-contaminant proteins", 
-            "content_id": "Grep1", 
-            "id": 7, 
-            "input_connections": {
-                "input": {
-                    "id": 5, 
-                    "output_name": "output_proteins"
-                }
-            }, 
-            "inputs": [
-                {
-                    "description": "runtime parameter for tool Select", 
-                    "name": "input"
-                }
-            ], 
-            "label": null, 
-            "name": "Select", 
-            "outputs": [
-                {
-                    "name": "out_file1", 
-                    "type": "input"
-                }
-            ], 
-            "position": {
-                "left": 1353, 
-                "top": 534
-            }, 
-            "post_job_actions": {
-                "HideDatasetActionout_file1": {
-                    "action_arguments": {}, 
-                    "action_type": "HideDatasetAction", 
-                    "output_name": "out_file1"
-                }
-            }, 
-            "tool_errors": null, 
-            "tool_id": "Grep1", 
-            "tool_state": "{\"__page__\": 0, \"input\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\", \"invert\": \"\\\"true\\\"\", \"__rerun_remap_job_id__\": null, \"pattern\": \"\\\"CONTAMINANT\\\"\"}", 
-            "tool_version": "1.0.1", 
-            "type": "tool", 
-            "uuid": "ad43cc9c-bac9-4292-87b9-805abb70280d", 
-            "workflow_outputs": []
-        }, 
-        "8": {
-            "annotation": "Output: identified non-contaminant proteins, validated to be \"Confident\".", 
-            "content_id": "Grep1", 
-            "id": 8, 
-            "input_connections": {
-                "input": {
-                    "id": 7, 
-                    "output_name": "out_file1"
-                }
-            }, 
-            "inputs": [
-                {
-                    "description": "runtime parameter for tool Select", 
-                    "name": "input"
-                }
-            ], 
-            "label": null, 
-            "name": "Select", 
-            "outputs": [
-                {
-                    "name": "out_file1", 
-                    "type": "input"
-                }
-            ], 
-            "position": {
-                "left": 1546, 
-                "top": 535
-            }, 
-            "post_job_actions": {
-                "HideDatasetActionout_file1": {
-                    "action_arguments": {}, 
-                    "action_type": "HideDatasetAction", 
-                    "output_name": "out_file1"
-                }
-            }, 
-            "tool_errors": null, 
-            "tool_id": "Grep1", 
-            "tool_state": "{\"__page__\": 0, \"input\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\", \"invert\": \"\\\"true\\\"\", \"__rerun_remap_job_id__\": null, \"pattern\": \"\\\"Doubtful\\\"\"}", 
-            "tool_version": "1.0.1", 
-            "type": "tool", 
-            "uuid": "0280af4a-a81d-4cd0-8531-402fe75fb936", 
-            "workflow_outputs": []
+  "a_galaxy_workflow": "true",
+  "annotation": "",
+  "format-version": "0.1",
+  "name": "ProteinID_SG_PS_Tutorial_WF_datasetCollection",
+  "steps": {
+    "0": {
+      "annotation": "Proteome Fasta database of organism of interest. Do not include decoys.",
+      "content_id": null,
+      "id": 0,
+      "input_connections": {},
+      "inputs": [
+        {
+          "description": "Proteome Fasta database of organism of interest. Do not include decoys.",
+          "name": "Input protein FASTA database"
         }
-    }, 
-    "uuid": "3a467a4d-4748-47a3-a5b6-ccdc06fe6423"
+      ],
+      "label": null,
+      "name": "Input dataset",
+      "outputs": [],
+      "position": {
+        "left": 216.5,
+        "top": 205.5
+      },
+      "tool_errors": null,
+      "tool_id": null,
+      "tool_state": "{\"name\": \"Input protein FASTA database\"}",
+      "tool_version": null,
+      "type": "data_input",
+      "uuid": "74015737-98ed-47e3-8cda-3f6cf7f97078",
+      "workflow_outputs": []
+    },
+    "1": {
+      "annotation": "Add all input files into a \"List of files\" first.",
+      "content_id": null,
+      "id": 1,
+      "input_connections": {},
+      "inputs": [
+        {
+          "description": "Add all input files into a \"List of files\" first.",
+          "name": "Input: List of mzML files"
+        }
+      ],
+      "label": null,
+      "name": "Input dataset collection",
+      "outputs": [],
+      "position": {
+        "left": 165,
+        "top": 300
+      },
+      "tool_errors": null,
+      "tool_id": null,
+      "tool_state": "{\"collection_type\": \"list\", \"name\": \"Input: List of mzML files\"}",
+      "tool_version": null,
+      "type": "data_collection_input",
+      "uuid": "1b360056-d424-4942-af3b-064d22841df8",
+      "workflow_outputs": []
+    },
+    "2": {
+      "annotation": "",
+      "content_id": "PeakPickerHiRes",
+      "id": 2,
+      "input_connections": {
+        "param_in": {
+          "id": 1,
+          "output_name": "output"
+        }
+      },
+      "inputs": [
+        {
+          "description": "runtime parameter for tool PeakPickerHiRes",
+          "name": "param_in"
+        }
+      ],
+      "label": null,
+      "name": "PeakPickerHiRes",
+      "outputs": [
+        {
+          "name": "param_out",
+          "type": "mzml"
+        }
+      ],
+      "position": {
+        "left": 410,
+        "top": 291
+      },
+      "post_job_actions": {
+        "HideDatasetActionparam_out": {
+          "action_arguments": {},
+          "action_type": "HideDatasetAction",
+          "output_name": "param_out"
+        }
+      },
+      "tool_errors": null,
+      "tool_id": "PeakPickerHiRes",
+      "tool_state": "{\"__page__\": 0, \"rep_param_algorithm_ms_levels\": \"[]\", \"param_algorithm_SignalToNoise_win_len\": \"\\\"200.0\\\"\", \"adv_opts\": \"{\\\"adv_opts_selector\\\": \\\"basic\\\", \\\"__current_case__\\\": 0}\", \"param_algorithm_SignalToNoise_bin_count\": \"\\\"30\\\"\", \"param_algorithm_report_FWHM_unit\": \"\\\"relative(ppm)\\\"\", \"param_in|__identifier__\": \"\\\"ST903.mzML centroided\\\"\", \"__rerun_remap_job_id__\": null, \"param_algorithm_signal_to_noise\": \"\\\"1.0\\\"\", \"param_algorithm_SignalToNoise_min_required_elements\": \"\\\"10\\\"\", \"param_algorithm_SignalToNoise_write_log_messages\": \"\\\"false\\\"\", \"chromInfo\": \"\\\"/usr/local/galaxy/galaxy-dist/tool-data/shared/ucsc/chrom/?.len\\\"\", \"param_algorithm_report_FWHM\": \"\\\"false\\\"\", \"param_in\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\"}",
+      "tool_version": "2.1.0",
+      "type": "tool",
+      "uuid": "ed6dbbc6-7166-4681-9cb1-6071977ec9f7",
+      "workflow_outputs": [],
+      "tool_shed_repository": {
+        "changeset_revision": "5ae104d0da6e",
+        "name": "openms_peakpickerhires",
+        "owner": "galaxyp",
+        "tool_shed": "toolshed.g2.bx.psu.edu"
+      }
+    },
+    "3": {
+      "annotation": "",
+      "content_id": "FileConverter",
+      "id": 3,
+      "input_connections": {
+        "param_in": {
+          "id": 2,
+          "output_name": "param_out"
+        }
+      },
+      "inputs": [
+        {
+          "description": "runtime parameter for tool FileConverter",
+          "name": "param_in"
+        }
+      ],
+      "label": null,
+      "name": "FileConverter",
+      "outputs": [
+        {
+          "name": "param_out",
+          "type": "_sniff_"
+        }
+      ],
+      "position": {
+        "left": 594,
+        "top": 339
+      },
+      "post_job_actions": {
+        "HideDatasetActionparam_out": {
+          "action_arguments": {},
+          "action_type": "HideDatasetAction",
+          "output_name": "param_out"
+        }
+      },
+      "tool_errors": null,
+      "tool_id": "FileConverter",
+      "tool_state": "{\"__page__\": 0, \"param_out_type\": \"\\\"mgf\\\"\", \"adv_opts\": \"{\\\"param_process_lowmemory\\\": \\\"false\\\", \\\"param_MGF_compact\\\": \\\"false\\\", \\\"adv_opts_selector\\\": \\\"advanced\\\", \\\"param_force\\\": \\\"false\\\", \\\"__current_case__\\\": 1, \\\"param_TIC_DTA2D\\\": \\\"false\\\"}\", \"__rerun_remap_job_id__\": null, \"param_in|__identifier__\": \"\\\"ST903.mzML centroided\\\"\", \"param_UID_postprocessing\": \"\\\"ensure\\\"\", \"param_write_mzML_index\": \"\\\"false\\\"\", \"chromInfo\": \"\\\"/usr/local/galaxy/galaxy-dist/tool-data/shared/ucsc/chrom/?.len\\\"\", \"param_in\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\"}",
+      "tool_version": "2.1.0",
+      "type": "tool",
+      "uuid": "94853922-971c-4f02-8fa1-9cb8f3b10bc5",
+      "workflow_outputs": [],
+      "tool_shed_repository": {
+        "changeset_revision": "6634cad7d797",
+        "name": "openms_fileconverter",
+        "owner": "galaxyp",
+        "tool_shed": "toolshed.g2.bx.psu.edu"
+      }
+    },
+    "4": {
+      "annotation": "",
+      "content_id": "toolshed.g2.bx.psu.edu/repos/galaxyp/peptideshaker/search_gui/2.9.0",
+      "id": 4,
+      "input_connections": {
+        "input_database": {
+          "id": 0,
+          "output_name": "output"
+        },
+        "peak_lists": {
+          "id": 3,
+          "output_name": "param_out"
+        }
+      },
+      "inputs": [
+        {
+          "description": "runtime parameter for tool Search GUI",
+          "name": "peak_lists"
+        },
+        {
+          "description": "runtime parameter for tool Search GUI",
+          "name": "input_database"
+        }
+      ],
+      "label": null,
+      "name": "Search GUI",
+      "outputs": [
+        {
+          "name": "searchgui_results",
+          "type": "searchgui_archive"
+        }
+      ],
+      "position": {
+        "left": 768,
+        "top": 207
+      },
+      "post_job_actions": {
+        "HideDatasetActionsearchgui_results": {
+          "action_arguments": {},
+          "action_type": "HideDatasetAction",
+          "output_name": "searchgui_results"
+        }
+      },
+      "tool_errors": null,
+      "tool_id": "toolshed.g2.bx.psu.edu/repos/galaxyp/peptideshaker/search_gui/2.9.0",
+      "tool_shed_repository": {
+        "changeset_revision": "78fad25eff17",
+        "name": "peptideshaker",
+        "owner": "galaxyp",
+        "tool_shed": "toolshed.g2.bx.psu.edu"
+      },
+      "tool_state": "{\"msgf\": \"{\\\"msgf_advanced\\\": \\\"no\\\", \\\"__current_case__\\\": 0}\", \"use_gene_mapping\": \"\\\"false\\\"\", \"min_charge\": \"\\\"2\\\"\", \"__page__\": 0, \"peak_lists\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\", \"engines\": \"[\\\"X!Tandem\\\", \\\"MSGF\\\"]\", \"__rerun_remap_job_id__\": null, \"create_decoy\": \"\\\"true\\\"\", \"enzyme\": \"\\\"Trypsin\\\"\", \"precursor_ion_tol_units\": \"\\\"1\\\"\", \"omssa\": \"{\\\"omssa_advanced\\\": \\\"no\\\", \\\"__current_case__\\\": 0}\", \"precursor_ion_tol\": \"\\\"10.0\\\"\", \"variable_modifications\": \"[\\\"Oxidation of M\\\"]\", \"input_database\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\", \"fragment_tol\": \"\\\"0.5\\\"\", \"reverse_ion\": \"\\\"y\\\"\", \"forward_ion\": \"\\\"b\\\"\", \"searchgui_advanced\": \"{\\\"searchgui_advanced_selector\\\": \\\"basic\\\", \\\"__current_case__\\\": 0}\", \"xtandem\": \"{\\\"__current_case__\\\": 0, \\\"xtandem_advanced\\\": \\\"no\\\"}\", \"max_charge\": \"\\\"4\\\"\", \"fixed_modifications\": \"[\\\"Carbamidomethylation of C\\\"]\", \"comet\": \"{\\\"comet_advanced\\\": \\\"no\\\", \\\"__current_case__\\\": 0}\", \"chromInfo\": \"\\\"/usr/local/galaxy/galaxy-dist/tool-data/shared/ucsc/chrom/?.len\\\"\", \"missed_cleavages\": \"\\\"2\\\"\"}",
+      "tool_version": "2.9.0",
+      "type": "tool",
+      "uuid": "d27ca46d-7f81-491d-9a4a-ef835fa5a3a8",
+      "workflow_outputs": []
+    },
+    "5": {
+      "annotation": "",
+      "content_id": "toolshed.g2.bx.psu.edu/repos/galaxyp/peptideshaker/peptide_shaker/1.11.0",
+      "id": 5,
+      "input_connections": {
+        "searchgui_input": {
+          "id": 4,
+          "output_name": "searchgui_results"
+        }
+      },
+      "inputs": [
+        {
+          "description": "runtime parameter for tool Peptide Shaker",
+          "name": "searchgui_input"
+        }
+      ],
+      "label": null,
+      "name": "Peptide Shaker",
+      "outputs": [
+        {
+          "name": "mzidentML",
+          "type": "mzid"
+        },
+        {
+          "name": "output_cps",
+          "type": "peptideshaker_archive"
+        },
+        {
+          "name": "output_zip",
+          "type": "zip"
+        },
+        {
+          "name": "output_certificate",
+          "type": "txt"
+        },
+        {
+          "name": "output_hierarchical",
+          "type": "tabular"
+        },
+        {
+          "name": "output_psm_phosphorylation",
+          "type": "tabular"
+        },
+        {
+          "name": "output_psm",
+          "type": "tabular"
+        },
+        {
+          "name": "output_peptides_phosphorylation",
+          "type": "tabular"
+        },
+        {
+          "name": "output_peptides",
+          "type": "tabular"
+        },
+        {
+          "name": "output_proteins_phosphorylation",
+          "type": "tabular"
+        },
+        {
+          "name": "output_proteins",
+          "type": "tabular"
+        }
+      ],
+      "position": {
+        "left": 1056,
+        "top": 210
+      },
+      "post_job_actions": {
+        "HideDatasetActionmzidentML": {
+          "action_arguments": {},
+          "action_type": "HideDatasetAction",
+          "output_name": "mzidentML"
+        },
+        "HideDatasetActionoutput_certificate": {
+          "action_arguments": {},
+          "action_type": "HideDatasetAction",
+          "output_name": "output_certificate"
+        },
+        "HideDatasetActionoutput_cps": {
+          "action_arguments": {},
+          "action_type": "HideDatasetAction",
+          "output_name": "output_cps"
+        },
+        "HideDatasetActionoutput_hierarchical": {
+          "action_arguments": {},
+          "action_type": "HideDatasetAction",
+          "output_name": "output_hierarchical"
+        },
+        "HideDatasetActionoutput_peptides_phosphorylation": {
+          "action_arguments": {},
+          "action_type": "HideDatasetAction",
+          "output_name": "output_peptides_phosphorylation"
+        },
+        "HideDatasetActionoutput_proteins_phosphorylation": {
+          "action_arguments": {},
+          "action_type": "HideDatasetAction",
+          "output_name": "output_proteins_phosphorylation"
+        },
+        "HideDatasetActionoutput_psm": {
+          "action_arguments": {},
+          "action_type": "HideDatasetAction",
+          "output_name": "output_psm"
+        },
+        "HideDatasetActionoutput_psm_phosphorylation": {
+          "action_arguments": {},
+          "action_type": "HideDatasetAction",
+          "output_name": "output_psm_phosphorylation"
+        },
+        "HideDatasetActionoutput_zip": {
+          "action_arguments": {},
+          "action_type": "HideDatasetAction",
+          "output_name": "output_zip"
+        }
+      },
+      "tool_errors": null,
+      "tool_id": "toolshed.g2.bx.psu.edu/repos/galaxyp/peptideshaker/peptide_shaker/1.11.0",
+      "tool_shed_repository": {
+        "changeset_revision": "78fad25eff17",
+        "name": "peptideshaker",
+        "owner": "galaxyp",
+        "tool_shed": "toolshed.g2.bx.psu.edu"
+      },
+      "tool_state": "{\"__page__\": 0, \"processing_options\": \"{\\\"processing_options_selector\\\": \\\"no\\\", \\\"__current_case__\\\": 0}\", \"__rerun_remap_job_id__\": null, \"filtering_options\": \"{\\\"filtering_options_selector\\\": \\\"no\\\", \\\"__current_case__\\\": 0}\", \"searchgui_input\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\", \"outputs\": \"[\\\"zip\\\", \\\"mzidentML\\\", \\\"3\\\", \\\"5\\\", \\\"7\\\"]\", \"chromInfo\": \"\\\"/usr/local/galaxy/galaxy-dist/tool-data/shared/ucsc/chrom/?.len\\\"\"}",
+      "tool_version": "1.11.0",
+      "type": "tool",
+      "uuid": "814dcbd4-945f-496b-906d-58e7ad93ac8e",
+      "workflow_outputs": [
+        {
+          "label": null,
+          "output_name": "output_proteins",
+          "uuid": "56f3da79-09c0-4ac8-8636-386de367f71e"
+        },
+        {
+          "label": null,
+          "output_name": "output_peptides",
+          "uuid": "a5766292-49b9-4340-888b-6b8d4a7d773d"
+        }
+      ]
+    },
+    "6": {
+      "annotation": "Output: all identified contaminant proteins",
+      "content_id": "Grep1",
+      "id": 6,
+      "input_connections": {
+        "input": {
+          "id": 5,
+          "output_name": "output_proteins"
+        }
+      },
+      "inputs": [
+        {
+          "description": "runtime parameter for tool Select",
+          "name": "input"
+        }
+      ],
+      "label": null,
+      "name": "Select",
+      "outputs": [
+        {
+          "name": "out_file1",
+          "type": "input"
+        }
+      ],
+      "position": {
+        "left": 1351,
+        "top": 424
+      },
+      "post_job_actions": {
+        "HideDatasetActionout_file1": {
+          "action_arguments": {},
+          "action_type": "HideDatasetAction",
+          "output_name": "out_file1"
+        }
+      },
+      "tool_errors": null,
+      "tool_id": "Grep1",
+      "tool_state": "{\"__page__\": 0, \"input\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\", \"invert\": \"\\\"false\\\"\", \"__rerun_remap_job_id__\": null, \"pattern\": \"\\\"CONTAMINANT\\\"\"}",
+      "tool_version": "1.0.1",
+      "type": "tool",
+      "uuid": "9270a579-e526-4386-807b-86a3fd7c4609",
+      "workflow_outputs": []
+    },
+    "7": {
+      "annotation": "Output: all identified non-contaminant proteins",
+      "content_id": "Grep1",
+      "id": 7,
+      "input_connections": {
+        "input": {
+          "id": 5,
+          "output_name": "output_proteins"
+        }
+      },
+      "inputs": [
+        {
+          "description": "runtime parameter for tool Select",
+          "name": "input"
+        }
+      ],
+      "label": null,
+      "name": "Select",
+      "outputs": [
+        {
+          "name": "out_file1",
+          "type": "input"
+        }
+      ],
+      "position": {
+        "left": 1353,
+        "top": 534
+      },
+      "post_job_actions": {
+        "HideDatasetActionout_file1": {
+          "action_arguments": {},
+          "action_type": "HideDatasetAction",
+          "output_name": "out_file1"
+        }
+      },
+      "tool_errors": null,
+      "tool_id": "Grep1",
+      "tool_state": "{\"__page__\": 0, \"input\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\", \"invert\": \"\\\"true\\\"\", \"__rerun_remap_job_id__\": null, \"pattern\": \"\\\"CONTAMINANT\\\"\"}",
+      "tool_version": "1.0.1",
+      "type": "tool",
+      "uuid": "ad43cc9c-bac9-4292-87b9-805abb70280d",
+      "workflow_outputs": []
+    },
+    "8": {
+      "annotation": "Output: identified non-contaminant proteins, validated to be \"Confident\".",
+      "content_id": "Grep1",
+      "id": 8,
+      "input_connections": {
+        "input": {
+          "id": 7,
+          "output_name": "out_file1"
+        }
+      },
+      "inputs": [
+        {
+          "description": "runtime parameter for tool Select",
+          "name": "input"
+        }
+      ],
+      "label": null,
+      "name": "Select",
+      "outputs": [
+        {
+          "name": "out_file1",
+          "type": "input"
+        }
+      ],
+      "position": {
+        "left": 1546,
+        "top": 535
+      },
+      "post_job_actions": {
+        "HideDatasetActionout_file1": {
+          "action_arguments": {},
+          "action_type": "HideDatasetAction",
+          "output_name": "out_file1"
+        }
+      },
+      "tool_errors": null,
+      "tool_id": "Grep1",
+      "tool_state": "{\"__page__\": 0, \"input\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\", \"invert\": \"\\\"true\\\"\", \"__rerun_remap_job_id__\": null, \"pattern\": \"\\\"Doubtful\\\"\"}",
+      "tool_version": "1.0.1",
+      "type": "tool",
+      "uuid": "0280af4a-a81d-4cd0-8531-402fe75fb936",
+      "workflow_outputs": []
+    }
+  },
+  "uuid": "3a467a4d-4748-47a3-a5b6-ccdc06fe6423"
 }

--- a/topics/proteomics/tutorials/proteogenomics-dbcreation/workflows/galaxy-workflow-mouse_rnaseq_dbcreation.ga
+++ b/topics/proteomics/tutorials/proteogenomics-dbcreation/workflows/galaxy-workflow-mouse_rnaseq_dbcreation.ga
@@ -1381,7 +1381,7 @@
         "tool_shed": "toolshed.g2.bx.psu.edu"
       },
       "tool_state": "{\"outputIndels\": \"\\\"true\\\"\", \"__page__\": null, \"outputSQLite\": \"\\\"true\\\"\", \"outputRData\": \"\\\"true\\\"\", \"genome_annotation\": \"{\\\"cosmic\\\": \\\"false\\\", \\\"bamInput\\\": {\\\"__class__\\\": \\\"RuntimeValue\\\"}, \\\"source\\\": \\\"builtin\\\", \\\"builtin\\\": \\\"mmusculus_gene_ensembl_89_dbsnp142\\\", \\\"__current_case__\\\": 0, \\\"vcfInput\\\": {\\\"__class__\\\": \\\"RuntimeValue\\\"}, \\\"dbsnpInCoding\\\": \\\"true\\\"}\", \"__rerun_remap_job_id__\": null, \"rpkmCutoff\": \"\\\"1.0\\\"\"}",
-      "tool_version": "1.16.1.0",
+      "tool_version": "1.22.0",
       "type": "tool",
       "uuid": "8a61b496-8961-4b74-a65a-8758939aa410",
       "workflow_outputs": []

--- a/topics/proteomics/tutorials/secretome-prediction/workflows/WF_secretomePrediction_goWolfpsort.ga
+++ b/topics/proteomics/tutorials/secretome-prediction/workflows/WF_secretomePrediction_goWolfpsort.ga
@@ -1,1361 +1,1295 @@
 {
-  "a_galaxy_workflow": "true",
-  "annotation": "version 1.0, 160318, published at https://github.com/Stortebecker/secretome_prediction",
-  "format-version": "0.1",
-  "name": "Secreted Proteins via GO annotation and WoLF PSORT for shCTSB paper",
-  "steps": {
-    "0": {
-      "annotation": "Input: Protein ID list\nFirst column has to be uniprot accessions",
-      "content_id": null,
-      "id": 0,
-      "input_connections": {},
-      "inputs": [
-        {
-          "description": "Input: Protein ID list\nFirst column has to be uniprot accessions",
-          "name": "Custom Protein list (uniprot accession)"
-        }
-      ],
-      "label": null,
-      "name": "Input dataset",
-      "outputs": [],
-      "position": {
-        "left": 293,
-        "top": 377
-      },
-      "tool_errors": null,
-      "tool_id": null,
-      "tool_state": "{\"name\": \"Custom Protein list (uniprot accession)\"}",
-      "tool_version": null,
-      "type": "data_input",
-      "uuid": "4d60060c-188b-4a93-8320-36f9b43e5765",
-      "workflow_outputs": [
-        {
-          "label": null,
-          "output_name": "output",
-          "uuid": "27022e50-f5dc-46b1-8b54-979f955eb050"
-        }
-      ]
-    },
-    "1": {
-      "annotation": "Input: Uniprot GO database file (choose the right organism)\nExample: ftp://ftp.ebi.ac.uk/pub/databases/GO/goa/HUMAN/gene_association.goa_human.gz",
-      "content_id": null,
-      "id": 1,
-      "input_connections": {},
-      "inputs": [
-        {
-          "description": "Input: Uniprot GO database file (choose the right organism)\nExample: ftp://ftp.ebi.ac.uk/pub/databases/GO/goa/HUMAN/gene_association.goa_human.gz",
-          "name": "Uniprot GO database"
-        }
-      ],
-      "label": null,
-      "name": "Input dataset",
-      "outputs": [],
-      "position": {
-        "left": 290,
-        "top": 507
-      },
-      "tool_errors": null,
-      "tool_id": null,
-      "tool_state": "{\"name\": \"Uniprot GO database\"}",
-      "tool_version": null,
-      "type": "data_input",
-      "uuid": "e8f4a577-7b6a-4cd0-9a74-2e68c4ae6c5a",
-      "workflow_outputs": [
-        {
-          "label": null,
-          "output_name": "output",
-          "uuid": "b8fa36c2-6bbf-40c1-a472-8d4a6a7096c3"
-        }
-      ]
-    },
-    "2": {
-      "annotation": "Input: Please downlad the Open Biomedical Ontology (OBO), i.e. \"GO term tree\" from\nhttp://purl.obolibrary.org/obo/go/go.obo",
-      "content_id": null,
-      "id": 2,
-      "input_connections": {},
-      "inputs": [
-        {
-          "description": "Input: Please downlad the Open Biomedical Ontology (OBO), i.e. \"GO term tree\" from\nhttp://purl.obolibrary.org/obo/go/go.obo",
-          "name": "Open Biomedical Ontology (OBO)"
-        }
-      ],
-      "label": null,
-      "name": "Input dataset",
-      "outputs": [],
-      "position": {
-        "left": 293,
-        "top": 790
-      },
-      "tool_errors": null,
-      "tool_id": null,
-      "tool_state": "{\"name\": \"Open Biomedical Ontology (OBO)\"}",
-      "tool_version": null,
-      "type": "data_input",
-      "uuid": "0640e1c4-4d77-49da-8473-0018e0a5db09",
-      "workflow_outputs": [
-        {
-          "label": null,
-          "output_name": "output",
-          "uuid": "4725c10d-9e7a-4e3f-9874-c302c34687cb"
-        }
-      ]
-    },
-    "3": {
-      "annotation": "Retrieves Fasta files for all proteins in the input list.",
-      "content_id": "toolshed.g2.bx.psu.edu/repos/bgruening/uniprot_rest_interface/uniprot/0.1",
-      "id": 3,
-      "input_connections": {
-        "infile": {
-          "id": 0,
-          "output_name": "output"
-        }
-      },
-      "inputs": [],
-      "label": null,
-      "name": "UniProt",
-      "outputs": [
-        {
-          "name": "outfile_retrieve_fasta",
-          "type": "fasta"
-        },
-        {
-          "name": "outfile_retrieve_gff",
-          "type": "gff"
-        },
-        {
-          "name": "outfile_retrieve_txt",
-          "type": "txt"
-        },
-        {
-          "name": "outfile_map",
-          "type": "tabular"
-        }
-      ],
-      "position": {
-        "left": 573.75,
-        "top": 258.75
-      },
-      "post_job_actions": {
-        "HideDatasetActionoutfile_map": {
-          "action_arguments": {},
-          "action_type": "HideDatasetAction",
-          "output_name": "outfile_map"
-        },
-        "HideDatasetActionoutfile_retrieve_fasta": {
-          "action_arguments": {},
-          "action_type": "HideDatasetAction",
-          "output_name": "outfile_retrieve_fasta"
-        },
-        "HideDatasetActionoutfile_retrieve_gff": {
-          "action_arguments": {},
-          "action_type": "HideDatasetAction",
-          "output_name": "outfile_retrieve_gff"
-        },
-        "HideDatasetActionoutfile_retrieve_txt": {
-          "action_arguments": {},
-          "action_type": "HideDatasetAction",
-          "output_name": "outfile_retrieve_txt"
-        }
-      },
-      "tool_errors": null,
-      "tool_id": "toolshed.g2.bx.psu.edu/repos/bgruening/uniprot_rest_interface/uniprot/0.1",
-      "tool_state": "{\"__page__\": 0, \"tool\": \"{\\\"format\\\": \\\"fasta\\\", \\\"__current_case__\\\": 1, \\\"tool_choice\\\": \\\"retrieve\\\"}\", \"__rerun_remap_job_id__\": null, \"id_column\": \"\\\"1\\\"\", \"infile\": \"null\"}",
-      "tool_version": "0.1",
-      "type": "tool",
-      "uuid": "d6d73f27-bb3e-4763-825a-23d457df38af",
-      "workflow_outputs": [],
+    "a_galaxy_workflow": "true", 
+    "annotation": "version 1.0, 160318, published at https://github.com/Stortebecker/secretome_prediction", 
+    "format-version": "0.1", 
+    "name": "Secreted Proteins via GO annotation and WoLF PSORT for shCTSB paper", 
+    "steps": {
+        "0": {
+            "annotation": "Input: Protein ID list\nFirst column has to be uniprot accessions", 
+            "content_id": null, 
+            "id": 0, 
+            "input_connections": {}, 
+            "inputs": [
+                {
+                    "description": "Input: Protein ID list\nFirst column has to be uniprot accessions", 
+                    "name": "Custom Protein list (uniprot accession)"
+                }
+            ], 
+            "label": null, 
+            "name": "Input dataset", 
+            "outputs": [], 
+            "position": {
+                "left": 293, 
+                "top": 377
+            }, 
+            "tool_errors": null, 
+            "tool_id": null, 
+            "tool_state": "{\"name\": \"Custom Protein list (uniprot accession)\"}", 
+            "tool_version": null, 
+            "type": "data_input", 
+            "uuid": "4d60060c-188b-4a93-8320-36f9b43e5765", 
+            "workflow_outputs": [
+                {
+                    "label": null, 
+                    "output_name": "output", 
+                    "uuid": "27022e50-f5dc-46b1-8b54-979f955eb050"
+                }
+            ]
+        }, 
+        "1": {
+            "annotation": "Input: Uniprot GO database file (choose the right organism)\nExample: ftp://ftp.ebi.ac.uk/pub/databases/GO/goa/HUMAN/gene_association.goa_human.gz", 
+            "content_id": null, 
+            "id": 1, 
+            "input_connections": {}, 
+            "inputs": [
+                {
+                    "description": "Input: Uniprot GO database file (choose the right organism)\nExample: ftp://ftp.ebi.ac.uk/pub/databases/GO/goa/HUMAN/gene_association.goa_human.gz", 
+                    "name": "Uniprot GO database"
+                }
+            ], 
+            "label": null, 
+            "name": "Input dataset", 
+            "outputs": [], 
+            "position": {
+                "left": 290, 
+                "top": 507
+            }, 
+            "tool_errors": null, 
+            "tool_id": null, 
+            "tool_state": "{\"name\": \"Uniprot GO database\"}", 
+            "tool_version": null, 
+            "type": "data_input", 
+            "uuid": "e8f4a577-7b6a-4cd0-9a74-2e68c4ae6c5a", 
+            "workflow_outputs": [
+                {
+                    "label": null, 
+                    "output_name": "output", 
+                    "uuid": "b8fa36c2-6bbf-40c1-a472-8d4a6a7096c3"
+                }
+            ]
+        }, 
+        "2": {
+            "annotation": "Input: Please downlad the Open Biomedical Ontology (OBO), i.e. \"GO term tree\" from\nhttp://purl.obolibrary.org/obo/go/go.obo", 
+            "content_id": null, 
+            "id": 2, 
+            "input_connections": {}, 
+            "inputs": [
+                {
+                    "description": "Input: Please downlad the Open Biomedical Ontology (OBO), i.e. \"GO term tree\" from\nhttp://purl.obolibrary.org/obo/go/go.obo", 
+                    "name": "Open Biomedical Ontology (OBO)"
+                }
+            ], 
+            "label": null, 
+            "name": "Input dataset", 
+            "outputs": [], 
+            "position": {
+                "left": 293, 
+                "top": 790
+            }, 
+            "tool_errors": null, 
+            "tool_id": null, 
+            "tool_state": "{\"name\": \"Open Biomedical Ontology (OBO)\"}", 
+            "tool_version": null, 
+            "type": "data_input", 
+            "uuid": "0640e1c4-4d77-49da-8473-0018e0a5db09", 
+            "workflow_outputs": [
+                {
+                    "label": null, 
+                    "output_name": "output", 
+                    "uuid": "4725c10d-9e7a-4e3f-9874-c302c34687cb"
+                }
+            ]
+        }, 
+        "3": {
+            "annotation": "Retrieves Fasta files for all proteins in the input list.", 
+            "content_id": "toolshed.g2.bx.psu.edu/repos/bgruening/uniprot_rest_interface/uniprot/0.1", 
+            "id": 3, 
+            "input_connections": {
+                "infile": {
+                    "id": 0, 
+                    "output_name": "output"
+                }
+            }, 
+            "inputs": [], 
+            "label": null, 
+            "name": "UniProt", 
+            "outputs": [
+                {
+                    "name": "outfile_retrieve_fasta", 
+                    "type": "fasta"
+                }, 
+                {
+                    "name": "outfile_retrieve_gff", 
+                    "type": "gff"
+                }, 
+                {
+                    "name": "outfile_retrieve_txt", 
+                    "type": "txt"
+                }, 
+                {
+                    "name": "outfile_map", 
+                    "type": "tabular"
+                }
+            ], 
+            "position": {
+                "left": 573.75, 
+                "top": 258.75
+            }, 
+            "post_job_actions": {
+                "HideDatasetActionoutfile_map": {
+                    "action_arguments": {}, 
+                    "action_type": "HideDatasetAction", 
+                    "output_name": "outfile_map"
+                }, 
+                "HideDatasetActionoutfile_retrieve_fasta": {
+                    "action_arguments": {}, 
+                    "action_type": "HideDatasetAction", 
+                    "output_name": "outfile_retrieve_fasta"
+                }, 
+                "HideDatasetActionoutfile_retrieve_gff": {
+                    "action_arguments": {}, 
+                    "action_type": "HideDatasetAction", 
+                    "output_name": "outfile_retrieve_gff"
+                }, 
+                "HideDatasetActionoutfile_retrieve_txt": {
+                    "action_arguments": {}, 
+                    "action_type": "HideDatasetAction", 
+                    "output_name": "outfile_retrieve_txt"
+                }
+            }, 
+            "tool_errors": null, 
+            "tool_id": "toolshed.g2.bx.psu.edu/repos/bgruening/uniprot_rest_interface/uniprot/0.1", 
+            "tool_state": "{\"__page__\": 0, \"tool\": \"{\\\"format\\\": \\\"fasta\\\", \\\"__current_case__\\\": 1, \\\"tool_choice\\\": \\\"retrieve\\\"}\", \"__rerun_remap_job_id__\": null, \"id_column\": \"\\\"1\\\"\", \"infile\": \"null\"}", 
+            "tool_version": "0.1", 
+            "type": "tool", 
+            "uuid": "d6d73f27-bb3e-4763-825a-23d457df38af", 
+            "workflow_outputs": [],
       "tool_shed_repository": {
         "changeset_revision": "f7ebd1b4783b",
         "name": "uniprot_rest_interface",
         "owner": "bgruening",
         "tool_shed": "toolshed.g2.bx.psu.edu"
       }
-    },
-    "4": {
-      "annotation": "Removes comment lines at the head of the Uniprot Go database file.",
-      "content_id": "Grep1",
-      "id": 4,
-      "input_connections": {
-        "input": {
-          "id": 1,
-          "output_name": "output"
-        }
-      },
-      "inputs": [],
-      "label": null,
-      "name": "Select",
-      "outputs": [
-        {
-          "name": "out_file1",
-          "type": "input"
-        }
-      ],
-      "position": {
-        "left": 552,
-        "top": 505
-      },
-      "post_job_actions": {
-        "ChangeDatatypeActionout_file1": {
-          "action_arguments": {
-            "newtype": "tabular"
-          },
-          "action_type": "ChangeDatatypeAction",
-          "output_name": "out_file1"
-        },
-        "HideDatasetActionout_file1": {
-          "action_arguments": {},
-          "action_type": "HideDatasetAction",
-          "output_name": "out_file1"
-        }
-      },
-      "tool_errors": null,
-      "tool_id": "Grep1",
-      "tool_state": "{\"__page__\": 0, \"input\": \"null\", \"invert\": \"\\\"true\\\"\", \"__rerun_remap_job_id__\": null, \"pattern\": \"\\\"^!\\\"\"}",
-      "tool_version": "1.0.1",
-      "type": "tool",
-      "uuid": "11c206f4-bc11-400c-8bd5-335bc8c6d63d",
-      "workflow_outputs": []
-    },
-    "5": {
-      "annotation": "GO:0043230 \"extracellular organelle\"",
-      "content_id": "get_subontology_from",
-      "id": 5,
-      "input_connections": {
-        "input_ontology": {
-          "id": 2,
-          "output_name": "output"
-        }
-      },
-      "inputs": [],
-      "label": null,
-      "name": "Get subontology from a given OBO term",
-      "outputs": [
-        {
-          "name": "output",
-          "type": "txt"
-        }
-      ],
-      "position": {
-        "left": 549,
-        "top": 663
-      },
-      "post_job_actions": {
-        "HideDatasetActionoutput": {
-          "action_arguments": {},
-          "action_type": "HideDatasetAction",
-          "output_name": "output"
-        }
-      },
-      "tool_errors": null,
-      "tool_id": "onto_tk_get_subontology_from",
-      "tool_state": "{\"__page__\": 0, \"__rerun_remap_job_id__\": null, \"new_root\": \"\\\"GO:0043230\\\"\", \"input_ontology\": \"null\"}",
-      "tool_version": "1.45.0",
-      "type": "tool",
-      "uuid": "636177a8-5b63-457c-acaa-518748094834",
-      "workflow_outputs": [],
-      "tool_shed_repository": {
-        "changeset_revision": "1b3796bc5ac0",
-        "name": "onto_tk_get_subontology_from",
-        "owner": "iuc",
-        "tool_shed": "toolshed.g2.bx.psu.edu"
-      }
-    },
-    "6": {
-      "annotation": "GO:0005576 \"extracellular region\"",
-      "content_id": "get_subontology_from",
-      "id": 6,
-      "input_connections": {
-        "input_ontology": {
-          "id": 2,
-          "output_name": "output"
-        }
-      },
-      "inputs": [],
-      "label": null,
-      "name": "Get subontology from a given OBO term",
-      "outputs": [
-        {
-          "name": "output",
-          "type": "txt"
-        }
-      ],
-      "position": {
-        "left": 549,
-        "top": 814
-      },
-      "post_job_actions": {
-        "HideDatasetActionoutput": {
-          "action_arguments": {},
-          "action_type": "HideDatasetAction",
-          "output_name": "output"
-        }
-      },
-      "tool_errors": null,
-      "tool_id": "onto_tk_get_subontology_from",
-      "tool_state": "{\"__page__\": 0, \"__rerun_remap_job_id__\": null, \"new_root\": \"\\\"GO:0005576\\\"\", \"input_ontology\": \"null\"}",
-      "tool_version": "1.45.0",
-      "type": "tool",
-      "uuid": "163ebfd8-82c8-430e-a37f-e6670cb5069e",
-      "workflow_outputs": [],
-      "tool_shed_repository": {
-        "changeset_revision": "1b3796bc5ac0",
-        "name": "onto_tk_get_subontology_from",
-        "owner": "iuc",
-        "tool_shed": "toolshed.g2.bx.psu.edu"
-      }
-    },
-    "7": {
-      "annotation": "GO:0005887 \"integral component of plasma membrane\"",
-      "content_id": "get_subontology_from",
-      "id": 7,
-      "input_connections": {
-        "input_ontology": {
-          "id": 2,
-          "output_name": "output"
-        }
-      },
-      "inputs": [],
-      "label": null,
-      "name": "Get subontology from a given OBO term",
-      "outputs": [
-        {
-          "name": "output",
-          "type": "txt"
-        }
-      ],
-      "position": {
-        "left": 551.75,
-        "top": 918.75
-      },
-      "post_job_actions": {
-        "HideDatasetActionoutput": {
-          "action_arguments": {},
-          "action_type": "HideDatasetAction",
-          "output_name": "output"
-        }
-      },
-      "tool_errors": null,
-      "tool_id": "onto_tk_get_subontology_from",
-      "tool_state": "{\"__page__\": 0, \"__rerun_remap_job_id__\": null, \"new_root\": \"\\\"GO:0005887\\\"\", \"input_ontology\": \"null\"}",
-      "tool_version": "1.45.0",
-      "type": "tool",
-      "uuid": "c3b4bd46-4f3a-46a0-927d-4fc15bc9f4d5",
-      "workflow_outputs": [],
-      "tool_shed_repository": {
-        "changeset_revision": "1b3796bc5ac0",
-        "name": "onto_tk_get_subontology_from",
-        "owner": "iuc",
-        "tool_shed": "toolshed.g2.bx.psu.edu"
-      }
-    },
-    "8": {
-      "annotation": "GO:0009986 \"cell surface\"",
-      "content_id": "get_subontology_from",
-      "id": 8,
-      "input_connections": {
-        "input_ontology": {
-          "id": 2,
-          "output_name": "output"
-        }
-      },
-      "inputs": [],
-      "label": null,
-      "name": "Get subontology from a given OBO term",
-      "outputs": [
-        {
-          "name": "output",
-          "type": "txt"
-        }
-      ],
-      "position": {
-        "left": 554.75,
-        "top": 1029.75
-      },
-      "post_job_actions": {
-        "HideDatasetActionoutput": {
-          "action_arguments": {},
-          "action_type": "HideDatasetAction",
-          "output_name": "output"
-        }
-      },
-      "tool_errors": null,
-      "tool_id": "onto_tk_get_subontology_from",
-      "tool_state": "{\"__page__\": 0, \"__rerun_remap_job_id__\": null, \"new_root\": \"\\\"GO:0009986\\\"\", \"input_ontology\": \"null\"}",
-      "tool_version": "1.45.0",
-      "type": "tool",
-      "uuid": "608f525c-f9f7-4ea5-abc6-89d97f171c53",
-      "workflow_outputs": [],
-      "tool_shed_repository": {
-        "changeset_revision": "1b3796bc5ac0",
-        "name": "onto_tk_get_subontology_from",
-        "owner": "iuc",
-        "tool_shed": "toolshed.g2.bx.psu.edu"
-      }
-    },
-    "9": {
-      "annotation": "GO:0005764 \"lysosome\"",
-      "content_id": "get_subontology_from",
-      "id": 9,
-      "input_connections": {
-        "input_ontology": {
-          "id": 2,
-          "output_name": "output"
-        }
-      },
-      "inputs": [],
-      "label": null,
-      "name": "Get subontology from a given OBO term",
-      "outputs": [
-        {
-          "name": "output",
-          "type": "txt"
-        }
-      ],
-      "position": {
-        "left": 556.75,
-        "top": 1137.75
-      },
-      "post_job_actions": {
-        "HideDatasetActionoutput": {
-          "action_arguments": {},
-          "action_type": "HideDatasetAction",
-          "output_name": "output"
-        }
-      },
-      "tool_errors": null,
-      "tool_id": "onto_tk_get_subontology_from",
-      "tool_state": "{\"__page__\": 0, \"__rerun_remap_job_id__\": null, \"new_root\": \"\\\"GO:0005764 \\\"\", \"input_ontology\": \"null\"}",
-      "tool_version": "1.45.0",
-      "type": "tool",
-      "uuid": "fbd3c1c0-a6e6-4b77-9d04-b19df7cac3f3",
-      "workflow_outputs": [],
-      "tool_shed_repository": {
-        "changeset_revision": "1b3796bc5ac0",
-        "name": "onto_tk_get_subontology_from",
-        "owner": "iuc",
-        "tool_shed": "toolshed.g2.bx.psu.edu"
-      }
-    },
-    "10": {
-      "annotation": "Predicts subcellular localization of all proteins in the input list.",
-      "content_id": "toolshed.g2.bx.psu.edu/repos/peterjc/tmhmm_and_signalp/wolf_psort/0.0.8",
-      "id": 10,
-      "input_connections": {
-        "fasta_file": {
-          "id": 3,
-          "output_name": "outfile_retrieve_fasta"
-        }
-      },
-      "inputs": [],
-      "label": null,
-      "name": "WoLF PSORT",
-      "outputs": [
-        {
-          "name": "tabular_file",
-          "type": "tabular"
-        }
-      ],
-      "position": {
-        "left": 886.75,
-        "top": 326.75
-      },
-      "post_job_actions": {
-        "HideDatasetActiontabular_file": {
-          "action_arguments": {},
-          "action_type": "HideDatasetAction",
-          "output_name": "tabular_file"
-        },
-        "RenameDatasetActiontabular_file": {
-          "action_arguments": {
-            "newname": "WoLF_PSORT_output"
-          },
-          "action_type": "RenameDatasetAction",
-          "output_name": "tabular_file"
-        }
-      },
-      "tool_errors": null,
-      "tool_id": "toolshed.g2.bx.psu.edu/repos/peterjc/tmhmm_and_signalp/wolf_psort/0.0.8",
-      "tool_state": "{\"__page__\": 0, \"fasta_file\": \"null\", \"organism\": \"\\\"animal\\\"\", \"__rerun_remap_job_id__\": null}",
-      "tool_version": "0.0.8",
-      "type": "tool",
-      "uuid": "60edfc44-cad4-4afd-8907-4003700d6576",
-      "workflow_outputs": [],
+        }, 
+        "4": {
+            "annotation": "Removes comment lines at the head of the Uniprot Go database file.", 
+            "content_id": "Grep1", 
+            "id": 4, 
+            "input_connections": {
+                "input": {
+                    "id": 1, 
+                    "output_name": "output"
+                }
+            }, 
+            "inputs": [], 
+            "label": null, 
+            "name": "Select", 
+            "outputs": [
+                {
+                    "name": "out_file1", 
+                    "type": "input"
+                }
+            ], 
+            "position": {
+                "left": 552, 
+                "top": 505
+            }, 
+            "post_job_actions": {
+                "ChangeDatatypeActionout_file1": {
+                    "action_arguments": {
+                        "newtype": "tabular"
+                    }, 
+                    "action_type": "ChangeDatatypeAction", 
+                    "output_name": "out_file1"
+                }, 
+                "HideDatasetActionout_file1": {
+                    "action_arguments": {}, 
+                    "action_type": "HideDatasetAction", 
+                    "output_name": "out_file1"
+                }
+            }, 
+            "tool_errors": null, 
+            "tool_id": "Grep1", 
+            "tool_state": "{\"__page__\": 0, \"input\": \"null\", \"invert\": \"\\\"true\\\"\", \"__rerun_remap_job_id__\": null, \"pattern\": \"\\\"^!\\\"\"}", 
+            "tool_version": "1.0.1", 
+            "type": "tool", 
+            "uuid": "11c206f4-bc11-400c-8bd5-335bc8c6d63d", 
+            "workflow_outputs": []
+        }, 
+        "5": {
+            "annotation": "GO:0043230 \"extracellular organelle\"", 
+            "content_id": "get_subontology_from", 
+            "id": 5, 
+            "input_connections": {
+                "input_ontology": {
+                    "id": 2, 
+                    "output_name": "output"
+                }
+            }, 
+            "inputs": [], 
+            "label": null, 
+            "name": "Get subontology from a given OBO term", 
+            "outputs": [
+                {
+                    "name": "output", 
+                    "type": "txt"
+                }
+            ], 
+            "position": {
+                "left": 549, 
+                "top": 663
+            }, 
+            "post_job_actions": {
+                "HideDatasetActionoutput": {
+                    "action_arguments": {}, 
+                    "action_type": "HideDatasetAction", 
+                    "output_name": "output"
+                }
+            }, 
+            "tool_errors": null, 
+            "tool_id": "get_subontology_from", 
+            "tool_state": "{\"__page__\": 0, \"__rerun_remap_job_id__\": null, \"new_root\": \"\\\"GO:0043230\\\"\", \"input_ontology\": \"null\"}", 
+            "tool_version": "1.22", 
+            "type": "tool", 
+            "uuid": "636177a8-5b63-457c-acaa-518748094834", 
+            "workflow_outputs": []
+        }, 
+        "6": {
+            "annotation": "GO:0005576 \"extracellular region\"", 
+            "content_id": "get_subontology_from", 
+            "id": 6, 
+            "input_connections": {
+                "input_ontology": {
+                    "id": 2, 
+                    "output_name": "output"
+                }
+            }, 
+            "inputs": [], 
+            "label": null, 
+            "name": "Get subontology from a given OBO term", 
+            "outputs": [
+                {
+                    "name": "output", 
+                    "type": "txt"
+                }
+            ], 
+            "position": {
+                "left": 549, 
+                "top": 814
+            }, 
+            "post_job_actions": {
+                "HideDatasetActionoutput": {
+                    "action_arguments": {}, 
+                    "action_type": "HideDatasetAction", 
+                    "output_name": "output"
+                }
+            }, 
+            "tool_errors": null, 
+            "tool_id": "get_subontology_from", 
+            "tool_state": "{\"__page__\": 0, \"__rerun_remap_job_id__\": null, \"new_root\": \"\\\"GO:0005576\\\"\", \"input_ontology\": \"null\"}", 
+            "tool_version": "1.22", 
+            "type": "tool", 
+            "uuid": "163ebfd8-82c8-430e-a37f-e6670cb5069e", 
+            "workflow_outputs": []
+        }, 
+        "7": {
+            "annotation": "GO:0005887 \"integral component of plasma membrane\"", 
+            "content_id": "get_subontology_from", 
+            "id": 7, 
+            "input_connections": {
+                "input_ontology": {
+                    "id": 2, 
+                    "output_name": "output"
+                }
+            }, 
+            "inputs": [], 
+            "label": null, 
+            "name": "Get subontology from a given OBO term", 
+            "outputs": [
+                {
+                    "name": "output", 
+                    "type": "txt"
+                }
+            ], 
+            "position": {
+                "left": 551.75, 
+                "top": 918.75
+            }, 
+            "post_job_actions": {
+                "HideDatasetActionoutput": {
+                    "action_arguments": {}, 
+                    "action_type": "HideDatasetAction", 
+                    "output_name": "output"
+                }
+            }, 
+            "tool_errors": null, 
+            "tool_id": "get_subontology_from", 
+            "tool_state": "{\"__page__\": 0, \"__rerun_remap_job_id__\": null, \"new_root\": \"\\\"GO:0005887\\\"\", \"input_ontology\": \"null\"}", 
+            "tool_version": "1.22", 
+            "type": "tool", 
+            "uuid": "c3b4bd46-4f3a-46a0-927d-4fc15bc9f4d5", 
+            "workflow_outputs": []
+        }, 
+        "8": {
+            "annotation": "GO:0009986 \"cell surface\"", 
+            "content_id": "get_subontology_from", 
+            "id": 8, 
+            "input_connections": {
+                "input_ontology": {
+                    "id": 2, 
+                    "output_name": "output"
+                }
+            }, 
+            "inputs": [], 
+            "label": null, 
+            "name": "Get subontology from a given OBO term", 
+            "outputs": [
+                {
+                    "name": "output", 
+                    "type": "txt"
+                }
+            ], 
+            "position": {
+                "left": 554.75, 
+                "top": 1029.75
+            }, 
+            "post_job_actions": {
+                "HideDatasetActionoutput": {
+                    "action_arguments": {}, 
+                    "action_type": "HideDatasetAction", 
+                    "output_name": "output"
+                }
+            }, 
+            "tool_errors": null, 
+            "tool_id": "get_subontology_from", 
+            "tool_state": "{\"__page__\": 0, \"__rerun_remap_job_id__\": null, \"new_root\": \"\\\"GO:0009986\\\"\", \"input_ontology\": \"null\"}", 
+            "tool_version": "1.22", 
+            "type": "tool", 
+            "uuid": "608f525c-f9f7-4ea5-abc6-89d97f171c53", 
+            "workflow_outputs": []
+        }, 
+        "9": {
+            "annotation": "GO:0005764 \"lysosome\"", 
+            "content_id": "get_subontology_from", 
+            "id": 9, 
+            "input_connections": {
+                "input_ontology": {
+                    "id": 2, 
+                    "output_name": "output"
+                }
+            }, 
+            "inputs": [], 
+            "label": null, 
+            "name": "Get subontology from a given OBO term", 
+            "outputs": [
+                {
+                    "name": "output", 
+                    "type": "txt"
+                }
+            ], 
+            "position": {
+                "left": 556.75, 
+                "top": 1137.75
+            }, 
+            "post_job_actions": {
+                "HideDatasetActionoutput": {
+                    "action_arguments": {}, 
+                    "action_type": "HideDatasetAction", 
+                    "output_name": "output"
+                }
+            }, 
+            "tool_errors": null, 
+            "tool_id": "get_subontology_from", 
+            "tool_state": "{\"__page__\": 0, \"__rerun_remap_job_id__\": null, \"new_root\": \"\\\"GO:0005764 \\\"\", \"input_ontology\": \"null\"}", 
+            "tool_version": "1.22", 
+            "type": "tool", 
+            "uuid": "fbd3c1c0-a6e6-4b77-9d04-b19df7cac3f3", 
+            "workflow_outputs": []
+        }, 
+        "10": {
+            "annotation": "Predicts subcellular localization of all proteins in the input list.", 
+            "content_id": "toolshed.g2.bx.psu.edu/repos/peterjc/tmhmm_and_signalp/wolf_psort/0.0.8", 
+            "id": 10, 
+            "input_connections": {
+                "fasta_file": {
+                    "id": 3, 
+                    "output_name": "outfile_retrieve_fasta"
+                }
+            }, 
+            "inputs": [], 
+            "label": null, 
+            "name": "WoLF PSORT", 
+            "outputs": [
+                {
+                    "name": "tabular_file", 
+                    "type": "tabular"
+                }
+            ], 
+            "position": {
+                "left": 886.75, 
+                "top": 326.75
+            }, 
+            "post_job_actions": {
+                "HideDatasetActiontabular_file": {
+                    "action_arguments": {}, 
+                    "action_type": "HideDatasetAction", 
+                    "output_name": "tabular_file"
+                }, 
+                "RenameDatasetActiontabular_file": {
+                    "action_arguments": {
+                        "newname": "WoLF_PSORT_output"
+                    }, 
+                    "action_type": "RenameDatasetAction", 
+                    "output_name": "tabular_file"
+                }
+            }, 
+            "tool_errors": null, 
+            "tool_id": "toolshed.g2.bx.psu.edu/repos/peterjc/tmhmm_and_signalp/wolf_psort/0.0.8", 
+            "tool_state": "{\"__page__\": 0, \"fasta_file\": \"null\", \"organism\": \"\\\"animal\\\"\", \"__rerun_remap_job_id__\": null}", 
+            "tool_version": "0.0.8", 
+            "type": "tool", 
+            "uuid": "60edfc44-cad4-4afd-8907-4003700d6576", 
+            "workflow_outputs": [],
       "tool_shed_repository": {
         "changeset_revision": "e6cc27d182a8",
         "name": "tmhmm_and_signalp",
         "owner": "peterjc",
         "tool_shed": "toolshed.g2.bx.psu.edu"
       }
-    },
-    "11": {
-      "annotation": "Annotates input protein list with GO annotations.",
-      "content_id": "toolshed.g2.bx.psu.edu/repos/bgruening/text_processing/tp_easyjoin_tool/1.0.0",
-      "id": 11,
-      "input_connections": {
-        "infile1": {
-          "id": 0,
-          "output_name": "output"
-        },
-        "infile2": {
-          "id": 4,
-          "output_name": "out_file1"
-        }
-      },
-      "inputs": [],
-      "label": null,
-      "name": "Join",
-      "outputs": [
-        {
-          "name": "output",
-          "type": "input"
-        }
-      ],
-      "position": {
-        "left": 939,
-        "top": 479
-      },
-      "post_job_actions": {
-        "ChangeDatatypeActionoutput": {
-          "action_arguments": {
-            "newtype": "tabular"
-          },
-          "action_type": "ChangeDatatypeAction",
-          "output_name": "output"
-        },
-        "HideDatasetActionoutput": {
-          "action_arguments": {},
-          "action_type": "HideDatasetAction",
-          "output_name": "output"
-        }
-      },
-      "tool_errors": null,
-      "tool_id": "toolshed.g2.bx.psu.edu/repos/bgruening/text_processing/tp_easyjoin_tool/1.0.0",
-      "tool_state": "{\"__page__\": 0, \"ignore_case\": \"\\\"False\\\"\", \"infile2\": \"null\", \"infile1\": \"null\", \"empty_string_filler\": \"\\\"0\\\"\", \"__rerun_remap_job_id__\": null, \"jointype\": \"\\\"-a 1\\\"\", \"header\": \"\\\"False\\\"\", \"column1\": \"\\\"1\\\"\", \"column2\": \"\\\"2\\\"\"}",
-      "tool_version": "1.0.0",
-      "type": "tool",
-      "uuid": "5bda528d-4d1d-49d5-8f18-dcd7b92152dc",
-      "workflow_outputs": []
-    },
-    "12": {
-      "annotation": "GO:0043230 \"extracellular organelle\"",
-      "content_id": "term_id_vs_term_name",
-      "id": 12,
-      "input_connections": {
-        "input_ontology": {
-          "id": 5,
-          "output_name": "output"
-        }
-      },
-      "inputs": [],
-      "label": null,
-      "name": "Get all the term IDs and term names of a given OBO ontology",
-      "outputs": [
-        {
-          "name": "output",
-          "type": "tabular"
-        }
-      ],
-      "position": {
-        "left": 872.25,
-        "top": 646.75
-      },
-      "post_job_actions": {
-        "HideDatasetActionoutput": {
-          "action_arguments": {},
-          "action_type": "HideDatasetAction",
-          "output_name": "output"
-        }
-      },
-      "tool_errors": null,
-      "tool_id": "onto_tk_term_id_vs_term_name",
-      "tool_state": "{\"__page__\": 0, \"__rerun_remap_job_id__\": null, \"input_ontology\": \"null\"}",
-      "tool_version": "1.45.0",
-      "type": "tool",
-      "uuid": "89bd62f8-6548-4411-a1f0-861364c43189",
-      "workflow_outputs": [],
-      "tool_shed_repository": {
-        "changeset_revision": "b2471db454a0",
-        "name": "onto_tk_term_id_vs_term_name",
-        "owner": "iuc",
-        "tool_shed": "toolshed.g2.bx.psu.edu"
-      }
-    },
-    "13": {
-      "annotation": "GO:0005576 \"extracellular region\"",
-      "content_id": "term_id_vs_term_name",
-      "id": 13,
-      "input_connections": {
-        "input_ontology": {
-          "id": 6,
-          "output_name": "output"
-        }
-      },
-      "inputs": [],
-      "label": null,
-      "name": "Get all the term IDs and term names of a given OBO ontology",
-      "outputs": [
-        {
-          "name": "output",
-          "type": "tabular"
-        }
-      ],
-      "position": {
-        "left": 867.25,
-        "top": 815.75
-      },
-      "post_job_actions": {
-        "HideDatasetActionoutput": {
-          "action_arguments": {},
-          "action_type": "HideDatasetAction",
-          "output_name": "output"
-        }
-      },
-      "tool_errors": null,
-      "tool_id": "onto_tk_term_id_vs_term_name",
-      "tool_state": "{\"__page__\": 0, \"__rerun_remap_job_id__\": null, \"input_ontology\": \"null\"}",
-      "tool_version": "1.45.0",
-      "type": "tool",
-      "uuid": "4ddbced9-e92d-467e-bbb9-7b2bcd8af58d",
-      "workflow_outputs": [],
-      "tool_shed_repository": {
-        "changeset_revision": "b2471db454a0",
-        "name": "onto_tk_term_id_vs_term_name",
-        "owner": "iuc",
-        "tool_shed": "toolshed.g2.bx.psu.edu"
-      }
-    },
-    "14": {
-      "annotation": "GO:0005887 \"integral component of plasma membrane\"",
-      "content_id": "term_id_vs_term_name",
-      "id": 14,
-      "input_connections": {
-        "input_ontology": {
-          "id": 7,
-          "output_name": "output"
-        }
-      },
-      "inputs": [],
-      "label": null,
-      "name": "Get all the term IDs and term names of a given OBO ontology",
-      "outputs": [
-        {
-          "name": "output",
-          "type": "tabular"
-        }
-      ],
-      "position": {
-        "left": 869.25,
-        "top": 922.75
-      },
-      "post_job_actions": {
-        "HideDatasetActionoutput": {
-          "action_arguments": {},
-          "action_type": "HideDatasetAction",
-          "output_name": "output"
-        },
-        "RenameDatasetActionoutput": {
-          "action_arguments": {
-            "newname": "integral component of plasma membrane subontology"
-          },
-          "action_type": "RenameDatasetAction",
-          "output_name": "output"
-        }
-      },
-      "tool_errors": null,
-      "tool_id": "onto_tk_term_id_vs_term_name",
-      "tool_state": "{\"__page__\": 0, \"__rerun_remap_job_id__\": null, \"input_ontology\": \"null\"}",
-      "tool_version": "1.45.0",
-      "type": "tool",
-      "uuid": "d1dc97ba-cae6-42e7-b0d6-67d94bd3ba30",
-      "workflow_outputs": [],
-      "tool_shed_repository": {
-        "changeset_revision": "b2471db454a0",
-        "name": "onto_tk_term_id_vs_term_name",
-        "owner": "iuc",
-        "tool_shed": "toolshed.g2.bx.psu.edu"
-      }
-    },
-    "15": {
-      "annotation": "GO:0009986 \"cell surface\"",
-      "content_id": "term_id_vs_term_name",
-      "id": 15,
-      "input_connections": {
-        "input_ontology": {
-          "id": 8,
-          "output_name": "output"
-        }
-      },
-      "inputs": [],
-      "label": null,
-      "name": "Get all the term IDs and term names of a given OBO ontology",
-      "outputs": [
-        {
-          "name": "output",
-          "type": "tabular"
-        }
-      ],
-      "position": {
-        "left": 872.25,
-        "top": 1030.75
-      },
-      "post_job_actions": {
-        "HideDatasetActionoutput": {
-          "action_arguments": {},
-          "action_type": "HideDatasetAction",
-          "output_name": "output"
-        },
-        "RenameDatasetActionoutput": {
-          "action_arguments": {
-            "newname": "cell surface subontology"
-          },
-          "action_type": "RenameDatasetAction",
-          "output_name": "output"
-        }
-      },
-      "tool_errors": null,
-      "tool_id": "onto_tk_term_id_vs_term_name",
-      "tool_state": "{\"__page__\": 0, \"__rerun_remap_job_id__\": null, \"input_ontology\": \"null\"}",
-      "tool_version": "1.45.0",
-      "type": "tool",
-      "uuid": "bfa87a5a-7770-4a09-ab7a-2fe04c5e24a7",
-      "workflow_outputs": [],
-      "tool_shed_repository": {
-        "changeset_revision": "b2471db454a0",
-        "name": "onto_tk_term_id_vs_term_name",
-        "owner": "iuc",
-        "tool_shed": "toolshed.g2.bx.psu.edu"
-      }
-    },
-    "16": {
-      "annotation": "GO:0005764 \"lysosome\"",
-      "content_id": "term_id_vs_term_name",
-      "id": 16,
-      "input_connections": {
-        "input_ontology": {
-          "id": 9,
-          "output_name": "output"
-        }
-      },
-      "inputs": [],
-      "label": null,
-      "name": "Get all the term IDs and term names of a given OBO ontology",
-      "outputs": [
-        {
-          "name": "output",
-          "type": "tabular"
-        }
-      ],
-      "position": {
-        "left": 871.25,
-        "top": 1140.75
-      },
-      "post_job_actions": {
-        "HideDatasetActionoutput": {
-          "action_arguments": {},
-          "action_type": "HideDatasetAction",
-          "output_name": "output"
-        }
-      },
-      "tool_errors": null,
-      "tool_id": "onto_tk_term_id_vs_term_name",
-      "tool_state": "{\"__page__\": 0, \"__rerun_remap_job_id__\": null, \"input_ontology\": \"null\"}",
-      "tool_version": "1.45.0",
-      "type": "tool",
-      "uuid": "0e3a5a39-27cc-4091-8831-615ebc60ed8c",
-      "workflow_outputs": [],
-      "tool_shed_repository": {
-        "changeset_revision": "b2471db454a0",
-        "name": "onto_tk_term_id_vs_term_name",
-        "owner": "iuc",
-        "tool_shed": "toolshed.g2.bx.psu.edu"
-      }
-    },
-    "17": {
-      "annotation": "Filters all proteins that are predicted to reside extracellularly.",
-      "content_id": "Filter1",
-      "id": 17,
-      "input_connections": {
-        "input": {
-          "id": 10,
-          "output_name": "tabular_file"
-        }
-      },
-      "inputs": [],
-      "label": null,
-      "name": "Filter",
-      "outputs": [
-        {
-          "name": "out_file1",
-          "type": "input"
-        }
-      ],
-      "position": {
-        "left": 1171.75,
-        "top": 288.75
-      },
-      "post_job_actions": {
-        "HideDatasetActionout_file1": {
-          "action_arguments": {},
-          "action_type": "HideDatasetAction",
-          "output_name": "out_file1"
-        }
-      },
-      "tool_errors": null,
-      "tool_id": "Filter1",
-      "tool_state": "{\"input\": \"null\", \"__rerun_remap_job_id__\": null, \"header_lines\": \"\\\"0\\\"\", \"cond\": \"\\\"c2=='extr'\\\"\", \"__page__\": 0}",
-      "tool_version": "1.1.0",
-      "type": "tool",
-      "uuid": "af1432da-a54e-4d3a-a643-719f6cdd6866",
-      "workflow_outputs": []
-    },
-    "18": {
-      "annotation": "Filters all proteins that are predicted to reside in lysosomes.",
-      "content_id": "Filter1",
-      "id": 18,
-      "input_connections": {
-        "input": {
-          "id": 10,
-          "output_name": "tabular_file"
-        }
-      },
-      "inputs": [],
-      "label": null,
-      "name": "Filter",
-      "outputs": [
-        {
-          "name": "out_file1",
-          "type": "input"
-        }
-      ],
-      "position": {
-        "left": 1172.75,
-        "top": 397.75
-      },
-      "post_job_actions": {
-        "HideDatasetActionout_file1": {
-          "action_arguments": {},
-          "action_type": "HideDatasetAction",
-          "output_name": "out_file1"
-        }
-      },
-      "tool_errors": null,
-      "tool_id": "Filter1",
-      "tool_state": "{\"input\": \"null\", \"__rerun_remap_job_id__\": null, \"header_lines\": \"\\\"0\\\"\", \"cond\": \"\\\"c2=='lyso'\\\"\", \"__page__\": 0}",
-      "tool_version": "1.1.0",
-      "type": "tool",
-      "uuid": "195b0060-48f2-4377-aa15-a96be6338d31",
-      "workflow_outputs": []
-    },
-    "19": {
-      "annotation": "",
-      "content_id": "toolshed.g2.bx.psu.edu/repos/bgruening/text_processing/tp_easyjoin_tool/1.0.0",
-      "id": 19,
-      "input_connections": {
-        "infile1": {
-          "id": 12,
-          "output_name": "output"
-        },
-        "infile2": {
-          "id": 13,
-          "output_name": "output"
-        }
-      },
-      "inputs": [],
-      "label": null,
-      "name": "Join",
-      "outputs": [
-        {
-          "name": "output",
-          "type": "input"
-        }
-      ],
-      "position": {
-        "left": 1184.75,
-        "top": 734.75
-      },
-      "post_job_actions": {
-        "HideDatasetActionoutput": {
-          "action_arguments": {},
-          "action_type": "HideDatasetAction",
-          "output_name": "output"
-        }
-      },
-      "tool_errors": null,
-      "tool_id": "toolshed.g2.bx.psu.edu/repos/bgruening/text_processing/tp_easyjoin_tool/1.0.0",
-      "tool_state": "{\"__page__\": 0, \"ignore_case\": \"\\\"False\\\"\", \"infile2\": \"null\", \"infile1\": \"null\", \"empty_string_filler\": \"\\\"0\\\"\", \"__rerun_remap_job_id__\": null, \"jointype\": \"\\\"-v 2\\\"\", \"header\": \"\\\"False\\\"\", \"column1\": \"\\\"1\\\"\", \"column2\": \"\\\"1\\\"\"}",
-      "tool_version": "1.0.0",
-      "type": "tool",
-      "uuid": "fba78726-c9fd-4789-9ed9-2969aa87d984",
-      "workflow_outputs": []
-    },
-    "20": {
-      "annotation": "Combines all GO annotations for \"integral to plasma membrane\" and \"cell surface\"",
-      "content_id": "toolshed.g2.bx.psu.edu/repos/bgruening/text_processing/tp_easyjoin_tool/1.0.0",
-      "id": 20,
-      "input_connections": {
-        "infile1": {
-          "id": 14,
-          "output_name": "output"
-        },
-        "infile2": {
-          "id": 15,
-          "output_name": "output"
-        }
-      },
-      "inputs": [],
-      "label": null,
-      "name": "Join",
-      "outputs": [
-        {
-          "name": "output",
-          "type": "input"
-        }
-      ],
-      "position": {
-        "left": 1189.75,
-        "top": 1009.75
-      },
-      "post_job_actions": {
-        "HideDatasetActionoutput": {
-          "action_arguments": {},
-          "action_type": "HideDatasetAction",
-          "output_name": "output"
-        }
-      },
-      "tool_errors": null,
-      "tool_id": "toolshed.g2.bx.psu.edu/repos/bgruening/text_processing/tp_easyjoin_tool/1.0.0",
-      "tool_state": "{\"__page__\": 0, \"ignore_case\": \"\\\"False\\\"\", \"infile2\": \"null\", \"infile1\": \"null\", \"empty_string_filler\": \"\\\"0\\\"\", \"__rerun_remap_job_id__\": null, \"jointype\": \"\\\"-a 1 -a 2\\\"\", \"header\": \"\\\"False\\\"\", \"column1\": \"\\\"1\\\"\", \"column2\": \"\\\"1\\\"\"}",
-      "tool_version": "1.0.0",
-      "type": "tool",
-      "uuid": "c699e36d-a983-4e66-820d-f00b1b904739",
-      "workflow_outputs": []
-    },
-    "21": {
-      "annotation": "Combines all proteins in the input list that are predicted by WolfPsort to be lysosomal and/or extracellular.",
-      "content_id": "toolshed.g2.bx.psu.edu/repos/bgruening/text_processing/tp_easyjoin_tool/1.0.0",
-      "id": 21,
-      "input_connections": {
-        "infile1": {
-          "id": 17,
-          "output_name": "out_file1"
-        },
-        "infile2": {
-          "id": 18,
-          "output_name": "out_file1"
-        }
-      },
-      "inputs": [],
-      "label": null,
-      "name": "Join",
-      "outputs": [
-        {
-          "name": "output",
-          "type": "input"
-        }
-      ],
-      "position": {
-        "left": 1390.75,
-        "top": 334.75
-      },
-      "post_job_actions": {
-        "HideDatasetActionoutput": {
-          "action_arguments": {},
-          "action_type": "HideDatasetAction",
-          "output_name": "output"
-        }
-      },
-      "tool_errors": null,
-      "tool_id": "toolshed.g2.bx.psu.edu/repos/bgruening/text_processing/tp_easyjoin_tool/1.0.0",
-      "tool_state": "{\"__page__\": 0, \"ignore_case\": \"\\\"False\\\"\", \"infile2\": \"null\", \"infile1\": \"null\", \"empty_string_filler\": \"\\\"0\\\"\", \"__rerun_remap_job_id__\": null, \"jointype\": \"\\\"-a 1 -a 2\\\"\", \"header\": \"\\\"False\\\"\", \"column1\": \"\\\"1\\\"\", \"column2\": \"\\\"1\\\"\"}",
-      "tool_version": "1.0.0",
-      "type": "tool",
-      "uuid": "4a244c68-b12d-46a7-950d-2846a8af8ef5",
-      "workflow_outputs": []
-    },
-    "22": {
-      "annotation": "Combines all GO annotations for \"extracellular region\", \"integral to plasma membrane\" and \"cell surface\" excluding \"extracellular organelle\"",
-      "content_id": "toolshed.g2.bx.psu.edu/repos/bgruening/text_processing/tp_easyjoin_tool/1.0.0",
-      "id": 22,
-      "input_connections": {
-        "infile1": {
-          "id": 19,
-          "output_name": "output"
-        },
-        "infile2": {
-          "id": 20,
-          "output_name": "output"
-        }
-      },
-      "inputs": [],
-      "label": null,
-      "name": "Join",
-      "outputs": [
-        {
-          "name": "output",
-          "type": "input"
-        }
-      ],
-      "position": {
-        "left": 1366.75,
-        "top": 864.75
-      },
-      "post_job_actions": {
-        "HideDatasetActionoutput": {
-          "action_arguments": {},
-          "action_type": "HideDatasetAction",
-          "output_name": "output"
-        }
-      },
-      "tool_errors": null,
-      "tool_id": "toolshed.g2.bx.psu.edu/repos/bgruening/text_processing/tp_easyjoin_tool/1.0.0",
-      "tool_state": "{\"__page__\": 0, \"ignore_case\": \"\\\"False\\\"\", \"infile2\": \"null\", \"infile1\": \"null\", \"empty_string_filler\": \"\\\"0\\\"\", \"__rerun_remap_job_id__\": null, \"jointype\": \"\\\"-a 1 -a 2\\\"\", \"header\": \"\\\"False\\\"\", \"column1\": \"\\\"1\\\"\", \"column2\": \"\\\"1\\\"\"}",
-      "tool_version": "1.0.0",
-      "type": "tool",
-      "uuid": "75b8acd7-7fd1-4ca4-be93-0542b6ed3c9d",
-      "workflow_outputs": []
-    },
-    "23": {
-      "annotation": "Extracts uniprot accessions from all proteins in the input list that are predicted by WolfPsort to be lysosomal and/or extracellular.",
-      "content_id": "Convert characters1",
-      "id": 23,
-      "input_connections": {
-        "input": {
-          "id": 21,
-          "output_name": "output"
-        }
-      },
-      "inputs": [],
-      "label": null,
-      "name": "Convert",
-      "outputs": [
-        {
-          "name": "out_file1",
-          "type": "tabular"
-        }
-      ],
-      "position": {
-        "left": 1513.75,
-        "top": 458.75
-      },
-      "post_job_actions": {
-        "HideDatasetActionout_file1": {
-          "action_arguments": {},
-          "action_type": "HideDatasetAction",
-          "output_name": "out_file1"
-        }
-      },
-      "tool_errors": null,
-      "tool_id": "Convert characters1",
-      "tool_state": "{\"__page__\": 0, \"__rerun_remap_job_id__\": null, \"condense\": \"\\\"True\\\"\", \"strip\": \"\\\"True\\\"\", \"input\": \"null\", \"convert_from\": \"\\\"P\\\"\"}",
-      "tool_version": "1.0.0",
-      "type": "tool",
-      "uuid": "8e195b7d-e1fa-4df4-9108-697d89119b53",
-      "workflow_outputs": []
-    },
-    "24": {
-      "annotation": "Combines all GO annotations for \"lysosome\", \"extracellular region\", \"integral to plasma membrane\" and \"cell surface\" excluding \"extracellular organelle\"",
-      "content_id": "toolshed.g2.bx.psu.edu/repos/bgruening/text_processing/tp_easyjoin_tool/1.0.0",
-      "id": 24,
-      "input_connections": {
-        "infile1": {
-          "id": 22,
-          "output_name": "output"
-        },
-        "infile2": {
-          "id": 16,
-          "output_name": "output"
-        }
-      },
-      "inputs": [],
-      "label": null,
-      "name": "Join",
-      "outputs": [
-        {
-          "name": "output",
-          "type": "input"
-        }
-      ],
-      "position": {
-        "left": 1502.75,
-        "top": 1036.75
-      },
-      "post_job_actions": {
-        "HideDatasetActionoutput": {
-          "action_arguments": {},
-          "action_type": "HideDatasetAction",
-          "output_name": "output"
-        }
-      },
-      "tool_errors": null,
-      "tool_id": "toolshed.g2.bx.psu.edu/repos/bgruening/text_processing/tp_easyjoin_tool/1.0.0",
-      "tool_state": "{\"__page__\": 0, \"ignore_case\": \"\\\"False\\\"\", \"infile2\": \"null\", \"infile1\": \"null\", \"empty_string_filler\": \"\\\"0\\\"\", \"__rerun_remap_job_id__\": null, \"jointype\": \"\\\"-a 1 -a 2\\\"\", \"header\": \"\\\"False\\\"\", \"column1\": \"\\\"1\\\"\", \"column2\": \"\\\"1\\\"\"}",
-      "tool_version": "1.0.0",
-      "type": "tool",
-      "uuid": "4855cffc-41b9-4a6f-8cd4-9427ec849b95",
-      "workflow_outputs": []
-    },
-    "25": {
-      "annotation": "Deletes all columns but the one containing uniprot accessions of extracellular proteins as predicted by WoLF PSORT.",
-      "content_id": "toolshed.g2.bx.psu.edu/repos/bgruening/text_processing/tp_cut_tool/1.0.0",
-      "id": 25,
-      "input_connections": {
-        "input": {
-          "id": 23,
-          "output_name": "out_file1"
-        }
-      },
-      "inputs": [],
-      "label": null,
-      "name": "Cut",
-      "outputs": [
-        {
-          "name": "output",
-          "type": "tabular"
-        }
-      ],
-      "position": {
-        "left": 1613.75,
-        "top": 554.75
-      },
-      "post_job_actions": {
-        "HideDatasetActionoutput": {
-          "action_arguments": {},
-          "action_type": "HideDatasetAction",
-          "output_name": "output"
-        }
-      },
-      "tool_errors": null,
-      "tool_id": "toolshed.g2.bx.psu.edu/repos/bgruening/text_processing/tp_cut_tool/1.0.0",
-      "tool_state": "{\"__page__\": 0, \"complement\": \"\\\"\\\"\", \"cut_type_options\": \"{\\\"list\\\": [\\\"2\\\"], \\\"cut_element\\\": \\\"-f\\\", \\\"__current_case__\\\": 0}\", \"delimiter\": \"\\\"\\\"\", \"input\": \"null\", \"__rerun_remap_job_id__\": null}",
-      "tool_version": "1.0.0",
-      "type": "tool",
-      "uuid": "1573af45-4165-4825-ae8d-57182571cf42",
-      "workflow_outputs": []
-    },
-    "26": {
-      "annotation": "filters out all proteins in the input protein list of interest that are annotated as \"extracellular region\" and \"lysosome\" and \"plasma membrane\" excluding \"extracellular organelle\" and \"cytoplasmic side of plasma membrane\"",
-      "content_id": "comp1",
-      "id": 26,
-      "input_connections": {
-        "input1": {
-          "id": 11,
-          "output_name": "output"
-        },
-        "input2": {
-          "id": 24,
-          "output_name": "output"
-        }
-      },
-      "inputs": [],
-      "label": null,
-      "name": "Compare two Datasets",
-      "outputs": [
-        {
-          "name": "out_file1",
-          "type": "input"
-        }
-      ],
-      "position": {
-        "left": 1514.75,
-        "top": 680.75
-      },
-      "post_job_actions": {
-        "HideDatasetActionout_file1": {
-          "action_arguments": {},
-          "action_type": "HideDatasetAction",
-          "output_name": "out_file1"
-        }
-      },
-      "tool_errors": null,
-      "tool_id": "comp1",
-      "tool_state": "{\"input2\": \"null\", \"__page__\": 0, \"input1\": \"null\", \"field2\": \"\\\"1\\\"\", \"__rerun_remap_job_id__\": null, \"field1\": \"\\\"6\\\"\", \"mode\": \"\\\"N\\\"\"}",
-      "tool_version": "1.0.2",
-      "type": "tool",
-      "uuid": "4e5095ba-1132-484b-875d-866676cb8910",
-      "workflow_outputs": [],
-      "tool_shed_repository": {
-        "changeset_revision": "c2a356708570",
-        "name": "sharplabtool",
-        "owner": "xuebing",
-        "tool_shed": "toolshed.g2.bx.psu.edu"
-      }
-    },
-    "27": {
-      "annotation": "cleans up the protein list for unique entries",
-      "content_id": "toolshed.g2.bx.psu.edu/repos/bgruening/unique/bg_uniq/0.3",
-      "id": 27,
-      "input_connections": {
-        "input": {
-          "id": 26,
-          "output_name": "out_file1"
-        }
-      },
-      "inputs": [],
-      "label": null,
-      "name": "Unique",
-      "outputs": [
-        {
-          "name": "outfile",
-          "type": "input"
-        }
-      ],
-      "position": {
-        "left": 1640.75,
-        "top": 806.75
-      },
-      "post_job_actions": {
-        "HideDatasetActionoutfile": {
-          "action_arguments": {},
-          "action_type": "HideDatasetAction",
-          "output_name": "outfile"
-        }
-      },
-      "tool_errors": null,
-      "tool_id": "toolshed.g2.bx.psu.edu/repos/bgruening/unique/bg_uniq/0.3",
-      "tool_state": "{\"__page__\": 0, \"ignore_case\": \"\\\"False\\\"\", \"adv_opts\": \"{\\\"column_end\\\": \\\"1\\\", \\\"column_start\\\": \\\"1\\\", \\\"adv_opts_selector\\\": \\\"advanced\\\", \\\"__current_case__\\\": 1}\", \"__rerun_remap_job_id__\": null, \"is_numeric\": \"\\\"False\\\"\", \"input\": \"null\"}",
-      "tool_version": "0.3",
-      "type": "tool",
-      "uuid": "89ab7414-9e60-40ae-9598-fee02fab0205",
-      "workflow_outputs": [],
+        }, 
+        "11": {
+            "annotation": "Annotates input protein list with GO annotations.", 
+            "content_id": "toolshed.g2.bx.psu.edu/repos/bgruening/text_processing/tp_easyjoin_tool/1.0.0", 
+            "id": 11, 
+            "input_connections": {
+                "infile1": {
+                    "id": 0, 
+                    "output_name": "output"
+                }, 
+                "infile2": {
+                    "id": 4, 
+                    "output_name": "out_file1"
+                }
+            }, 
+            "inputs": [], 
+            "label": null, 
+            "name": "Join", 
+            "outputs": [
+                {
+                    "name": "output", 
+                    "type": "input"
+                }
+            ], 
+            "position": {
+                "left": 939, 
+                "top": 479
+            }, 
+            "post_job_actions": {
+                "ChangeDatatypeActionoutput": {
+                    "action_arguments": {
+                        "newtype": "tabular"
+                    }, 
+                    "action_type": "ChangeDatatypeAction", 
+                    "output_name": "output"
+                }, 
+                "HideDatasetActionoutput": {
+                    "action_arguments": {}, 
+                    "action_type": "HideDatasetAction", 
+                    "output_name": "output"
+                }
+            }, 
+            "tool_errors": null, 
+            "tool_id": "toolshed.g2.bx.psu.edu/repos/bgruening/text_processing/tp_easyjoin_tool/1.0.0", 
+            "tool_state": "{\"__page__\": 0, \"ignore_case\": \"\\\"False\\\"\", \"infile2\": \"null\", \"infile1\": \"null\", \"empty_string_filler\": \"\\\"0\\\"\", \"__rerun_remap_job_id__\": null, \"jointype\": \"\\\"-a 1\\\"\", \"header\": \"\\\"False\\\"\", \"column1\": \"\\\"1\\\"\", \"column2\": \"\\\"2\\\"\"}", 
+            "tool_version": "1.0.0", 
+            "type": "tool", 
+            "uuid": "5bda528d-4d1d-49d5-8f18-dcd7b92152dc", 
+            "workflow_outputs": []
+        }, 
+        "12": {
+            "annotation": "GO:0043230 \"extracellular organelle\"", 
+            "content_id": "term_id_vs_term_name", 
+            "id": 12, 
+            "input_connections": {
+                "input_ontology": {
+                    "id": 5, 
+                    "output_name": "output"
+                }
+            }, 
+            "inputs": [], 
+            "label": null, 
+            "name": "Get all the term IDs and term names of a given OBO ontology", 
+            "outputs": [
+                {
+                    "name": "output", 
+                    "type": "tabular"
+                }
+            ], 
+            "position": {
+                "left": 872.25, 
+                "top": 646.75
+            }, 
+            "post_job_actions": {
+                "HideDatasetActionoutput": {
+                    "action_arguments": {}, 
+                    "action_type": "HideDatasetAction", 
+                    "output_name": "output"
+                }
+            }, 
+            "tool_errors": null, 
+            "tool_id": "term_id_vs_term_name", 
+            "tool_state": "{\"__page__\": 0, \"__rerun_remap_job_id__\": null, \"input_ontology\": \"null\"}", 
+            "tool_version": "1.22", 
+            "type": "tool", 
+            "uuid": "89bd62f8-6548-4411-a1f0-861364c43189", 
+            "workflow_outputs": []
+        }, 
+        "13": {
+            "annotation": "GO:0005576 \"extracellular region\"", 
+            "content_id": "term_id_vs_term_name", 
+            "id": 13, 
+            "input_connections": {
+                "input_ontology": {
+                    "id": 6, 
+                    "output_name": "output"
+                }
+            }, 
+            "inputs": [], 
+            "label": null, 
+            "name": "Get all the term IDs and term names of a given OBO ontology", 
+            "outputs": [
+                {
+                    "name": "output", 
+                    "type": "tabular"
+                }
+            ], 
+            "position": {
+                "left": 867.25, 
+                "top": 815.75
+            }, 
+            "post_job_actions": {
+                "HideDatasetActionoutput": {
+                    "action_arguments": {}, 
+                    "action_type": "HideDatasetAction", 
+                    "output_name": "output"
+                }
+            }, 
+            "tool_errors": null, 
+            "tool_id": "term_id_vs_term_name", 
+            "tool_state": "{\"__page__\": 0, \"__rerun_remap_job_id__\": null, \"input_ontology\": \"null\"}", 
+            "tool_version": "1.22", 
+            "type": "tool", 
+            "uuid": "4ddbced9-e92d-467e-bbb9-7b2bcd8af58d", 
+            "workflow_outputs": []
+        }, 
+        "14": {
+            "annotation": "GO:0005887 \"integral component of plasma membrane\"", 
+            "content_id": "term_id_vs_term_name", 
+            "id": 14, 
+            "input_connections": {
+                "input_ontology": {
+                    "id": 7, 
+                    "output_name": "output"
+                }
+            }, 
+            "inputs": [], 
+            "label": null, 
+            "name": "Get all the term IDs and term names of a given OBO ontology", 
+            "outputs": [
+                {
+                    "name": "output", 
+                    "type": "tabular"
+                }
+            ], 
+            "position": {
+                "left": 869.25, 
+                "top": 922.75
+            }, 
+            "post_job_actions": {
+                "HideDatasetActionoutput": {
+                    "action_arguments": {}, 
+                    "action_type": "HideDatasetAction", 
+                    "output_name": "output"
+                }, 
+                "RenameDatasetActionoutput": {
+                    "action_arguments": {
+                        "newname": "integral component of plasma membrane subontology"
+                    }, 
+                    "action_type": "RenameDatasetAction", 
+                    "output_name": "output"
+                }
+            }, 
+            "tool_errors": null, 
+            "tool_id": "term_id_vs_term_name", 
+            "tool_state": "{\"__page__\": 0, \"__rerun_remap_job_id__\": null, \"input_ontology\": \"null\"}", 
+            "tool_version": "1.22", 
+            "type": "tool", 
+            "uuid": "d1dc97ba-cae6-42e7-b0d6-67d94bd3ba30", 
+            "workflow_outputs": []
+        }, 
+        "15": {
+            "annotation": "GO:0009986 \"cell surface\"", 
+            "content_id": "term_id_vs_term_name", 
+            "id": 15, 
+            "input_connections": {
+                "input_ontology": {
+                    "id": 8, 
+                    "output_name": "output"
+                }
+            }, 
+            "inputs": [], 
+            "label": null, 
+            "name": "Get all the term IDs and term names of a given OBO ontology", 
+            "outputs": [
+                {
+                    "name": "output", 
+                    "type": "tabular"
+                }
+            ], 
+            "position": {
+                "left": 872.25, 
+                "top": 1030.75
+            }, 
+            "post_job_actions": {
+                "HideDatasetActionoutput": {
+                    "action_arguments": {}, 
+                    "action_type": "HideDatasetAction", 
+                    "output_name": "output"
+                }, 
+                "RenameDatasetActionoutput": {
+                    "action_arguments": {
+                        "newname": "cell surface subontology"
+                    }, 
+                    "action_type": "RenameDatasetAction", 
+                    "output_name": "output"
+                }
+            }, 
+            "tool_errors": null, 
+            "tool_id": "term_id_vs_term_name", 
+            "tool_state": "{\"__page__\": 0, \"__rerun_remap_job_id__\": null, \"input_ontology\": \"null\"}", 
+            "tool_version": "1.22", 
+            "type": "tool", 
+            "uuid": "bfa87a5a-7770-4a09-ab7a-2fe04c5e24a7", 
+            "workflow_outputs": []
+        }, 
+        "16": {
+            "annotation": "GO:0005764 \"lysosome\"", 
+            "content_id": "term_id_vs_term_name", 
+            "id": 16, 
+            "input_connections": {
+                "input_ontology": {
+                    "id": 9, 
+                    "output_name": "output"
+                }
+            }, 
+            "inputs": [], 
+            "label": null, 
+            "name": "Get all the term IDs and term names of a given OBO ontology", 
+            "outputs": [
+                {
+                    "name": "output", 
+                    "type": "tabular"
+                }
+            ], 
+            "position": {
+                "left": 871.25, 
+                "top": 1140.75
+            }, 
+            "post_job_actions": {
+                "HideDatasetActionoutput": {
+                    "action_arguments": {}, 
+                    "action_type": "HideDatasetAction", 
+                    "output_name": "output"
+                }
+            }, 
+            "tool_errors": null, 
+            "tool_id": "term_id_vs_term_name", 
+            "tool_state": "{\"__page__\": 0, \"__rerun_remap_job_id__\": null, \"input_ontology\": \"null\"}", 
+            "tool_version": "1.22", 
+            "type": "tool", 
+            "uuid": "0e3a5a39-27cc-4091-8831-615ebc60ed8c", 
+            "workflow_outputs": []
+        }, 
+        "17": {
+            "annotation": "Filters all proteins that are predicted to reside extracellularly.", 
+            "content_id": "Filter1", 
+            "id": 17, 
+            "input_connections": {
+                "input": {
+                    "id": 10, 
+                    "output_name": "tabular_file"
+                }
+            }, 
+            "inputs": [], 
+            "label": null, 
+            "name": "Filter", 
+            "outputs": [
+                {
+                    "name": "out_file1", 
+                    "type": "input"
+                }
+            ], 
+            "position": {
+                "left": 1171.75, 
+                "top": 288.75
+            }, 
+            "post_job_actions": {
+                "HideDatasetActionout_file1": {
+                    "action_arguments": {}, 
+                    "action_type": "HideDatasetAction", 
+                    "output_name": "out_file1"
+                }
+            }, 
+            "tool_errors": null, 
+            "tool_id": "Filter1", 
+            "tool_state": "{\"input\": \"null\", \"__rerun_remap_job_id__\": null, \"header_lines\": \"\\\"0\\\"\", \"cond\": \"\\\"c2=='extr'\\\"\", \"__page__\": 0}", 
+            "tool_version": "1.1.0", 
+            "type": "tool", 
+            "uuid": "af1432da-a54e-4d3a-a643-719f6cdd6866", 
+            "workflow_outputs": []
+        }, 
+        "18": {
+            "annotation": "Filters all proteins that are predicted to reside in lysosomes.", 
+            "content_id": "Filter1", 
+            "id": 18, 
+            "input_connections": {
+                "input": {
+                    "id": 10, 
+                    "output_name": "tabular_file"
+                }
+            }, 
+            "inputs": [], 
+            "label": null, 
+            "name": "Filter", 
+            "outputs": [
+                {
+                    "name": "out_file1", 
+                    "type": "input"
+                }
+            ], 
+            "position": {
+                "left": 1172.75, 
+                "top": 397.75
+            }, 
+            "post_job_actions": {
+                "HideDatasetActionout_file1": {
+                    "action_arguments": {}, 
+                    "action_type": "HideDatasetAction", 
+                    "output_name": "out_file1"
+                }
+            }, 
+            "tool_errors": null, 
+            "tool_id": "Filter1", 
+            "tool_state": "{\"input\": \"null\", \"__rerun_remap_job_id__\": null, \"header_lines\": \"\\\"0\\\"\", \"cond\": \"\\\"c2=='lyso'\\\"\", \"__page__\": 0}", 
+            "tool_version": "1.1.0", 
+            "type": "tool", 
+            "uuid": "195b0060-48f2-4377-aa15-a96be6338d31", 
+            "workflow_outputs": []
+        }, 
+        "19": {
+            "annotation": "", 
+            "content_id": "toolshed.g2.bx.psu.edu/repos/bgruening/text_processing/tp_easyjoin_tool/1.0.0", 
+            "id": 19, 
+            "input_connections": {
+                "infile1": {
+                    "id": 12, 
+                    "output_name": "output"
+                }, 
+                "infile2": {
+                    "id": 13, 
+                    "output_name": "output"
+                }
+            }, 
+            "inputs": [], 
+            "label": null, 
+            "name": "Join", 
+            "outputs": [
+                {
+                    "name": "output", 
+                    "type": "input"
+                }
+            ], 
+            "position": {
+                "left": 1184.75, 
+                "top": 734.75
+            }, 
+            "post_job_actions": {
+                "HideDatasetActionoutput": {
+                    "action_arguments": {}, 
+                    "action_type": "HideDatasetAction", 
+                    "output_name": "output"
+                }
+            }, 
+            "tool_errors": null, 
+            "tool_id": "toolshed.g2.bx.psu.edu/repos/bgruening/text_processing/tp_easyjoin_tool/1.0.0", 
+            "tool_state": "{\"__page__\": 0, \"ignore_case\": \"\\\"False\\\"\", \"infile2\": \"null\", \"infile1\": \"null\", \"empty_string_filler\": \"\\\"0\\\"\", \"__rerun_remap_job_id__\": null, \"jointype\": \"\\\"-v 2\\\"\", \"header\": \"\\\"False\\\"\", \"column1\": \"\\\"1\\\"\", \"column2\": \"\\\"1\\\"\"}", 
+            "tool_version": "1.0.0", 
+            "type": "tool", 
+            "uuid": "fba78726-c9fd-4789-9ed9-2969aa87d984", 
+            "workflow_outputs": []
+        }, 
+        "20": {
+            "annotation": "Combines all GO annotations for \"integral to plasma membrane\" and \"cell surface\"", 
+            "content_id": "toolshed.g2.bx.psu.edu/repos/bgruening/text_processing/tp_easyjoin_tool/1.0.0", 
+            "id": 20, 
+            "input_connections": {
+                "infile1": {
+                    "id": 14, 
+                    "output_name": "output"
+                }, 
+                "infile2": {
+                    "id": 15, 
+                    "output_name": "output"
+                }
+            }, 
+            "inputs": [], 
+            "label": null, 
+            "name": "Join", 
+            "outputs": [
+                {
+                    "name": "output", 
+                    "type": "input"
+                }
+            ], 
+            "position": {
+                "left": 1189.75, 
+                "top": 1009.75
+            }, 
+            "post_job_actions": {
+                "HideDatasetActionoutput": {
+                    "action_arguments": {}, 
+                    "action_type": "HideDatasetAction", 
+                    "output_name": "output"
+                }
+            }, 
+            "tool_errors": null, 
+            "tool_id": "toolshed.g2.bx.psu.edu/repos/bgruening/text_processing/tp_easyjoin_tool/1.0.0", 
+            "tool_state": "{\"__page__\": 0, \"ignore_case\": \"\\\"False\\\"\", \"infile2\": \"null\", \"infile1\": \"null\", \"empty_string_filler\": \"\\\"0\\\"\", \"__rerun_remap_job_id__\": null, \"jointype\": \"\\\"-a 1 -a 2\\\"\", \"header\": \"\\\"False\\\"\", \"column1\": \"\\\"1\\\"\", \"column2\": \"\\\"1\\\"\"}", 
+            "tool_version": "1.0.0", 
+            "type": "tool", 
+            "uuid": "c699e36d-a983-4e66-820d-f00b1b904739", 
+            "workflow_outputs": []
+        }, 
+        "21": {
+            "annotation": "Combines all proteins in the input list that are predicted by WolfPsort to be lysosomal and/or extracellular.", 
+            "content_id": "toolshed.g2.bx.psu.edu/repos/bgruening/text_processing/tp_easyjoin_tool/1.0.0", 
+            "id": 21, 
+            "input_connections": {
+                "infile1": {
+                    "id": 17, 
+                    "output_name": "out_file1"
+                }, 
+                "infile2": {
+                    "id": 18, 
+                    "output_name": "out_file1"
+                }
+            }, 
+            "inputs": [], 
+            "label": null, 
+            "name": "Join", 
+            "outputs": [
+                {
+                    "name": "output", 
+                    "type": "input"
+                }
+            ], 
+            "position": {
+                "left": 1390.75, 
+                "top": 334.75
+            }, 
+            "post_job_actions": {
+                "HideDatasetActionoutput": {
+                    "action_arguments": {}, 
+                    "action_type": "HideDatasetAction", 
+                    "output_name": "output"
+                }
+            }, 
+            "tool_errors": null, 
+            "tool_id": "toolshed.g2.bx.psu.edu/repos/bgruening/text_processing/tp_easyjoin_tool/1.0.0", 
+            "tool_state": "{\"__page__\": 0, \"ignore_case\": \"\\\"False\\\"\", \"infile2\": \"null\", \"infile1\": \"null\", \"empty_string_filler\": \"\\\"0\\\"\", \"__rerun_remap_job_id__\": null, \"jointype\": \"\\\"-a 1 -a 2\\\"\", \"header\": \"\\\"False\\\"\", \"column1\": \"\\\"1\\\"\", \"column2\": \"\\\"1\\\"\"}", 
+            "tool_version": "1.0.0", 
+            "type": "tool", 
+            "uuid": "4a244c68-b12d-46a7-950d-2846a8af8ef5", 
+            "workflow_outputs": []
+        }, 
+        "22": {
+            "annotation": "Combines all GO annotations for \"extracellular region\", \"integral to plasma membrane\" and \"cell surface\" excluding \"extracellular organelle\"", 
+            "content_id": "toolshed.g2.bx.psu.edu/repos/bgruening/text_processing/tp_easyjoin_tool/1.0.0", 
+            "id": 22, 
+            "input_connections": {
+                "infile1": {
+                    "id": 19, 
+                    "output_name": "output"
+                }, 
+                "infile2": {
+                    "id": 20, 
+                    "output_name": "output"
+                }
+            }, 
+            "inputs": [], 
+            "label": null, 
+            "name": "Join", 
+            "outputs": [
+                {
+                    "name": "output", 
+                    "type": "input"
+                }
+            ], 
+            "position": {
+                "left": 1366.75, 
+                "top": 864.75
+            }, 
+            "post_job_actions": {
+                "HideDatasetActionoutput": {
+                    "action_arguments": {}, 
+                    "action_type": "HideDatasetAction", 
+                    "output_name": "output"
+                }
+            }, 
+            "tool_errors": null, 
+            "tool_id": "toolshed.g2.bx.psu.edu/repos/bgruening/text_processing/tp_easyjoin_tool/1.0.0", 
+            "tool_state": "{\"__page__\": 0, \"ignore_case\": \"\\\"False\\\"\", \"infile2\": \"null\", \"infile1\": \"null\", \"empty_string_filler\": \"\\\"0\\\"\", \"__rerun_remap_job_id__\": null, \"jointype\": \"\\\"-a 1 -a 2\\\"\", \"header\": \"\\\"False\\\"\", \"column1\": \"\\\"1\\\"\", \"column2\": \"\\\"1\\\"\"}", 
+            "tool_version": "1.0.0", 
+            "type": "tool", 
+            "uuid": "75b8acd7-7fd1-4ca4-be93-0542b6ed3c9d", 
+            "workflow_outputs": []
+        }, 
+        "23": {
+            "annotation": "Extracts uniprot accessions from all proteins in the input list that are predicted by WolfPsort to be lysosomal and/or extracellular.", 
+            "content_id": "Convert characters1", 
+            "id": 23, 
+            "input_connections": {
+                "input": {
+                    "id": 21, 
+                    "output_name": "output"
+                }
+            }, 
+            "inputs": [], 
+            "label": null, 
+            "name": "Convert", 
+            "outputs": [
+                {
+                    "name": "out_file1", 
+                    "type": "tabular"
+                }
+            ], 
+            "position": {
+                "left": 1513.75, 
+                "top": 458.75
+            }, 
+            "post_job_actions": {
+                "HideDatasetActionout_file1": {
+                    "action_arguments": {}, 
+                    "action_type": "HideDatasetAction", 
+                    "output_name": "out_file1"
+                }
+            }, 
+            "tool_errors": null, 
+            "tool_id": "Convert characters1", 
+            "tool_state": "{\"__page__\": 0, \"__rerun_remap_job_id__\": null, \"condense\": \"\\\"True\\\"\", \"strip\": \"\\\"True\\\"\", \"input\": \"null\", \"convert_from\": \"\\\"P\\\"\"}", 
+            "tool_version": "1.0.0", 
+            "type": "tool", 
+            "uuid": "8e195b7d-e1fa-4df4-9108-697d89119b53", 
+            "workflow_outputs": []
+        }, 
+        "24": {
+            "annotation": "Combines all GO annotations for \"lysosome\", \"extracellular region\", \"integral to plasma membrane\" and \"cell surface\" excluding \"extracellular organelle\"", 
+            "content_id": "toolshed.g2.bx.psu.edu/repos/bgruening/text_processing/tp_easyjoin_tool/1.0.0", 
+            "id": 24, 
+            "input_connections": {
+                "infile1": {
+                    "id": 22, 
+                    "output_name": "output"
+                }, 
+                "infile2": {
+                    "id": 16, 
+                    "output_name": "output"
+                }
+            }, 
+            "inputs": [], 
+            "label": null, 
+            "name": "Join", 
+            "outputs": [
+                {
+                    "name": "output", 
+                    "type": "input"
+                }
+            ], 
+            "position": {
+                "left": 1502.75, 
+                "top": 1036.75
+            }, 
+            "post_job_actions": {
+                "HideDatasetActionoutput": {
+                    "action_arguments": {}, 
+                    "action_type": "HideDatasetAction", 
+                    "output_name": "output"
+                }
+            }, 
+            "tool_errors": null, 
+            "tool_id": "toolshed.g2.bx.psu.edu/repos/bgruening/text_processing/tp_easyjoin_tool/1.0.0", 
+            "tool_state": "{\"__page__\": 0, \"ignore_case\": \"\\\"False\\\"\", \"infile2\": \"null\", \"infile1\": \"null\", \"empty_string_filler\": \"\\\"0\\\"\", \"__rerun_remap_job_id__\": null, \"jointype\": \"\\\"-a 1 -a 2\\\"\", \"header\": \"\\\"False\\\"\", \"column1\": \"\\\"1\\\"\", \"column2\": \"\\\"1\\\"\"}", 
+            "tool_version": "1.0.0", 
+            "type": "tool", 
+            "uuid": "4855cffc-41b9-4a6f-8cd4-9427ec849b95", 
+            "workflow_outputs": []
+        }, 
+        "25": {
+            "annotation": "Deletes all columns but the one containing uniprot accessions of extracellular proteins as predicted by WoLF PSORT.", 
+            "content_id": "toolshed.g2.bx.psu.edu/repos/bgruening/text_processing/tp_cut_tool/1.0.0", 
+            "id": 25, 
+            "input_connections": {
+                "input": {
+                    "id": 23, 
+                    "output_name": "out_file1"
+                }
+            }, 
+            "inputs": [], 
+            "label": null, 
+            "name": "Cut", 
+            "outputs": [
+                {
+                    "name": "output", 
+                    "type": "tabular"
+                }
+            ], 
+            "position": {
+                "left": 1613.75, 
+                "top": 554.75
+            }, 
+            "post_job_actions": {
+                "HideDatasetActionoutput": {
+                    "action_arguments": {}, 
+                    "action_type": "HideDatasetAction", 
+                    "output_name": "output"
+                }
+            }, 
+            "tool_errors": null, 
+            "tool_id": "toolshed.g2.bx.psu.edu/repos/bgruening/text_processing/tp_cut_tool/1.0.0", 
+            "tool_state": "{\"__page__\": 0, \"complement\": \"\\\"\\\"\", \"cut_type_options\": \"{\\\"list\\\": [\\\"2\\\"], \\\"cut_element\\\": \\\"-f\\\", \\\"__current_case__\\\": 0}\", \"delimiter\": \"\\\"\\\"\", \"input\": \"null\", \"__rerun_remap_job_id__\": null}", 
+            "tool_version": "1.0.0", 
+            "type": "tool", 
+            "uuid": "1573af45-4165-4825-ae8d-57182571cf42", 
+            "workflow_outputs": []
+        }, 
+        "26": {
+            "annotation": "filters out all proteins in the input protein list of interest that are annotated as \"extracellular region\" and \"lysosome\" and \"plasma membrane\" excluding \"extracellular organelle\" and \"cytoplasmic side of plasma membrane\"", 
+            "content_id": "comp1", 
+            "id": 26, 
+            "input_connections": {
+                "input1": {
+                    "id": 11, 
+                    "output_name": "output"
+                }, 
+                "input2": {
+                    "id": 24, 
+                    "output_name": "output"
+                }
+            }, 
+            "inputs": [], 
+            "label": null, 
+            "name": "Compare two Datasets", 
+            "outputs": [
+                {
+                    "name": "out_file1", 
+                    "type": "input"
+                }
+            ], 
+            "position": {
+                "left": 1514.75, 
+                "top": 680.75
+            }, 
+            "post_job_actions": {
+                "HideDatasetActionout_file1": {
+                    "action_arguments": {}, 
+                    "action_type": "HideDatasetAction", 
+                    "output_name": "out_file1"
+                }
+            }, 
+            "tool_errors": null, 
+            "tool_id": "comp1", 
+            "tool_state": "{\"input2\": \"null\", \"__page__\": 0, \"input1\": \"null\", \"field2\": \"\\\"1\\\"\", \"__rerun_remap_job_id__\": null, \"field1\": \"\\\"6\\\"\", \"mode\": \"\\\"N\\\"\"}", 
+            "tool_version": "1.0.2", 
+            "type": "tool", 
+            "uuid": "4e5095ba-1132-484b-875d-866676cb8910", 
+            "workflow_outputs": []
+        }, 
+        "27": {
+            "annotation": "cleans up the protein list for unique entries", 
+            "content_id": "toolshed.g2.bx.psu.edu/repos/bgruening/unique/bg_uniq/0.3", 
+            "id": 27, 
+            "input_connections": {
+                "input": {
+                    "id": 26, 
+                    "output_name": "out_file1"
+                }
+            }, 
+            "inputs": [], 
+            "label": null, 
+            "name": "Unique", 
+            "outputs": [
+                {
+                    "name": "outfile", 
+                    "type": "input"
+                }
+            ], 
+            "position": {
+                "left": 1640.75, 
+                "top": 806.75
+            }, 
+            "post_job_actions": {
+                "HideDatasetActionoutfile": {
+                    "action_arguments": {}, 
+                    "action_type": "HideDatasetAction", 
+                    "output_name": "outfile"
+                }
+            }, 
+            "tool_errors": null, 
+            "tool_id": "toolshed.g2.bx.psu.edu/repos/bgruening/unique/bg_uniq/0.3", 
+            "tool_state": "{\"__page__\": 0, \"ignore_case\": \"\\\"False\\\"\", \"adv_opts\": \"{\\\"column_end\\\": \\\"1\\\", \\\"column_start\\\": \\\"1\\\", \\\"adv_opts_selector\\\": \\\"advanced\\\", \\\"__current_case__\\\": 1}\", \"__rerun_remap_job_id__\": null, \"is_numeric\": \"\\\"False\\\"\", \"input\": \"null\"}", 
+            "tool_version": "0.3", 
+            "type": "tool", 
+            "uuid": "89ab7414-9e60-40ae-9598-fee02fab0205", 
+            "workflow_outputs": [],
       "tool_shed_repository": {
         "changeset_revision": "7ce75adb93be",
         "name": "unique",
         "owner": "bgruening",
         "tool_shed": "toolshed.g2.bx.psu.edu"
       }
-    },
-    "28": {
-      "annotation": "Deletes all columns but the one containing uniprot accessions of secreted and shed (i.e. \"secretome\") proteins.",
-      "content_id": "toolshed.g2.bx.psu.edu/repos/bgruening/text_processing/tp_cut_tool/1.0.0",
-      "id": 28,
-      "input_connections": {
-        "input": {
-          "id": 27,
-          "output_name": "outfile"
-        }
-      },
-      "inputs": [],
-      "label": null,
-      "name": "Cut",
-      "outputs": [
-        {
-          "name": "output",
-          "type": "tabular"
-        }
-      ],
-      "position": {
-        "left": 1730.75,
-        "top": 905.75
-      },
-      "post_job_actions": {
-        "HideDatasetActionoutput": {
-          "action_arguments": {},
-          "action_type": "HideDatasetAction",
-          "output_name": "output"
-        }
-      },
-      "tool_errors": null,
-      "tool_id": "toolshed.g2.bx.psu.edu/repos/bgruening/text_processing/tp_cut_tool/1.0.0",
-      "tool_state": "{\"__page__\": 0, \"complement\": \"\\\"\\\"\", \"cut_type_options\": \"{\\\"list\\\": [\\\"1\\\"], \\\"cut_element\\\": \\\"-f\\\", \\\"__current_case__\\\": 0}\", \"delimiter\": \"\\\"\\\"\", \"input\": \"null\", \"__rerun_remap_job_id__\": null}",
-      "tool_version": "1.0.0",
-      "type": "tool",
-      "uuid": "0ad689c9-abf9-4e2b-a3a9-f670c03c3d8b",
-      "workflow_outputs": []
-    },
-    "29": {
-      "annotation": "Combines all proteins that are either predicted by WoLF PSORT to be shed or secreted or annotated in the GO database to be shed or secreted.",
-      "content_id": "toolshed.g2.bx.psu.edu/repos/bgruening/text_processing/tp_easyjoin_tool/1.0.0",
-      "id": 29,
-      "input_connections": {
-        "infile1": {
-          "id": 25,
-          "output_name": "output"
-        },
-        "infile2": {
-          "id": 28,
-          "output_name": "output"
-        }
-      },
-      "inputs": [],
-      "label": null,
-      "name": "Join",
-      "outputs": [
-        {
-          "name": "output",
-          "type": "input"
-        }
-      ],
-      "position": {
-        "left": 1880.75,
-        "top": 649.75
-      },
-      "post_job_actions": {
-        "HideDatasetActionoutput": {
-          "action_arguments": {},
-          "action_type": "HideDatasetAction",
-          "output_name": "output"
-        }
-      },
-      "tool_errors": null,
-      "tool_id": "toolshed.g2.bx.psu.edu/repos/bgruening/text_processing/tp_easyjoin_tool/1.0.0",
-      "tool_state": "{\"__page__\": 0, \"ignore_case\": \"\\\"False\\\"\", \"infile2\": \"null\", \"infile1\": \"null\", \"empty_string_filler\": \"\\\"0\\\"\", \"__rerun_remap_job_id__\": null, \"jointype\": \"\\\"-a 1 -a 2\\\"\", \"header\": \"\\\"False\\\"\", \"column1\": \"\\\"1\\\"\", \"column2\": \"\\\"1\\\"\"}",
-      "tool_version": "1.0.0",
-      "type": "tool",
-      "uuid": "87aa3f42-5408-4475-af7a-c368fed485cd",
-      "workflow_outputs": []
-    },
-    "30": {
-      "annotation": "Final output. Unique entries of all proteins that are either predicted by WoLF PSORT to be shed or secreted or annotated in the GO database to be shed or secreted.",
-      "content_id": "toolshed.g2.bx.psu.edu/repos/bgruening/text_processing/tp_sorted_uniq/1.0.0",
-      "id": 30,
-      "input_connections": {
-        "infile": {
-          "id": 29,
-          "output_name": "output"
-        }
-      },
-      "inputs": [],
-      "label": null,
-      "name": "Unique",
-      "outputs": [
-        {
-          "name": "outfile",
-          "type": "input"
-        }
-      ],
-      "position": {
-        "left": 1964.75,
-        "top": 787.75
-      },
-      "post_job_actions": {
-        "RenameDatasetActionoutfile": {
-          "action_arguments": {
-            "newname": "secretome_proteins"
-          },
-          "action_type": "RenameDatasetAction",
-          "output_name": "outfile"
-        }
-      },
-      "tool_errors": null,
-      "tool_id": "toolshed.g2.bx.psu.edu/repos/bgruening/text_processing/tp_sorted_uniq/1.0.0",
-      "tool_state": "{\"__page__\": 0, \"ignore_case\": \"\\\"False\\\"\", \"adv_opts\": \"{\\\"adv_opts_selector\\\": \\\"basic\\\", \\\"__current_case__\\\": 0}\", \"__rerun_remap_job_id__\": null, \"is_numeric\": \"\\\"False\\\"\", \"infile\": \"null\"}",
-      "tool_version": "1.0.0",
-      "type": "tool",
-      "uuid": "5ca3dd78-27ed-4f4f-95f6-c25fa4fd43b6",
-      "workflow_outputs": [
-        {
-          "label": "Secretome proteins",
-          "output_name": "outfile",
-          "uuid": "14e0c6dc-436b-4c4c-9292-d5e00cca8c92"
-        }
-      ],
+        }, 
+        "28": {
+            "annotation": "Deletes all columns but the one containing uniprot accessions of secreted and shed (i.e. \"secretome\") proteins.", 
+            "content_id": "toolshed.g2.bx.psu.edu/repos/bgruening/text_processing/tp_cut_tool/1.0.0", 
+            "id": 28, 
+            "input_connections": {
+                "input": {
+                    "id": 27, 
+                    "output_name": "outfile"
+                }
+            }, 
+            "inputs": [], 
+            "label": null, 
+            "name": "Cut", 
+            "outputs": [
+                {
+                    "name": "output", 
+                    "type": "tabular"
+                }
+            ], 
+            "position": {
+                "left": 1730.75, 
+                "top": 905.75
+            }, 
+            "post_job_actions": {
+                "HideDatasetActionoutput": {
+                    "action_arguments": {}, 
+                    "action_type": "HideDatasetAction", 
+                    "output_name": "output"
+                }
+            }, 
+            "tool_errors": null, 
+            "tool_id": "toolshed.g2.bx.psu.edu/repos/bgruening/text_processing/tp_cut_tool/1.0.0", 
+            "tool_state": "{\"__page__\": 0, \"complement\": \"\\\"\\\"\", \"cut_type_options\": \"{\\\"list\\\": [\\\"1\\\"], \\\"cut_element\\\": \\\"-f\\\", \\\"__current_case__\\\": 0}\", \"delimiter\": \"\\\"\\\"\", \"input\": \"null\", \"__rerun_remap_job_id__\": null}", 
+            "tool_version": "1.0.0", 
+            "type": "tool", 
+            "uuid": "0ad689c9-abf9-4e2b-a3a9-f670c03c3d8b", 
+            "workflow_outputs": []
+        }, 
+        "29": {
+            "annotation": "Combines all proteins that are either predicted by WoLF PSORT to be shed or secreted or annotated in the GO database to be shed or secreted.", 
+            "content_id": "toolshed.g2.bx.psu.edu/repos/bgruening/text_processing/tp_easyjoin_tool/1.0.0", 
+            "id": 29, 
+            "input_connections": {
+                "infile1": {
+                    "id": 25, 
+                    "output_name": "output"
+                }, 
+                "infile2": {
+                    "id": 28, 
+                    "output_name": "output"
+                }
+            }, 
+            "inputs": [], 
+            "label": null, 
+            "name": "Join", 
+            "outputs": [
+                {
+                    "name": "output", 
+                    "type": "input"
+                }
+            ], 
+            "position": {
+                "left": 1880.75, 
+                "top": 649.75
+            }, 
+            "post_job_actions": {
+                "HideDatasetActionoutput": {
+                    "action_arguments": {}, 
+                    "action_type": "HideDatasetAction", 
+                    "output_name": "output"
+                }
+            }, 
+            "tool_errors": null, 
+            "tool_id": "toolshed.g2.bx.psu.edu/repos/bgruening/text_processing/tp_easyjoin_tool/1.0.0", 
+            "tool_state": "{\"__page__\": 0, \"ignore_case\": \"\\\"False\\\"\", \"infile2\": \"null\", \"infile1\": \"null\", \"empty_string_filler\": \"\\\"0\\\"\", \"__rerun_remap_job_id__\": null, \"jointype\": \"\\\"-a 1 -a 2\\\"\", \"header\": \"\\\"False\\\"\", \"column1\": \"\\\"1\\\"\", \"column2\": \"\\\"1\\\"\"}", 
+            "tool_version": "1.0.0", 
+            "type": "tool", 
+            "uuid": "87aa3f42-5408-4475-af7a-c368fed485cd", 
+            "workflow_outputs": []
+        }, 
+        "30": {
+            "annotation": "Final output. Unique entries of all proteins that are either predicted by WoLF PSORT to be shed or secreted or annotated in the GO database to be shed or secreted.", 
+            "content_id": "toolshed.g2.bx.psu.edu/repos/bgruening/text_processing/tp_sorted_uniq/1.0.0", 
+            "id": 30, 
+            "input_connections": {
+                "infile": {
+                    "id": 29, 
+                    "output_name": "output"
+                }
+            }, 
+            "inputs": [], 
+            "label": null, 
+            "name": "Unique", 
+            "outputs": [
+                {
+                    "name": "outfile", 
+                    "type": "input"
+                }
+            ], 
+            "position": {
+                "left": 1964.75, 
+                "top": 787.75
+            }, 
+            "post_job_actions": {
+                "RenameDatasetActionoutfile": {
+                    "action_arguments": {
+                        "newname": "secretome_proteins"
+                    }, 
+                    "action_type": "RenameDatasetAction", 
+                    "output_name": "outfile"
+                }
+            }, 
+            "tool_errors": null, 
+            "tool_id": "toolshed.g2.bx.psu.edu/repos/bgruening/text_processing/tp_sorted_uniq/1.0.0", 
+            "tool_state": "{\"__page__\": 0, \"ignore_case\": \"\\\"False\\\"\", \"adv_opts\": \"{\\\"adv_opts_selector\\\": \\\"basic\\\", \\\"__current_case__\\\": 0}\", \"__rerun_remap_job_id__\": null, \"is_numeric\": \"\\\"False\\\"\", \"infile\": \"null\"}", 
+            "tool_version": "1.0.0", 
+            "type": "tool", 
+            "uuid": "5ca3dd78-27ed-4f4f-95f6-c25fa4fd43b6", 
+            "workflow_outputs": [
+                {
+                    "label": "Secretome proteins", 
+                    "output_name": "outfile", 
+                    "uuid": "14e0c6dc-436b-4c4c-9292-d5e00cca8c92"
+                }
+            ],
       "tool_shed_repository": {
         "changeset_revision": "288462ec2630",
         "name": "text_processing",
         "owner": "bgruening",
         "tool_shed": "toolshed.g2.bx.psu.edu"
       }
-    }
-  },
-  "uuid": "017c3db3-46ca-4ff7-9e50-132679765355"
+        }
+    }, 
+    "uuid": "017c3db3-46ca-4ff7-9e50-132679765355"
 }

--- a/topics/proteomics/tutorials/secretome-prediction/workflows/WF_secretomePrediction_goWolfpsort.ga
+++ b/topics/proteomics/tutorials/secretome-prediction/workflows/WF_secretomePrediction_goWolfpsort.ga
@@ -1,1271 +1,1361 @@
 {
-    "a_galaxy_workflow": "true", 
-    "annotation": "version 1.0, 160318, published at https://github.com/Stortebecker/secretome_prediction", 
-    "format-version": "0.1", 
-    "name": "Secreted Proteins via GO annotation and WoLF PSORT for shCTSB paper", 
-    "steps": {
-        "0": {
-            "annotation": "Input: Protein ID list\nFirst column has to be uniprot accessions", 
-            "content_id": null, 
-            "id": 0, 
-            "input_connections": {}, 
-            "inputs": [
-                {
-                    "description": "Input: Protein ID list\nFirst column has to be uniprot accessions", 
-                    "name": "Custom Protein list (uniprot accession)"
-                }
-            ], 
-            "label": null, 
-            "name": "Input dataset", 
-            "outputs": [], 
-            "position": {
-                "left": 293, 
-                "top": 377
-            }, 
-            "tool_errors": null, 
-            "tool_id": null, 
-            "tool_state": "{\"name\": \"Custom Protein list (uniprot accession)\"}", 
-            "tool_version": null, 
-            "type": "data_input", 
-            "uuid": "4d60060c-188b-4a93-8320-36f9b43e5765", 
-            "workflow_outputs": [
-                {
-                    "label": null, 
-                    "output_name": "output", 
-                    "uuid": "27022e50-f5dc-46b1-8b54-979f955eb050"
-                }
-            ]
-        }, 
-        "1": {
-            "annotation": "Input: Uniprot GO database file (choose the right organism)\nExample: ftp://ftp.ebi.ac.uk/pub/databases/GO/goa/HUMAN/gene_association.goa_human.gz", 
-            "content_id": null, 
-            "id": 1, 
-            "input_connections": {}, 
-            "inputs": [
-                {
-                    "description": "Input: Uniprot GO database file (choose the right organism)\nExample: ftp://ftp.ebi.ac.uk/pub/databases/GO/goa/HUMAN/gene_association.goa_human.gz", 
-                    "name": "Uniprot GO database"
-                }
-            ], 
-            "label": null, 
-            "name": "Input dataset", 
-            "outputs": [], 
-            "position": {
-                "left": 290, 
-                "top": 507
-            }, 
-            "tool_errors": null, 
-            "tool_id": null, 
-            "tool_state": "{\"name\": \"Uniprot GO database\"}", 
-            "tool_version": null, 
-            "type": "data_input", 
-            "uuid": "e8f4a577-7b6a-4cd0-9a74-2e68c4ae6c5a", 
-            "workflow_outputs": [
-                {
-                    "label": null, 
-                    "output_name": "output", 
-                    "uuid": "b8fa36c2-6bbf-40c1-a472-8d4a6a7096c3"
-                }
-            ]
-        }, 
-        "2": {
-            "annotation": "Input: Please downlad the Open Biomedical Ontology (OBO), i.e. \"GO term tree\" from\nhttp://purl.obolibrary.org/obo/go/go.obo", 
-            "content_id": null, 
-            "id": 2, 
-            "input_connections": {}, 
-            "inputs": [
-                {
-                    "description": "Input: Please downlad the Open Biomedical Ontology (OBO), i.e. \"GO term tree\" from\nhttp://purl.obolibrary.org/obo/go/go.obo", 
-                    "name": "Open Biomedical Ontology (OBO)"
-                }
-            ], 
-            "label": null, 
-            "name": "Input dataset", 
-            "outputs": [], 
-            "position": {
-                "left": 293, 
-                "top": 790
-            }, 
-            "tool_errors": null, 
-            "tool_id": null, 
-            "tool_state": "{\"name\": \"Open Biomedical Ontology (OBO)\"}", 
-            "tool_version": null, 
-            "type": "data_input", 
-            "uuid": "0640e1c4-4d77-49da-8473-0018e0a5db09", 
-            "workflow_outputs": [
-                {
-                    "label": null, 
-                    "output_name": "output", 
-                    "uuid": "4725c10d-9e7a-4e3f-9874-c302c34687cb"
-                }
-            ]
-        }, 
-        "3": {
-            "annotation": "Retrieves Fasta files for all proteins in the input list.", 
-            "content_id": "toolshed.g2.bx.psu.edu/repos/bgruening/uniprot_rest_interface/uniprot/0.1", 
-            "id": 3, 
-            "input_connections": {
-                "infile": {
-                    "id": 0, 
-                    "output_name": "output"
-                }
-            }, 
-            "inputs": [], 
-            "label": null, 
-            "name": "UniProt", 
-            "outputs": [
-                {
-                    "name": "outfile_retrieve_fasta", 
-                    "type": "fasta"
-                }, 
-                {
-                    "name": "outfile_retrieve_gff", 
-                    "type": "gff"
-                }, 
-                {
-                    "name": "outfile_retrieve_txt", 
-                    "type": "txt"
-                }, 
-                {
-                    "name": "outfile_map", 
-                    "type": "tabular"
-                }
-            ], 
-            "position": {
-                "left": 573.75, 
-                "top": 258.75
-            }, 
-            "post_job_actions": {
-                "HideDatasetActionoutfile_map": {
-                    "action_arguments": {}, 
-                    "action_type": "HideDatasetAction", 
-                    "output_name": "outfile_map"
-                }, 
-                "HideDatasetActionoutfile_retrieve_fasta": {
-                    "action_arguments": {}, 
-                    "action_type": "HideDatasetAction", 
-                    "output_name": "outfile_retrieve_fasta"
-                }, 
-                "HideDatasetActionoutfile_retrieve_gff": {
-                    "action_arguments": {}, 
-                    "action_type": "HideDatasetAction", 
-                    "output_name": "outfile_retrieve_gff"
-                }, 
-                "HideDatasetActionoutfile_retrieve_txt": {
-                    "action_arguments": {}, 
-                    "action_type": "HideDatasetAction", 
-                    "output_name": "outfile_retrieve_txt"
-                }
-            }, 
-            "tool_errors": null, 
-            "tool_id": "toolshed.g2.bx.psu.edu/repos/bgruening/uniprot_rest_interface/uniprot/0.1", 
-            "tool_state": "{\"__page__\": 0, \"tool\": \"{\\\"format\\\": \\\"fasta\\\", \\\"__current_case__\\\": 1, \\\"tool_choice\\\": \\\"retrieve\\\"}\", \"__rerun_remap_job_id__\": null, \"id_column\": \"\\\"1\\\"\", \"infile\": \"null\"}", 
-            "tool_version": "0.1", 
-            "type": "tool", 
-            "uuid": "d6d73f27-bb3e-4763-825a-23d457df38af", 
-            "workflow_outputs": []
-        }, 
-        "4": {
-            "annotation": "Removes comment lines at the head of the Uniprot Go database file.", 
-            "content_id": "Grep1", 
-            "id": 4, 
-            "input_connections": {
-                "input": {
-                    "id": 1, 
-                    "output_name": "output"
-                }
-            }, 
-            "inputs": [], 
-            "label": null, 
-            "name": "Select", 
-            "outputs": [
-                {
-                    "name": "out_file1", 
-                    "type": "input"
-                }
-            ], 
-            "position": {
-                "left": 552, 
-                "top": 505
-            }, 
-            "post_job_actions": {
-                "ChangeDatatypeActionout_file1": {
-                    "action_arguments": {
-                        "newtype": "tabular"
-                    }, 
-                    "action_type": "ChangeDatatypeAction", 
-                    "output_name": "out_file1"
-                }, 
-                "HideDatasetActionout_file1": {
-                    "action_arguments": {}, 
-                    "action_type": "HideDatasetAction", 
-                    "output_name": "out_file1"
-                }
-            }, 
-            "tool_errors": null, 
-            "tool_id": "Grep1", 
-            "tool_state": "{\"__page__\": 0, \"input\": \"null\", \"invert\": \"\\\"true\\\"\", \"__rerun_remap_job_id__\": null, \"pattern\": \"\\\"^!\\\"\"}", 
-            "tool_version": "1.0.1", 
-            "type": "tool", 
-            "uuid": "11c206f4-bc11-400c-8bd5-335bc8c6d63d", 
-            "workflow_outputs": []
-        }, 
-        "5": {
-            "annotation": "GO:0043230 \"extracellular organelle\"", 
-            "content_id": "get_subontology_from", 
-            "id": 5, 
-            "input_connections": {
-                "input_ontology": {
-                    "id": 2, 
-                    "output_name": "output"
-                }
-            }, 
-            "inputs": [], 
-            "label": null, 
-            "name": "Get subontology from a given OBO term", 
-            "outputs": [
-                {
-                    "name": "output", 
-                    "type": "txt"
-                }
-            ], 
-            "position": {
-                "left": 549, 
-                "top": 663
-            }, 
-            "post_job_actions": {
-                "HideDatasetActionoutput": {
-                    "action_arguments": {}, 
-                    "action_type": "HideDatasetAction", 
-                    "output_name": "output"
-                }
-            }, 
-            "tool_errors": null, 
-            "tool_id": "get_subontology_from", 
-            "tool_state": "{\"__page__\": 0, \"__rerun_remap_job_id__\": null, \"new_root\": \"\\\"GO:0043230\\\"\", \"input_ontology\": \"null\"}", 
-            "tool_version": "1.22", 
-            "type": "tool", 
-            "uuid": "636177a8-5b63-457c-acaa-518748094834", 
-            "workflow_outputs": []
-        }, 
-        "6": {
-            "annotation": "GO:0005576 \"extracellular region\"", 
-            "content_id": "get_subontology_from", 
-            "id": 6, 
-            "input_connections": {
-                "input_ontology": {
-                    "id": 2, 
-                    "output_name": "output"
-                }
-            }, 
-            "inputs": [], 
-            "label": null, 
-            "name": "Get subontology from a given OBO term", 
-            "outputs": [
-                {
-                    "name": "output", 
-                    "type": "txt"
-                }
-            ], 
-            "position": {
-                "left": 549, 
-                "top": 814
-            }, 
-            "post_job_actions": {
-                "HideDatasetActionoutput": {
-                    "action_arguments": {}, 
-                    "action_type": "HideDatasetAction", 
-                    "output_name": "output"
-                }
-            }, 
-            "tool_errors": null, 
-            "tool_id": "get_subontology_from", 
-            "tool_state": "{\"__page__\": 0, \"__rerun_remap_job_id__\": null, \"new_root\": \"\\\"GO:0005576\\\"\", \"input_ontology\": \"null\"}", 
-            "tool_version": "1.22", 
-            "type": "tool", 
-            "uuid": "163ebfd8-82c8-430e-a37f-e6670cb5069e", 
-            "workflow_outputs": []
-        }, 
-        "7": {
-            "annotation": "GO:0005887 \"integral component of plasma membrane\"", 
-            "content_id": "get_subontology_from", 
-            "id": 7, 
-            "input_connections": {
-                "input_ontology": {
-                    "id": 2, 
-                    "output_name": "output"
-                }
-            }, 
-            "inputs": [], 
-            "label": null, 
-            "name": "Get subontology from a given OBO term", 
-            "outputs": [
-                {
-                    "name": "output", 
-                    "type": "txt"
-                }
-            ], 
-            "position": {
-                "left": 551.75, 
-                "top": 918.75
-            }, 
-            "post_job_actions": {
-                "HideDatasetActionoutput": {
-                    "action_arguments": {}, 
-                    "action_type": "HideDatasetAction", 
-                    "output_name": "output"
-                }
-            }, 
-            "tool_errors": null, 
-            "tool_id": "get_subontology_from", 
-            "tool_state": "{\"__page__\": 0, \"__rerun_remap_job_id__\": null, \"new_root\": \"\\\"GO:0005887\\\"\", \"input_ontology\": \"null\"}", 
-            "tool_version": "1.22", 
-            "type": "tool", 
-            "uuid": "c3b4bd46-4f3a-46a0-927d-4fc15bc9f4d5", 
-            "workflow_outputs": []
-        }, 
-        "8": {
-            "annotation": "GO:0009986 \"cell surface\"", 
-            "content_id": "get_subontology_from", 
-            "id": 8, 
-            "input_connections": {
-                "input_ontology": {
-                    "id": 2, 
-                    "output_name": "output"
-                }
-            }, 
-            "inputs": [], 
-            "label": null, 
-            "name": "Get subontology from a given OBO term", 
-            "outputs": [
-                {
-                    "name": "output", 
-                    "type": "txt"
-                }
-            ], 
-            "position": {
-                "left": 554.75, 
-                "top": 1029.75
-            }, 
-            "post_job_actions": {
-                "HideDatasetActionoutput": {
-                    "action_arguments": {}, 
-                    "action_type": "HideDatasetAction", 
-                    "output_name": "output"
-                }
-            }, 
-            "tool_errors": null, 
-            "tool_id": "get_subontology_from", 
-            "tool_state": "{\"__page__\": 0, \"__rerun_remap_job_id__\": null, \"new_root\": \"\\\"GO:0009986\\\"\", \"input_ontology\": \"null\"}", 
-            "tool_version": "1.22", 
-            "type": "tool", 
-            "uuid": "608f525c-f9f7-4ea5-abc6-89d97f171c53", 
-            "workflow_outputs": []
-        }, 
-        "9": {
-            "annotation": "GO:0005764 \"lysosome\"", 
-            "content_id": "get_subontology_from", 
-            "id": 9, 
-            "input_connections": {
-                "input_ontology": {
-                    "id": 2, 
-                    "output_name": "output"
-                }
-            }, 
-            "inputs": [], 
-            "label": null, 
-            "name": "Get subontology from a given OBO term", 
-            "outputs": [
-                {
-                    "name": "output", 
-                    "type": "txt"
-                }
-            ], 
-            "position": {
-                "left": 556.75, 
-                "top": 1137.75
-            }, 
-            "post_job_actions": {
-                "HideDatasetActionoutput": {
-                    "action_arguments": {}, 
-                    "action_type": "HideDatasetAction", 
-                    "output_name": "output"
-                }
-            }, 
-            "tool_errors": null, 
-            "tool_id": "get_subontology_from", 
-            "tool_state": "{\"__page__\": 0, \"__rerun_remap_job_id__\": null, \"new_root\": \"\\\"GO:0005764 \\\"\", \"input_ontology\": \"null\"}", 
-            "tool_version": "1.22", 
-            "type": "tool", 
-            "uuid": "fbd3c1c0-a6e6-4b77-9d04-b19df7cac3f3", 
-            "workflow_outputs": []
-        }, 
-        "10": {
-            "annotation": "Predicts subcellular localization of all proteins in the input list.", 
-            "content_id": "toolshed.g2.bx.psu.edu/repos/peterjc/tmhmm_and_signalp/wolf_psort/0.0.8", 
-            "id": 10, 
-            "input_connections": {
-                "fasta_file": {
-                    "id": 3, 
-                    "output_name": "outfile_retrieve_fasta"
-                }
-            }, 
-            "inputs": [], 
-            "label": null, 
-            "name": "WoLF PSORT", 
-            "outputs": [
-                {
-                    "name": "tabular_file", 
-                    "type": "tabular"
-                }
-            ], 
-            "position": {
-                "left": 886.75, 
-                "top": 326.75
-            }, 
-            "post_job_actions": {
-                "HideDatasetActiontabular_file": {
-                    "action_arguments": {}, 
-                    "action_type": "HideDatasetAction", 
-                    "output_name": "tabular_file"
-                }, 
-                "RenameDatasetActiontabular_file": {
-                    "action_arguments": {
-                        "newname": "WoLF_PSORT_output"
-                    }, 
-                    "action_type": "RenameDatasetAction", 
-                    "output_name": "tabular_file"
-                }
-            }, 
-            "tool_errors": null, 
-            "tool_id": "toolshed.g2.bx.psu.edu/repos/peterjc/tmhmm_and_signalp/wolf_psort/0.0.8", 
-            "tool_state": "{\"__page__\": 0, \"fasta_file\": \"null\", \"organism\": \"\\\"animal\\\"\", \"__rerun_remap_job_id__\": null}", 
-            "tool_version": "0.0.8", 
-            "type": "tool", 
-            "uuid": "60edfc44-cad4-4afd-8907-4003700d6576", 
-            "workflow_outputs": []
-        }, 
-        "11": {
-            "annotation": "Annotates input protein list with GO annotations.", 
-            "content_id": "toolshed.g2.bx.psu.edu/repos/bgruening/text_processing/tp_easyjoin_tool/1.0.0", 
-            "id": 11, 
-            "input_connections": {
-                "infile1": {
-                    "id": 0, 
-                    "output_name": "output"
-                }, 
-                "infile2": {
-                    "id": 4, 
-                    "output_name": "out_file1"
-                }
-            }, 
-            "inputs": [], 
-            "label": null, 
-            "name": "Join", 
-            "outputs": [
-                {
-                    "name": "output", 
-                    "type": "input"
-                }
-            ], 
-            "position": {
-                "left": 939, 
-                "top": 479
-            }, 
-            "post_job_actions": {
-                "ChangeDatatypeActionoutput": {
-                    "action_arguments": {
-                        "newtype": "tabular"
-                    }, 
-                    "action_type": "ChangeDatatypeAction", 
-                    "output_name": "output"
-                }, 
-                "HideDatasetActionoutput": {
-                    "action_arguments": {}, 
-                    "action_type": "HideDatasetAction", 
-                    "output_name": "output"
-                }
-            }, 
-            "tool_errors": null, 
-            "tool_id": "toolshed.g2.bx.psu.edu/repos/bgruening/text_processing/tp_easyjoin_tool/1.0.0", 
-            "tool_state": "{\"__page__\": 0, \"ignore_case\": \"\\\"False\\\"\", \"infile2\": \"null\", \"infile1\": \"null\", \"empty_string_filler\": \"\\\"0\\\"\", \"__rerun_remap_job_id__\": null, \"jointype\": \"\\\"-a 1\\\"\", \"header\": \"\\\"False\\\"\", \"column1\": \"\\\"1\\\"\", \"column2\": \"\\\"2\\\"\"}", 
-            "tool_version": "1.0.0", 
-            "type": "tool", 
-            "uuid": "5bda528d-4d1d-49d5-8f18-dcd7b92152dc", 
-            "workflow_outputs": []
-        }, 
-        "12": {
-            "annotation": "GO:0043230 \"extracellular organelle\"", 
-            "content_id": "term_id_vs_term_name", 
-            "id": 12, 
-            "input_connections": {
-                "input_ontology": {
-                    "id": 5, 
-                    "output_name": "output"
-                }
-            }, 
-            "inputs": [], 
-            "label": null, 
-            "name": "Get all the term IDs and term names of a given OBO ontology", 
-            "outputs": [
-                {
-                    "name": "output", 
-                    "type": "tabular"
-                }
-            ], 
-            "position": {
-                "left": 872.25, 
-                "top": 646.75
-            }, 
-            "post_job_actions": {
-                "HideDatasetActionoutput": {
-                    "action_arguments": {}, 
-                    "action_type": "HideDatasetAction", 
-                    "output_name": "output"
-                }
-            }, 
-            "tool_errors": null, 
-            "tool_id": "term_id_vs_term_name", 
-            "tool_state": "{\"__page__\": 0, \"__rerun_remap_job_id__\": null, \"input_ontology\": \"null\"}", 
-            "tool_version": "1.22", 
-            "type": "tool", 
-            "uuid": "89bd62f8-6548-4411-a1f0-861364c43189", 
-            "workflow_outputs": []
-        }, 
-        "13": {
-            "annotation": "GO:0005576 \"extracellular region\"", 
-            "content_id": "term_id_vs_term_name", 
-            "id": 13, 
-            "input_connections": {
-                "input_ontology": {
-                    "id": 6, 
-                    "output_name": "output"
-                }
-            }, 
-            "inputs": [], 
-            "label": null, 
-            "name": "Get all the term IDs and term names of a given OBO ontology", 
-            "outputs": [
-                {
-                    "name": "output", 
-                    "type": "tabular"
-                }
-            ], 
-            "position": {
-                "left": 867.25, 
-                "top": 815.75
-            }, 
-            "post_job_actions": {
-                "HideDatasetActionoutput": {
-                    "action_arguments": {}, 
-                    "action_type": "HideDatasetAction", 
-                    "output_name": "output"
-                }
-            }, 
-            "tool_errors": null, 
-            "tool_id": "term_id_vs_term_name", 
-            "tool_state": "{\"__page__\": 0, \"__rerun_remap_job_id__\": null, \"input_ontology\": \"null\"}", 
-            "tool_version": "1.22", 
-            "type": "tool", 
-            "uuid": "4ddbced9-e92d-467e-bbb9-7b2bcd8af58d", 
-            "workflow_outputs": []
-        }, 
-        "14": {
-            "annotation": "GO:0005887 \"integral component of plasma membrane\"", 
-            "content_id": "term_id_vs_term_name", 
-            "id": 14, 
-            "input_connections": {
-                "input_ontology": {
-                    "id": 7, 
-                    "output_name": "output"
-                }
-            }, 
-            "inputs": [], 
-            "label": null, 
-            "name": "Get all the term IDs and term names of a given OBO ontology", 
-            "outputs": [
-                {
-                    "name": "output", 
-                    "type": "tabular"
-                }
-            ], 
-            "position": {
-                "left": 869.25, 
-                "top": 922.75
-            }, 
-            "post_job_actions": {
-                "HideDatasetActionoutput": {
-                    "action_arguments": {}, 
-                    "action_type": "HideDatasetAction", 
-                    "output_name": "output"
-                }, 
-                "RenameDatasetActionoutput": {
-                    "action_arguments": {
-                        "newname": "integral component of plasma membrane subontology"
-                    }, 
-                    "action_type": "RenameDatasetAction", 
-                    "output_name": "output"
-                }
-            }, 
-            "tool_errors": null, 
-            "tool_id": "term_id_vs_term_name", 
-            "tool_state": "{\"__page__\": 0, \"__rerun_remap_job_id__\": null, \"input_ontology\": \"null\"}", 
-            "tool_version": "1.22", 
-            "type": "tool", 
-            "uuid": "d1dc97ba-cae6-42e7-b0d6-67d94bd3ba30", 
-            "workflow_outputs": []
-        }, 
-        "15": {
-            "annotation": "GO:0009986 \"cell surface\"", 
-            "content_id": "term_id_vs_term_name", 
-            "id": 15, 
-            "input_connections": {
-                "input_ontology": {
-                    "id": 8, 
-                    "output_name": "output"
-                }
-            }, 
-            "inputs": [], 
-            "label": null, 
-            "name": "Get all the term IDs and term names of a given OBO ontology", 
-            "outputs": [
-                {
-                    "name": "output", 
-                    "type": "tabular"
-                }
-            ], 
-            "position": {
-                "left": 872.25, 
-                "top": 1030.75
-            }, 
-            "post_job_actions": {
-                "HideDatasetActionoutput": {
-                    "action_arguments": {}, 
-                    "action_type": "HideDatasetAction", 
-                    "output_name": "output"
-                }, 
-                "RenameDatasetActionoutput": {
-                    "action_arguments": {
-                        "newname": "cell surface subontology"
-                    }, 
-                    "action_type": "RenameDatasetAction", 
-                    "output_name": "output"
-                }
-            }, 
-            "tool_errors": null, 
-            "tool_id": "term_id_vs_term_name", 
-            "tool_state": "{\"__page__\": 0, \"__rerun_remap_job_id__\": null, \"input_ontology\": \"null\"}", 
-            "tool_version": "1.22", 
-            "type": "tool", 
-            "uuid": "bfa87a5a-7770-4a09-ab7a-2fe04c5e24a7", 
-            "workflow_outputs": []
-        }, 
-        "16": {
-            "annotation": "GO:0005764 \"lysosome\"", 
-            "content_id": "term_id_vs_term_name", 
-            "id": 16, 
-            "input_connections": {
-                "input_ontology": {
-                    "id": 9, 
-                    "output_name": "output"
-                }
-            }, 
-            "inputs": [], 
-            "label": null, 
-            "name": "Get all the term IDs and term names of a given OBO ontology", 
-            "outputs": [
-                {
-                    "name": "output", 
-                    "type": "tabular"
-                }
-            ], 
-            "position": {
-                "left": 871.25, 
-                "top": 1140.75
-            }, 
-            "post_job_actions": {
-                "HideDatasetActionoutput": {
-                    "action_arguments": {}, 
-                    "action_type": "HideDatasetAction", 
-                    "output_name": "output"
-                }
-            }, 
-            "tool_errors": null, 
-            "tool_id": "term_id_vs_term_name", 
-            "tool_state": "{\"__page__\": 0, \"__rerun_remap_job_id__\": null, \"input_ontology\": \"null\"}", 
-            "tool_version": "1.22", 
-            "type": "tool", 
-            "uuid": "0e3a5a39-27cc-4091-8831-615ebc60ed8c", 
-            "workflow_outputs": []
-        }, 
-        "17": {
-            "annotation": "Filters all proteins that are predicted to reside extracellularly.", 
-            "content_id": "Filter1", 
-            "id": 17, 
-            "input_connections": {
-                "input": {
-                    "id": 10, 
-                    "output_name": "tabular_file"
-                }
-            }, 
-            "inputs": [], 
-            "label": null, 
-            "name": "Filter", 
-            "outputs": [
-                {
-                    "name": "out_file1", 
-                    "type": "input"
-                }
-            ], 
-            "position": {
-                "left": 1171.75, 
-                "top": 288.75
-            }, 
-            "post_job_actions": {
-                "HideDatasetActionout_file1": {
-                    "action_arguments": {}, 
-                    "action_type": "HideDatasetAction", 
-                    "output_name": "out_file1"
-                }
-            }, 
-            "tool_errors": null, 
-            "tool_id": "Filter1", 
-            "tool_state": "{\"input\": \"null\", \"__rerun_remap_job_id__\": null, \"header_lines\": \"\\\"0\\\"\", \"cond\": \"\\\"c2=='extr'\\\"\", \"__page__\": 0}", 
-            "tool_version": "1.1.0", 
-            "type": "tool", 
-            "uuid": "af1432da-a54e-4d3a-a643-719f6cdd6866", 
-            "workflow_outputs": []
-        }, 
-        "18": {
-            "annotation": "Filters all proteins that are predicted to reside in lysosomes.", 
-            "content_id": "Filter1", 
-            "id": 18, 
-            "input_connections": {
-                "input": {
-                    "id": 10, 
-                    "output_name": "tabular_file"
-                }
-            }, 
-            "inputs": [], 
-            "label": null, 
-            "name": "Filter", 
-            "outputs": [
-                {
-                    "name": "out_file1", 
-                    "type": "input"
-                }
-            ], 
-            "position": {
-                "left": 1172.75, 
-                "top": 397.75
-            }, 
-            "post_job_actions": {
-                "HideDatasetActionout_file1": {
-                    "action_arguments": {}, 
-                    "action_type": "HideDatasetAction", 
-                    "output_name": "out_file1"
-                }
-            }, 
-            "tool_errors": null, 
-            "tool_id": "Filter1", 
-            "tool_state": "{\"input\": \"null\", \"__rerun_remap_job_id__\": null, \"header_lines\": \"\\\"0\\\"\", \"cond\": \"\\\"c2=='lyso'\\\"\", \"__page__\": 0}", 
-            "tool_version": "1.1.0", 
-            "type": "tool", 
-            "uuid": "195b0060-48f2-4377-aa15-a96be6338d31", 
-            "workflow_outputs": []
-        }, 
-        "19": {
-            "annotation": "", 
-            "content_id": "toolshed.g2.bx.psu.edu/repos/bgruening/text_processing/tp_easyjoin_tool/1.0.0", 
-            "id": 19, 
-            "input_connections": {
-                "infile1": {
-                    "id": 12, 
-                    "output_name": "output"
-                }, 
-                "infile2": {
-                    "id": 13, 
-                    "output_name": "output"
-                }
-            }, 
-            "inputs": [], 
-            "label": null, 
-            "name": "Join", 
-            "outputs": [
-                {
-                    "name": "output", 
-                    "type": "input"
-                }
-            ], 
-            "position": {
-                "left": 1184.75, 
-                "top": 734.75
-            }, 
-            "post_job_actions": {
-                "HideDatasetActionoutput": {
-                    "action_arguments": {}, 
-                    "action_type": "HideDatasetAction", 
-                    "output_name": "output"
-                }
-            }, 
-            "tool_errors": null, 
-            "tool_id": "toolshed.g2.bx.psu.edu/repos/bgruening/text_processing/tp_easyjoin_tool/1.0.0", 
-            "tool_state": "{\"__page__\": 0, \"ignore_case\": \"\\\"False\\\"\", \"infile2\": \"null\", \"infile1\": \"null\", \"empty_string_filler\": \"\\\"0\\\"\", \"__rerun_remap_job_id__\": null, \"jointype\": \"\\\"-v 2\\\"\", \"header\": \"\\\"False\\\"\", \"column1\": \"\\\"1\\\"\", \"column2\": \"\\\"1\\\"\"}", 
-            "tool_version": "1.0.0", 
-            "type": "tool", 
-            "uuid": "fba78726-c9fd-4789-9ed9-2969aa87d984", 
-            "workflow_outputs": []
-        }, 
-        "20": {
-            "annotation": "Combines all GO annotations for \"integral to plasma membrane\" and \"cell surface\"", 
-            "content_id": "toolshed.g2.bx.psu.edu/repos/bgruening/text_processing/tp_easyjoin_tool/1.0.0", 
-            "id": 20, 
-            "input_connections": {
-                "infile1": {
-                    "id": 14, 
-                    "output_name": "output"
-                }, 
-                "infile2": {
-                    "id": 15, 
-                    "output_name": "output"
-                }
-            }, 
-            "inputs": [], 
-            "label": null, 
-            "name": "Join", 
-            "outputs": [
-                {
-                    "name": "output", 
-                    "type": "input"
-                }
-            ], 
-            "position": {
-                "left": 1189.75, 
-                "top": 1009.75
-            }, 
-            "post_job_actions": {
-                "HideDatasetActionoutput": {
-                    "action_arguments": {}, 
-                    "action_type": "HideDatasetAction", 
-                    "output_name": "output"
-                }
-            }, 
-            "tool_errors": null, 
-            "tool_id": "toolshed.g2.bx.psu.edu/repos/bgruening/text_processing/tp_easyjoin_tool/1.0.0", 
-            "tool_state": "{\"__page__\": 0, \"ignore_case\": \"\\\"False\\\"\", \"infile2\": \"null\", \"infile1\": \"null\", \"empty_string_filler\": \"\\\"0\\\"\", \"__rerun_remap_job_id__\": null, \"jointype\": \"\\\"-a 1 -a 2\\\"\", \"header\": \"\\\"False\\\"\", \"column1\": \"\\\"1\\\"\", \"column2\": \"\\\"1\\\"\"}", 
-            "tool_version": "1.0.0", 
-            "type": "tool", 
-            "uuid": "c699e36d-a983-4e66-820d-f00b1b904739", 
-            "workflow_outputs": []
-        }, 
-        "21": {
-            "annotation": "Combines all proteins in the input list that are predicted by WolfPsort to be lysosomal and/or extracellular.", 
-            "content_id": "toolshed.g2.bx.psu.edu/repos/bgruening/text_processing/tp_easyjoin_tool/1.0.0", 
-            "id": 21, 
-            "input_connections": {
-                "infile1": {
-                    "id": 17, 
-                    "output_name": "out_file1"
-                }, 
-                "infile2": {
-                    "id": 18, 
-                    "output_name": "out_file1"
-                }
-            }, 
-            "inputs": [], 
-            "label": null, 
-            "name": "Join", 
-            "outputs": [
-                {
-                    "name": "output", 
-                    "type": "input"
-                }
-            ], 
-            "position": {
-                "left": 1390.75, 
-                "top": 334.75
-            }, 
-            "post_job_actions": {
-                "HideDatasetActionoutput": {
-                    "action_arguments": {}, 
-                    "action_type": "HideDatasetAction", 
-                    "output_name": "output"
-                }
-            }, 
-            "tool_errors": null, 
-            "tool_id": "toolshed.g2.bx.psu.edu/repos/bgruening/text_processing/tp_easyjoin_tool/1.0.0", 
-            "tool_state": "{\"__page__\": 0, \"ignore_case\": \"\\\"False\\\"\", \"infile2\": \"null\", \"infile1\": \"null\", \"empty_string_filler\": \"\\\"0\\\"\", \"__rerun_remap_job_id__\": null, \"jointype\": \"\\\"-a 1 -a 2\\\"\", \"header\": \"\\\"False\\\"\", \"column1\": \"\\\"1\\\"\", \"column2\": \"\\\"1\\\"\"}", 
-            "tool_version": "1.0.0", 
-            "type": "tool", 
-            "uuid": "4a244c68-b12d-46a7-950d-2846a8af8ef5", 
-            "workflow_outputs": []
-        }, 
-        "22": {
-            "annotation": "Combines all GO annotations for \"extracellular region\", \"integral to plasma membrane\" and \"cell surface\" excluding \"extracellular organelle\"", 
-            "content_id": "toolshed.g2.bx.psu.edu/repos/bgruening/text_processing/tp_easyjoin_tool/1.0.0", 
-            "id": 22, 
-            "input_connections": {
-                "infile1": {
-                    "id": 19, 
-                    "output_name": "output"
-                }, 
-                "infile2": {
-                    "id": 20, 
-                    "output_name": "output"
-                }
-            }, 
-            "inputs": [], 
-            "label": null, 
-            "name": "Join", 
-            "outputs": [
-                {
-                    "name": "output", 
-                    "type": "input"
-                }
-            ], 
-            "position": {
-                "left": 1366.75, 
-                "top": 864.75
-            }, 
-            "post_job_actions": {
-                "HideDatasetActionoutput": {
-                    "action_arguments": {}, 
-                    "action_type": "HideDatasetAction", 
-                    "output_name": "output"
-                }
-            }, 
-            "tool_errors": null, 
-            "tool_id": "toolshed.g2.bx.psu.edu/repos/bgruening/text_processing/tp_easyjoin_tool/1.0.0", 
-            "tool_state": "{\"__page__\": 0, \"ignore_case\": \"\\\"False\\\"\", \"infile2\": \"null\", \"infile1\": \"null\", \"empty_string_filler\": \"\\\"0\\\"\", \"__rerun_remap_job_id__\": null, \"jointype\": \"\\\"-a 1 -a 2\\\"\", \"header\": \"\\\"False\\\"\", \"column1\": \"\\\"1\\\"\", \"column2\": \"\\\"1\\\"\"}", 
-            "tool_version": "1.0.0", 
-            "type": "tool", 
-            "uuid": "75b8acd7-7fd1-4ca4-be93-0542b6ed3c9d", 
-            "workflow_outputs": []
-        }, 
-        "23": {
-            "annotation": "Extracts uniprot accessions from all proteins in the input list that are predicted by WolfPsort to be lysosomal and/or extracellular.", 
-            "content_id": "Convert characters1", 
-            "id": 23, 
-            "input_connections": {
-                "input": {
-                    "id": 21, 
-                    "output_name": "output"
-                }
-            }, 
-            "inputs": [], 
-            "label": null, 
-            "name": "Convert", 
-            "outputs": [
-                {
-                    "name": "out_file1", 
-                    "type": "tabular"
-                }
-            ], 
-            "position": {
-                "left": 1513.75, 
-                "top": 458.75
-            }, 
-            "post_job_actions": {
-                "HideDatasetActionout_file1": {
-                    "action_arguments": {}, 
-                    "action_type": "HideDatasetAction", 
-                    "output_name": "out_file1"
-                }
-            }, 
-            "tool_errors": null, 
-            "tool_id": "Convert characters1", 
-            "tool_state": "{\"__page__\": 0, \"__rerun_remap_job_id__\": null, \"condense\": \"\\\"True\\\"\", \"strip\": \"\\\"True\\\"\", \"input\": \"null\", \"convert_from\": \"\\\"P\\\"\"}", 
-            "tool_version": "1.0.0", 
-            "type": "tool", 
-            "uuid": "8e195b7d-e1fa-4df4-9108-697d89119b53", 
-            "workflow_outputs": []
-        }, 
-        "24": {
-            "annotation": "Combines all GO annotations for \"lysosome\", \"extracellular region\", \"integral to plasma membrane\" and \"cell surface\" excluding \"extracellular organelle\"", 
-            "content_id": "toolshed.g2.bx.psu.edu/repos/bgruening/text_processing/tp_easyjoin_tool/1.0.0", 
-            "id": 24, 
-            "input_connections": {
-                "infile1": {
-                    "id": 22, 
-                    "output_name": "output"
-                }, 
-                "infile2": {
-                    "id": 16, 
-                    "output_name": "output"
-                }
-            }, 
-            "inputs": [], 
-            "label": null, 
-            "name": "Join", 
-            "outputs": [
-                {
-                    "name": "output", 
-                    "type": "input"
-                }
-            ], 
-            "position": {
-                "left": 1502.75, 
-                "top": 1036.75
-            }, 
-            "post_job_actions": {
-                "HideDatasetActionoutput": {
-                    "action_arguments": {}, 
-                    "action_type": "HideDatasetAction", 
-                    "output_name": "output"
-                }
-            }, 
-            "tool_errors": null, 
-            "tool_id": "toolshed.g2.bx.psu.edu/repos/bgruening/text_processing/tp_easyjoin_tool/1.0.0", 
-            "tool_state": "{\"__page__\": 0, \"ignore_case\": \"\\\"False\\\"\", \"infile2\": \"null\", \"infile1\": \"null\", \"empty_string_filler\": \"\\\"0\\\"\", \"__rerun_remap_job_id__\": null, \"jointype\": \"\\\"-a 1 -a 2\\\"\", \"header\": \"\\\"False\\\"\", \"column1\": \"\\\"1\\\"\", \"column2\": \"\\\"1\\\"\"}", 
-            "tool_version": "1.0.0", 
-            "type": "tool", 
-            "uuid": "4855cffc-41b9-4a6f-8cd4-9427ec849b95", 
-            "workflow_outputs": []
-        }, 
-        "25": {
-            "annotation": "Deletes all columns but the one containing uniprot accessions of extracellular proteins as predicted by WoLF PSORT.", 
-            "content_id": "toolshed.g2.bx.psu.edu/repos/bgruening/text_processing/tp_cut_tool/1.0.0", 
-            "id": 25, 
-            "input_connections": {
-                "input": {
-                    "id": 23, 
-                    "output_name": "out_file1"
-                }
-            }, 
-            "inputs": [], 
-            "label": null, 
-            "name": "Cut", 
-            "outputs": [
-                {
-                    "name": "output", 
-                    "type": "tabular"
-                }
-            ], 
-            "position": {
-                "left": 1613.75, 
-                "top": 554.75
-            }, 
-            "post_job_actions": {
-                "HideDatasetActionoutput": {
-                    "action_arguments": {}, 
-                    "action_type": "HideDatasetAction", 
-                    "output_name": "output"
-                }
-            }, 
-            "tool_errors": null, 
-            "tool_id": "toolshed.g2.bx.psu.edu/repos/bgruening/text_processing/tp_cut_tool/1.0.0", 
-            "tool_state": "{\"__page__\": 0, \"complement\": \"\\\"\\\"\", \"cut_type_options\": \"{\\\"list\\\": [\\\"2\\\"], \\\"cut_element\\\": \\\"-f\\\", \\\"__current_case__\\\": 0}\", \"delimiter\": \"\\\"\\\"\", \"input\": \"null\", \"__rerun_remap_job_id__\": null}", 
-            "tool_version": "1.0.0", 
-            "type": "tool", 
-            "uuid": "1573af45-4165-4825-ae8d-57182571cf42", 
-            "workflow_outputs": []
-        }, 
-        "26": {
-            "annotation": "filters out all proteins in the input protein list of interest that are annotated as \"extracellular region\" and \"lysosome\" and \"plasma membrane\" excluding \"extracellular organelle\" and \"cytoplasmic side of plasma membrane\"", 
-            "content_id": "comp1", 
-            "id": 26, 
-            "input_connections": {
-                "input1": {
-                    "id": 11, 
-                    "output_name": "output"
-                }, 
-                "input2": {
-                    "id": 24, 
-                    "output_name": "output"
-                }
-            }, 
-            "inputs": [], 
-            "label": null, 
-            "name": "Compare two Datasets", 
-            "outputs": [
-                {
-                    "name": "out_file1", 
-                    "type": "input"
-                }
-            ], 
-            "position": {
-                "left": 1514.75, 
-                "top": 680.75
-            }, 
-            "post_job_actions": {
-                "HideDatasetActionout_file1": {
-                    "action_arguments": {}, 
-                    "action_type": "HideDatasetAction", 
-                    "output_name": "out_file1"
-                }
-            }, 
-            "tool_errors": null, 
-            "tool_id": "comp1", 
-            "tool_state": "{\"input2\": \"null\", \"__page__\": 0, \"input1\": \"null\", \"field2\": \"\\\"1\\\"\", \"__rerun_remap_job_id__\": null, \"field1\": \"\\\"6\\\"\", \"mode\": \"\\\"N\\\"\"}", 
-            "tool_version": "1.0.2", 
-            "type": "tool", 
-            "uuid": "4e5095ba-1132-484b-875d-866676cb8910", 
-            "workflow_outputs": []
-        }, 
-        "27": {
-            "annotation": "cleans up the protein list for unique entries", 
-            "content_id": "toolshed.g2.bx.psu.edu/repos/bgruening/unique/bg_uniq/0.3", 
-            "id": 27, 
-            "input_connections": {
-                "input": {
-                    "id": 26, 
-                    "output_name": "out_file1"
-                }
-            }, 
-            "inputs": [], 
-            "label": null, 
-            "name": "Unique", 
-            "outputs": [
-                {
-                    "name": "outfile", 
-                    "type": "input"
-                }
-            ], 
-            "position": {
-                "left": 1640.75, 
-                "top": 806.75
-            }, 
-            "post_job_actions": {
-                "HideDatasetActionoutfile": {
-                    "action_arguments": {}, 
-                    "action_type": "HideDatasetAction", 
-                    "output_name": "outfile"
-                }
-            }, 
-            "tool_errors": null, 
-            "tool_id": "toolshed.g2.bx.psu.edu/repos/bgruening/unique/bg_uniq/0.3", 
-            "tool_state": "{\"__page__\": 0, \"ignore_case\": \"\\\"False\\\"\", \"adv_opts\": \"{\\\"column_end\\\": \\\"1\\\", \\\"column_start\\\": \\\"1\\\", \\\"adv_opts_selector\\\": \\\"advanced\\\", \\\"__current_case__\\\": 1}\", \"__rerun_remap_job_id__\": null, \"is_numeric\": \"\\\"False\\\"\", \"input\": \"null\"}", 
-            "tool_version": "0.3", 
-            "type": "tool", 
-            "uuid": "89ab7414-9e60-40ae-9598-fee02fab0205", 
-            "workflow_outputs": []
-        }, 
-        "28": {
-            "annotation": "Deletes all columns but the one containing uniprot accessions of secreted and shed (i.e. \"secretome\") proteins.", 
-            "content_id": "toolshed.g2.bx.psu.edu/repos/bgruening/text_processing/tp_cut_tool/1.0.0", 
-            "id": 28, 
-            "input_connections": {
-                "input": {
-                    "id": 27, 
-                    "output_name": "outfile"
-                }
-            }, 
-            "inputs": [], 
-            "label": null, 
-            "name": "Cut", 
-            "outputs": [
-                {
-                    "name": "output", 
-                    "type": "tabular"
-                }
-            ], 
-            "position": {
-                "left": 1730.75, 
-                "top": 905.75
-            }, 
-            "post_job_actions": {
-                "HideDatasetActionoutput": {
-                    "action_arguments": {}, 
-                    "action_type": "HideDatasetAction", 
-                    "output_name": "output"
-                }
-            }, 
-            "tool_errors": null, 
-            "tool_id": "toolshed.g2.bx.psu.edu/repos/bgruening/text_processing/tp_cut_tool/1.0.0", 
-            "tool_state": "{\"__page__\": 0, \"complement\": \"\\\"\\\"\", \"cut_type_options\": \"{\\\"list\\\": [\\\"1\\\"], \\\"cut_element\\\": \\\"-f\\\", \\\"__current_case__\\\": 0}\", \"delimiter\": \"\\\"\\\"\", \"input\": \"null\", \"__rerun_remap_job_id__\": null}", 
-            "tool_version": "1.0.0", 
-            "type": "tool", 
-            "uuid": "0ad689c9-abf9-4e2b-a3a9-f670c03c3d8b", 
-            "workflow_outputs": []
-        }, 
-        "29": {
-            "annotation": "Combines all proteins that are either predicted by WoLF PSORT to be shed or secreted or annotated in the GO database to be shed or secreted.", 
-            "content_id": "toolshed.g2.bx.psu.edu/repos/bgruening/text_processing/tp_easyjoin_tool/1.0.0", 
-            "id": 29, 
-            "input_connections": {
-                "infile1": {
-                    "id": 25, 
-                    "output_name": "output"
-                }, 
-                "infile2": {
-                    "id": 28, 
-                    "output_name": "output"
-                }
-            }, 
-            "inputs": [], 
-            "label": null, 
-            "name": "Join", 
-            "outputs": [
-                {
-                    "name": "output", 
-                    "type": "input"
-                }
-            ], 
-            "position": {
-                "left": 1880.75, 
-                "top": 649.75
-            }, 
-            "post_job_actions": {
-                "HideDatasetActionoutput": {
-                    "action_arguments": {}, 
-                    "action_type": "HideDatasetAction", 
-                    "output_name": "output"
-                }
-            }, 
-            "tool_errors": null, 
-            "tool_id": "toolshed.g2.bx.psu.edu/repos/bgruening/text_processing/tp_easyjoin_tool/1.0.0", 
-            "tool_state": "{\"__page__\": 0, \"ignore_case\": \"\\\"False\\\"\", \"infile2\": \"null\", \"infile1\": \"null\", \"empty_string_filler\": \"\\\"0\\\"\", \"__rerun_remap_job_id__\": null, \"jointype\": \"\\\"-a 1 -a 2\\\"\", \"header\": \"\\\"False\\\"\", \"column1\": \"\\\"1\\\"\", \"column2\": \"\\\"1\\\"\"}", 
-            "tool_version": "1.0.0", 
-            "type": "tool", 
-            "uuid": "87aa3f42-5408-4475-af7a-c368fed485cd", 
-            "workflow_outputs": []
-        }, 
-        "30": {
-            "annotation": "Final output. Unique entries of all proteins that are either predicted by WoLF PSORT to be shed or secreted or annotated in the GO database to be shed or secreted.", 
-            "content_id": "toolshed.g2.bx.psu.edu/repos/bgruening/text_processing/tp_sorted_uniq/1.0.0", 
-            "id": 30, 
-            "input_connections": {
-                "infile": {
-                    "id": 29, 
-                    "output_name": "output"
-                }
-            }, 
-            "inputs": [], 
-            "label": null, 
-            "name": "Unique", 
-            "outputs": [
-                {
-                    "name": "outfile", 
-                    "type": "input"
-                }
-            ], 
-            "position": {
-                "left": 1964.75, 
-                "top": 787.75
-            }, 
-            "post_job_actions": {
-                "RenameDatasetActionoutfile": {
-                    "action_arguments": {
-                        "newname": "secretome_proteins"
-                    }, 
-                    "action_type": "RenameDatasetAction", 
-                    "output_name": "outfile"
-                }
-            }, 
-            "tool_errors": null, 
-            "tool_id": "toolshed.g2.bx.psu.edu/repos/bgruening/text_processing/tp_sorted_uniq/1.0.0", 
-            "tool_state": "{\"__page__\": 0, \"ignore_case\": \"\\\"False\\\"\", \"adv_opts\": \"{\\\"adv_opts_selector\\\": \\\"basic\\\", \\\"__current_case__\\\": 0}\", \"__rerun_remap_job_id__\": null, \"is_numeric\": \"\\\"False\\\"\", \"infile\": \"null\"}", 
-            "tool_version": "1.0.0", 
-            "type": "tool", 
-            "uuid": "5ca3dd78-27ed-4f4f-95f6-c25fa4fd43b6", 
-            "workflow_outputs": [
-                {
-                    "label": "Secretome proteins", 
-                    "output_name": "outfile", 
-                    "uuid": "14e0c6dc-436b-4c4c-9292-d5e00cca8c92"
-                }
-            ]
+  "a_galaxy_workflow": "true",
+  "annotation": "version 1.0, 160318, published at https://github.com/Stortebecker/secretome_prediction",
+  "format-version": "0.1",
+  "name": "Secreted Proteins via GO annotation and WoLF PSORT for shCTSB paper",
+  "steps": {
+    "0": {
+      "annotation": "Input: Protein ID list\nFirst column has to be uniprot accessions",
+      "content_id": null,
+      "id": 0,
+      "input_connections": {},
+      "inputs": [
+        {
+          "description": "Input: Protein ID list\nFirst column has to be uniprot accessions",
+          "name": "Custom Protein list (uniprot accession)"
         }
-    }, 
-    "uuid": "017c3db3-46ca-4ff7-9e50-132679765355"
+      ],
+      "label": null,
+      "name": "Input dataset",
+      "outputs": [],
+      "position": {
+        "left": 293,
+        "top": 377
+      },
+      "tool_errors": null,
+      "tool_id": null,
+      "tool_state": "{\"name\": \"Custom Protein list (uniprot accession)\"}",
+      "tool_version": null,
+      "type": "data_input",
+      "uuid": "4d60060c-188b-4a93-8320-36f9b43e5765",
+      "workflow_outputs": [
+        {
+          "label": null,
+          "output_name": "output",
+          "uuid": "27022e50-f5dc-46b1-8b54-979f955eb050"
+        }
+      ]
+    },
+    "1": {
+      "annotation": "Input: Uniprot GO database file (choose the right organism)\nExample: ftp://ftp.ebi.ac.uk/pub/databases/GO/goa/HUMAN/gene_association.goa_human.gz",
+      "content_id": null,
+      "id": 1,
+      "input_connections": {},
+      "inputs": [
+        {
+          "description": "Input: Uniprot GO database file (choose the right organism)\nExample: ftp://ftp.ebi.ac.uk/pub/databases/GO/goa/HUMAN/gene_association.goa_human.gz",
+          "name": "Uniprot GO database"
+        }
+      ],
+      "label": null,
+      "name": "Input dataset",
+      "outputs": [],
+      "position": {
+        "left": 290,
+        "top": 507
+      },
+      "tool_errors": null,
+      "tool_id": null,
+      "tool_state": "{\"name\": \"Uniprot GO database\"}",
+      "tool_version": null,
+      "type": "data_input",
+      "uuid": "e8f4a577-7b6a-4cd0-9a74-2e68c4ae6c5a",
+      "workflow_outputs": [
+        {
+          "label": null,
+          "output_name": "output",
+          "uuid": "b8fa36c2-6bbf-40c1-a472-8d4a6a7096c3"
+        }
+      ]
+    },
+    "2": {
+      "annotation": "Input: Please downlad the Open Biomedical Ontology (OBO), i.e. \"GO term tree\" from\nhttp://purl.obolibrary.org/obo/go/go.obo",
+      "content_id": null,
+      "id": 2,
+      "input_connections": {},
+      "inputs": [
+        {
+          "description": "Input: Please downlad the Open Biomedical Ontology (OBO), i.e. \"GO term tree\" from\nhttp://purl.obolibrary.org/obo/go/go.obo",
+          "name": "Open Biomedical Ontology (OBO)"
+        }
+      ],
+      "label": null,
+      "name": "Input dataset",
+      "outputs": [],
+      "position": {
+        "left": 293,
+        "top": 790
+      },
+      "tool_errors": null,
+      "tool_id": null,
+      "tool_state": "{\"name\": \"Open Biomedical Ontology (OBO)\"}",
+      "tool_version": null,
+      "type": "data_input",
+      "uuid": "0640e1c4-4d77-49da-8473-0018e0a5db09",
+      "workflow_outputs": [
+        {
+          "label": null,
+          "output_name": "output",
+          "uuid": "4725c10d-9e7a-4e3f-9874-c302c34687cb"
+        }
+      ]
+    },
+    "3": {
+      "annotation": "Retrieves Fasta files for all proteins in the input list.",
+      "content_id": "toolshed.g2.bx.psu.edu/repos/bgruening/uniprot_rest_interface/uniprot/0.1",
+      "id": 3,
+      "input_connections": {
+        "infile": {
+          "id": 0,
+          "output_name": "output"
+        }
+      },
+      "inputs": [],
+      "label": null,
+      "name": "UniProt",
+      "outputs": [
+        {
+          "name": "outfile_retrieve_fasta",
+          "type": "fasta"
+        },
+        {
+          "name": "outfile_retrieve_gff",
+          "type": "gff"
+        },
+        {
+          "name": "outfile_retrieve_txt",
+          "type": "txt"
+        },
+        {
+          "name": "outfile_map",
+          "type": "tabular"
+        }
+      ],
+      "position": {
+        "left": 573.75,
+        "top": 258.75
+      },
+      "post_job_actions": {
+        "HideDatasetActionoutfile_map": {
+          "action_arguments": {},
+          "action_type": "HideDatasetAction",
+          "output_name": "outfile_map"
+        },
+        "HideDatasetActionoutfile_retrieve_fasta": {
+          "action_arguments": {},
+          "action_type": "HideDatasetAction",
+          "output_name": "outfile_retrieve_fasta"
+        },
+        "HideDatasetActionoutfile_retrieve_gff": {
+          "action_arguments": {},
+          "action_type": "HideDatasetAction",
+          "output_name": "outfile_retrieve_gff"
+        },
+        "HideDatasetActionoutfile_retrieve_txt": {
+          "action_arguments": {},
+          "action_type": "HideDatasetAction",
+          "output_name": "outfile_retrieve_txt"
+        }
+      },
+      "tool_errors": null,
+      "tool_id": "toolshed.g2.bx.psu.edu/repos/bgruening/uniprot_rest_interface/uniprot/0.1",
+      "tool_state": "{\"__page__\": 0, \"tool\": \"{\\\"format\\\": \\\"fasta\\\", \\\"__current_case__\\\": 1, \\\"tool_choice\\\": \\\"retrieve\\\"}\", \"__rerun_remap_job_id__\": null, \"id_column\": \"\\\"1\\\"\", \"infile\": \"null\"}",
+      "tool_version": "0.1",
+      "type": "tool",
+      "uuid": "d6d73f27-bb3e-4763-825a-23d457df38af",
+      "workflow_outputs": [],
+      "tool_shed_repository": {
+        "changeset_revision": "f7ebd1b4783b",
+        "name": "uniprot_rest_interface",
+        "owner": "bgruening",
+        "tool_shed": "toolshed.g2.bx.psu.edu"
+      }
+    },
+    "4": {
+      "annotation": "Removes comment lines at the head of the Uniprot Go database file.",
+      "content_id": "Grep1",
+      "id": 4,
+      "input_connections": {
+        "input": {
+          "id": 1,
+          "output_name": "output"
+        }
+      },
+      "inputs": [],
+      "label": null,
+      "name": "Select",
+      "outputs": [
+        {
+          "name": "out_file1",
+          "type": "input"
+        }
+      ],
+      "position": {
+        "left": 552,
+        "top": 505
+      },
+      "post_job_actions": {
+        "ChangeDatatypeActionout_file1": {
+          "action_arguments": {
+            "newtype": "tabular"
+          },
+          "action_type": "ChangeDatatypeAction",
+          "output_name": "out_file1"
+        },
+        "HideDatasetActionout_file1": {
+          "action_arguments": {},
+          "action_type": "HideDatasetAction",
+          "output_name": "out_file1"
+        }
+      },
+      "tool_errors": null,
+      "tool_id": "Grep1",
+      "tool_state": "{\"__page__\": 0, \"input\": \"null\", \"invert\": \"\\\"true\\\"\", \"__rerun_remap_job_id__\": null, \"pattern\": \"\\\"^!\\\"\"}",
+      "tool_version": "1.0.1",
+      "type": "tool",
+      "uuid": "11c206f4-bc11-400c-8bd5-335bc8c6d63d",
+      "workflow_outputs": []
+    },
+    "5": {
+      "annotation": "GO:0043230 \"extracellular organelle\"",
+      "content_id": "get_subontology_from",
+      "id": 5,
+      "input_connections": {
+        "input_ontology": {
+          "id": 2,
+          "output_name": "output"
+        }
+      },
+      "inputs": [],
+      "label": null,
+      "name": "Get subontology from a given OBO term",
+      "outputs": [
+        {
+          "name": "output",
+          "type": "txt"
+        }
+      ],
+      "position": {
+        "left": 549,
+        "top": 663
+      },
+      "post_job_actions": {
+        "HideDatasetActionoutput": {
+          "action_arguments": {},
+          "action_type": "HideDatasetAction",
+          "output_name": "output"
+        }
+      },
+      "tool_errors": null,
+      "tool_id": "onto_tk_get_subontology_from",
+      "tool_state": "{\"__page__\": 0, \"__rerun_remap_job_id__\": null, \"new_root\": \"\\\"GO:0043230\\\"\", \"input_ontology\": \"null\"}",
+      "tool_version": "1.45.0",
+      "type": "tool",
+      "uuid": "636177a8-5b63-457c-acaa-518748094834",
+      "workflow_outputs": [],
+      "tool_shed_repository": {
+        "changeset_revision": "1b3796bc5ac0",
+        "name": "onto_tk_get_subontology_from",
+        "owner": "iuc",
+        "tool_shed": "toolshed.g2.bx.psu.edu"
+      }
+    },
+    "6": {
+      "annotation": "GO:0005576 \"extracellular region\"",
+      "content_id": "get_subontology_from",
+      "id": 6,
+      "input_connections": {
+        "input_ontology": {
+          "id": 2,
+          "output_name": "output"
+        }
+      },
+      "inputs": [],
+      "label": null,
+      "name": "Get subontology from a given OBO term",
+      "outputs": [
+        {
+          "name": "output",
+          "type": "txt"
+        }
+      ],
+      "position": {
+        "left": 549,
+        "top": 814
+      },
+      "post_job_actions": {
+        "HideDatasetActionoutput": {
+          "action_arguments": {},
+          "action_type": "HideDatasetAction",
+          "output_name": "output"
+        }
+      },
+      "tool_errors": null,
+      "tool_id": "onto_tk_get_subontology_from",
+      "tool_state": "{\"__page__\": 0, \"__rerun_remap_job_id__\": null, \"new_root\": \"\\\"GO:0005576\\\"\", \"input_ontology\": \"null\"}",
+      "tool_version": "1.45.0",
+      "type": "tool",
+      "uuid": "163ebfd8-82c8-430e-a37f-e6670cb5069e",
+      "workflow_outputs": [],
+      "tool_shed_repository": {
+        "changeset_revision": "1b3796bc5ac0",
+        "name": "onto_tk_get_subontology_from",
+        "owner": "iuc",
+        "tool_shed": "toolshed.g2.bx.psu.edu"
+      }
+    },
+    "7": {
+      "annotation": "GO:0005887 \"integral component of plasma membrane\"",
+      "content_id": "get_subontology_from",
+      "id": 7,
+      "input_connections": {
+        "input_ontology": {
+          "id": 2,
+          "output_name": "output"
+        }
+      },
+      "inputs": [],
+      "label": null,
+      "name": "Get subontology from a given OBO term",
+      "outputs": [
+        {
+          "name": "output",
+          "type": "txt"
+        }
+      ],
+      "position": {
+        "left": 551.75,
+        "top": 918.75
+      },
+      "post_job_actions": {
+        "HideDatasetActionoutput": {
+          "action_arguments": {},
+          "action_type": "HideDatasetAction",
+          "output_name": "output"
+        }
+      },
+      "tool_errors": null,
+      "tool_id": "onto_tk_get_subontology_from",
+      "tool_state": "{\"__page__\": 0, \"__rerun_remap_job_id__\": null, \"new_root\": \"\\\"GO:0005887\\\"\", \"input_ontology\": \"null\"}",
+      "tool_version": "1.45.0",
+      "type": "tool",
+      "uuid": "c3b4bd46-4f3a-46a0-927d-4fc15bc9f4d5",
+      "workflow_outputs": [],
+      "tool_shed_repository": {
+        "changeset_revision": "1b3796bc5ac0",
+        "name": "onto_tk_get_subontology_from",
+        "owner": "iuc",
+        "tool_shed": "toolshed.g2.bx.psu.edu"
+      }
+    },
+    "8": {
+      "annotation": "GO:0009986 \"cell surface\"",
+      "content_id": "get_subontology_from",
+      "id": 8,
+      "input_connections": {
+        "input_ontology": {
+          "id": 2,
+          "output_name": "output"
+        }
+      },
+      "inputs": [],
+      "label": null,
+      "name": "Get subontology from a given OBO term",
+      "outputs": [
+        {
+          "name": "output",
+          "type": "txt"
+        }
+      ],
+      "position": {
+        "left": 554.75,
+        "top": 1029.75
+      },
+      "post_job_actions": {
+        "HideDatasetActionoutput": {
+          "action_arguments": {},
+          "action_type": "HideDatasetAction",
+          "output_name": "output"
+        }
+      },
+      "tool_errors": null,
+      "tool_id": "onto_tk_get_subontology_from",
+      "tool_state": "{\"__page__\": 0, \"__rerun_remap_job_id__\": null, \"new_root\": \"\\\"GO:0009986\\\"\", \"input_ontology\": \"null\"}",
+      "tool_version": "1.45.0",
+      "type": "tool",
+      "uuid": "608f525c-f9f7-4ea5-abc6-89d97f171c53",
+      "workflow_outputs": [],
+      "tool_shed_repository": {
+        "changeset_revision": "1b3796bc5ac0",
+        "name": "onto_tk_get_subontology_from",
+        "owner": "iuc",
+        "tool_shed": "toolshed.g2.bx.psu.edu"
+      }
+    },
+    "9": {
+      "annotation": "GO:0005764 \"lysosome\"",
+      "content_id": "get_subontology_from",
+      "id": 9,
+      "input_connections": {
+        "input_ontology": {
+          "id": 2,
+          "output_name": "output"
+        }
+      },
+      "inputs": [],
+      "label": null,
+      "name": "Get subontology from a given OBO term",
+      "outputs": [
+        {
+          "name": "output",
+          "type": "txt"
+        }
+      ],
+      "position": {
+        "left": 556.75,
+        "top": 1137.75
+      },
+      "post_job_actions": {
+        "HideDatasetActionoutput": {
+          "action_arguments": {},
+          "action_type": "HideDatasetAction",
+          "output_name": "output"
+        }
+      },
+      "tool_errors": null,
+      "tool_id": "onto_tk_get_subontology_from",
+      "tool_state": "{\"__page__\": 0, \"__rerun_remap_job_id__\": null, \"new_root\": \"\\\"GO:0005764 \\\"\", \"input_ontology\": \"null\"}",
+      "tool_version": "1.45.0",
+      "type": "tool",
+      "uuid": "fbd3c1c0-a6e6-4b77-9d04-b19df7cac3f3",
+      "workflow_outputs": [],
+      "tool_shed_repository": {
+        "changeset_revision": "1b3796bc5ac0",
+        "name": "onto_tk_get_subontology_from",
+        "owner": "iuc",
+        "tool_shed": "toolshed.g2.bx.psu.edu"
+      }
+    },
+    "10": {
+      "annotation": "Predicts subcellular localization of all proteins in the input list.",
+      "content_id": "toolshed.g2.bx.psu.edu/repos/peterjc/tmhmm_and_signalp/wolf_psort/0.0.8",
+      "id": 10,
+      "input_connections": {
+        "fasta_file": {
+          "id": 3,
+          "output_name": "outfile_retrieve_fasta"
+        }
+      },
+      "inputs": [],
+      "label": null,
+      "name": "WoLF PSORT",
+      "outputs": [
+        {
+          "name": "tabular_file",
+          "type": "tabular"
+        }
+      ],
+      "position": {
+        "left": 886.75,
+        "top": 326.75
+      },
+      "post_job_actions": {
+        "HideDatasetActiontabular_file": {
+          "action_arguments": {},
+          "action_type": "HideDatasetAction",
+          "output_name": "tabular_file"
+        },
+        "RenameDatasetActiontabular_file": {
+          "action_arguments": {
+            "newname": "WoLF_PSORT_output"
+          },
+          "action_type": "RenameDatasetAction",
+          "output_name": "tabular_file"
+        }
+      },
+      "tool_errors": null,
+      "tool_id": "toolshed.g2.bx.psu.edu/repos/peterjc/tmhmm_and_signalp/wolf_psort/0.0.8",
+      "tool_state": "{\"__page__\": 0, \"fasta_file\": \"null\", \"organism\": \"\\\"animal\\\"\", \"__rerun_remap_job_id__\": null}",
+      "tool_version": "0.0.8",
+      "type": "tool",
+      "uuid": "60edfc44-cad4-4afd-8907-4003700d6576",
+      "workflow_outputs": [],
+      "tool_shed_repository": {
+        "changeset_revision": "e6cc27d182a8",
+        "name": "tmhmm_and_signalp",
+        "owner": "peterjc",
+        "tool_shed": "toolshed.g2.bx.psu.edu"
+      }
+    },
+    "11": {
+      "annotation": "Annotates input protein list with GO annotations.",
+      "content_id": "toolshed.g2.bx.psu.edu/repos/bgruening/text_processing/tp_easyjoin_tool/1.0.0",
+      "id": 11,
+      "input_connections": {
+        "infile1": {
+          "id": 0,
+          "output_name": "output"
+        },
+        "infile2": {
+          "id": 4,
+          "output_name": "out_file1"
+        }
+      },
+      "inputs": [],
+      "label": null,
+      "name": "Join",
+      "outputs": [
+        {
+          "name": "output",
+          "type": "input"
+        }
+      ],
+      "position": {
+        "left": 939,
+        "top": 479
+      },
+      "post_job_actions": {
+        "ChangeDatatypeActionoutput": {
+          "action_arguments": {
+            "newtype": "tabular"
+          },
+          "action_type": "ChangeDatatypeAction",
+          "output_name": "output"
+        },
+        "HideDatasetActionoutput": {
+          "action_arguments": {},
+          "action_type": "HideDatasetAction",
+          "output_name": "output"
+        }
+      },
+      "tool_errors": null,
+      "tool_id": "toolshed.g2.bx.psu.edu/repos/bgruening/text_processing/tp_easyjoin_tool/1.0.0",
+      "tool_state": "{\"__page__\": 0, \"ignore_case\": \"\\\"False\\\"\", \"infile2\": \"null\", \"infile1\": \"null\", \"empty_string_filler\": \"\\\"0\\\"\", \"__rerun_remap_job_id__\": null, \"jointype\": \"\\\"-a 1\\\"\", \"header\": \"\\\"False\\\"\", \"column1\": \"\\\"1\\\"\", \"column2\": \"\\\"2\\\"\"}",
+      "tool_version": "1.0.0",
+      "type": "tool",
+      "uuid": "5bda528d-4d1d-49d5-8f18-dcd7b92152dc",
+      "workflow_outputs": []
+    },
+    "12": {
+      "annotation": "GO:0043230 \"extracellular organelle\"",
+      "content_id": "term_id_vs_term_name",
+      "id": 12,
+      "input_connections": {
+        "input_ontology": {
+          "id": 5,
+          "output_name": "output"
+        }
+      },
+      "inputs": [],
+      "label": null,
+      "name": "Get all the term IDs and term names of a given OBO ontology",
+      "outputs": [
+        {
+          "name": "output",
+          "type": "tabular"
+        }
+      ],
+      "position": {
+        "left": 872.25,
+        "top": 646.75
+      },
+      "post_job_actions": {
+        "HideDatasetActionoutput": {
+          "action_arguments": {},
+          "action_type": "HideDatasetAction",
+          "output_name": "output"
+        }
+      },
+      "tool_errors": null,
+      "tool_id": "onto_tk_term_id_vs_term_name",
+      "tool_state": "{\"__page__\": 0, \"__rerun_remap_job_id__\": null, \"input_ontology\": \"null\"}",
+      "tool_version": "1.45.0",
+      "type": "tool",
+      "uuid": "89bd62f8-6548-4411-a1f0-861364c43189",
+      "workflow_outputs": [],
+      "tool_shed_repository": {
+        "changeset_revision": "b2471db454a0",
+        "name": "onto_tk_term_id_vs_term_name",
+        "owner": "iuc",
+        "tool_shed": "toolshed.g2.bx.psu.edu"
+      }
+    },
+    "13": {
+      "annotation": "GO:0005576 \"extracellular region\"",
+      "content_id": "term_id_vs_term_name",
+      "id": 13,
+      "input_connections": {
+        "input_ontology": {
+          "id": 6,
+          "output_name": "output"
+        }
+      },
+      "inputs": [],
+      "label": null,
+      "name": "Get all the term IDs and term names of a given OBO ontology",
+      "outputs": [
+        {
+          "name": "output",
+          "type": "tabular"
+        }
+      ],
+      "position": {
+        "left": 867.25,
+        "top": 815.75
+      },
+      "post_job_actions": {
+        "HideDatasetActionoutput": {
+          "action_arguments": {},
+          "action_type": "HideDatasetAction",
+          "output_name": "output"
+        }
+      },
+      "tool_errors": null,
+      "tool_id": "onto_tk_term_id_vs_term_name",
+      "tool_state": "{\"__page__\": 0, \"__rerun_remap_job_id__\": null, \"input_ontology\": \"null\"}",
+      "tool_version": "1.45.0",
+      "type": "tool",
+      "uuid": "4ddbced9-e92d-467e-bbb9-7b2bcd8af58d",
+      "workflow_outputs": [],
+      "tool_shed_repository": {
+        "changeset_revision": "b2471db454a0",
+        "name": "onto_tk_term_id_vs_term_name",
+        "owner": "iuc",
+        "tool_shed": "toolshed.g2.bx.psu.edu"
+      }
+    },
+    "14": {
+      "annotation": "GO:0005887 \"integral component of plasma membrane\"",
+      "content_id": "term_id_vs_term_name",
+      "id": 14,
+      "input_connections": {
+        "input_ontology": {
+          "id": 7,
+          "output_name": "output"
+        }
+      },
+      "inputs": [],
+      "label": null,
+      "name": "Get all the term IDs and term names of a given OBO ontology",
+      "outputs": [
+        {
+          "name": "output",
+          "type": "tabular"
+        }
+      ],
+      "position": {
+        "left": 869.25,
+        "top": 922.75
+      },
+      "post_job_actions": {
+        "HideDatasetActionoutput": {
+          "action_arguments": {},
+          "action_type": "HideDatasetAction",
+          "output_name": "output"
+        },
+        "RenameDatasetActionoutput": {
+          "action_arguments": {
+            "newname": "integral component of plasma membrane subontology"
+          },
+          "action_type": "RenameDatasetAction",
+          "output_name": "output"
+        }
+      },
+      "tool_errors": null,
+      "tool_id": "onto_tk_term_id_vs_term_name",
+      "tool_state": "{\"__page__\": 0, \"__rerun_remap_job_id__\": null, \"input_ontology\": \"null\"}",
+      "tool_version": "1.45.0",
+      "type": "tool",
+      "uuid": "d1dc97ba-cae6-42e7-b0d6-67d94bd3ba30",
+      "workflow_outputs": [],
+      "tool_shed_repository": {
+        "changeset_revision": "b2471db454a0",
+        "name": "onto_tk_term_id_vs_term_name",
+        "owner": "iuc",
+        "tool_shed": "toolshed.g2.bx.psu.edu"
+      }
+    },
+    "15": {
+      "annotation": "GO:0009986 \"cell surface\"",
+      "content_id": "term_id_vs_term_name",
+      "id": 15,
+      "input_connections": {
+        "input_ontology": {
+          "id": 8,
+          "output_name": "output"
+        }
+      },
+      "inputs": [],
+      "label": null,
+      "name": "Get all the term IDs and term names of a given OBO ontology",
+      "outputs": [
+        {
+          "name": "output",
+          "type": "tabular"
+        }
+      ],
+      "position": {
+        "left": 872.25,
+        "top": 1030.75
+      },
+      "post_job_actions": {
+        "HideDatasetActionoutput": {
+          "action_arguments": {},
+          "action_type": "HideDatasetAction",
+          "output_name": "output"
+        },
+        "RenameDatasetActionoutput": {
+          "action_arguments": {
+            "newname": "cell surface subontology"
+          },
+          "action_type": "RenameDatasetAction",
+          "output_name": "output"
+        }
+      },
+      "tool_errors": null,
+      "tool_id": "onto_tk_term_id_vs_term_name",
+      "tool_state": "{\"__page__\": 0, \"__rerun_remap_job_id__\": null, \"input_ontology\": \"null\"}",
+      "tool_version": "1.45.0",
+      "type": "tool",
+      "uuid": "bfa87a5a-7770-4a09-ab7a-2fe04c5e24a7",
+      "workflow_outputs": [],
+      "tool_shed_repository": {
+        "changeset_revision": "b2471db454a0",
+        "name": "onto_tk_term_id_vs_term_name",
+        "owner": "iuc",
+        "tool_shed": "toolshed.g2.bx.psu.edu"
+      }
+    },
+    "16": {
+      "annotation": "GO:0005764 \"lysosome\"",
+      "content_id": "term_id_vs_term_name",
+      "id": 16,
+      "input_connections": {
+        "input_ontology": {
+          "id": 9,
+          "output_name": "output"
+        }
+      },
+      "inputs": [],
+      "label": null,
+      "name": "Get all the term IDs and term names of a given OBO ontology",
+      "outputs": [
+        {
+          "name": "output",
+          "type": "tabular"
+        }
+      ],
+      "position": {
+        "left": 871.25,
+        "top": 1140.75
+      },
+      "post_job_actions": {
+        "HideDatasetActionoutput": {
+          "action_arguments": {},
+          "action_type": "HideDatasetAction",
+          "output_name": "output"
+        }
+      },
+      "tool_errors": null,
+      "tool_id": "onto_tk_term_id_vs_term_name",
+      "tool_state": "{\"__page__\": 0, \"__rerun_remap_job_id__\": null, \"input_ontology\": \"null\"}",
+      "tool_version": "1.45.0",
+      "type": "tool",
+      "uuid": "0e3a5a39-27cc-4091-8831-615ebc60ed8c",
+      "workflow_outputs": [],
+      "tool_shed_repository": {
+        "changeset_revision": "b2471db454a0",
+        "name": "onto_tk_term_id_vs_term_name",
+        "owner": "iuc",
+        "tool_shed": "toolshed.g2.bx.psu.edu"
+      }
+    },
+    "17": {
+      "annotation": "Filters all proteins that are predicted to reside extracellularly.",
+      "content_id": "Filter1",
+      "id": 17,
+      "input_connections": {
+        "input": {
+          "id": 10,
+          "output_name": "tabular_file"
+        }
+      },
+      "inputs": [],
+      "label": null,
+      "name": "Filter",
+      "outputs": [
+        {
+          "name": "out_file1",
+          "type": "input"
+        }
+      ],
+      "position": {
+        "left": 1171.75,
+        "top": 288.75
+      },
+      "post_job_actions": {
+        "HideDatasetActionout_file1": {
+          "action_arguments": {},
+          "action_type": "HideDatasetAction",
+          "output_name": "out_file1"
+        }
+      },
+      "tool_errors": null,
+      "tool_id": "Filter1",
+      "tool_state": "{\"input\": \"null\", \"__rerun_remap_job_id__\": null, \"header_lines\": \"\\\"0\\\"\", \"cond\": \"\\\"c2=='extr'\\\"\", \"__page__\": 0}",
+      "tool_version": "1.1.0",
+      "type": "tool",
+      "uuid": "af1432da-a54e-4d3a-a643-719f6cdd6866",
+      "workflow_outputs": []
+    },
+    "18": {
+      "annotation": "Filters all proteins that are predicted to reside in lysosomes.",
+      "content_id": "Filter1",
+      "id": 18,
+      "input_connections": {
+        "input": {
+          "id": 10,
+          "output_name": "tabular_file"
+        }
+      },
+      "inputs": [],
+      "label": null,
+      "name": "Filter",
+      "outputs": [
+        {
+          "name": "out_file1",
+          "type": "input"
+        }
+      ],
+      "position": {
+        "left": 1172.75,
+        "top": 397.75
+      },
+      "post_job_actions": {
+        "HideDatasetActionout_file1": {
+          "action_arguments": {},
+          "action_type": "HideDatasetAction",
+          "output_name": "out_file1"
+        }
+      },
+      "tool_errors": null,
+      "tool_id": "Filter1",
+      "tool_state": "{\"input\": \"null\", \"__rerun_remap_job_id__\": null, \"header_lines\": \"\\\"0\\\"\", \"cond\": \"\\\"c2=='lyso'\\\"\", \"__page__\": 0}",
+      "tool_version": "1.1.0",
+      "type": "tool",
+      "uuid": "195b0060-48f2-4377-aa15-a96be6338d31",
+      "workflow_outputs": []
+    },
+    "19": {
+      "annotation": "",
+      "content_id": "toolshed.g2.bx.psu.edu/repos/bgruening/text_processing/tp_easyjoin_tool/1.0.0",
+      "id": 19,
+      "input_connections": {
+        "infile1": {
+          "id": 12,
+          "output_name": "output"
+        },
+        "infile2": {
+          "id": 13,
+          "output_name": "output"
+        }
+      },
+      "inputs": [],
+      "label": null,
+      "name": "Join",
+      "outputs": [
+        {
+          "name": "output",
+          "type": "input"
+        }
+      ],
+      "position": {
+        "left": 1184.75,
+        "top": 734.75
+      },
+      "post_job_actions": {
+        "HideDatasetActionoutput": {
+          "action_arguments": {},
+          "action_type": "HideDatasetAction",
+          "output_name": "output"
+        }
+      },
+      "tool_errors": null,
+      "tool_id": "toolshed.g2.bx.psu.edu/repos/bgruening/text_processing/tp_easyjoin_tool/1.0.0",
+      "tool_state": "{\"__page__\": 0, \"ignore_case\": \"\\\"False\\\"\", \"infile2\": \"null\", \"infile1\": \"null\", \"empty_string_filler\": \"\\\"0\\\"\", \"__rerun_remap_job_id__\": null, \"jointype\": \"\\\"-v 2\\\"\", \"header\": \"\\\"False\\\"\", \"column1\": \"\\\"1\\\"\", \"column2\": \"\\\"1\\\"\"}",
+      "tool_version": "1.0.0",
+      "type": "tool",
+      "uuid": "fba78726-c9fd-4789-9ed9-2969aa87d984",
+      "workflow_outputs": []
+    },
+    "20": {
+      "annotation": "Combines all GO annotations for \"integral to plasma membrane\" and \"cell surface\"",
+      "content_id": "toolshed.g2.bx.psu.edu/repos/bgruening/text_processing/tp_easyjoin_tool/1.0.0",
+      "id": 20,
+      "input_connections": {
+        "infile1": {
+          "id": 14,
+          "output_name": "output"
+        },
+        "infile2": {
+          "id": 15,
+          "output_name": "output"
+        }
+      },
+      "inputs": [],
+      "label": null,
+      "name": "Join",
+      "outputs": [
+        {
+          "name": "output",
+          "type": "input"
+        }
+      ],
+      "position": {
+        "left": 1189.75,
+        "top": 1009.75
+      },
+      "post_job_actions": {
+        "HideDatasetActionoutput": {
+          "action_arguments": {},
+          "action_type": "HideDatasetAction",
+          "output_name": "output"
+        }
+      },
+      "tool_errors": null,
+      "tool_id": "toolshed.g2.bx.psu.edu/repos/bgruening/text_processing/tp_easyjoin_tool/1.0.0",
+      "tool_state": "{\"__page__\": 0, \"ignore_case\": \"\\\"False\\\"\", \"infile2\": \"null\", \"infile1\": \"null\", \"empty_string_filler\": \"\\\"0\\\"\", \"__rerun_remap_job_id__\": null, \"jointype\": \"\\\"-a 1 -a 2\\\"\", \"header\": \"\\\"False\\\"\", \"column1\": \"\\\"1\\\"\", \"column2\": \"\\\"1\\\"\"}",
+      "tool_version": "1.0.0",
+      "type": "tool",
+      "uuid": "c699e36d-a983-4e66-820d-f00b1b904739",
+      "workflow_outputs": []
+    },
+    "21": {
+      "annotation": "Combines all proteins in the input list that are predicted by WolfPsort to be lysosomal and/or extracellular.",
+      "content_id": "toolshed.g2.bx.psu.edu/repos/bgruening/text_processing/tp_easyjoin_tool/1.0.0",
+      "id": 21,
+      "input_connections": {
+        "infile1": {
+          "id": 17,
+          "output_name": "out_file1"
+        },
+        "infile2": {
+          "id": 18,
+          "output_name": "out_file1"
+        }
+      },
+      "inputs": [],
+      "label": null,
+      "name": "Join",
+      "outputs": [
+        {
+          "name": "output",
+          "type": "input"
+        }
+      ],
+      "position": {
+        "left": 1390.75,
+        "top": 334.75
+      },
+      "post_job_actions": {
+        "HideDatasetActionoutput": {
+          "action_arguments": {},
+          "action_type": "HideDatasetAction",
+          "output_name": "output"
+        }
+      },
+      "tool_errors": null,
+      "tool_id": "toolshed.g2.bx.psu.edu/repos/bgruening/text_processing/tp_easyjoin_tool/1.0.0",
+      "tool_state": "{\"__page__\": 0, \"ignore_case\": \"\\\"False\\\"\", \"infile2\": \"null\", \"infile1\": \"null\", \"empty_string_filler\": \"\\\"0\\\"\", \"__rerun_remap_job_id__\": null, \"jointype\": \"\\\"-a 1 -a 2\\\"\", \"header\": \"\\\"False\\\"\", \"column1\": \"\\\"1\\\"\", \"column2\": \"\\\"1\\\"\"}",
+      "tool_version": "1.0.0",
+      "type": "tool",
+      "uuid": "4a244c68-b12d-46a7-950d-2846a8af8ef5",
+      "workflow_outputs": []
+    },
+    "22": {
+      "annotation": "Combines all GO annotations for \"extracellular region\", \"integral to plasma membrane\" and \"cell surface\" excluding \"extracellular organelle\"",
+      "content_id": "toolshed.g2.bx.psu.edu/repos/bgruening/text_processing/tp_easyjoin_tool/1.0.0",
+      "id": 22,
+      "input_connections": {
+        "infile1": {
+          "id": 19,
+          "output_name": "output"
+        },
+        "infile2": {
+          "id": 20,
+          "output_name": "output"
+        }
+      },
+      "inputs": [],
+      "label": null,
+      "name": "Join",
+      "outputs": [
+        {
+          "name": "output",
+          "type": "input"
+        }
+      ],
+      "position": {
+        "left": 1366.75,
+        "top": 864.75
+      },
+      "post_job_actions": {
+        "HideDatasetActionoutput": {
+          "action_arguments": {},
+          "action_type": "HideDatasetAction",
+          "output_name": "output"
+        }
+      },
+      "tool_errors": null,
+      "tool_id": "toolshed.g2.bx.psu.edu/repos/bgruening/text_processing/tp_easyjoin_tool/1.0.0",
+      "tool_state": "{\"__page__\": 0, \"ignore_case\": \"\\\"False\\\"\", \"infile2\": \"null\", \"infile1\": \"null\", \"empty_string_filler\": \"\\\"0\\\"\", \"__rerun_remap_job_id__\": null, \"jointype\": \"\\\"-a 1 -a 2\\\"\", \"header\": \"\\\"False\\\"\", \"column1\": \"\\\"1\\\"\", \"column2\": \"\\\"1\\\"\"}",
+      "tool_version": "1.0.0",
+      "type": "tool",
+      "uuid": "75b8acd7-7fd1-4ca4-be93-0542b6ed3c9d",
+      "workflow_outputs": []
+    },
+    "23": {
+      "annotation": "Extracts uniprot accessions from all proteins in the input list that are predicted by WolfPsort to be lysosomal and/or extracellular.",
+      "content_id": "Convert characters1",
+      "id": 23,
+      "input_connections": {
+        "input": {
+          "id": 21,
+          "output_name": "output"
+        }
+      },
+      "inputs": [],
+      "label": null,
+      "name": "Convert",
+      "outputs": [
+        {
+          "name": "out_file1",
+          "type": "tabular"
+        }
+      ],
+      "position": {
+        "left": 1513.75,
+        "top": 458.75
+      },
+      "post_job_actions": {
+        "HideDatasetActionout_file1": {
+          "action_arguments": {},
+          "action_type": "HideDatasetAction",
+          "output_name": "out_file1"
+        }
+      },
+      "tool_errors": null,
+      "tool_id": "Convert characters1",
+      "tool_state": "{\"__page__\": 0, \"__rerun_remap_job_id__\": null, \"condense\": \"\\\"True\\\"\", \"strip\": \"\\\"True\\\"\", \"input\": \"null\", \"convert_from\": \"\\\"P\\\"\"}",
+      "tool_version": "1.0.0",
+      "type": "tool",
+      "uuid": "8e195b7d-e1fa-4df4-9108-697d89119b53",
+      "workflow_outputs": []
+    },
+    "24": {
+      "annotation": "Combines all GO annotations for \"lysosome\", \"extracellular region\", \"integral to plasma membrane\" and \"cell surface\" excluding \"extracellular organelle\"",
+      "content_id": "toolshed.g2.bx.psu.edu/repos/bgruening/text_processing/tp_easyjoin_tool/1.0.0",
+      "id": 24,
+      "input_connections": {
+        "infile1": {
+          "id": 22,
+          "output_name": "output"
+        },
+        "infile2": {
+          "id": 16,
+          "output_name": "output"
+        }
+      },
+      "inputs": [],
+      "label": null,
+      "name": "Join",
+      "outputs": [
+        {
+          "name": "output",
+          "type": "input"
+        }
+      ],
+      "position": {
+        "left": 1502.75,
+        "top": 1036.75
+      },
+      "post_job_actions": {
+        "HideDatasetActionoutput": {
+          "action_arguments": {},
+          "action_type": "HideDatasetAction",
+          "output_name": "output"
+        }
+      },
+      "tool_errors": null,
+      "tool_id": "toolshed.g2.bx.psu.edu/repos/bgruening/text_processing/tp_easyjoin_tool/1.0.0",
+      "tool_state": "{\"__page__\": 0, \"ignore_case\": \"\\\"False\\\"\", \"infile2\": \"null\", \"infile1\": \"null\", \"empty_string_filler\": \"\\\"0\\\"\", \"__rerun_remap_job_id__\": null, \"jointype\": \"\\\"-a 1 -a 2\\\"\", \"header\": \"\\\"False\\\"\", \"column1\": \"\\\"1\\\"\", \"column2\": \"\\\"1\\\"\"}",
+      "tool_version": "1.0.0",
+      "type": "tool",
+      "uuid": "4855cffc-41b9-4a6f-8cd4-9427ec849b95",
+      "workflow_outputs": []
+    },
+    "25": {
+      "annotation": "Deletes all columns but the one containing uniprot accessions of extracellular proteins as predicted by WoLF PSORT.",
+      "content_id": "toolshed.g2.bx.psu.edu/repos/bgruening/text_processing/tp_cut_tool/1.0.0",
+      "id": 25,
+      "input_connections": {
+        "input": {
+          "id": 23,
+          "output_name": "out_file1"
+        }
+      },
+      "inputs": [],
+      "label": null,
+      "name": "Cut",
+      "outputs": [
+        {
+          "name": "output",
+          "type": "tabular"
+        }
+      ],
+      "position": {
+        "left": 1613.75,
+        "top": 554.75
+      },
+      "post_job_actions": {
+        "HideDatasetActionoutput": {
+          "action_arguments": {},
+          "action_type": "HideDatasetAction",
+          "output_name": "output"
+        }
+      },
+      "tool_errors": null,
+      "tool_id": "toolshed.g2.bx.psu.edu/repos/bgruening/text_processing/tp_cut_tool/1.0.0",
+      "tool_state": "{\"__page__\": 0, \"complement\": \"\\\"\\\"\", \"cut_type_options\": \"{\\\"list\\\": [\\\"2\\\"], \\\"cut_element\\\": \\\"-f\\\", \\\"__current_case__\\\": 0}\", \"delimiter\": \"\\\"\\\"\", \"input\": \"null\", \"__rerun_remap_job_id__\": null}",
+      "tool_version": "1.0.0",
+      "type": "tool",
+      "uuid": "1573af45-4165-4825-ae8d-57182571cf42",
+      "workflow_outputs": []
+    },
+    "26": {
+      "annotation": "filters out all proteins in the input protein list of interest that are annotated as \"extracellular region\" and \"lysosome\" and \"plasma membrane\" excluding \"extracellular organelle\" and \"cytoplasmic side of plasma membrane\"",
+      "content_id": "comp1",
+      "id": 26,
+      "input_connections": {
+        "input1": {
+          "id": 11,
+          "output_name": "output"
+        },
+        "input2": {
+          "id": 24,
+          "output_name": "output"
+        }
+      },
+      "inputs": [],
+      "label": null,
+      "name": "Compare two Datasets",
+      "outputs": [
+        {
+          "name": "out_file1",
+          "type": "input"
+        }
+      ],
+      "position": {
+        "left": 1514.75,
+        "top": 680.75
+      },
+      "post_job_actions": {
+        "HideDatasetActionout_file1": {
+          "action_arguments": {},
+          "action_type": "HideDatasetAction",
+          "output_name": "out_file1"
+        }
+      },
+      "tool_errors": null,
+      "tool_id": "comp1",
+      "tool_state": "{\"input2\": \"null\", \"__page__\": 0, \"input1\": \"null\", \"field2\": \"\\\"1\\\"\", \"__rerun_remap_job_id__\": null, \"field1\": \"\\\"6\\\"\", \"mode\": \"\\\"N\\\"\"}",
+      "tool_version": "1.0.2",
+      "type": "tool",
+      "uuid": "4e5095ba-1132-484b-875d-866676cb8910",
+      "workflow_outputs": [],
+      "tool_shed_repository": {
+        "changeset_revision": "c2a356708570",
+        "name": "sharplabtool",
+        "owner": "xuebing",
+        "tool_shed": "toolshed.g2.bx.psu.edu"
+      }
+    },
+    "27": {
+      "annotation": "cleans up the protein list for unique entries",
+      "content_id": "toolshed.g2.bx.psu.edu/repos/bgruening/unique/bg_uniq/0.3",
+      "id": 27,
+      "input_connections": {
+        "input": {
+          "id": 26,
+          "output_name": "out_file1"
+        }
+      },
+      "inputs": [],
+      "label": null,
+      "name": "Unique",
+      "outputs": [
+        {
+          "name": "outfile",
+          "type": "input"
+        }
+      ],
+      "position": {
+        "left": 1640.75,
+        "top": 806.75
+      },
+      "post_job_actions": {
+        "HideDatasetActionoutfile": {
+          "action_arguments": {},
+          "action_type": "HideDatasetAction",
+          "output_name": "outfile"
+        }
+      },
+      "tool_errors": null,
+      "tool_id": "toolshed.g2.bx.psu.edu/repos/bgruening/unique/bg_uniq/0.3",
+      "tool_state": "{\"__page__\": 0, \"ignore_case\": \"\\\"False\\\"\", \"adv_opts\": \"{\\\"column_end\\\": \\\"1\\\", \\\"column_start\\\": \\\"1\\\", \\\"adv_opts_selector\\\": \\\"advanced\\\", \\\"__current_case__\\\": 1}\", \"__rerun_remap_job_id__\": null, \"is_numeric\": \"\\\"False\\\"\", \"input\": \"null\"}",
+      "tool_version": "0.3",
+      "type": "tool",
+      "uuid": "89ab7414-9e60-40ae-9598-fee02fab0205",
+      "workflow_outputs": [],
+      "tool_shed_repository": {
+        "changeset_revision": "7ce75adb93be",
+        "name": "unique",
+        "owner": "bgruening",
+        "tool_shed": "toolshed.g2.bx.psu.edu"
+      }
+    },
+    "28": {
+      "annotation": "Deletes all columns but the one containing uniprot accessions of secreted and shed (i.e. \"secretome\") proteins.",
+      "content_id": "toolshed.g2.bx.psu.edu/repos/bgruening/text_processing/tp_cut_tool/1.0.0",
+      "id": 28,
+      "input_connections": {
+        "input": {
+          "id": 27,
+          "output_name": "outfile"
+        }
+      },
+      "inputs": [],
+      "label": null,
+      "name": "Cut",
+      "outputs": [
+        {
+          "name": "output",
+          "type": "tabular"
+        }
+      ],
+      "position": {
+        "left": 1730.75,
+        "top": 905.75
+      },
+      "post_job_actions": {
+        "HideDatasetActionoutput": {
+          "action_arguments": {},
+          "action_type": "HideDatasetAction",
+          "output_name": "output"
+        }
+      },
+      "tool_errors": null,
+      "tool_id": "toolshed.g2.bx.psu.edu/repos/bgruening/text_processing/tp_cut_tool/1.0.0",
+      "tool_state": "{\"__page__\": 0, \"complement\": \"\\\"\\\"\", \"cut_type_options\": \"{\\\"list\\\": [\\\"1\\\"], \\\"cut_element\\\": \\\"-f\\\", \\\"__current_case__\\\": 0}\", \"delimiter\": \"\\\"\\\"\", \"input\": \"null\", \"__rerun_remap_job_id__\": null}",
+      "tool_version": "1.0.0",
+      "type": "tool",
+      "uuid": "0ad689c9-abf9-4e2b-a3a9-f670c03c3d8b",
+      "workflow_outputs": []
+    },
+    "29": {
+      "annotation": "Combines all proteins that are either predicted by WoLF PSORT to be shed or secreted or annotated in the GO database to be shed or secreted.",
+      "content_id": "toolshed.g2.bx.psu.edu/repos/bgruening/text_processing/tp_easyjoin_tool/1.0.0",
+      "id": 29,
+      "input_connections": {
+        "infile1": {
+          "id": 25,
+          "output_name": "output"
+        },
+        "infile2": {
+          "id": 28,
+          "output_name": "output"
+        }
+      },
+      "inputs": [],
+      "label": null,
+      "name": "Join",
+      "outputs": [
+        {
+          "name": "output",
+          "type": "input"
+        }
+      ],
+      "position": {
+        "left": 1880.75,
+        "top": 649.75
+      },
+      "post_job_actions": {
+        "HideDatasetActionoutput": {
+          "action_arguments": {},
+          "action_type": "HideDatasetAction",
+          "output_name": "output"
+        }
+      },
+      "tool_errors": null,
+      "tool_id": "toolshed.g2.bx.psu.edu/repos/bgruening/text_processing/tp_easyjoin_tool/1.0.0",
+      "tool_state": "{\"__page__\": 0, \"ignore_case\": \"\\\"False\\\"\", \"infile2\": \"null\", \"infile1\": \"null\", \"empty_string_filler\": \"\\\"0\\\"\", \"__rerun_remap_job_id__\": null, \"jointype\": \"\\\"-a 1 -a 2\\\"\", \"header\": \"\\\"False\\\"\", \"column1\": \"\\\"1\\\"\", \"column2\": \"\\\"1\\\"\"}",
+      "tool_version": "1.0.0",
+      "type": "tool",
+      "uuid": "87aa3f42-5408-4475-af7a-c368fed485cd",
+      "workflow_outputs": []
+    },
+    "30": {
+      "annotation": "Final output. Unique entries of all proteins that are either predicted by WoLF PSORT to be shed or secreted or annotated in the GO database to be shed or secreted.",
+      "content_id": "toolshed.g2.bx.psu.edu/repos/bgruening/text_processing/tp_sorted_uniq/1.0.0",
+      "id": 30,
+      "input_connections": {
+        "infile": {
+          "id": 29,
+          "output_name": "output"
+        }
+      },
+      "inputs": [],
+      "label": null,
+      "name": "Unique",
+      "outputs": [
+        {
+          "name": "outfile",
+          "type": "input"
+        }
+      ],
+      "position": {
+        "left": 1964.75,
+        "top": 787.75
+      },
+      "post_job_actions": {
+        "RenameDatasetActionoutfile": {
+          "action_arguments": {
+            "newname": "secretome_proteins"
+          },
+          "action_type": "RenameDatasetAction",
+          "output_name": "outfile"
+        }
+      },
+      "tool_errors": null,
+      "tool_id": "toolshed.g2.bx.psu.edu/repos/bgruening/text_processing/tp_sorted_uniq/1.0.0",
+      "tool_state": "{\"__page__\": 0, \"ignore_case\": \"\\\"False\\\"\", \"adv_opts\": \"{\\\"adv_opts_selector\\\": \\\"basic\\\", \\\"__current_case__\\\": 0}\", \"__rerun_remap_job_id__\": null, \"is_numeric\": \"\\\"False\\\"\", \"infile\": \"null\"}",
+      "tool_version": "1.0.0",
+      "type": "tool",
+      "uuid": "5ca3dd78-27ed-4f4f-95f6-c25fa4fd43b6",
+      "workflow_outputs": [
+        {
+          "label": "Secretome proteins",
+          "output_name": "outfile",
+          "uuid": "14e0c6dc-436b-4c4c-9292-d5e00cca8c92"
+        }
+      ],
+      "tool_shed_repository": {
+        "changeset_revision": "288462ec2630",
+        "name": "text_processing",
+        "owner": "bgruening",
+        "tool_shed": "toolshed.g2.bx.psu.edu"
+      }
+    }
+  },
+  "uuid": "017c3db3-46ca-4ff7-9e50-132679765355"
 }

--- a/topics/sequence-analysis/tutorials/mapping/workflows/mapping-jbrowse.ga
+++ b/topics/sequence-analysis/tutorials/mapping/workflows/mapping-jbrowse.ga
@@ -2,7 +2,7 @@
   "a_galaxy_workflow": "true",
   "annotation": "",
   "format-version": "0.1",
-  "name": "GTN - Sequence analyses - Mapping (imported from uploaded file)",
+  "name": "GTN - Sequence analyses - Mapping - jbrowse",
   "steps": {
     "0": {
       "annotation": "",

--- a/topics/visualisation/tutorials/circos/workflows/main_workflow.ga
+++ b/topics/visualisation/tutorials/circos/workflows/main_workflow.ga
@@ -1,1 +1,126 @@
-{"annotation": "", "a_galaxy_workflow": "true", "format-version": "0.1", "version": 1, "name": "asdf", "uuid": "9006b0f5-8510-4f48-bda9-fcf5ac626b95", "tags": [], "steps": {"1": {"workflow_outputs": [], "position": {"top": 598, "left": 200}, "id": 1, "uuid": "3fa30125-fd7e-494c-99ba-7afb4e49f333", "inputs": [{"name": "Chromsomes", "description": ""}], "tool_id": null, "label": "Chromsomes", "content_id": null, "tool_state": "{\"name\": \"Chromsomes\"}", "input_connections": {}, "type": "data_input", "errors": null, "name": "Input dataset", "outputs": [], "annotation": "", "tool_version": null}, "0": {"workflow_outputs": [], "position": {"top": 358, "left": 200}, "id": 0, "uuid": "24f62bb0-cf08-4877-b408-9f9ec24cf45f", "inputs": [{"name": "highlight-0.tabular", "description": ""}], "tool_id": null, "label": "highlight-0.tabular", "content_id": null, "tool_state": "{\"name\": \"highlight-0.tabular\"}", "input_connections": {}, "type": "data_input", "errors": null, "name": "Input dataset", "outputs": [], "annotation": "", "tool_version": null}, "2": {"workflow_outputs": [], "position": {"top": 324, "left": 473}, "id": 2, "uuid": "0ee778ee-2bc1-4042-9359-f6dae90ff544", "inputs": [{"name": "reference_genome", "description": "runtime parameter for tool Circos"}], "tool_id": "circos", "label": null, "content_id": "circos", "errors": null, "tool_state": "{\"__page__\": null, \"ideogram\": \"{\\\"bands\\\": {\\\"band_stroke_color\\\": \\\"#000000\\\", \\\"band_stroke_thickness\\\": \\\"2\\\", \\\"band_transparency\\\": \\\"0\\\", \\\"fill_bands\\\": \\\"true\\\", \\\"show_bands\\\": \\\"true\\\", \\\"transparency\\\": \\\"1.0\\\"}, \\\"ideogram_labels\\\": {\\\"parallel\\\": \\\"true\\\", \\\"radius_offset\\\": \\\"0.075\\\", \\\"show_label\\\": \\\"false\\\", \\\"size\\\": \\\"24\\\"}, \\\"radius\\\": \\\"0.9\\\", \\\"spacing\\\": \\\"0.005\\\", \\\"thickness\\\": \\\"0.0\\\", \\\"units\\\": \\\"mb\\\"}\", \"sec_highlight\": \"{\\\"data\\\": [{\\\"__index__\\\": 0, \\\"data_source\\\": {\\\"__class__\\\": \\\"RuntimeValue\\\"}, \\\"fill_color\\\": \\\"#000000\\\", \\\"fill_color_alpha\\\": \\\"1.0\\\", \\\"r0\\\": \\\"0.9\\\", \\\"r1\\\": \\\"0.99\\\", \\\"sec_rule\\\": {\\\"rules\\\": []}}, {\\\"__index__\\\": 1, \\\"data_source\\\": {\\\"__class__\\\": \\\"RuntimeValue\\\"}, \\\"fill_color\\\": \\\"#000000\\\", \\\"fill_color_alpha\\\": \\\"1.0\\\", \\\"r0\\\": \\\"0.8\\\", \\\"r1\\\": \\\"0.89\\\", \\\"sec_rule\\\": {\\\"rules\\\": [{\\\"__index__\\\": 0, \\\"actions\\\": [{\\\"__index__\\\": 0, \\\"action\\\": {\\\"__current_case__\\\": 1, \\\"action_select\\\": \\\"fill_color\\\", \\\"action_value\\\": \\\"#8064a2\\\", \\\"transparency\\\": \\\"1.0\\\"}}], \\\"conditions\\\": [{\\\"__index__\\\": 0, \\\"application\\\": {\\\"__current_case__\\\": 3, \\\"application_select\\\": \\\"random\\\", \\\"value\\\": \\\"0.1\\\"}}], \\\"continue_flow\\\": \\\"true\\\"}, {\\\"__index__\\\": 1, \\\"actions\\\": [{\\\"__index__\\\": 0, \\\"action\\\": {\\\"__current_case__\\\": 1, \\\"action_select\\\": \\\"fill_color\\\", \\\"action_value\\\": \\\"#ffff00\\\", \\\"transparency\\\": \\\"1.0\\\"}}], \\\"conditions\\\": [{\\\"__index__\\\": 0, \\\"application\\\": {\\\"__current_case__\\\": 2, \\\"application_select\\\": \\\"pos\\\", \\\"pos_gt\\\": \\\"5000000.0\\\", \\\"pos_lt\\\": \\\"5000000.0\\\", \\\"pos_lt_sub\\\": \\\"true\\\"}}, {\\\"__index__\\\": 1, \\\"application\\\": {\\\"__current_case__\\\": 3, \\\"application_select\\\": \\\"random\\\", \\\"value\\\": \\\"0.1\\\"}}], \\\"continue_flow\\\": \\\"true\\\"}]}}, {\\\"__index__\\\": 2, \\\"data_source\\\": {\\\"__class__\\\": \\\"RuntimeValue\\\"}, \\\"fill_color\\\": \\\"#000000\\\", \\\"fill_color_alpha\\\": \\\"1.0\\\", \\\"r0\\\": \\\"0.7\\\", \\\"r1\\\": \\\"0.79\\\", \\\"sec_rule\\\": {\\\"rules\\\": [{\\\"__index__\\\": 0, \\\"actions\\\": [{\\\"__index__\\\": 0, \\\"action\\\": {\\\"__current_case__\\\": 1, \\\"action_select\\\": \\\"fill_color\\\", \\\"action_value\\\": \\\"#8064a2\\\", \\\"transparency\\\": \\\"1.0\\\"}}], \\\"conditions\\\": [{\\\"__index__\\\": 0, \\\"application\\\": {\\\"__current_case__\\\": 3, \\\"application_select\\\": \\\"random\\\", \\\"value\\\": \\\"0.2\\\"}}], \\\"continue_flow\\\": \\\"true\\\"}, {\\\"__index__\\\": 1, \\\"actions\\\": [{\\\"__index__\\\": 0, \\\"action\\\": {\\\"__current_case__\\\": 1, \\\"action_select\\\": \\\"fill_color\\\", \\\"action_value\\\": \\\"#ffff00\\\", \\\"transparency\\\": \\\"1.0\\\"}}], \\\"conditions\\\": [{\\\"__index__\\\": 0, \\\"application\\\": {\\\"__current_case__\\\": 3, \\\"application_select\\\": \\\"random\\\", \\\"value\\\": \\\"0.2\\\"}}], \\\"continue_flow\\\": \\\"false\\\"}]}}]}\", \"plot_options\": \"{\\\"background\\\": {\\\"__current_case__\\\": 1, \\\"background_color\\\": \\\"#000000\\\", \\\"background_select\\\": \\\"color\\\", \\\"transparency\\\": \\\"1.0\\\"}, \\\"colour_profile\\\": null, \\\"radius\\\": \\\"1500\\\"}\", \"outputs\": \"{\\\"png\\\": \\\"true\\\", \\\"svg\\\": \\\"false\\\", \\\"tar\\\": \\\"false\\\"}\", \"__rerun_remap_job_id__\": null, \"ticks\": \"{\\\"radius\\\": \\\"1.0\\\", \\\"show_ticks\\\": \\\"false\\\", \\\"tick_group\\\": []}\", \"reference_genome\": \"{\\\"bands\\\": {\\\"__class__\\\": \\\"RuntimeValue\\\"}, \\\"convert_bands\\\": \\\"true\\\", \\\"limit_chromosomes\\\": \\\"\\\", \\\"ref\\\": {\\\"__current_case__\\\": 2, \\\"input_karyotype\\\": {\\\"__class__\\\": \\\"RuntimeValue\\\"}, \\\"ref_source\\\": \\\"karyotype\\\"}}\", \"chromInfo\": \"\\\"/home/hxr/arbeit/galaxy/tool-data/shared/ucsc/chrom/?.len\\\"\", \"sec_links\": \"{\\\"data\\\": []}\", \"sec_tdd\": \"{\\\"data\\\": []}\"}", "input_connections": {"sec_highlight|data_2|data_source": {"output_name": "output", "id": 0}, "sec_highlight|data_0|data_source": {"output_name": "output", "id": 0}, "sec_highlight|data_1|data_source": {"output_name": "output", "id": 0}, "reference_genome|ref|input_karyotype": {"output_name": "output", "id": 1}}, "type": "tool", "post_job_actions": {}, "name": "Circos", "outputs": [{"name": "output_png", "type": "png"}, {"name": "output_svg", "type": "svg"}, {"name": "output_tar", "type": "tar.gz"}], "annotation": "", "tool_version": "0.91"}}}
+{
+  "a_galaxy_workflow": "true",
+  "annotation": "",
+  "format-version": "0.1",
+  "name": "asdf",
+  "steps": {
+    "0": {
+      "annotation": "",
+      "content_id": null,
+      "errors": null,
+      "id": 0,
+      "input_connections": {},
+      "inputs": [
+        {
+          "description": "",
+          "name": "highlight-0.tabular"
+        }
+      ],
+      "label": "highlight-0.tabular",
+      "name": "Input dataset",
+      "outputs": [],
+      "position": {
+        "left": 200,
+        "top": 358
+      },
+      "tool_id": null,
+      "tool_state": "{\"name\": \"highlight-0.tabular\"}",
+      "tool_version": null,
+      "type": "data_input",
+      "uuid": "24f62bb0-cf08-4877-b408-9f9ec24cf45f",
+      "workflow_outputs": []
+    },
+    "1": {
+      "annotation": "",
+      "content_id": null,
+      "errors": null,
+      "id": 1,
+      "input_connections": {},
+      "inputs": [
+        {
+          "description": "",
+          "name": "Chromsomes"
+        }
+      ],
+      "label": "Chromsomes",
+      "name": "Input dataset",
+      "outputs": [],
+      "position": {
+        "left": 200,
+        "top": 598
+      },
+      "tool_id": null,
+      "tool_state": "{\"name\": \"Chromsomes\"}",
+      "tool_version": null,
+      "type": "data_input",
+      "uuid": "3fa30125-fd7e-494c-99ba-7afb4e49f333",
+      "workflow_outputs": []
+    },
+    "2": {
+      "annotation": "",
+      "content_id": "circos",
+      "errors": null,
+      "id": 2,
+      "input_connections": {
+        "reference_genome|ref|input_karyotype": {
+          "id": 1,
+          "output_name": "output"
+        },
+        "sec_highlight|data_0|data_source": {
+          "id": 0,
+          "output_name": "output"
+        },
+        "sec_highlight|data_1|data_source": {
+          "id": 0,
+          "output_name": "output"
+        },
+        "sec_highlight|data_2|data_source": {
+          "id": 0,
+          "output_name": "output"
+        }
+      },
+      "inputs": [
+        {
+          "description": "runtime parameter for tool Circos",
+          "name": "reference_genome"
+        }
+      ],
+      "label": null,
+      "name": "Circos",
+      "outputs": [
+        {
+          "name": "output_png",
+          "type": "png"
+        },
+        {
+          "name": "output_svg",
+          "type": "svg"
+        },
+        {
+          "name": "output_tar",
+          "type": "tar.gz"
+        }
+      ],
+      "position": {
+        "left": 473,
+        "top": 324
+      },
+      "post_job_actions": {},
+      "tool_id": "circos_wiggle_to_scatter",
+      "tool_state": "{\"__page__\": null, \"ideogram\": \"{\\\"bands\\\": {\\\"band_stroke_color\\\": \\\"#000000\\\", \\\"band_stroke_thickness\\\": \\\"2\\\", \\\"band_transparency\\\": \\\"0\\\", \\\"fill_bands\\\": \\\"true\\\", \\\"show_bands\\\": \\\"true\\\", \\\"transparency\\\": \\\"1.0\\\"}, \\\"ideogram_labels\\\": {\\\"parallel\\\": \\\"true\\\", \\\"radius_offset\\\": \\\"0.075\\\", \\\"show_label\\\": \\\"false\\\", \\\"size\\\": \\\"24\\\"}, \\\"radius\\\": \\\"0.9\\\", \\\"spacing\\\": \\\"0.005\\\", \\\"thickness\\\": \\\"0.0\\\", \\\"units\\\": \\\"mb\\\"}\", \"sec_highlight\": \"{\\\"data\\\": [{\\\"__index__\\\": 0, \\\"data_source\\\": {\\\"__class__\\\": \\\"RuntimeValue\\\"}, \\\"fill_color\\\": \\\"#000000\\\", \\\"fill_color_alpha\\\": \\\"1.0\\\", \\\"r0\\\": \\\"0.9\\\", \\\"r1\\\": \\\"0.99\\\", \\\"sec_rule\\\": {\\\"rules\\\": []}}, {\\\"__index__\\\": 1, \\\"data_source\\\": {\\\"__class__\\\": \\\"RuntimeValue\\\"}, \\\"fill_color\\\": \\\"#000000\\\", \\\"fill_color_alpha\\\": \\\"1.0\\\", \\\"r0\\\": \\\"0.8\\\", \\\"r1\\\": \\\"0.89\\\", \\\"sec_rule\\\": {\\\"rules\\\": [{\\\"__index__\\\": 0, \\\"actions\\\": [{\\\"__index__\\\": 0, \\\"action\\\": {\\\"__current_case__\\\": 1, \\\"action_select\\\": \\\"fill_color\\\", \\\"action_value\\\": \\\"#8064a2\\\", \\\"transparency\\\": \\\"1.0\\\"}}], \\\"conditions\\\": [{\\\"__index__\\\": 0, \\\"application\\\": {\\\"__current_case__\\\": 3, \\\"application_select\\\": \\\"random\\\", \\\"value\\\": \\\"0.1\\\"}}], \\\"continue_flow\\\": \\\"true\\\"}, {\\\"__index__\\\": 1, \\\"actions\\\": [{\\\"__index__\\\": 0, \\\"action\\\": {\\\"__current_case__\\\": 1, \\\"action_select\\\": \\\"fill_color\\\", \\\"action_value\\\": \\\"#ffff00\\\", \\\"transparency\\\": \\\"1.0\\\"}}], \\\"conditions\\\": [{\\\"__index__\\\": 0, \\\"application\\\": {\\\"__current_case__\\\": 2, \\\"application_select\\\": \\\"pos\\\", \\\"pos_gt\\\": \\\"5000000.0\\\", \\\"pos_lt\\\": \\\"5000000.0\\\", \\\"pos_lt_sub\\\": \\\"true\\\"}}, {\\\"__index__\\\": 1, \\\"application\\\": {\\\"__current_case__\\\": 3, \\\"application_select\\\": \\\"random\\\", \\\"value\\\": \\\"0.1\\\"}}], \\\"continue_flow\\\": \\\"true\\\"}]}}, {\\\"__index__\\\": 2, \\\"data_source\\\": {\\\"__class__\\\": \\\"RuntimeValue\\\"}, \\\"fill_color\\\": \\\"#000000\\\", \\\"fill_color_alpha\\\": \\\"1.0\\\", \\\"r0\\\": \\\"0.7\\\", \\\"r1\\\": \\\"0.79\\\", \\\"sec_rule\\\": {\\\"rules\\\": [{\\\"__index__\\\": 0, \\\"actions\\\": [{\\\"__index__\\\": 0, \\\"action\\\": {\\\"__current_case__\\\": 1, \\\"action_select\\\": \\\"fill_color\\\", \\\"action_value\\\": \\\"#8064a2\\\", \\\"transparency\\\": \\\"1.0\\\"}}], \\\"conditions\\\": [{\\\"__index__\\\": 0, \\\"application\\\": {\\\"__current_case__\\\": 3, \\\"application_select\\\": \\\"random\\\", \\\"value\\\": \\\"0.2\\\"}}], \\\"continue_flow\\\": \\\"true\\\"}, {\\\"__index__\\\": 1, \\\"actions\\\": [{\\\"__index__\\\": 0, \\\"action\\\": {\\\"__current_case__\\\": 1, \\\"action_select\\\": \\\"fill_color\\\", \\\"action_value\\\": \\\"#ffff00\\\", \\\"transparency\\\": \\\"1.0\\\"}}], \\\"conditions\\\": [{\\\"__index__\\\": 0, \\\"application\\\": {\\\"__current_case__\\\": 3, \\\"application_select\\\": \\\"random\\\", \\\"value\\\": \\\"0.2\\\"}}], \\\"continue_flow\\\": \\\"false\\\"}]}}]}\", \"plot_options\": \"{\\\"background\\\": {\\\"__current_case__\\\": 1, \\\"background_color\\\": \\\"#000000\\\", \\\"background_select\\\": \\\"color\\\", \\\"transparency\\\": \\\"1.0\\\"}, \\\"colour_profile\\\": null, \\\"radius\\\": \\\"1500\\\"}\", \"outputs\": \"{\\\"png\\\": \\\"true\\\", \\\"svg\\\": \\\"false\\\", \\\"tar\\\": \\\"false\\\"}\", \"__rerun_remap_job_id__\": null, \"ticks\": \"{\\\"radius\\\": \\\"1.0\\\", \\\"show_ticks\\\": \\\"false\\\", \\\"tick_group\\\": []}\", \"reference_genome\": \"{\\\"bands\\\": {\\\"__class__\\\": \\\"RuntimeValue\\\"}, \\\"convert_bands\\\": \\\"true\\\", \\\"limit_chromosomes\\\": \\\"\\\", \\\"ref\\\": {\\\"__current_case__\\\": 2, \\\"input_karyotype\\\": {\\\"__class__\\\": \\\"RuntimeValue\\\"}, \\\"ref_source\\\": \\\"karyotype\\\"}}\", \"chromInfo\": \"\\\"/home/hxr/arbeit/galaxy/tool-data/shared/ucsc/chrom/?.len\\\"\", \"sec_links\": \"{\\\"data\\\": []}\", \"sec_tdd\": \"{\\\"data\\\": []}\"}",
+      "tool_version": "0.69.8+galaxy2",
+      "type": "tool",
+      "uuid": "0ee778ee-2bc1-4042-9359-f6dae90ff544",
+      "workflow_outputs": [],
+      "tool_shed_repository": {
+        "changeset_revision": "fd59d783248a",
+        "name": "circos",
+        "owner": "iuc",
+        "tool_shed": "toolshed.g2.bx.psu.edu"
+      }
+    }
+  },
+  "tags": [],
+  "uuid": "9006b0f5-8510-4f48-bda9-fcf5ac626b95",
+  "version": 1
+}


### PR DESCRIPTION
Multiple tools were not detected by ephermeris 'workflow-to-tools'. It turned out that this was caused by the lack of a "tool_shed_repository" key in the step of the workflow. I made a script that detects and fixes these problems where possible. I am still trying out the workflows for a manual check, but the results seem already promising.

- Added tool_shed_repository keys were possible in following workflows:
-> CTB workflow
-> Find Exons with the highest number of SNPs (or other features)
-> Database Handling Tutorial Workflow2 including Mycoplasma
-> Database Handling Tutorial Workflow
-> tails triple dimethyl OpenMS2.1
-> ProteinID_SG_PS_Tutorial_WF_datasetCollection
-> Peptide and Protein ID Tutorial
-> Secreted Proteins via GO annotation and WoLF PSORT for shCTSB paper ( `get_subontology_from` and `term_id_vs_term_name` not directly replacable with `onto_tk_term_id_vs_term_name` and `onto_tk_get_subontology_from`, help needed. Will be added to #1710 )
-> asdf
- fixed duplicate in workflow name 'Identification of the binding sites of the Estrogen receptor'
- ewas tour was empty and giving problems if installed on galaxy
- fixed duplicate in workflow name 'GTN - Sequence analyses - Mapping'

**NOTE: Not yet to be merged, still to be tested**