### PR TITLE
Speed up jekyll serve

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -52,10 +52,11 @@ install: clean create-env ## install dependencies
 .PHONY: install
 
 serve-full: ## run a local server (You can specify PORT=, HOST=, and FLAGS= to set the port, host or to pass additional flags)
+	@echo "Tip: to serve in incremental mode (faster rebuilds), use the command: make serve FLAGS=--incremental" && echo "" && \
 	$(ACTIVATE_ENV) && \
 		mv Gemfile Gemfile.backup || true && \
 		mv Gemfile.lock Gemfile.lock.backup || true && \
-		${JEKYLL} serve --incremental --strict_front_matter -d _site/training-material -P ${PORT} -H ${HOST} ${FLAGS}
+		${JEKYLL} serve --strict_front_matter -d _site/training-material -P ${PORT} -H ${HOST} ${FLAGS}
 .PHONY: serve-full
 
 serve: ## serve with some plugins disabled for speed

--- a/Makefile
+++ b/Makefile
@@ -51,12 +51,20 @@ install: clean create-env ## install dependencies
 		gem install addressable:'2.5.2' jekyll jekyll-feed jekyll-scholar jekyll-redirect-from jekyll-last-modified-at csl-styles awesome_bot html-proofer pkg-config kwalify
 .PHONY: install
 
-serve: ## run a local server (You can specify PORT=, HOST=, and FLAGS= to set the port, host or to pass additional flags)
-	@echo "Tip: to serve in incremental mode (faster rebuilds), use the command: make serve FLAGS=--incremental" && echo "" && \
+serve-full: ## run a local server (You can specify PORT=, HOST=, and FLAGS= to set the port, host or to pass additional flags)
 	$(ACTIVATE_ENV) && \
 		mv Gemfile Gemfile.backup || true && \
 		mv Gemfile.lock Gemfile.lock.backup || true && \
-		${JEKYLL} serve --strict_front_matter -d _site/training-material -P ${PORT} -H ${HOST} ${FLAGS}
+		${JEKYLL} serve --incremental --strict_front_matter -d _site/training-material -P ${PORT} -H ${HOST} ${FLAGS}
+.PHONY: serve-full
+
+serve: ## serve with some plugins disabled for speed
+	@echo "This will build the website with citations disabled. To run the full preview (slower), use make serve-full" && echo "" && \
+
+	$(ACTIVATE_ENV) && \
+		mv Gemfile Gemfile.backup || true && \
+		mv Gemfile.lock Gemfile.lock.backup || true && \
+		${JEKYLL} serve --strict_front_matter -d _site/training-material --incremental --config _config.yml,_config-dev.yml -P ${PORT} -H ${HOST} ${FLAGS}
 .PHONY: serve
 
 detached-serve: ## run a local server in detached mode (You can specify PORT=, HOST=, and FLAGS= to set the port, host or to pass additional flags to Jekyll)

--- a/Makefile
+++ b/Makefile
@@ -61,7 +61,6 @@ serve-full: ## run a local server (You can specify PORT=, HOST=, and FLAGS= to s
 
 serve: ## serve with some plugins disabled for speed
 	@echo "This will build the website with citations disabled. To run the full preview (slower), use make serve-full" && echo "" && \
-
 	$(ACTIVATE_ENV) && \
 		mv Gemfile Gemfile.backup || true && \
 		mv Gemfile.lock Gemfile.lock.backup || true && \

--- a/Makefile
+++ b/Makefile
@@ -51,7 +51,8 @@ install: clean create-env ## install dependencies
 		gem install addressable:'2.5.2' jekyll jekyll-feed jekyll-scholar jekyll-redirect-from jekyll-last-modified-at csl-styles awesome_bot html-proofer pkg-config kwalify
 .PHONY: install
 
-serve-full: ## run a local server (You can specify PORT=, HOST=, and FLAGS= to set the port, host or to pass additional flags)
+serve: ## run a local server (You can specify PORT=, HOST=, and FLAGS= to set the port, host or to pass additional flags)
+	@echo "Tip: Want faster builds? Use 'serve-quick' in place of 'serve'." && echo "" && \
 	@echo "Tip: to serve in incremental mode (faster rebuilds), use the command: make serve FLAGS=--incremental" && echo "" && \
 	$(ACTIVATE_ENV) && \
 		mv Gemfile Gemfile.backup || true && \
@@ -59,8 +60,8 @@ serve-full: ## run a local server (You can specify PORT=, HOST=, and FLAGS= to s
 		${JEKYLL} serve --strict_front_matter -d _site/training-material -P ${PORT} -H ${HOST} ${FLAGS}
 .PHONY: serve-full
 
-serve: ## serve with some plugins disabled for speed
-	@echo "This will build the website with citations disabled. To run the full preview (slower), use make serve-full" && echo "" && \
+serve-quick: ## run a local server (faster, some plugins disabled for speed)
+	@echo "This will build the website with citations and other content disabled, and incremental on by default. To run the full preview (slower), use make serve-full" && echo "" && \
 	$(ACTIVATE_ENV) && \
 		mv Gemfile Gemfile.backup || true && \
 		mv Gemfile.lock Gemfile.lock.backup || true && \

--- a/_config-dev.yml
+++ b/_config-dev.yml
@@ -1,0 +1,9 @@
+# Exclude jekyll-scholar for speed
+plugins:
+  - jekyll-feed
+  - jekyll-redirect-from
+  - jekyll-last-modified-at
+
+# include the fake scholar plugin to prevent "unknown tag" errors
+plugins_dir: [_plugins,_plugins_dev]
+

--- a/_plugins_dev/jekyll-scholar-fake.rb
+++ b/_plugins_dev/jekyll-scholar-fake.rb
@@ -1,0 +1,33 @@
+module Jekyll
+  class CiteTag < Liquid::Tag
+
+    def initialize(tag_name, text, tokens)
+      super
+      @text = text.strip
+    end
+
+    def render(context)
+        %Q(<span class="text-muted">[citation hidden; run 'make serve-full' to show]</span>)
+    end
+
+    private
+  end
+
+  class BibTag < Liquid::Tag
+
+    def initialize(tag_name, text, tokens)
+      super
+      @text = text.strip
+    end
+
+    def render(context)
+        %Q([bibliography])
+    end
+
+    private
+  end
+
+end
+
+Liquid::Template.register_tag('cite', Jekyll::CiteTag)
+Liquid::Template.register_tag('bibliography', Jekyll::BibTag)


### PR DESCRIPTION
The `jekyll-scholar` plugin was resulting in very long build times; this disables the plugin by default. It led to a ~3x speedup for me for the initial build,  and might also fix the problem with re-build times in the `--incremental` increasing over time (not sure tho)

This means citations/the bibliography will no longer be rendered when you do `make serve`, but `make serve-full` will enable you to still build the full site. A hint to this effect is shown in the tutorials in place of the real citations. `--incremental` is now also enabled on by default

we could also leave make serve as it is now, and add a make-quick target? There are also other things we could disable, e.g. all the contributor pages, but that doesn't take all that much time

