### PR TITLE
Support setting theme by URL

### DIFF
--- a/assets/js/theme.js
+++ b/assets/js/theme.js
@@ -9,6 +9,12 @@
 
 	onDocumentReady(function () {
 		function getThemePreference(){
+			params = (new URL(document.location)).searchParams;
+			paramTheme = params.get('theme')
+
+			if(paramTheme){
+				setThemePreference(paramTheme);
+			}
 			return localStorage.getItem('training-theme');
 		}
 


### PR DESCRIPTION
For @TKlingstrom :)

Just add `?theme=....` e.g. `https://training.galaxyproject.org/?theme=rainbow` will work after deployment.