### PR TITLE
Ignore jekyll-cache directory and fix merge conflict

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ decktape-*/
 vendor
 *.swp
 .jekyll-metadata
+.jekyll-cache

--- a/_config.yml
+++ b/_config.yml
@@ -161,6 +161,8 @@ exclude:
   - package-lock.json
   - CONTRIBUTING.md
   - CONTRIBUTORS.yaml
+  - CODEOWNERS
+  - CODE_OF_CONDUCT.md
   - LICENSE.md
   - README.md
   - Makefile
@@ -174,6 +176,7 @@ exclude:
   - templates/
   - vendor/
   - node_modules/
+  - .jekyll-cache/
 include:
   - .nojekyll
 

--- a/topics/contributing/tutorials/create-new-topic/tutorial.md
+++ b/topics/contributing/tutorials/create-new-topic/tutorial.md
@@ -135,13 +135,9 @@ Once the topic name has been chosen, we can create it.
 > 4. Check that a YAML file with your topic name has been generated in `metadata` folder
 > 5. Make sure that Jekyll is running
 >
-<<<<<<< HEAD
->    > Want to learn how to start Jekyll? [Check out our tutorial to serve the website locally]({% link topics/contributing/tutorials/running-jekyll/tutorial.md %})
-=======
 >    > ### {% icon comment %} Jekyll
 >    > Want to learn how to start Jekyll? [Check out our tutorial to serve the website locally]({% link topics/contributing/tutorials/running-jekyll/tutorial.md %})
 >    {: .comment}
->>>>>>> master
 >
 > 6. Check if the topic has been correctly added at [http://localhost:4000/training-material/](http://localhost:4000/training-material/)
 >
@@ -190,13 +186,9 @@ Several metadata are defined in `metadata.yaml` file in your topic folder to :
 > 2. Fill the correct metadata of the topic
 > 3. Make sure that Jekyll is running
 >
-<<<<<<< HEAD
->    > Want to learn how to start Jekyll? [Check out our tutorial to serve the website locally]({% link topics/contributing/tutorials/running-jekyll/tutorial.md %})
-=======
 >    > ### {% icon comment %} Jekyll
 >    > Want to learn how to start Jekyll? [Check out our tutorial to serve the website locally]({% link topics/contributing/tutorials/running-jekyll/tutorial.md %})
 >    {: .comment}
->>>>>>> master
 >
 > 4. Check how it changes the local website
 >


### PR DESCRIPTION
jekyll4 creates a `.jekyll-cache` directory, added this to gitignore and exclude from `_site`

also fixes a merge conflict left in a tutorial spotted by @bedroesb (Thanks!!)