### PR TITLE
Make translations more obvious

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -25,7 +25,13 @@ gitter_url: "https://gitter.im/Galaxy-Training-Network/Lobby"
 logo: "assets/images/GTN.png"
 small_logo: "assets/images/GTN-60px.png"
 help_url: https://help.galaxyproject.org/
-other_languages: "fr, ja, es, pt, ar"
+other_languages: #"fr, ja, es, pt, ar"
+  fr: Français
+  ja: 日本語
+  es: Español
+  pt: Português
+  ar: العربية
+
 words_to_not_translate:
 - bed
 - dna
@@ -115,6 +121,7 @@ icon-tag:
   instances: fas fa-globe
   interactive_tour: fas fa-magic
   keypoints: fas fa-key
+  language: fas fa-language
   last_modification: far fa-calendar
   level: fas fa-graduation-cap
   linkedin: fab fa-linkedin

--- a/_includes/resource-handson.html
+++ b/_includes/resource-handson.html
@@ -16,7 +16,7 @@
         </a>
         <ul class="dropdown-menu">
         {% for lang in language %}
-            <a class="dropdown-item" href="https://translate.google.com/translate?hl=jp&sl=en&tl={{ lang }}&u=https%3A%2F%2Ftraining.galaxyproject.org%2Ftopics%2F{{ include.topic }}%2Ftutorials%2F{{ include.material.tutorial_name }}%2Ftutorial.html&edit-text=&act=url" title="{{ inst[0] }}">
+            <a class="dropdown-item" href="https://translate.google.com/translate?hl=jp&sl=en&tl={{ lang[0] }}&u=https%3A%2F%2Ftraining.galaxyproject.org%2Ftopics%2F{{ include.topic }}%2Ftutorials%2F{{ include.material.tutorial_name }}%2Ftutorial.html&edit-text=&act=url" title="{{ inst[0] }}">
                 {{ lang[1] }}
             </a>
         {% endfor %}

--- a/_includes/resource-handson.html
+++ b/_includes/resource-handson.html
@@ -17,8 +17,11 @@
         <ul class="dropdown-menu">
         {% for lang in language %}
             <a class="dropdown-item" href="https://translate.google.com/translate?hl=jp&sl=en&tl={{ lang }}&u=https%3A%2F%2Ftraining.galaxyproject.org%2Ftopics%2F{{ include.topic }}%2Ftutorials%2F{{ include.material.tutorial_name }}%2Ftutorial.html&edit-text=&act=url" title="{{ inst[0] }}">
-                {{ lang | upcase }}
+                {{ lang[1] }}
             </a>
         {% endfor %}
+        <a class="dropdown-item" href="https://translate.google.com/translate?hl=jp&sl=en&tl=&u=https%3A%2F%2Ftraining.galaxyproject.org%2Ftopics%2F{{ include.topic }}%2Ftutorials%2F{{ include.material.tutorial_name }}%2Ftutorial.html&edit-text=&act=url" title="{{ inst[0] }}">
+            And more!
+        </a>
     </span>
 {% endif %}

--- a/_layouts/topic.html
+++ b/_layouts/topic.html
@@ -8,7 +8,7 @@ layout: base
 {% assign contributors = site.data['contributors'] %}
 {% assign instances = site.data['instances'] %}
 {% assign topic_material = site.pages | topic_filter:page.topic_name %}
-{% assign language = site.other_languages | split: ", " %}
+{% assign language = site.other_languages %}
 
 {% if topic.gitter %}
 <script>

--- a/_layouts/tutorial_hands_on.html
+++ b/_layouts/tutorial_hands_on.html
@@ -58,7 +58,7 @@ layout: base
 
                     <li class="nav-item dropdown">
                         <a href="#" class="nav-link dropdown-toggle" data-toggle="dropdown" aria-expanded="false" title="Language Selector">
-                            Language {% icon language %}
+                            {% icon language %} Language
                         </a>
                         <div class="dropdown-menu">
                             {% for lang in site.other_languages %}

--- a/_layouts/tutorial_hands_on.html
+++ b/_layouts/tutorial_hands_on.html
@@ -6,7 +6,7 @@ layout: base
 {% assign contributors = site.data['contributors'] %}
 {% assign instances = site.data['instances'] %}
 {% assign topic_material = site.pages | topic_filter:page.topic_name %}
-{% assign language = site.other_languages | split: ", " %}
+{% assign language = site.other_languages  %}
 
 {% assign intro_link = false %}
 {% assign intro_target = "" %}
@@ -57,15 +57,18 @@ layout: base
                     </li>
 
                     <li class="nav-item dropdown">
-                        <a href="#" class="nav-link dropdown-toggle" data-toggle="dropdown" aria-expanded="false" title="EN">
-                            EN
+                        <a href="#" class="nav-link dropdown-toggle" data-toggle="dropdown" aria-expanded="false" title="Language Selector">
+                            Language {% icon language %}
                         </a>
                         <div class="dropdown-menu">
-                            {% for lang in language %}
-                            <a class="dropdown-item" href="https://translate.google.com/translate?hl=jp&sl=en&tl={{ lang }}&u=https%3A%2F%2Ftraining.galaxyproject.org%2Ftopics%2F{{ topic.name }}%2Ftutorials%2F{{ page.tutorial_name }}%2Ftutorial.html&edit-text=&act=url" title="{{ inst[0] }}">
-                                {{ lang | upcase }}
+                            {% for lang in site.other_languages %}
+                            <a class="dropdown-item" href="https://translate.google.com/translate?hl=jp&sl=en&tl={{ lang[0] }}&u=https%3A%2F%2Ftraining.galaxyproject.org%2Ftopics%2F{{ topic.name }}%2Ftutorials%2F{{ page.tutorial_name }}%2Ftutorial.html&edit-text=&act=url" title="{{ inst[0] }}">
+                                {{ lang[1] }}
                             </a>
                             {% endfor %}
+                            <a class="dropdown-item" href="https://translate.google.com/translate?hl=jp&sl=en&tl=&u=https%3A%2F%2Ftraining.galaxyproject.org%2Ftopics%2F{{ include.topic }}%2Ftutorials%2F{{ include.material.tutorial_name }}%2Ftutorial.html&edit-text=&act=url" title="{{ inst[0] }}">
+                                And more!
+                            </a>
                         </div>
                     </li>
 


### PR DESCRIPTION
Fixes https://github.com/galaxyproject/training-material/issues/1878

![image](https://user-images.githubusercontent.com/458683/83145711-878fc780-a0f5-11ea-840a-a220e987676d.png)

Also switches to native names for languages as is more preferred. I don't super love this translation icon but that should be fixed with #1898 and the newer icon https://fontawesome.com/icons/language?style=solid
