### PR TITLE
Update CONTRIBUTORS.yaml

### DIFF
--- a/CONTRIBUTORS.yaml
+++ b/CONTRIBUTORS.yaml
@@ -588,3 +588,8 @@ yvanlebras:
     twitter: Yvan2935
     gitter: yvanlebras
     orcid: 0000-0002-8504-068X
+
+miaomiaozhou88:
+    name: Miaomiao Zhou
+    email: m.zhou1@avans.nl
+    


### PR DESCRIPTION
Add miaomiaozhou88 as contributor. As promised, Avans will start contribute to galaxy training materials by using our own training data/scheme. The audience level is undergraduate (HBO) and post-HBO biologists/biochemists/ecologists.