### PR TITLE
Add admin training compatibility notice

### DIFF
--- a/snippets/admin-testing.md
+++ b/snippets/admin-testing.md
@@ -1,0 +1,9 @@
+> ### {% icon tip %} Operating System Compatability
+>
+> These Ansible roles and training materials were last tested on Centos 7 and Ubuntu 18.04, but will probably work on other RHEL and Debian variants.
+>
+> The roles that are used in these training are currently used by `usegalaxy.*`, and other, servers in maintaining their infrastructure. ([US](https://github.com/galaxyproject/infrastructure-playbook/), [EU](https://github.com/usegalaxy-eu/infrastructure-playbook), both are running CentOS 7)
+>
+> If you have an issue running these trainings on your OS flavour, please report [the issue](https://github.com/galaxyproject/training-material/issues/new) in the training material and we can see if it is possible to solve.
+>
+{: .tip}

--- a/topics/admin/tutorials/ansible-galaxy/tutorial.md
+++ b/topics/admin/tutorials/ansible-galaxy/tutorial.md
@@ -47,6 +47,7 @@ We want to give you a comprehensive understanding of how the Galaxy installation
 >
 {: .agenda}
 
+{% include snippets/admin-testing.md %}
 
 # Playbook Overview
 

--- a/topics/admin/tutorials/ansible/tutorial.md
+++ b/topics/admin/tutorials/ansible/tutorial.md
@@ -37,6 +37,7 @@ This will be a very practical training with emphasis on looking at examples from
 >
 {: .agenda}
 
+{% include snippets/admin-testing.md %}
 
 # What is Ansible?
 


### PR DESCRIPTION
To address the mistaken belief in that

> This is focused for paid distros. Centos 7/8 builds do not work due to package requirements and availability

[from the tutorial feedback](https://github.com/galaxyproject/training-material/issues/989#issuecomment-624070315)