### PR TITLE
Add download links for datasets

### DIFF
--- a/topics/statistics/tutorials/regression_machinelearning/data-library.yaml
+++ b/topics/statistics/tutorials/regression_machinelearning/data-library.yaml
@@ -6,23 +6,22 @@ destination:
   synopsis: Galaxy Training Network Material. See https://training.galaxyproject.org
 items:
 - name: Statistics and machine learning
-  description: Statistical Analyses for omics data and machine learning using Galaxy
-    tools
+  description: Statistical Analyses for omics data and machine learning using Galaxy tools.
   items:
   - name: Regression in Machine Learning
     items:
     - name: 'DOI: 10.5281/zenodo.2545213'
       description: latest
       items:
-      - url: https://zenodo.org/record/2545213/files/test_rows.csv?download=1
+      - url: https://zenodo.org/record/2545213/files/test_rows.csv
         src: url
         ext: csv
-        info: https://zenodo.org/record/2545213
-      - url: https://zenodo.org/record/2545213/files/test_rows_labels.csv?download=1
+        info: http://doi.org/10.5281/zenodo.2545213
+      - url: https://zenodo.org/record/2545213/files/test_rows_labels.csv
         src: url
         ext: csv
-        info: https://zenodo.org/record/2545213
-      - url: https://zenodo.org/record/2545213/files/train_rows.csv?download=1
+        info: http://doi.org/10.5281/zenodo.2545213
+      - url: https://zenodo.org/record/2545213/files/train_rows.csv
         src: url
         ext: csv
-        info: https://zenodo.org/record/2545213
+        info: http://doi.org/10.5281/zenodo.2545213

--- a/topics/statistics/tutorials/regression_machinelearning/data-library.yaml
+++ b/topics/statistics/tutorials/regression_machinelearning/data-library.yaml
@@ -13,15 +13,15 @@ items:
     - name: 'DOI: 10.5281/zenodo.2545213'
       description: latest
       items:
-      - url: https://zenodo.org/record/2545213/files/test_rows.csv
+      - url: https://zenodo.org/api/files/f1431fd7-a9dc-426d-ac78-3eaaa61a8d29/test_rows.csv
         src: url
         ext: csv
         info: http://doi.org/10.5281/zenodo.2545213
-      - url: https://zenodo.org/record/2545213/files/test_rows_labels.csv
+      - url: https://zenodo.org/api/files/f1431fd7-a9dc-426d-ac78-3eaaa61a8d29/test_rows_labels.csv
         src: url
         ext: csv
         info: http://doi.org/10.5281/zenodo.2545213
-      - url: https://zenodo.org/record/2545213/files/train_rows.csv
+      - url: https://zenodo.org/api/files/f1431fd7-a9dc-426d-ac78-3eaaa61a8d29/train_rows.csv
         src: url
         ext: csv
         info: http://doi.org/10.5281/zenodo.2545213

--- a/topics/statistics/tutorials/regression_machinelearning/data-library.yaml
+++ b/topics/statistics/tutorials/regression_machinelearning/data-library.yaml
@@ -11,18 +11,18 @@ items:
   items:
   - name: Regression in Machine Learning
     items:
-    - name: 'DOI: 10.5281/zenodo.2545213#.XEWTJ9-YVa0'
+    - name: 'DOI: 10.5281/zenodo.2545213'
       description: latest
       items:
-      - url: https://zenodo.org/api/files/f1431fd7-a9dc-426d-ac78-3eaaa61a8d29/test_rows.csv
+      - url: https://zenodo.org/record/2545213/files/test_rows.csv?download=1
         src: url
         ext: csv
-        info: https://zenodo.org/record/2545213#.XEWTJ9-YVa0
-      - url: https://zenodo.org/api/files/f1431fd7-a9dc-426d-ac78-3eaaa61a8d29/test_rows_labels.csv
+        info: https://zenodo.org/record/2545213
+      - url: https://zenodo.org/record/2545213/files/test_rows_labels.csv?download=1
         src: url
         ext: csv
-        info: https://zenodo.org/record/2545213#.XEWTJ9-YVa0
-      - url: https://zenodo.org/api/files/f1431fd7-a9dc-426d-ac78-3eaaa61a8d29/train_rows.csv
+        info: https://zenodo.org/record/2545213
+      - url: https://zenodo.org/record/2545213/files/train_rows.csv?download=1
         src: url
         ext: csv
-        info: https://zenodo.org/record/2545213#.XEWTJ9-YVa0
+        info: https://zenodo.org/record/2545213


### PR DESCRIPTION
The links for datasets should be downloadable and should not show them as raw files. That's why I think the datasets do not get automatically uploaded to the data library. The links in "Basics of machine learning" tutorial has downloadable links mentioned in the yaml file 

Thanks!

ping @bgruening 