### PR TITLE
Add .dockstore.yml

### DIFF
--- a/.dockstore.yml
+++ b/.dockstore.yml
@@ -1,0 +1,17 @@
+version: 1.2
+workflows:
+  - name: intro-short
+    subclass: GXFORMAT2
+    primaryDescriptorPath: topics/introduction/tutorials/galaxy-intro-short/workflows/Galaxy-Workflow-galaxy-intro-short.ga
+  - name: intro-everyone
+    subclass: GXFORMAT2
+    primaryDescriptorPath: topics/introduction/tutorials/galaxy-intro-101-everyone/workflows/main_workflow.ga
+  - name: de-novo
+    subclass: GXFORMAT2
+    primaryDescriptorPath: topics/transcriptomics/tutorials/full-de-novo/workflows/main_workflow.ga
+  - name: dip
+    subclass: GXFORMAT2
+    primaryDescriptorPath: topics/variant-analysis/tutorials/dip/workflows/diploid.ga
+  - name: genome-annotation
+    subclass: GXFORMAT2
+    primaryDescriptorPath: topics/genome-annotation/tutorials/annotation-with-prokka/workflows/Galaxy-Workflow-Workflow_constructed_from_history__prokka-workflow_.ga


### PR DESCRIPTION
The .dockstore.yml works in conjunction with GitHub apps to notify [Dockstore](https://dockstore.org) when a Galaxy workflow has been updated in GitHub.

This .dockstore.yml adds the workflows listed in dockstore/dockstore#3186, suggested by @MoHeydarian .

I have also discussed this with @jmchilton . If the PR gets merged, he will do the work as a Dockstore user to publish these workflows on Dockstore.

Thanks!