### PR TITLE
Fix to SCSS: Duplicate Matrix definition

### DIFF
--- a/assets/css/main.scss
+++ b/assets/css/main.scss
@@ -38,31 +38,6 @@ $details-color: $light-gray;
 $feedback-color: #86D486;
 
 
-@mixin matrix-table (){
-  table {
-      width:unset;
-      margin-left:auto;
-      margin-right:auto;
-  }
-
-  table thead th {
-      border-bottom: 2px solid #777;
-      text-align: left;
-  }
-
-  table td:first-child, table th:first-child  {
-      border-right: 2px solid #777;
-      font-weight: bold;
-      text-align: left;
-  }
-
-  table td:not(first-child), table th:not(first-child) {
-      text-align: center;
-      border-right: 1px solid #ddd;
-      border-left: 1px solid #ddd;
-  }
-}
-
 @mixin tutorial-box ($bg-color, $color: rgba(255,255,255,.75)) {
     margin-top: 3 * $tutorial-box-spacing;
     padding: $tutorial-box-spacing $tutorial-box-spacing - 0.11rem $tutorial-box-spacing;


### PR DESCRIPTION
Hi, not sure how this happened.

The `matrix-table` mixin class is defined twice, same parameters and everything.