### PR TITLE
Climate panoply tutorial remove enable false for review

### DIFF
--- a/topics/climate/metadata.yaml
+++ b/topics/climate/metadata.yaml
@@ -1,6 +1,5 @@
 ---
 name: climate
-enable: false
 type: use
 title: Climate
 summary: Learn to analyze climate data through Galaxy.

--- a/topics/climate/tutorials/panoply/tutorial.md
+++ b/topics/climate/tutorials/panoply/tutorial.md
@@ -1,6 +1,5 @@
 ---
 layout: tutorial_hands_on
-enable: false
 title: Visualize Climate data with Panoply netCDF viewer
 zenodo_link: 'https://doi.org/10.5281/zenodo.3695482'
 questions:


### PR DESCRIPTION
The training is ready to be reviewed. Especially nice to get feedback from non climate specialists because panoply is a tool that could be used by anyone interested in visualizing netCDF data on maps.