### PR TITLE
[metatranscriptomics slides] fix speaker notes for group abundance slides

### DIFF
--- a/topics/metagenomics/tutorials/metatranscriptomics/slides.html
+++ b/topics/metagenomics/tutorials/metatranscriptomics/slides.html
@@ -355,10 +355,10 @@ About the caveat: The theoretical problem is that we quantify species abundance 
 ![functional analysis workflow schematic](../../images/metatranscriptomics/workflow_functional.png)
 
 ???
-HUMAnN2 
+HUMAnN2
 - next generation
 - HMP Unified Metabolic Analysis Network
-- developed by Huttenhower lab 
+- developed by Huttenhower lab
 - itself a workflow/pipeline
 - basically answering the question about what the microbial community is capable of?
 
@@ -481,13 +481,15 @@ UNINTEGRATED: no pathway detected.
 ???
 Gene familes are too large depending on the complexity thus to simplify users can regroup gene families using grouping tool, can download mapping files.
 HUMAnN2 regroups Uniref 50/90 values to Go terms to get a broad overview.
+
 ---
 
 ## Group Abundances
 
 ![](../../images/metatranscriptomics/results_group_abundances.png)
 
-??? 
+
+???
 Group abundances converts GO terms to Go slim (subset of GO terms) into Mol function, biological process and cellular components.
 
 ---
@@ -567,7 +569,7 @@ explain about datasets first
 cellulose 1,4 beta-cellulobiosidase responsible for hydrolysis of cellulose
 Gene encoding for the cellulose-binding domain
 protein shows an initial decrease and subsequent
-increase during cellulose degradation. 
+increase during cellulose degradation.
 ---
 
 ## Functions associated with a selected taxon
@@ -576,7 +578,7 @@ increase during cellulose degradation.
 
 ???
 In gene abundance, Coprothermobacter and Clostridium were observed to be the
-most abundant. 
+most abundant.
 In this figure we are looking at Coprothermobacter only->Glycolysis is observed to be the most abundant functional pathway across time points in
 Coprothermobacter
 


### PR DESCRIPTION
a trailing space after `???` marker for speaker notes caused them to be shown on the slide