### PR TITLE
Added job conf section to ansible-galaxy tutorial

### DIFF
--- a/topics/admin/tutorials/ansible-galaxy/tutorial.md
+++ b/topics/admin/tutorials/ansible-galaxy/tutorial.md
@@ -1955,7 +1955,7 @@ There are a lot of other plugins available for Galaxy for using other resources 
 >    {: .code-in}
 >
 >    > ### {% icon code-out %} Output: Bash
->    > ```ini
+>    > ```xml
 >    >    <job_conf>
 >    >        <plugins workers="4">
 >    >            <plugin id="local" type="runner" load="galaxy.jobs.runners.local:LocalJobRunner"/>

--- a/topics/admin/tutorials/ansible-galaxy/tutorial.md
+++ b/topics/admin/tutorials/ansible-galaxy/tutorial.md
@@ -8,7 +8,7 @@ questions:
 objectives:
 - Have an understanding of how Galaxy's Ansible roles are structured and interact with one another
 - Be able to use an Ansible playbook to install different flavors of Galaxy for different purposes
-time_estimation: "2h:30m"
+time_estimation: "2h30m"
 key_points:
 - Basic deployment with Ansible is surprisingly easy
 - Complexity can grow over time as your organisation does, no need to start with playbooks like UseGalaxy.org

--- a/topics/admin/tutorials/ansible-galaxy/tutorial.md
+++ b/topics/admin/tutorials/ansible-galaxy/tutorial.md
@@ -1870,7 +1870,7 @@ The job configuration file allows Galaxy to run jobs in multiple locations using
 
 ### The job conf file - basics
 
-The `job_conf.xml` has three basic sections:
+The `job_conf.xml` file has three basic sections:
 * **Plugins** - This section lists the types of resources that this Galaxy server is configured to use and tells Galaxy to load the drivers for each type.
 * **Destinations** - This section lists the different locations or queues etc that Galaxy can send jobs to. Each one has a name and uses a *plugin* to communicate with that location. They can specify things like the number of cpu's, amount of RAM to be allocated etc for DRMAA locations. Usually one of the destinations is set to be the default.
 * **Tools** - This section lists the various tools that Galaxy would like to send to the non-default *destination*. Each line in this section pairs up a tool in Galaxy with a particular job *destination*. Then everytime Galaxy gets a job for that particular tool, it is always sent to that *destination*.

--- a/topics/admin/tutorials/ansible-galaxy/tutorial.md
+++ b/topics/admin/tutorials/ansible-galaxy/tutorial.md
@@ -1859,7 +1859,7 @@ Now that your production-ready Galaxy is running, try registering a new user and
 
 In order to be the administrator user, you will need to register an account with the same email address you used in the group variables under the `admin_users` setting.
 
-## Job Configuration (Optional)
+## Job Configuration
 
 One of the most important configuration files for a large Galaxy server is the `job_conf.xml` file. This file tells Galaxy where to run all of the jobs that users execute. If Galaxy can't find a job conf file or none have been specified in the `galaxy.yml` file, it will use a default configuration. The default configuration is the `job_conf.xml.sample_basic` file. This file is located at: `/srv/galaxy/server/lib/galaxy/config/sample/job_conf.xml.sample_basic`, though there is a symlink to the file in `/srv/galaxy/server/config`.
 

--- a/topics/admin/tutorials/ansible-galaxy/tutorial.md
+++ b/topics/admin/tutorials/ansible-galaxy/tutorial.md
@@ -1872,7 +1872,7 @@ The job configuration file allows Galaxy to run jobs in multiple locations using
 
 The `job_conf.xml` file has three basic sections:
 * **Plugins** - This section lists the types of job management systems that this Galaxy server is configured to use and tells Galaxy to load the drivers for each type.
-* **Destinations** - This section lists the different locations or queues etc that Galaxy can send jobs to. Each one has a name and uses a *plugin* to communicate with that location. They can specify things like the number of cpu's, amount of RAM to be allocated etc for DRMAA locations. Usually one of the destinations is set to be the default.
+* **Destinations** - This section lists the different locations, queues, etc. that Galaxy can send jobs to. Each one has a name and uses a *plugin* to communicate with that location. They can specify things like the number of CPUs, amount of RAM to be allocated, etc. for DRMAA locations. Usually, one of the destinations is set to be the default.
 * **Tools** - This section lists the various tools that Galaxy would like to send to the non-default *destination*. Each line in this section pairs up a tool in Galaxy with a particular job *destination*. Then everytime Galaxy gets a job for that particular tool, it is always sent to that *destination*.
 
 The basic `job_conf.xml` file looks like this:

