### PR TITLE
Make the creation of an ansible.cfg with `inventory` set non-optional

### DIFF
--- a/topics/admin/tutorials/ansible-galaxy/tutorial.md
+++ b/topics/admin/tutorials/ansible-galaxy/tutorial.md
@@ -590,33 +590,6 @@ The configuration is quite simple thanks to the many sensible defaults that are 
 >
 {: .hands_on}
 
-> ### {% icon details %} Simplifying the command line with ansible.cfg
-> Typing `-i hosts` every time can be a bit repetitive, you can save having to type this flag by creating an `ansible.cfg` file (next to your playbook) with the following contents:
->
-> ```ini
-> [defaults]
-> inventory = hosts
-> ```
->
-> There are some additional useful options that you might want to add to your `ansible.cfg` file:
->
-> ```ini
-> [ssh_connection]
-> pipelining = true
-> [defaults]
-> retry_files_enabled = false
-> ```
->
-> Pipelining will make [ansible run faster](https://docs.ansible.com/ansible/latest/reference_appendices/config.html#ansible-pipelining) by significantly reducing the number of new SSH connections that must be opened. Setting `retry_files_enabled = false` will prevent Ansible from creating `playbook.retry` files whenever a playbook crashes before finishing. These are rarely useful for the cases in which we run Ansible.
->
-> For users running with the local connection, you can specify this in your `hosts` inventory file:
->
-> ```ini
-> [galaxyservers]
-> your.host.name ansible_connection=local
-> ```
-{: .details}
-
 Galaxy is now configured with an admin user, a database, and a place to store data. Additionally we've immediately configured the mules for production Galaxy serving. So we're ready to set up supervisord which will manage the Galaxy processes!
 
 > ### {% icon hands_on %} Hands-on: (Optional) Launching uWSGI by hand
@@ -627,6 +600,36 @@ Galaxy is now configured with an admin user, a database, and a place to store da
 > 4. Activate virtualenv (`. ../venv/bin/activate`)
 > 5. `uwsgi --yaml ../config/galaxy.yml`
 > 6. Access at port `<ip address>:8080` once the server has started
+{: .hands_on}
+
+### A brief aside: Reduce repetitive typing
+
+No system administrator likes reptitive tasks, and throughout these Ansible-based tutorials, we will be running the playbook repeatedly. So far this has been done with:
+
+```console
+$ ansible-playbook -i hosts <playbook>.yml
+```
+
+However, the inventory file, `hosts`, never changes. The `-i` option can be eliminated.
+
+> ### {% icon hands_on %} Simplifying the command line with ansible.cfg
+>
+> You can save having to type the `-i` flag by creating an `ansible.cfg` file (next to your playbook) with the following contents:
+>
+> ```ini
+> [defaults]
+> inventory = hosts
+> ```
+>
+> There is an additional useful option that you might want to add to your `ansible.cfg` file if you are connecting over SSH:
+>
+> ```ini
+> [ssh_connection]
+> pipelining = true
+> ```
+>
+> Pipelining will make [ansible run faster](https://docs.ansible.com/ansible/latest/reference_appendices/config.html#ansible-pipelining) by significantly reducing the number of new SSH connections that must be opened.
+>
 {: .hands_on}
 
 ## Supervisord
@@ -1055,7 +1058,7 @@ But not you! You spent the day writing this Ansible playbook that describes your
 
 > ### {% icon hands_on %} Hands-on: Revert the Apocalypse
 >
-> 1. `ansible-playbook -i hosts galaxy.yml`
+> 1. `ansible-playbook galaxy.yml`
 >
 {: .hands_on}
 

--- a/topics/admin/tutorials/connect-to-compute-cluster/tutorial.md
+++ b/topics/admin/tutorials/connect-to-compute-cluster/tutorial.md
@@ -90,7 +90,7 @@ be taken into consideration when choosing where to run jobs and what parameters 
 >        - galaxyproject.slurm
 >    ```
 >
-> 5. Run the playbook (`ansible-playbook -i hosts slurm.yml`)
+> 5. Run the playbook (`ansible-playbook slurm.yml`)
 >
 {: .hands_on}
 
@@ -272,7 +272,7 @@ Above Slurm in the stack is slurm-drmaa, a library that provides a translational
 >            name: slurm-drmaa1
 >    ```
 >
-> 2. Run the playbook (`ansible-playbook -i hosts slurm.yml`)
+> 2. Run the playbook (`ansible-playbook slurm.yml`)
 >
 {: .hands_on}
 
@@ -346,7 +346,7 @@ At the top of the stack sits Galaxy. Galaxy must now be configured to use the cl
 >
 >      The variable `galaxy_config_files` is an array of hashes, each with `src` and `dest`, the files from src will be copied to dest on the server. `galaxy_template_files` exist to template files out.
 >
-> 5. Run your *Galaxy* playbook (`ansible-playbook -i hosts galaxy.yml`)
+> 5. Run your *Galaxy* playbook (`ansible-playbook galaxy.yml`)
 >
 > 6. Follow the logs with `journalctl -f -u galaxy`
 >

--- a/topics/admin/tutorials/cvmfs/tutorial.md
+++ b/topics/admin/tutorials/cvmfs/tutorial.md
@@ -127,7 +127,7 @@ If the terms "ansible", "role" and "playbook" mean nothing to you, please checko
 > 5. Run the playbook
 >
 >    ```
->    ansible-playbook -i hosts cvmfs_playbook.yml
+>    ansible-playbook cvmfs_playbook.yml
 >    ```
 {: .hands_on}
 
@@ -232,7 +232,7 @@ Now all we need to do is tell Galaxy how to find it! This tutorial assumes that 
 >    > If you've set up your Galaxy server using the [Galaxy Installation with Ansible]({% link topics/admin/tutorials/ansible-galaxy/tutorial.md %}) tutorial, you will have created a *handler* for restarting Galaxy (its name is set in the `galaxy_restart_handler_name` option in your group vars). You will need to define that handler in the CVMFS playbook the same way as you defined it in your original playbook. This also means that Ansible will perform the restart step below for you!
 >    {: .comment}
 >
-> 3. Re-run the CVMFS playbook (`ansible-playbook -i hosts cvmfs_playbook.yml`)
+> 3. Re-run the CVMFS playbook (`ansible-playbook cvmfs_playbook.yml`)
 >
 > 4. Restart Galaxy
 >

--- a/topics/admin/tutorials/heterogeneous-compute/tutorial.md
+++ b/topics/admin/tutorials/heterogeneous-compute/tutorial.md
@@ -249,7 +249,7 @@ We also need to create the dependency resolver file so pulsar knows how to find 
 > 1. Run the playbook. If your remote pulsar machine uses a different key, you may need to supply the `ansible-playbook` command with the private key for the connection using the `--private-key key.pem` option.
 >
 >    ```bash
->    ansible-playbook -i hosts pulsar_playbook.yml
+>    ansible-playbook pulsar_playbook.yml
 >    ```
 >
 >    After the script has run, pulsar will be installed on the remote machines!

--- a/topics/admin/tutorials/tiaas/tutorial.md
+++ b/topics/admin/tutorials/tiaas/tutorial.md
@@ -136,7 +136,7 @@ This tutorial will go cover how to set up such a service on your own Galaxy serv
 >
 >    ```
 >
-> 5. Run the playbook (`ansible-playbook -i hosts galaxy.yml`)
+> 5. Run the playbook (`ansible-playbook galaxy.yml`)
 >
 {: .hands_on}
 


### PR DESCRIPTION
So that `-i hosts` does not need to be invoked in every Ansible tutorial.

I did leave `-i hosts` in a few tutorials because they either precede this training (ansible) or are more self-contained (monitoring, jenkins).