### PR TITLE
Remove unnecessary unicode bytes

### DIFF
--- a/topics/visualisation/metadata.yaml
+++ b/topics/visualisation/metadata.yaml
@@ -1,4 +1,4 @@
-﻿---
+---
 name: "visualisation"
 type: "use"
 title: "Visualisation"


### PR DESCRIPTION
since github isn't showing it:

```
commit 9e2512eebc37b0c11b040bbf84c3d977b13bda47 (HEAD -> fix, origin/fix, master)
Author: Helena Rasche <hxr@hx42.org>
Date:   Thu May 28 08:04:30 2020 +0200

    more weird bytes

diff --git a/topics/visualisation/metadata.yaml b/topics/visualisation/metadata.yaml
index 79a777574..75452ce97 100644
--- a/topics/visualisation/metadata.yaml
+++ b/topics/visualisation/metadata.yaml
@@ -1,4 +1,4 @@
-<U+FEFF>---
+---
 name: "visualisation"
 type: "use"
 title: "Visualisation"
```