--- a/topics/admin/tutorials/ansible-galaxy/tutorial.md
+++ b/topics/admin/tutorials/ansible-galaxy/tutorial.md
@@ -27,7 +27,7 @@ requirements:
     tutorials:
       - ansible
   - type: "none"
-    title: "A VM with at least 2 vCPUs and 4 GB RAM"
+    title: "A VM with at least 2 vCPUs and 4 GB RAM with Ubuntu 18.04 - 20.04 for preference."
 ---
 
 # Overview
@@ -1456,7 +1456,7 @@ The configuration is quite simple thanks to the many sensible defaults that are 
 > 6. Access at port `<ip address>:8080` once the server has started
 {: .hands_on}
 
-Galaxy is now configured with an admin user, a database, and a place to store data. Additionally we've immediately configured the mules for production Galaxy serving. So we're ready to set up systemd which will manage the Galaxy processes!. Get back to your user with which you have ran ansible-playbook. First by deactivating virtual environment with `deactivate` and then with `exit` leave galaxy user. 
+Galaxy is now configured with an admin user, a database, and a place to store data. Additionally we've immediately configured the mules for production Galaxy serving. So we're ready to set up systemd which will manage the Galaxy processes!. Get back to your user with which you have ran ansible-playbook. First by deactivating virtual environment with `deactivate` and then with `exit` leave galaxy user.
 
 ## systemd
 
@@ -1858,6 +1858,97 @@ For this, we will use NGINX. It is possible to configure Galaxy with Apache and 
 Now that your production-ready Galaxy is running, try registering a new user and logging in!
 
 In order to be the administrator user, you will need to register an account with the same email address you used in the group variables under the `admin_users` setting.
