### PR TITLE
New tool tag / GTN webhook

### DIFF
--- a/_plugins/jekyll-tool-tag.rb
+++ b/_plugins/jekyll-tool-tag.rb
@@ -7,20 +7,21 @@ module Jekyll
     end
 
     def render(context)
-      parts = @text.split('|')
-      # The first part should be any text, the last should be the tool_id/tool_version
-      # {% tool Group on Column %} → INVALID
-      # {% tool Group on Column|Grouping1 %}
-      # {% tool Group on Column|Grouping1/1.0.0 %}
-      # {% tool Group on Column|toolshed.g2.bx.psu.edu/repos/devteam/fastqc/fastqc/0.72+galaxy1 %}
+      FORMAT = /\[(.*)\]\((.*)\)/
 
-      if parts.length == 1
-        raise SyntaxError.new(
-          "No tool defined for: '#{@parts}'. "
-        )
-      elsif parts.length == 2
-        %Q(<span class="tool" data-tool="#{parts[1]}" title="Tested with #{parts[1]}"><strong>#{parts[0]}</strong> <i class="fas fa-wrench" aria-hidden="true"></i><span class="visually-hidden">Tool: #{parts[0]}</span></span> )elsif parts.length == 3
-        %Q(<span class="tool" data-tool="#{parts[1]}" title="Tested with #{parts[1]} version #{parts[2]}" data-version="#{parts[2]}"><strong>#{parts[0]}</strong> <i class="fas fa-wrench" aria-hidden="true"></i><i aria-hidden="true" class="fas fa-cog"></i></span>)
+      # The first part should be any text, the last should be the tool_id/tool_version
+      # {% tool Group on Column %}
+      # {% tool [Group on Column]() %}
+      # {% tool [Group on Column](Grouping1) %}
+      # {% tool [Group on Column](Grouping1/1.0.0) %}
+      # {% tool [Group on Column](toolshed.g2.bx.psu.edu/repos/devteam/fastqc/fastqc/0.72+galaxy1) %}
+
+      m = @text.match(FORMAT)
+
+      if m
+        %Q(<span class="tool" data-tool="#{m[2]}" title="Tested with #{m[2]}"><strong>#{m[1]}</strong> <i class="fas fa-wrench" aria-hidden="true"></i><span class="visually-hidden">Tool: #{m[2]}</span></span> )
+      else
+        %Q(<span class="tool"><strong>#{@text}</strong> <i class="fas fa-wrench" aria-hidden="true"></i></span> )
       end
 
     end

--- a/_plugins/jekyll-tool-tag.rb
+++ b/_plugins/jekyll-tool-tag.rb
@@ -18,9 +18,8 @@ module Jekyll
           "No tool defined for: '#{@parts}'. "
         )
       elsif parts.length == 2
-          %Q(<span class="tool" data-tool="#{parts[1]}"><strong>#{parts[0]}</strong> <i class="fas fa-wrench" aria-hidden="true"></i><span class="visually-hidden">Tool: #{parts[0]}</span></span> )
-      elsif parts.length == 3
-          %Q(<span class="tool" data-tool="#{parts[1]}" data-version="#{parts[2]}"><strong>#{parts[0]}</strong> <i class="fas fa-wrench" aria-hidden="true"></i><span class="visually-hidden">Tool: #{parts[0]}</span></span> )
+        %Q(<span class="tool" data-tool="#{parts[1]}" title="Tested with #{parts[1]}"><strong>#{parts[0]}</strong> <i class="fas fa-wrench" aria-hidden="true"></i><span class="visually-hidden">Tool: #{parts[0]}</span></span> )elsif parts.length == 3
+        %Q(<span class="tool" data-tool="#{parts[1]}" title="Tested with #{parts[1]} version #{parts[2]}" data-version="#{parts[2]}"><strong>#{parts[0]}</strong> <i class="fas fa-wrench" aria-hidden="true"></i><i aria-hidden="true" class="fas fa-cog"></i></span>)
       end
 
     end

--- a/_plugins/jekyll-tool-tag.rb
+++ b/_plugins/jekyll-tool-tag.rb
@@ -19,9 +19,9 @@ module Jekyll
       m = @text.match(format)
 
       if m
-        %Q(<span class="tool" data-tool="#{m[2]}" title="Tested with #{m[2]}"><strong>#{m[1]}</strong> <i class="fas fa-wrench" aria-hidden="true"></i><span class="visually-hidden">Tool: #{m[2]}</span></span> )
+        %Q(<span class="tool" data-tool="#{m[2]}" title="Tested with #{m[2]}"><strong>#{m[1]}</strong> <i class="fas fa-wrench" aria-hidden="true"></i><i aria-hidden="true" class="fas fa-cog"></i><span class="visually-hidden">Tool: #{m[2]}</span></span> )
       else
-        %Q(<span class="tool"><strong>#{@text}</strong> <i class="fas fa-wrench" aria-hidden="true"></i></span> )
+        %Q(<span><strong>#{@text}</strong> <i class="fas fa-wrench" aria-hidden="true"></i></span> )
       end
 
     end

--- a/_plugins/jekyll-tool-tag.rb
+++ b/_plugins/jekyll-tool-tag.rb
@@ -1,0 +1,30 @@
+module Jekyll
+  class ToolTag < Liquid::Tag
+
+    def initialize(tag_name, text, tokens)
+      super
+      @text = text.strip
+    end
+
+    def render(context)
+      parts = @text.split('/')
+      # The first part should be any text, the last should be the tool_id/tool_version
+      # {% tool Group on Column %} → INVALID
+      # {% tool Group on Column/Grouping1 %}
+      # {% tool Group on Column/Grouping1/1.0.0 %}
+
+      if parts.length == 1
+        raise SyntaxError.new(
+          "No tool defined for: '#{@parts}'. "
+        )
+      elsif parts.length == 2
+          %Q(<span class="tool" data-tool="#{parts[1]}"><strong>#{parts[0]}</strong> <i class="fas fa-wrench" aria-hidden="true"></i><span class="visually-hidden">Tool: #{parts[0]}</span></span> )
+      elsif parts.length == 3
+          %Q(<span class="tool" data-tool="#{parts[1]}" data-version="#{parts[2]}"><strong>#{parts[0]}</strong> <i class="fas fa-wrench" aria-hidden="true"></i><span class="visually-hidden">Tool: #{parts[0]}</span></span> )
+      end
+
+    end
+  end
+end
+
+Liquid::Template.register_tag('tool', Jekyll::ToolTag)

--- a/_plugins/jekyll-tool-tag.rb
+++ b/_plugins/jekyll-tool-tag.rb
@@ -7,11 +7,12 @@ module Jekyll
     end
 
     def render(context)
-      parts = @text.split('/')
+      parts = @text.split('|')
       # The first part should be any text, the last should be the tool_id/tool_version
       # {% tool Group on Column %} → INVALID
-      # {% tool Group on Column/Grouping1 %}
-      # {% tool Group on Column/Grouping1/1.0.0 %}
+      # {% tool Group on Column|Grouping1 %}
+      # {% tool Group on Column|Grouping1/1.0.0 %}
+      # {% tool Group on Column|toolshed.g2.bx.psu.edu/repos/devteam/fastqc/fastqc/0.72+galaxy1 %}
 
       if parts.length == 1
         raise SyntaxError.new(

--- a/_plugins/jekyll-tool-tag.rb
+++ b/_plugins/jekyll-tool-tag.rb
@@ -11,7 +11,6 @@ module Jekyll
 
       # The first part should be any text, the last should be the tool_id/tool_version
       # {% tool Group on Column %}
-      # {% tool [Group on Column]() %}
       # {% tool [Group on Column](Grouping1) %}
       # {% tool [Group on Column](Grouping1/1.0.0) %}
       # {% tool [Group on Column](toolshed.g2.bx.psu.edu/repos/devteam/fastqc/fastqc/0.72+galaxy1) %}

--- a/_plugins/jekyll-tool-tag.rb
+++ b/_plugins/jekyll-tool-tag.rb
@@ -7,7 +7,7 @@ module Jekyll
     end
 
     def render(context)
-      FORMAT = /\[(.*)\]\((.*)\)/
+      format = /\[(.*)\]\((.*)\)/
 
       # The first part should be any text, the last should be the tool_id/tool_version
       # {% tool Group on Column %}
@@ -16,7 +16,7 @@ module Jekyll
       # {% tool [Group on Column](Grouping1/1.0.0) %}
       # {% tool [Group on Column](toolshed.g2.bx.psu.edu/repos/devteam/fastqc/fastqc/0.72+galaxy1) %}
 
-      m = @text.match(FORMAT)
+      m = @text.match(format)
 
       if m
         %Q(<span class="tool" data-tool="#{m[2]}" title="Tested with #{m[2]}"><strong>#{m[1]}</strong> <i class="fas fa-wrench" aria-hidden="true"></i><span class="visually-hidden">Tool: #{m[2]}</span></span> )

--- a/assets/css/main.scss
+++ b/assets/css/main.scss
@@ -864,5 +864,19 @@ span.tool {
 
 	&:hover {
 		border: 1px solid blue;
+
+	}
+
+	&.galaxy-proxy-active {
+		cursor: pointer;
+		color:#fff;
+		background-color:#007bff;
+		border-color:#007bff;
+		padding: 0.2em 0.5em;
+	}
+
+	&.galaxy-proxy-active:hover {
+		background-color:#0069d9;
+		border-color:#0062cc;
 	}
 }

--- a/assets/css/main.scss
+++ b/assets/css/main.scss
@@ -856,3 +856,13 @@ div.supporting_material{
 .card {
   margin-top: 1em;
 }
+
+span.tool {
+	border: 1px solid #999;
+	padding: 2px;
+	border-radius: 5px;
+
+	&:hover {
+		border: 1px solid blue;
+	}
+}

--- a/topics/contributing/tutorials/create-new-tutorial-content/tutorial.md
+++ b/topics/contributing/tutorials/create-new-tutorial-content/tutorial.md
@@ -411,7 +411,7 @@ We find that having users walk through the tutorial, doing all of the steps is i
 >
 >        This parameter should be length of reads - 1
 >
-> 2. **MultiQC** {% icon tool %}: Aggregate the STAR logs with
+> 2. {% tool [MultiQC](toolshed.g2.bx.psu.edu/repos/iuc/multiqc/multiqc/1.8+galaxy0) %}: Aggregate the STAR logs with
 >      - *"Which tool was used generate logs?"*: `STAR`
 >      - *"Type of FastQC output?"*: `Log`
 >      - *"STAR log output"*: the generated `log` files (multiple datasets)
@@ -443,7 +443,7 @@ This will be rendered like:
 >
 >        This parameter should be length of reads - 1
 >
-> 2. **MultiQC** {% icon tool %}: Aggregate the STAR logs with
+> 2. {% tool [MultiQC](toolshed.g2.bx.psu.edu/repos/iuc/multiqc/multiqc/1.8+galaxy0) %}: Aggregate the STAR logs with
 >      - *"Which tool was used generate logs?"*: `STAR`
 >      - *"Type of FastQC output?"*: `Log`
 >      - *"STAR log output"*: the generated `log` files (multiple datasets)
@@ -484,6 +484,25 @@ which, when rendered, look like:
 >      - *"param1"*: `42`
 {: .hands_on}
 
+## Tool Links
+
+With the new [GTN in Galaxy Webhook](https://github.com/galaxyproject/galaxy/pull/10024), trainees can view training directly within Galaxy. As part of this, we enable those trainees to click on tools, and have those tools directly activated in Galaxy, enabling for a seamless training experience for trainees.
+
+![GIF of a user using the GTN in Galaxy webhook.](../../images/88277962-ddda4a80-cce1-11ea-92cd-41b1df063db0.gif "A gif showing how the GTN in Galaxy webhook works. A student clicks the learning hat icon in the masthead of a Galaxy server, and an overlay is activated showing the GTN website. Within the GTN they can browse around and their place in tutorials is saved. While following a tutorial the student reches a step which instructs them to run a specific tool. Instead of the normal experience searching for a tool (quite difficult on large servers), they click a blue button and the tool is activated in Galaxy, and the overlay is closed. The student can reactivate the overlay at any time and return to their place in the tutorial.")
+
+To enable these in your tutorial you can use the following syntax:
+
+{% raw %}
+```
+- {% tool MultiQC %}
+- {% tool [MultiQC](toolshed.g2.bx.psu.edu/repos/iuc/multiqc/multiqc/1.8+galaxy0) %}
+```
+{% endraw %}
+
+Which will be rendered as:
+
+- {% tool MultiQC %}
+- {% tool [MultiQC](toolshed.g2.bx.psu.edu/repos/iuc/multiqc/multiqc/1.8+galaxy0) %}
 
 ## **Questions** and **solution** boxes
 

--- a/topics/contributing/tutorials/create-new-tutorial-content/tutorial.md
+++ b/topics/contributing/tutorials/create-new-tutorial-content/tutorial.md
@@ -506,6 +506,10 @@ Which will be rendered as:
 - {% tool [MultiQC](toolshed.g2.bx.psu.edu/repos/iuc/multiqc/multiqc/1.8+galaxy0) %}
 - {% tool [Import some data](upload1) %}
 
+When viewed through Galaxy, students will see:
+
+<span data-tool="upload1" title="Tested with upload1" class="tool galaxy-proxy-active"><strong>Import some data</strong> <i class="fas fa-wrench" aria-hidden="true"></i><i aria-hidden="true" class="fas fa-cog"></i><span class="visually-hidden">Tool: upload1</span></span>
+
 ## **Questions** and **solution** boxes
 
 Questions can be added to force trainees to think about what they are currently doing, and to put things in perspective.

--- a/topics/contributing/tutorials/create-new-tutorial-content/tutorial.md
+++ b/topics/contributing/tutorials/create-new-tutorial-content/tutorial.md
@@ -496,6 +496,7 @@ To enable these in your tutorial you can use the following syntax:
 ```
 - {% tool MultiQC %}
 - {% tool [MultiQC](toolshed.g2.bx.psu.edu/repos/iuc/multiqc/multiqc/1.8+galaxy0) %}
+- {% tool [Import some data](upload1) %}
 ```
 {% endraw %}
 
@@ -503,6 +504,7 @@ Which will be rendered as:
 
 - {% tool MultiQC %}
 - {% tool [MultiQC](toolshed.g2.bx.psu.edu/repos/iuc/multiqc/multiqc/1.8+galaxy0) %}
+- {% tool [Import some data](upload1) %}
 
 ## **Questions** and **solution** boxes
 

--- a/topics/introduction/tutorials/galaxy-intro-101-everyone/tutorial.md
+++ b/topics/introduction/tutorials/galaxy-intro-101-everyone/tutorial.md
@@ -112,7 +112,7 @@ In other words, using a workflow makes it possible to apply the same procedure t
 
 > ### {% icon hands_on %} Hands-on: Data upload
 >
-> 1. **Import** {% icon galaxy-upload %} the file `iris.csv` from [Zenodo](https://zenodo.org/record/1319069/files/iris.csv) or from the data library (ask your instructor)
+> 1. {% tool [Import](upload1) %} the file `iris.csv` from [Zenodo](https://zenodo.org/record/1319069/files/iris.csv) or from the data library (ask your instructor)
 >
 >    ```
 >    https://zenodo.org/record/1319069/files/iris.csv
@@ -624,7 +624,7 @@ Now that we have built our workflow, let's use it on some different data. For ex
 >
 >    {% include snippets/create_new_history.md %}
 >
-> 2. **Import** {% icon galaxy-upload %} the file `diamonds.csv` from [Zenodo](https://zenodo.org/record/3540705/files/diamonds.csv) or from the data library (ask your instructor)
+> 2. {% tool [Import](upload1) %} the file `diamonds.csv` from [Zenodo](https://zenodo.org/record/3540705/files/diamonds.csv) or from the data library (ask your instructor)
 >
 >    ```
 >    https://zenodo.org/record/3540705/files/diamonds.csv

--- a/topics/introduction/tutorials/galaxy-intro-101-everyone/tutorial.md
+++ b/topics/introduction/tutorials/galaxy-intro-101-everyone/tutorial.md
@@ -198,7 +198,7 @@ Now it is time to run your first tool! We saw in the previous step that our file
 
 > ### {% icon hands_on %} Hands-on: Removing header
 >
-> 1. **Remove beginning** {% icon tool %} with the following parameters:
+> 1. {% tool [Remove Beginning](Remove+beginning1) %} with the following parameters:
 >    - *Remove first*: `1` (to remove the first line only)
 >    - {% icon param-file %} *"from"*: select the **iris tabular** file from your history
 >    - Click **Execute**
@@ -246,7 +246,7 @@ In order to answer this question, we will have to look at column 5 of our file, 
 
 > ### {% icon hands_on %} Hands-on: Extract species
 >
-> 1. **Cut** columns from a table {% icon tool %} with the following parameters:
+> 1. {% tool [Cut](Cut1) %} columns from a table with the following parameters:
 >      - *"Cut columns"*: `c5`
 >      - *"Delimited by"*: `Tab`
 >      - {% icon param-file %} *"From"*: `iris clean` dataset
@@ -257,7 +257,7 @@ In order to answer this question, we will have to look at column 5 of our file, 
 >
 > 3. **View** {% icon galaxy-eye %} the resulting file
 >
-> 4. **Unique** occurrences of each record {% icon tool %} with the following parameters:
+> 4. {% tool [Unique](toolshed.g2.bx.psu.edu/repos/bgruening/text_processing/tp_sorted_uniq/1.1.0) %} occurrences of each record  with the following parameters:
 >      - {% icon param-file %} *"File to scan for unique values"*: `iris species column` (the output from **Cut** {% icon tool %})
 >
 > 5. **Rename** {% icon galaxy-pencil %} the dataset to `iris species`
@@ -296,7 +296,7 @@ Like we mentioned before, there are often multiple ways to reach your answer in 
 > 3. **Rename** {% icon galaxy-pencil %} the dataset to `iris species group`
 >
 > > ### {% icon solution %} Solution
-> > 1. **Group** {% icon tool %} with the following parameters:
+> > 1. {% tool [Group](Grouping1) %}   with the following parameters:
 > >   - *"Select data"* select `iris clean` dataset
 > >   - *"Group by column"*: `Column: 5`
 > >
@@ -381,7 +381,7 @@ In our dataset, we have the following features measured for each sample:
 
 > ### {% icon hands_on %} Hands-on: Get the mean and sample standard deviation of Iris flower features
 >
-> 1. **Datamash** {% icon tool %} with the following parameters:
+> 1. {% tool [Datamash](toolshed.g2.bx.psu.edu/repos/iuc/datamash_ops/datamash_ops/1.1.0) %} with the following parameters:
 >    - {% icon param-file %} *"Input tabular dataset"*: `iris tabular`
 >    - *"Group by fields"*: `5`
 >    - *"Input file has a header line"*: `Yes`
@@ -446,7 +446,7 @@ check whether we can spot any immediate patterns.
 
 > ### {% icon hands_on %} Hands-on: Plot iris feature pairs in two dimensions
 >
-> 1. **Scatterplot w ggplot2** {% icon tool %} with the following parameters:
+> 1. {% tool [Scatterplot w ggplot2](toolshed.g2.bx.psu.edu/repos/iuc/ggplot2_point/ggplot2_point/2.2.1+galaxy1) %}   with the following parameters:
 >    - {% icon param-file %} *"Input tabular dataset"*: **iris clean**
 >    - *"Column to plot on x-axis"*: `1`
 >    - *"Column to plot on y-axis"*: `2`
@@ -489,7 +489,7 @@ check whether we can spot any immediate patterns.
 >  > > 1. We get similar results than with Summary and statistics: *Iris setosa* can clearly be distinguished from *Iris versicolor* and
 >  > > *Iris virginica*. We can also see that sepal width and length are not sufficient features to differentiate *Iris versicolor* from *Iris
 >    > > virginica*.
->  > > 2. **Scatterplot w ggplot2** {% icon tool %} with the following parameters:
+>  > > 2. {% tool [Scatterplot w ggplot2](toolshed.g2.bx.psu.edu/repos/iuc/ggplot2_point/ggplot2_point/2.2.1+galaxy1) %} with the following parameters:
 >  > >     - {% icon param-file %} *"Input tabular dataset"*: `iris clean`
 >  > >     - *"Column to plot on x-axis"*: `3`
 >  > >     - *"Column to plot on y-axis"*: `4`

--- a/topics/introduction/tutorials/galaxy-intro-101/tutorial.md
+++ b/topics/introduction/tutorials/galaxy-intro-101/tutorial.md
@@ -191,7 +191,7 @@ Our objective is to find which exon contains the most SNPs. Therefore we have to
 
 > ### {% icon hands_on %} Hands-on: Finding Exons
 >
-> 1. **Join** {% icon tool %} the intervals of two datasets side-by-side:
+> 1. {% tool [Join](toolshed.g2.bx.psu.edu/repos/devteam/join/gops_join_1/1.0.0) %}   the intervals of two datasets side-by-side:
 >
 >    Enter the word `join` in the search bar of the tool panel, and select the
 >    tool named `Join - the intervals of two datasets side-by-side`
@@ -248,7 +248,7 @@ Since each line in our file represents a single overlap between SNP and exon, we
 
 > ### {% icon hands_on %} Hands-on: Counting SNPs
 >
-> 1. **Group** {% icon tool %} data by a column and perform aggregate operation on other columns:
+> 1. {% tool [Group](Grouping1) %} data by a column and perform aggregate operation on other columns:
 >
 >    - *"Select data"*: select the output dataset from **Join** {% icon tool %}
 >    - *"Group by column"*: `Column: 4` (the column with the exon IDs)
@@ -280,7 +280,7 @@ Now that we have a list of all exons, and the number of SNPs they contain, we wo
 
 > ### {% icon hands_on %} Hands-on: Sorting
 >
-> 1. **Sort** {% icon tool %} data in ascending or descending order:
+> 1. {% tool [Sort](toolshed.g2.bx.psu.edu/repos/bgruening/text_processing/tp_sort_header_tool/1.1.1) %} data in ascending or descending order:
 >
 >    - *"Sort Query"*: Output from **Group** {% icon tool %}
 >    - *"Column Selections"*:
@@ -314,7 +314,7 @@ Let's say we want a list with just the top-5 exons with highest number of SNPs.
 
 > ### {% icon hands_on %} Hands-on: Select first
 >
-> 1. **Select first** {% icon tool %} lines from a dataset:
+> 1. {% tool [Select first](Show+beginning1) %} lines from a dataset:
 >
 >    - *"Select first"*: `5`
 >    - *"from"*: The output from **Sort** {% icon tool %}
@@ -332,7 +332,7 @@ Congratulations! You have now determined which exons on chromosome 22 have the h
 
 > ### {% icon hands_on %} Hands-on: Compare two Datasets
 >
-> 1. **Compare two Datasets** {% icon tool %} to find common or distinct rows:
+> 1. {% tool [Compare two Datasets](comp1) %} to find common or distinct rows:
 >
 >    - *"Compare"*: `Exons`
 >    - *"Using column"*: `Column: 4`

--- a/topics/introduction/tutorials/galaxy-intro-peaks2genes/tutorial.md
+++ b/topics/introduction/tutorials/galaxy-intro-peaks2genes/tutorial.md
@@ -298,7 +298,7 @@ In order to convert the chromosome names we have therefore two things to do:
 
 > ### {% icon hands_on %} Hands-on: Adjust chromosome names
 >
-> 1. **Replace Text** {% icon tool %}: Run **Replace Text in a specific column** with the following settings:
+> 1. {% tool [Replace Text](toolshed.g2.bx.psu.edu/repos/bgruening/text_processing/tp_replace_in_column/1.1.3) %} in a specific column with the following settings:
 >     - *"File to process"*: our peak file `GSE37268_mof3.out.hpeak.txt.gz`
 >     - *"in column"*: `1`
 >     - *"Find pattern"*: `[0-9]+`
@@ -311,7 +311,7 @@ In order to convert the chromosome names we have therefore two things to do:
 >
 > 2. Rename your output file `chr prefix added`.
 >
-> 3. **Replace Text** {% icon tool %}: Let's rerun the tool with
+> 3. {% tool [Replace Text](toolshed.g2.bx.psu.edu/repos/bgruening/text_processing/tp_replace_in_column/1.1.3) %}  : Let's rerun the tool with
 >    - *"File to process"*: the output from the last run, `chr prefix added`
 >    - *"in column"*: `1`
 >    - *"Find pattern"*: `chr20`
@@ -325,7 +325,7 @@ In order to convert the chromosome names we have therefore two things to do:
 >
 > 4. Rename your output file `chrX fixed`
 >
-> 5. **Replace Text** {% icon tool %}: Rerun this tool to do the same for chromosome Y
+> 5. {% tool [Replace Text](toolshed.g2.bx.psu.edu/repos/bgruening/text_processing/tp_replace_in_column/1.1.3) %}  : Rerun this tool to do the same for chromosome Y
 >    - *"File to process"*: `chrX fixed`, the output from the last run
 >    - *"in column"*: `1`
 >    - *"Find pattern"*: `chr21`
@@ -359,7 +359,7 @@ you want to include transcriptions factors in ChIP-seq experiments. There is no 
 
 > ### {% icon hands_on %} Hands-on: Add promoter region to gene records
 >
-> 1. **Get Flanks** {% icon tool %}: Run **Get flanks returns flanking region/s for every gene** with the following settings:
+> 1. {% tool [Get Flanks](toolshed.g2.bx.psu.edu/repos/devteam/get_flanks/get_flanks1/1.0.0) %} returns flanking region/s for every gene, with the following settings:
 >     - *"Select data"*: `Genes` file from UCSC
 >     - *"Region"*: `Around Start`
 >     - *"Location of the flanking region/s"*: `Upstream`
@@ -403,7 +403,7 @@ It's time to find the overlapping intervals (finally!). To do that, we want to e
 
 > ### {% icon hands_on %} Hands-on: Find Overlaps
 >
-> 1. **Intersect** {% icon tool %}: Run **Intersect the intervals of two datasets** with the following settings:
+> 1. {% tool [Intersect](toolshed.g2.bx.psu.edu/repos/devteam/intersect/gops_intersect_1/1.0.0) %} the intervals of two datasets, with the following settings:
 >     - *"Return"*: `Overlapping Intervals`
 >     - *"of"*: the UCSC file with promoter regions (`Promoter regions`)
 >     - *"that intersect"*: our peak region file from **Replace** (`Peak regions BED`)
@@ -422,7 +422,7 @@ We will group the table by chromosome and count the number of genes with peaks o
 
 > ### {% icon hands_on %} Hands-on: Count genes on different chromosomes
 >
-> 1. **Group** {% icon tool %}: Run **Group data by a column and perform aggregate operation on other columns** with the following settings:
+> 1. {% tool [Group](Grouping1) %}  data by a column and perform aggregate operation on other columns with the following settings:
 >     - *"Select data"* to the result of the intersection
 >     - *"Group by column"*:`Column 1`
 >     - Press **Insert Operation** and choose:
@@ -557,7 +557,7 @@ We need to generate a new BED file from the original peak file that contains the
 
 > ### {% icon hands_on %} Hands-on: Create peak summit file
 >
-> 1. **Compute an expression on every row** {% icon tool %} with the following parameters:
+> 1. {% tool [Compute an expression on every row](toolshed.g2.bx.psu.edu/repos/devteam/column_maker/Add_a_column1/1.3.0) %} with the following parameters:
 >   - *"Add expression"*: `c2+c5`
 >   - *"as a new column to"*: our peak file `Peak regions` (the interval format file)
 >   - *"Round result?"*: `YES`
@@ -566,7 +566,7 @@ We need to generate a new BED file from the original peak file that contains the
 >
 > 2. Rename the output `Peak regions new column`
 >
-> 3. **Compute an expression on every row** {% icon tool %}: rerun this tool on the last result with:
+> 3. {% tool [Compute an expression on every row](toolshed.g2.bx.psu.edu/repos/devteam/column_maker/Add_a_column1/1.3.0) %} rerun this tool on the last result with:
 >   - *"Add expression"*: `c8+1`
 >   - *"as a new column to"*: the `Peak regions new column` file we just created
 >   - *"Round result?"*: `YES`
@@ -577,7 +577,7 @@ We need to generate a new BED file from the original peak file that contains the
 Now we cut out just the chromosome plus the start and end of the summit:
 
 > ### {% icon hands_on %} Hands-on: Cut out columns
-> 1. **Cut** {% icon tool %}: Run **Cut columns from a table** with the following settings:
+> 1. {% tool [Cut](cut1) %} columns from a table with the following settings:
 >   - *"Cut columns"*: `c1,c8,c9`
 >   - *"Delimited by Tab"*: `Tab`
 >   - *"From"*: `Peak summit regions`

--- a/topics/introduction/tutorials/galaxy-intro-peaks2genes/tutorial.md
+++ b/topics/introduction/tutorials/galaxy-intro-peaks2genes/tutorial.md
@@ -603,7 +603,7 @@ The RefSeq genes we downloaded from UCSC did only contain the RefSeq identifiers
 
 > ### {% icon hands_on %} Hands-on: Data upload
 >
-> 1. From [Zenodo](https://zenodo.org/record/1025586) or from the data library, import the file `mm9.RefSeq_genes_from_UCSC.bed`
+> 1. {% tool [Import](upload1) %} `mm9.RefSeq_genes_from_UCSC.bed` from [Zenodo](https://zenodo.org/record/1025586) or from the data library:
 >
 >    ```
 >    https://zenodo.org/record/1025586/files/mm9.RefSeq_genes_from_UCSC.bed

--- a/topics/introduction/tutorials/galaxy-intro-short/tutorial.md
+++ b/topics/introduction/tutorials/galaxy-intro-short/tutorial.md
@@ -144,7 +144,7 @@ Let's look at the quality of the reads in this file.
 
 > ### {% icon hands_on %} Hands-on: Use a tool
 > 1. Type **FastQC** in the tools panel search box (top)
-> 2. Click on the **FastQC** {% icon tool %} tool
+> 2. Click on the {% tool FastQC/fastqc %} tool
 >
 >    The tool will be displayed in the central Galaxy panel.
 >
@@ -197,7 +197,7 @@ Let's run a tool to filter out lower-quality reads from our FASTQ file.
 
 > ### {% icon hands_on %} Hands-on: Run another tool
 > 1. Type **Filter by quality** in the tools panel search box (top)
-> 2. Click on the tool **Filter by quality** {% icon tool %}
+> 2. Click on the tool {% tool Filter by quality/cshl_fastq_quality_filter/1.0.1 %}
 > 3. Set the following parameters:
 >    - {% icon param-file %} *"Input FASTQ file"*: the input FASTQ file
 >    - *"Quality cut-off value"*: 35

--- a/topics/introduction/tutorials/galaxy-intro-short/tutorial.md
+++ b/topics/introduction/tutorials/galaxy-intro-short/tutorial.md
@@ -144,7 +144,7 @@ Let's look at the quality of the reads in this file.
 
 > ### {% icon hands_on %} Hands-on: Use a tool
 > 1. Type **FastQC** in the tools panel search box (top)
-> 2. Click on the {% tool FastQC/fastqc %} tool
+> 2. Click on the {% tool FastQC|fastqc %} tool
 >
 >    The tool will be displayed in the central Galaxy panel.
 >
@@ -197,7 +197,7 @@ Let's run a tool to filter out lower-quality reads from our FASTQ file.
 
 > ### {% icon hands_on %} Hands-on: Run another tool
 > 1. Type **Filter by quality** in the tools panel search box (top)
-> 2. Click on the tool {% tool Filter by quality/cshl_fastq_quality_filter/1.0.1 %}
+> 2. Click on the tool {% tool Filter by quality|cshl_fastq_quality_filter/1.0.1 %}
 > 3. Set the following parameters:
 >    - {% icon param-file %} *"Input FASTQ file"*: the input FASTQ file
 >    - *"Quality cut-off value"*: 35

--- a/topics/introduction/tutorials/galaxy-intro-short/tutorial.md
+++ b/topics/introduction/tutorials/galaxy-intro-short/tutorial.md
@@ -144,7 +144,7 @@ Let's look at the quality of the reads in this file.
 
 > ### {% icon hands_on %} Hands-on: Use a tool
 > 1. Type **FastQC** in the tools panel search box (top)
-> 2. Click on the {% tool FastQC|fastqc %} tool
+> 2. Click on the {% tool [FastQC](toolshed.g2.bx.psu.edu/repos/devteam/fastqc/fastqc/0.72) %} tool
 >
 >    The tool will be displayed in the central Galaxy panel.
 >
@@ -197,7 +197,7 @@ Let's run a tool to filter out lower-quality reads from our FASTQ file.
 
 > ### {% icon hands_on %} Hands-on: Run another tool
 > 1. Type **Filter by quality** in the tools panel search box (top)
-> 2. Click on the tool {% tool Filter by quality|cshl_fastq_quality_filter/1.0.1 %}
+> 2. Click on the tool {% tool [Filter by quality](toolshed.g2.bx.psu.edu/repos/devteam/fastq_quality_filter/cshl_fastq_quality_filter/1.0.1) %}
 > 3. Set the following parameters:
 >    - {% icon param-file %} *"Input FASTQ file"*: the input FASTQ file
 >    - *"Quality cut-off value"*: 35

--- a/topics/introduction/tutorials/galaxy-intro-strands/tutorial.md
+++ b/topics/introduction/tutorials/galaxy-intro-strands/tutorial.md
@@ -397,8 +397,7 @@ Of the tools in the **Operate on Genomic Intervals** toolbox, **Join** and parti
 
 > ### {% icon hands_on %} Hands-on: Genomic Interval Tools
 >
-> 1. In the tool panel, *click* **Intersect** in the **Operate on Genomic Intervals** toolbox.
-> 2. **Intersect** {% icon tool %} with the following parameters:
+> 1. {% tool [Intersect](toolshed.g2.bx.psu.edu/repos/devteam/intersect/gops_intersect_1/1.0.0) %} with the following parameters:
 >     - **Return** to `Overlapping Intervals`.
 >       - This looks like it might return whole genes, while `Overlapping pieces` may return only the parts that overlap.  We suspect that whole genes might be more useful.
 >     - **of** (the first dataset) to `Genes, forward strand`
@@ -434,7 +433,7 @@ It turns out that **Lift-Over** and **Collection Operations** are not what we wa
 >
 > 1. *Open* the **Text Manipulation** toolbox.
 > 2. Near the top of the toolbox is **Concatenate datasets tail-to-head**. *Click* on it.  Lets try that tool.
-> 3. **Concatenate** {% icon tool %} with the following parameters:
+> 3. {% tool [Concatenate](cat1) %} with the following parameters:
 >   * *Set* **Concatenate Dataset** to `Overlapping reverse genes`.
 >   * *Click* **+ Insert Dataset**.  This adds a second dataset pull-down menu to the form.
 >   * *Select* `Overlapping forward genes` as the second dataset.

--- a/topics/visualisation/tutorials/circos/tutorial.md
+++ b/topics/visualisation/tutorials/circos/tutorial.md
@@ -250,7 +250,7 @@ In this section we will reproduce this Circos plot step by step.
 >
 >    {% include snippets/create_new_history.md %}
 >
-> 2. {% tool Import Data/upload %}
+> 2. {% tool Import Data|upload %}
 >    - Import the sample data files to your history, either from a shared data library (if available), or from Zenodo using the following URLs:
 >
 >    ```
@@ -278,7 +278,7 @@ As the first step to this Circos plot, let's configure the ideogram (set of chro
 
 > ### {% icon hands_on %} Hands-on: Set ideogram configuration
 >
-> 1. {% tool Circos/circos/0.69.8+galaxy7 %} visualizes data in a ciruclar layout with the following parameters:
+> 1. {% tool Circos|circos|0.69.8+galaxy7 %} visualizes data in a ciruclar layout with the following parameters:
 >    - In *"Karyotype"*:
 >        - *"Reference Genome"*: `Karyotype`
 >            - {% icon param-file %} *"Karyotype Configuration"*: `hg18_karyotype.tsv`
@@ -422,7 +422,7 @@ So in order to convert this to Circos format, we need to
 
 > ### {% icon hands_on %} Hands-on: Prepare input data
 >
-> 1. {% tool Select/Grep1 %} lines that match an expression with the following parameters:
+> 1. {% tool Select|Grep1 %} lines that match an expression with the following parameters:
 >    - {% icon param-file %} *"Select lines from"*: `VCaP highConfidenceJunctions.tsv`
 >    - *"that"*: `NOT Matching`
 >    - *"the pattern"*: `^[#><]`
@@ -607,15 +607,15 @@ This is pretty close to the format expected by Circos for 2D data tracks (`chr -
 
 > ### {% icon hands_on %} Hands-on: Prepare CNV input file
 >
-> 1. {% tool Remove beginning/Remove+beginning1 %} of a file with the following parameters:
+> 1. {% tool Remove beginning|Remove+beginning1 %} of a file with the following parameters:
 >    - *"Remove first"*: `1`
 >    - {% icon param-file %} *"from"*: `VCaP copy number.tsv`
 >
-> 2. {% tool Cut/Cut1 %} columns from a table  with the following parameters:
+> 2. {% tool Cut|Cut1 %} columns from a table  with the following parameters:
 >    - *"Cut columns"*: `c1,c2,c3,c4`
 >    - {% icon param-file %} *"From"*: output of **Remove beginning** {% icon tool %}
 >
-> 3. {% tool Select random lines/random_lines1 %} with the following parameters:
+> 3. {% tool Select random lines|random_lines1 %} with the following parameters:
 >    - *"Randomly select"*: `25000`
 >    - {% icon param-file %} *"from"*: output of **Cut** {% icon tool %}
 >
@@ -788,11 +788,11 @@ We will make another scatterplot, so our data should be in the same format as th
 
 > ### {% icon hands_on %} Hands-on: Prepare the B-allele frequency table
 >
-> 1. {% tool Remove beginning/Remove+beginning1 %} with the following parameters:
+> 1. {% tool Remove beginning|Remove+beginning1 %} with the following parameters:
 >    - *"Remove first"*: `1`
 >    - {% icon param-file %} *"from"*: `B-allele frequence.tsv`
 >
-> 2. {% tool Select random lines/random_lines1 %} with the following parameters:
+> 2. {% tool Select random lines|random_lines1 %} with the following parameters:
 >    - *"Randomly select"*: `25000`
 >    - {% icon param-file %} *"from"*: output of **Select** {% icon tool %}
 >    - *"Set a random seed"*: `Don't set seed`
@@ -1022,7 +1022,7 @@ Let's start by creating the ideogram for our plot:
 
 > ### {% icon hands_on %} Hands-on: Set ideogram configuration
 >
-> 1. {% tool Circos/circos/0.69.8+galaxy7 %} with the following parameters:
+> 1. {% tool Circos|circos|0.69.8+galaxy7 %} with the following parameters:
 >    - In *"Karyotype"*:
 >        - *"Reference Genome"*: `Karyotype`
 >            - {% icon param-file %} *"Karyotype Configuration"*: `debate_karyotype.tab`
@@ -1208,7 +1208,7 @@ We will now create the plot all at once. Normally, this would be a more iterativ
 
 > ### {% icon hands_on %} Hands-on: Circos
 >
-> 1. {% tool Circos/circos/0.69.8+galaxy7 %} with the following parameters:
+> 1. {% tool Circos|circos|0.69.8+galaxy7 %} with the following parameters:
 >    - In *"Karyotype"*:
 >        - *"Reference Genome"*: `Karyotype`
 >            - {% icon param-file %} *"Karyotype Configuration"*: `chrom.tab`

--- a/topics/visualisation/tutorials/circos/tutorial.md
+++ b/topics/visualisation/tutorials/circos/tutorial.md
@@ -250,7 +250,7 @@ In this section we will reproduce this Circos plot step by step.
 >
 >    {% include snippets/create_new_history.md %}
 >
-> 2. **Import Data.**
+> 2. {% tool Import Data/upload %}
 >    - Import the sample data files to your history, either from a shared data library (if available), or from Zenodo using the following URLs:
 >
 >    ```
@@ -278,7 +278,7 @@ As the first step to this Circos plot, let's configure the ideogram (set of chro
 
 > ### {% icon hands_on %} Hands-on: Set ideogram configuration
 >
-> 1. **Circos** visualizes data in a ciruclar layout {% icon tool %} with the following parameters:
+> 1. {% tool Circos/circos/0.69.8+galaxy7 %} visualizes data in a ciruclar layout with the following parameters:
 >    - In *"Karyotype"*:
 >        - *"Reference Genome"*: `Karyotype`
 >            - {% icon param-file %} *"Karyotype Configuration"*: `hg18_karyotype.tsv`
@@ -422,7 +422,7 @@ So in order to convert this to Circos format, we need to
 
 > ### {% icon hands_on %} Hands-on: Prepare input data
 >
-> 1. **Select** lines that match an expression {% icon tool %} with the following parameters:
+> 1. {% tool Select/Grep1 %} lines that match an expression with the following parameters:
 >    - {% icon param-file %} *"Select lines from"*: `VCaP highConfidenceJunctions.tsv`
 >    - *"that"*: `NOT Matching`
 >    - *"the pattern"*: `^[#><]`
@@ -607,15 +607,15 @@ This is pretty close to the format expected by Circos for 2D data tracks (`chr -
 
 > ### {% icon hands_on %} Hands-on: Prepare CNV input file
 >
-> 1. **Remove beginning** of a file {% icon tool %} with the following parameters:
+> 1. {% tool Remove beginning/Remove+beginning1 %} of a file with the following parameters:
 >    - *"Remove first"*: `1`
 >    - {% icon param-file %} *"from"*: `VCaP copy number.tsv`
 >
-> 2. **Cut** columns from a table {% icon tool %} with the following parameters:
+> 2. {% tool Cut/Cut1 %} columns from a table  with the following parameters:
 >    - *"Cut columns"*: `c1,c2,c3,c4`
 >    - {% icon param-file %} *"From"*: output of **Remove beginning** {% icon tool %}
 >
-> 3. **Select random lines** {% icon tool %} with the following parameters:
+> 3. {% tool Select random lines/random_lines1 %} with the following parameters:
 >    - *"Randomly select"*: `25000`
 >    - {% icon param-file %} *"from"*: output of **Cut** {% icon tool %}
 >
@@ -788,11 +788,11 @@ We will make another scatterplot, so our data should be in the same format as th
 
 > ### {% icon hands_on %} Hands-on: Prepare the B-allele frequency table
 >
-> 1. **Remove beginning** of a file {% icon tool %} with the following parameters:
+> 1. {% tool Remove beginning/Remove+beginning1 %} with the following parameters:
 >    - *"Remove first"*: `1`
 >    - {% icon param-file %} *"from"*: `B-allele frequence.tsv`
 >
-> 2. **Select random lines** {% icon tool %} with the following parameters:
+> 2. {% tool Select random lines/random_lines1 %} with the following parameters:
 >    - *"Randomly select"*: `25000`
 >    - {% icon param-file %} *"from"*: output of **Select** {% icon tool %}
 >    - *"Set a random seed"*: `Don't set seed`
@@ -1022,7 +1022,7 @@ Let's start by creating the ideogram for our plot:
 
 > ### {% icon hands_on %} Hands-on: Set ideogram configuration
 >
-> 1. **Circos** {% icon tool %} with the following parameters:
+> 1. {% tool Circos/circos/0.69.8+galaxy7 %} with the following parameters:
 >    - In *"Karyotype"*:
 >        - *"Reference Genome"*: `Karyotype`
 >            - {% icon param-file %} *"Karyotype Configuration"*: `debate_karyotype.tab`
@@ -1208,7 +1208,7 @@ We will now create the plot all at once. Normally, this would be a more iterativ
 
 > ### {% icon hands_on %} Hands-on: Circos
 >
-> 1. **Circos** {% icon tool %} with the following parameters:
+> 1. {% tool Circos/circos/0.69.8+galaxy7 %} with the following parameters:
 >    - In *"Karyotype"*:
 >        - *"Reference Genome"*: `Karyotype`
 >            - {% icon param-file %} *"Karyotype Configuration"*: `chrom.tab`

--- a/topics/visualisation/tutorials/circos/tutorial.md
+++ b/topics/visualisation/tutorials/circos/tutorial.md
@@ -250,7 +250,7 @@ In this section we will reproduce this Circos plot step by step.
 >
 >    {% include snippets/create_new_history.md %}
 >
-> 2. {% tool Import Data|upload %}
+> 2. {% tool [Import Data](upload1) %}
 >    - Import the sample data files to your history, either from a shared data library (if available), or from Zenodo using the following URLs:
 >
 >    ```
@@ -278,7 +278,7 @@ As the first step to this Circos plot, let's configure the ideogram (set of chro
 
 > ### {% icon hands_on %} Hands-on: Set ideogram configuration
 >
-> 1. {% tool Circos|circos|0.69.8+galaxy7 %} visualizes data in a ciruclar layout with the following parameters:
+> 1. {% tool [Circos](toolshed.g2.bx.psu.edu/repos/iuc/circos/circos/0.69.8+galaxy7) %} visualizes data in a ciruclar layout with the following parameters:
 >    - In *"Karyotype"*:
 >        - *"Reference Genome"*: `Karyotype`
 >            - {% icon param-file %} *"Karyotype Configuration"*: `hg18_karyotype.tsv`
@@ -422,7 +422,7 @@ So in order to convert this to Circos format, we need to
 
 > ### {% icon hands_on %} Hands-on: Prepare input data
 >
-> 1. {% tool Select|Grep1 %} lines that match an expression with the following parameters:
+> 1. {% tool [Select](Grep1) %} lines that match an expression with the following parameters:
 >    - {% icon param-file %} *"Select lines from"*: `VCaP highConfidenceJunctions.tsv`
 >    - *"that"*: `NOT Matching`
 >    - *"the pattern"*: `^[#><]`
@@ -607,15 +607,15 @@ This is pretty close to the format expected by Circos for 2D data tracks (`chr -
 
 > ### {% icon hands_on %} Hands-on: Prepare CNV input file
 >
-> 1. {% tool Remove beginning|Remove+beginning1 %} of a file with the following parameters:
+> 1. {% tool [Remove beginning](Remove+beginning1) %} of a file with the following parameters:
 >    - *"Remove first"*: `1`
 >    - {% icon param-file %} *"from"*: `VCaP copy number.tsv`
 >
-> 2. {% tool Cut|Cut1 %} columns from a table  with the following parameters:
+> 2. {% tool [Cut](Cut1) %} columns from a table  with the following parameters:
 >    - *"Cut columns"*: `c1,c2,c3,c4`
 >    - {% icon param-file %} *"From"*: output of **Remove beginning** {% icon tool %}
 >
-> 3. {% tool Select random lines|random_lines1 %} with the following parameters:
+> 3. {% tool [Select random lines](random_lines1) %} with the following parameters:
 >    - *"Randomly select"*: `25000`
 >    - {% icon param-file %} *"from"*: output of **Cut** {% icon tool %}
 >
@@ -788,11 +788,11 @@ We will make another scatterplot, so our data should be in the same format as th
 
 > ### {% icon hands_on %} Hands-on: Prepare the B-allele frequency table
 >
-> 1. {% tool Remove beginning|Remove+beginning1 %} with the following parameters:
+> 1. {% tool [Remove beginning](Remove+beginning1) %} with the following parameters:
 >    - *"Remove first"*: `1`
 >    - {% icon param-file %} *"from"*: `B-allele frequence.tsv`
 >
-> 2. {% tool Select random lines|random_lines1 %} with the following parameters:
+> 2. {% tool [Select random lines](random_lines1) %} with the following parameters:
 >    - *"Randomly select"*: `25000`
 >    - {% icon param-file %} *"from"*: output of **Select** {% icon tool %}
 >    - *"Set a random seed"*: `Don't set seed`
@@ -1022,7 +1022,7 @@ Let's start by creating the ideogram for our plot:
 
 > ### {% icon hands_on %} Hands-on: Set ideogram configuration
 >
-> 1. {% tool Circos|circos|0.69.8+galaxy7 %} with the following parameters:
+> 1. {% tool [Circos](toolshed.g2.bx.psu.edu/repos/iuc/circos/circos/0.69.8+galaxy7) %} with the following parameters:
 >    - In *"Karyotype"*:
 >        - *"Reference Genome"*: `Karyotype`
 >            - {% icon param-file %} *"Karyotype Configuration"*: `debate_karyotype.tab`
@@ -1208,7 +1208,7 @@ We will now create the plot all at once. Normally, this would be a more iterativ
 
 > ### {% icon hands_on %} Hands-on: Circos
 >
-> 1. {% tool Circos|circos|0.69.8+galaxy7 %} with the following parameters:
+> 1. {% tool [Circos](toolshed.g2.bx.psu.edu/repos/iuc/circos/circos/0.69.8+galaxy7) %} with the following parameters:
 >    - In *"Karyotype"*:
 >        - *"Reference Genome"*: `Karyotype`
 >            - {% icon param-file %} *"Karyotype Configuration"*: `chrom.tab`


### PR DESCRIPTION
In support of https://github.com/galaxyproject/galaxy/pull/10024, we can now annotate training materials with the precise tool ID and optionally version.

We will add this to planemo so most people won't care about it, but for the older tutorials we can migrate them or encourage authors to, in order to take advantage of the webhook.

Please see https://github.com/galaxyproject/galaxy/pull/10024 for more information on what the tool tag will be used for.

I have converted a couple of training materials, but we should focus on doing the rest of the introductory ones before merging.