+
+## Job Configuration (Optional)
+
+One of the most important configuration files for a large Galaxy server is the `job_conf.xml` file. This file tells Galaxy where to run all of the jobs that users execute. If Galaxy can't find a job conf file or none have been specified in the `galaxy.yml` file, it will use a default configuration. The default configuration is the `job_conf.xml.sample_basic` file. This file is located at: `/srv/galaxy/server/lib/galaxy/config/sample/job_conf.xml.sample_basic`, though there is a symlink to the file in `/srv/galaxy/server/config`.
+
+The job configuration file allows Galaxy to run jobs in multiple locations using a variety of different mechanisms. Some of these mechanisms include:
+* Local - Galaxy runs jobs on the same computer that Galaxy itself is running on.
+* DRMAA - Galaxy can connect to a cluster and submit jobs via a distributed resource manager such as Slurm, Condor, PBS Torque or Sun Grid Engine.
+* Pulsar - Galaxy can also send jobs to remote compute hosts over the internet using Pulsar.
+
+### The job conf file - basics
+
+The `job_conf.xml` has three basic sections:
+* **Plugins** - This section lists the types of resources that this Galaxy server is configured to use and tells Galaxy to load the drivers for each type.
+* **Destinations** - This section lists the different locations or queues etc that Galaxy can send jobs to. Each one has a name and uses a *plugin* to communicate with that location. They can specify things like the number of cpu's, amount of RAM to be allocated etc for DRMAA locations. Usually one of the destinations is set to be the default.
+* **Tools** - This section lists the various tools that Galaxy would like to send to the non-default *destination*. Each line in this section pairs up a tool in Galaxy with a particular job *destination*. Then everytime Galaxy gets a job for that particular tool, it is always sent to that *destination*.
+
+The basic `job_conf.xml` file looks like this:
+
+{% raw %}
+```xml
+<job_conf>
+    <plugins workers="4">
+        <plugin id="local" type="runner" load="galaxy.jobs.runners.local:LocalJobRunner"/>
+    </plugins>
+    <destinations>
+        <destination id="local" runner="local"/>
+    </destinations>
+    <tools>
+    </tools>
+</job_conf>
+```
+
+The above `job_conf.xml` file defines a *plugin* and *destination* to allow Galaxy to run user jobs on the local computer (i.e. The computer that Galaxy is running on.)
+
+Firstly, the plugins section contains a plugin called "local" which is of type "runner" and then loads the python code module for supporting local jobs. Next the destinations section contains a destination called "local" using the runner "local". As this is the only destination specified, it is also the default. So now everytime a user clicks "Execute" on a tool form, Galaxy will run the corresponding job locally using the python code specified.
+
+There are a lot of other plugins available for Galaxy for using other resources such as docker containers, kubernetes hosts, Pulsar destinations and HPC clusters to name a few. See the Galaxy documentation on [job configuration](https://docs.galaxyproject.org/en/master/admin/jobs.html) for more details on these plugins and their configuration. There is also an advanced sample job conf file located at: `/srv/galaxy/server/lib/galaxy/config/sample/job_conf.xml.sample_advanced`
+
+{% endraw %}
+
+> ### {% icon hands_on %} Hands-on: Job Conf
+>
+> 1. If the folder does not exist, create `templates/galaxy/config` next to your `galaxy.yml` playbook (`mkdir -p templates/galaxy/config/`).
+>
+> 2. Create `templates/galaxy/config/job_conf.xml.j2` with the following contents:
+>
+>    ```xml
+>    <job_conf>
+>        <plugins workers="4">
+>            <plugin id="local" type="runner" load="galaxy.jobs.runners.local:LocalJobRunner"/>
+>        </plugins>
+>        <destinations default="local">
+>            <destination id="local" runner="local"/>
+>        </destinations>
+>        <tools>
+>        </tools>
+>    </job_conf>
+>    ```
+>
+> 3. Inform `galaxyproject.galaxy` of where you would like the `job_conf.xml` to reside in your group variables:
+>
+>    {% raw %}
+>    ```yaml
+>    galaxy_config:
+>      galaxy:
+>        # ... existing configuration options in the `galaxy` section ...
+>        job_config_file: "{{ galaxy_config_dir }}/job_conf.xml"
+>    ```
+>    {% endraw %}
+>
+>    And then deploy the new config file using the `galaxy_config_templates` var in your group vars:
+>
+>    {% raw %}
+>    ```yaml
+>    galaxy_config_templates:
+>      # ... possible existing config file definitions
+>      - src: templates/galaxy/config/job_conf.xml.j2
+>        dest: "{{ galaxy_config.galaxy.job_config_file }}"
+>    ```
+>    {% endraw %}
+>
+> 4. Run the playbook. At the very end, you should see output like the following indicating that Galaxy has been restarted:
+>
+>    ```
+>    RUNNING HANDLER [restart galaxy] ****************************************
+>    changed: [galaxy.example.org]
+>    ```
+> 5. Checkout the new job_conf.xml file in `/srv/galaxy/config`.
+>
+{: .hands_on}
 
 ## Disaster Strikes! (Optional)
 

--- a/topics/admin/tutorials/ansible-galaxy/tutorial.md
+++ b/topics/admin/tutorials/ansible-galaxy/tutorial.md
@@ -1873,7 +1873,7 @@ The job configuration file allows Galaxy to run jobs in multiple locations using
 The `job_conf.xml` file has three basic sections:
 * **Plugins** - This section lists the types of job management systems that this Galaxy server is configured to use and tells Galaxy to load the drivers for each type.
 * **Destinations** - This section lists the different locations, queues, etc. that Galaxy can send jobs to. Each one has a name and uses a *plugin* to communicate with that location. They can specify things like the number of CPUs, amount of RAM to be allocated, etc. for DRMAA locations. Usually, one of the destinations is set to be the default.
-* **Tools** - This section lists the various tools that Galaxy would like to send to the non-default *destination*. Each line in this section pairs up a tool in Galaxy with a particular job *destination*. Then everytime Galaxy gets a job for that particular tool, it is always sent to that *destination*.
+* **Tools** - This section lists the various tools that you would like to send to a non-default *destination*. Each line in this section pairs up a tool in Galaxy with a particular job *destination*. Every time Galaxy gets a job for that particular tool, it is always sent to that *destination*.
 
 The basic `job_conf.xml` file looks like this:
 

--- a/topics/admin/tutorials/ansible-galaxy/tutorial.md
+++ b/topics/admin/tutorials/ansible-galaxy/tutorial.md
@@ -8,7 +8,7 @@ questions:
 objectives:
 - Have an understanding of how Galaxy's Ansible roles are structured and interact with one another
 - Be able to use an Ansible playbook to install different flavors of Galaxy for different purposes
-time_estimation: "2h"
+time_estimation: "2hr 30min"
 key_points:
 - Basic deployment with Ansible is surprisingly easy
 - Complexity can grow over time as your organisation does, no need to start with playbooks like UseGalaxy.org
@@ -1946,7 +1946,28 @@ There are a lot of other plugins available for Galaxy for using other resources 
 >    RUNNING HANDLER [restart galaxy] ****************************************
 >    changed: [galaxy.example.org]
 >    ```
-> 5. Checkout the new job_conf.xml file in `/srv/galaxy/config`.
+> 5. Checkout the new job_conf.xml file.
+>
+>    > ### {% icon code-in %} Input: Bash
+>    > ```bash
+>    > cat /srv/galaxy/config/job_conf.xml
+>    > ```
+>    {: .code-in}
+>
+>    > ### {% icon code-out %} Output: Bash
+>    > ```ini
+>    >    <job_conf>
+>    >        <plugins workers="4">
+>    >            <plugin id="local" type="runner" load="galaxy.jobs.runners.local:LocalJobRunner"/>
+>    >        </plugins>
+>    >        <destinations default="local">
+>    >            <destination id="local" runner="local"/>
+>    >        </destinations>
+>    >        <tools>
+>    >        </tools>
+>    >    </job_conf>
+>    > ```
+>    {: .code-out}
 >
 {: .hands_on}
 

--- a/topics/admin/tutorials/ansible-galaxy/tutorial.md
+++ b/topics/admin/tutorials/ansible-galaxy/tutorial.md
@@ -1861,9 +1861,10 @@ In order to be the administrator user, you will need to register an account with
 
 ## Job Configuration
 
-One of the most important configuration files for a large Galaxy server is the `job_conf.xml` file. This file tells Galaxy where to run all of the jobs that users execute. If Galaxy can't find a job conf file or none have been specified in the `galaxy.yml` file, it will use a default configuration. The default configuration is the `job_conf.xml.sample_basic` file. This file is located at: `/srv/galaxy/server/lib/galaxy/config/sample/job_conf.xml.sample_basic`, though there is a symlink to the file in `/srv/galaxy/server/config`.
+One of the most important configuration files for a large Galaxy server is the `job_conf.xml` file. This file tells Galaxy where to run all of the jobs that users execute. If Galaxy can't find a job conf file or none has been specified in the `galaxy.yml` file, it will use a default configuration, `job_conf.xml.sample_basic` file. This file is deployed to `/srv/galaxy/server/lib/galaxy/config/sample/job_conf.xml.sample_basic` (or see it [in the codebase](https://github.com/galaxyproject/galaxy/blob/release_20.05/lib/galaxy/config/sample/job_conf.xml.sample_basic)), though there is a symlink to the file in `/srv/galaxy/server/config`.
 
 The job configuration file allows Galaxy to run jobs in multiple locations using a variety of different mechanisms. Some of these mechanisms include:
+
 * Local - Galaxy runs jobs on the same computer that Galaxy itself is running on.
 * DRMAA - Galaxy can connect to a cluster and submit jobs via a distributed resource manager such as Slurm, Condor, PBS Torque or Sun Grid Engine.
 * Pulsar - Galaxy can also send jobs to remote compute hosts over the internet using Pulsar.
@@ -1871,7 +1872,8 @@ The job configuration file allows Galaxy to run jobs in multiple locations using
 ### The job conf file - basics
 
 The `job_conf.xml` file has three basic sections:
-* **Plugins** - This section lists the types of job management systems that this Galaxy server is configured to use and tells Galaxy to load the drivers for each type.
+
+* **Plugins** - This section lists the types of job management systems that this Galaxy server is configured to use, and tells Galaxy to load the drivers for each type.
 * **Destinations** - This section lists the different locations, queues, etc. that Galaxy can send jobs to. Each one has a name and uses a *plugin* to communicate with that location. They can specify things like the number of CPUs, amount of RAM to be allocated, etc. for DRMAA locations. Usually, one of the destinations is set to be the default.
 * **Tools** - This section lists the various tools that you would like to send to a non-default *destination*. Each line in this section pairs up a tool in Galaxy with a particular job *destination*. Every time Galaxy gets a job for that particular tool, it is always sent to that *destination*.
 
@@ -1896,8 +1898,9 @@ The above `job_conf.xml` file defines a *plugin* and *destination* to allow Gala
 
 Firstly, the plugins section contains a plugin called "local" which is of type "runner" and then loads the python code module for supporting local jobs. Next the destinations section contains a destination called "local" using the runner "local". As this is the only destination specified, it is also the default. So now everytime a user clicks "Execute" on a tool form, Galaxy will run the corresponding job locally using the python code specified.
 
-There are a lot of other plugins available for Galaxy for using other resources such as docker containers, kubernetes hosts, Pulsar destinations and HPC clusters to name a few. See the Galaxy documentation on [job configuration](https://docs.galaxyproject.org/en/master/admin/jobs.html) for more details on these plugins and their configuration. There is also an advanced sample job conf file located at: `/srv/galaxy/server/lib/galaxy/config/sample/job_conf.xml.sample_advanced`
-
+> ### {% icon tip %} Want to use something else?
+> There are a lot of other plugins available for Galaxy for using other resources such as docker containers, kubernetes hosts, Pulsar destinations and HPC clusters to name a few. See the Galaxy documentation on [job configuration](https://docs.galaxyproject.org/en/master/admin/jobs.html) for more details on these plugins and their configuration. There is also an advanced sample job conf file located at: `/srv/galaxy/server/lib/galaxy/config/sample/job_conf.xml.sample_advanced`
+{: .tip}
 
 > ### {% icon hands_on %} Hands-on: Job Conf
 >
@@ -1940,12 +1943,13 @@ There are a lot of other plugins available for Galaxy for using other resources 
 >    ```
 >    {% endraw %}
 >
-> 4. Run the playbook. At the very end, you should see output like the following indicating that Galaxy has been restarted:
+> 4. Run the playbook: `ansible-playbook galaxy.yml`. At the very end, you should see output like the following indicating that Galaxy has been restarted:
 >
 >    ```
 >    RUNNING HANDLER [restart galaxy] ****************************************
 >    changed: [galaxy.example.org]
 >    ```
+>
 > 5. Checkout the new job_conf.xml file.
 >
 >    > ### {% icon code-in %} Input: Bash
@@ -1956,16 +1960,16 @@ There are a lot of other plugins available for Galaxy for using other resources 
 >
 >    > ### {% icon code-out %} Output: Bash
 >    > ```xml
->    >    <job_conf>
->    >        <plugins workers="4">
->    >            <plugin id="local_plugin" type="runner" load="galaxy.jobs.runners.local:LocalJobRunner"/>
->    >        </plugins>
->    >        <destinations default="local_destination">
->    >            <destination id="local_destination" runner="local_plugin"/>
->    >        </destinations>
->    >        <tools>
->    >        </tools>
->    >    </job_conf>
+>    > <job_conf>
+>    >     <plugins workers="4">
+>    >         <plugin id="local_plugin" type="runner" load="galaxy.jobs.runners.local:LocalJobRunner"/>
+>    >     </plugins>
+>    >     <destinations default="local_destination">
+>    >         <destination id="local_destination" runner="local_plugin"/>
+>    >     </destinations>
+>    >     <tools>
+>    >     </tools>
+>    > </job_conf>
 >    > ```
 >    {: .code-out}
 >

--- a/topics/admin/tutorials/ansible-galaxy/tutorial.md
+++ b/topics/admin/tutorials/ansible-galaxy/tutorial.md
@@ -1890,6 +1890,7 @@ The basic `job_conf.xml` file looks like this:
     </tools>
 </job_conf>
 ```
+{% endraw %}
 
 The above `job_conf.xml` file defines a *plugin* and *destination* to allow Galaxy to run user jobs on the local computer (i.e. The computer that Galaxy is running on.)
 
@@ -1897,21 +1898,20 @@ Firstly, the plugins section contains a plugin called "local" which is of type "
 
 There are a lot of other plugins available for Galaxy for using other resources such as docker containers, kubernetes hosts, Pulsar destinations and HPC clusters to name a few. See the Galaxy documentation on [job configuration](https://docs.galaxyproject.org/en/master/admin/jobs.html) for more details on these plugins and their configuration. There is also an advanced sample job conf file located at: `/srv/galaxy/server/lib/galaxy/config/sample/job_conf.xml.sample_advanced`
 
-{% endraw %}
 
 > ### {% icon hands_on %} Hands-on: Job Conf
 >
 > 1. If the folder does not exist, create `templates/galaxy/config` next to your `galaxy.yml` playbook (`mkdir -p templates/galaxy/config/`).
 >
-> 2. Create `templates/galaxy/config/job_conf.xml.j2` with the following contents:
+> 2. Create `templates/galaxy/config/job_conf.xml.j2` with the following contents (note that we have changed the names of the plugin and destination from the basic sample file to provide a bit more clarity):
 >
 >    ```xml
 >    <job_conf>
 >        <plugins workers="4">
->            <plugin id="local" type="runner" load="galaxy.jobs.runners.local:LocalJobRunner"/>
+>            <plugin id="local_plugin" type="runner" load="galaxy.jobs.runners.local:LocalJobRunner"/>
 >        </plugins>
->        <destinations default="local">
->            <destination id="local" runner="local"/>
+>        <destinations default="local_destination">
+>            <destination id="local_destination" runner="local_plugin"/>
 >        </destinations>
 >        <tools>
 >        </tools>
@@ -1958,10 +1958,10 @@ There are a lot of other plugins available for Galaxy for using other resources 
 >    > ```xml
 >    >    <job_conf>
 >    >        <plugins workers="4">
->    >            <plugin id="local" type="runner" load="galaxy.jobs.runners.local:LocalJobRunner"/>
+>    >            <plugin id="local_plugin" type="runner" load="galaxy.jobs.runners.local:LocalJobRunner"/>
 >    >        </plugins>
->    >        <destinations default="local">
->    >            <destination id="local" runner="local"/>
+>    >        <destinations default="local_destination">
+>    >            <destination id="local_destination" runner="local_plugin"/>
 >    >        </destinations>
 >    >        <tools>
 >    >        </tools>

--- a/topics/admin/tutorials/ansible-galaxy/tutorial.md
+++ b/topics/admin/tutorials/ansible-galaxy/tutorial.md
@@ -1871,7 +1871,7 @@ The job configuration file allows Galaxy to run jobs in multiple locations using
 ### The job conf file - basics
 
 The `job_conf.xml` file has three basic sections:
-* **Plugins** - This section lists the types of resources that this Galaxy server is configured to use and tells Galaxy to load the drivers for each type.
+* **Plugins** - This section lists the types of job management systems that this Galaxy server is configured to use and tells Galaxy to load the drivers for each type.
 * **Destinations** - This section lists the different locations or queues etc that Galaxy can send jobs to. Each one has a name and uses a *plugin* to communicate with that location. They can specify things like the number of cpu's, amount of RAM to be allocated etc for DRMAA locations. Usually one of the destinations is set to be the default.
 * **Tools** - This section lists the various tools that Galaxy would like to send to the non-default *destination*. Each line in this section pairs up a tool in Galaxy with a particular job *destination*. Then everytime Galaxy gets a job for that particular tool, it is always sent to that *destination*.
 

--- a/topics/admin/tutorials/ansible-galaxy/tutorial.md
+++ b/topics/admin/tutorials/ansible-galaxy/tutorial.md
@@ -27,7 +27,7 @@ requirements:
     tutorials:
       - ansible
   - type: "none"
-    title: "A VM with at least 2 vCPUs and 4 GB RAM with Ubuntu 18.04 - 20.04 for preference."
+    title: "A VM with at least 2 vCPUs and 4 GB RAM, preferably running Ubuntu 18.04 - 20.04."
 ---
 
 # Overview

--- a/topics/admin/tutorials/ansible-galaxy/tutorial.md
+++ b/topics/admin/tutorials/ansible-galaxy/tutorial.md
@@ -8,7 +8,7 @@ questions:
 objectives:
 - Have an understanding of how Galaxy's Ansible roles are structured and interact with one another
 - Be able to use an Ansible playbook to install different flavors of Galaxy for different purposes
-time_estimation: "2hr 30min"
+time_estimation: "2h:30m"
 key_points:
 - Basic deployment with Ansible is surprisingly easy
 - Complexity can grow over time as your organisation does, no need to start with playbooks like UseGalaxy.org

--- a/topics/admin/tutorials/ansible-galaxy/tutorial.md
+++ b/topics/admin/tutorials/ansible-galaxy/tutorial.md
@@ -1918,7 +1918,7 @@ There are a lot of other plugins available for Galaxy for using other resources 
 >    </job_conf>
 >    ```
 >
-> 3. Inform `galaxyproject.galaxy` of where you would like the `job_conf.xml` to reside in your group variables:
+> 3. Inform `galaxyproject.galaxy` of where you would like the `job_conf.xml` to reside, by setting it in your `group_vars/galaxyservers.yml`:
 >
 >    {% raw %}
 >    ```yaml


### PR DESCRIPTION
Adds the missing section on creation of a simple job conf file to the ansible-galaxy tutorial. This allows for a single day or other shortened course to then go onto other modules like the Pulsar tutorial with the required job conf file in place.