### PR TITLE
Update test for assembly general-introduction and add test for debruijn-graph-assembly

### DIFF
--- a/topics/assembly/tutorials/debruijn-graph-assembly/workflows/debruijn-graph-job1.yml
+++ b/topics/assembly/tutorials/debruijn-graph-assembly/workflows/debruijn-graph-job1.yml
@@ -1,0 +1,6 @@
+mutant_R1:
+  class: File
+  location: https://zenodo.org/api/files/287966da-5411-4f79-8cfb-0ffa84d0d6cc/mutant_R1.fastq
+mutant_R2:
+  class: File
+  location: https://zenodo.org/api/files/287966da-5411-4f79-8cfb-0ffa84d0d6cc/mutant_R2.fastq

--- a/topics/assembly/tutorials/debruijn-graph-assembly/workflows/debruijn-graph-tests.yml
+++ b/topics/assembly/tutorials/debruijn-graph-assembly/workflows/debruijn-graph-tests.yml
@@ -1,0 +1,11 @@
+- doc: Test for debruijn-graph.ga
+  job: debruijn-graph-job1.yml
+  outputs:
+    fasta_stats_spades:
+      asserts:
+        has_text_matching:
+          expression: 'len_N50\s*132559'
+    fasta_stats_velvet:
+      asserts:
+        has_text_matching:
+          expression: 'GC_content\s*33.6'

--- a/topics/assembly/tutorials/debruijn-graph-assembly/workflows/debruijn-graph.ga
+++ b/topics/assembly/tutorials/debruijn-graph-assembly/workflows/debruijn-graph.ga
@@ -16,7 +16,7 @@
           "name": "mutant_R1.fastq"
         }
       ],
-      "label": null,
+      "label": "mutant_R1",
       "name": "Input dataset",
       "outputs": [],
       "position": {
@@ -42,7 +42,7 @@
           "name": "mutant_R2.fastq"
         }
       ],
-      "label": null,
+      "label": "mutant_R2",
       "name": "Input dataset",
       "outputs": [],
       "position": {
@@ -208,7 +208,13 @@
       "tool_version": "1.0.1",
       "type": "tool",
       "uuid": "4999cd50-69fd-4e57-af95-8c73ece1fe31",
-      "workflow_outputs": []
+      "workflow_outputs": [
+        {
+          "label": "fasta_stats_velvet",
+          "output_name": "stats",
+          "uuid": "dacb84a5-5482-4ab0-81ad-e92af21636cd"
+        }
+      ]
     },
     "5": {
       "annotation": "",
@@ -246,7 +252,13 @@
       "tool_version": "1.0.1",
       "type": "tool",
       "uuid": "bfc90a5a-640d-4633-b4df-2f8ccdbfe95b",
-      "workflow_outputs": []
+      "workflow_outputs": [
+        {
+          "label": "fasta_stats_spades",
+          "output_name": "stats",
+          "uuid": "ff376be9-7361-48c6-b1c8-d9f951b9c6fa"
+        }
+      ]
     }
   },
   "tags": [

--- a/topics/assembly/tutorials/general-introduction/data-library.yaml
+++ b/topics/assembly/tutorials/general-introduction/data-library.yaml
@@ -25,3 +25,7 @@ items:
         src: url
         ext: fastqsanger
         info: https://doi.org/10.5281/zenodo.582600
+      - url: https://zenodo.org/api/files/287966da-5411-4f79-8cfb-0ffa84d0d6cc/wildtype.fna
+        src: url
+        ext: fasta
+        info: https://doi.org/10.5281/zenodo.582600

--- a/topics/assembly/tutorials/general-introduction/workflows/assembly-general-introduction-job.yml
+++ b/topics/assembly/tutorials/general-introduction/workflows/assembly-general-introduction-job.yml
@@ -5,3 +5,6 @@ mutant_R1.fastq:
 mutant_R2.fastq:
   class: File
   location: https://zenodo.org/record/582600/files/mutant_R2.fastq
+wildtype.fna:
+  class: File
+  location: https://zenodo.org/api/files/287966da-5411-4f79-8cfb-0ffa84d0d6cc/wildtype.fna

--- a/topics/assembly/tutorials/general-introduction/workflows/assembly-general-introduction-test.yml
+++ b/topics/assembly/tutorials/general-introduction/workflows/assembly-general-introduction-test.yml
@@ -1,8 +1,23 @@
 ---
-- doc: Test sample data for the unicycler assembly workflow
+- doc: Test for the unicycler assembly general introduction workflow
   job: assembly-general-introduction-job.yml
   outputs:
     fasta_stats_tabular:
       asserts:
         has_line:
           line: 'GC_content	33.6'
+  outputs:
+    velvet_contigs:
+      asserts:
+        has_line:
+          line: '>NODE_1_length_933_cov_35.767418'
+    velvet_stats:
+      asserts:
+        has_text_matching:
+          expression: '1\s*933\s*2\s*1\s*0.000000\s*35.767417\s*32.496249\s*0.000000\s*0.000000\s*0.000000\s*0.000000\s*0.000000\s*0.000000\s*0\s*0\s*0\s*0\s*0'
+    quast_report_html:
+      asserts:
+        has_text:
+          text: '<html'
+
+

--- a/topics/assembly/tutorials/general-introduction/workflows/assembly-general-introduction.ga
+++ b/topics/assembly/tutorials/general-introduction/workflows/assembly-general-introduction.ga
@@ -80,7 +80,7 @@
                     "name": "Genome file"
                 }
             ], 
-            "label": "Genome file", 
+            "label": "wildtype.fna", 
             "name": "Input dataset", 
             "outputs": [], 
             "position": {
@@ -155,12 +155,12 @@
             "uuid": "3a5a44fd-e16b-4069-82f3-2cd7eabada8b", 
             "workflow_outputs": [
                 {
-                    "label": null, 
+                    "label": "fastqc_html", 
                     "output_name": "html_file", 
                     "uuid": "22a51e6e-2e5f-4415-a127-e0b1c179a1b1"
                 }, 
                 {
-                    "label": null, 
+                    "label": "fastqc_txt", 
                     "output_name": "text_file", 
                     "uuid": "51ec8c05-eb47-4359-9120-0eca1a6d5c2f"
                 }
@@ -278,12 +278,12 @@
             "uuid": "af9b6352-c51e-4f0c-83f6-4f5b9272985a", 
             "workflow_outputs": [
                 {
-                    "label": null, 
+                    "label": "output_pairs", 
                     "output_name": "outfile_pairs", 
                     "uuid": "225edf5f-3b90-4f84-a38a-5c786000a3fc"
                 }, 
                 {
-                    "label": null, 
+                    "label": "output_singles", 
                     "output_name": "outfile_singles", 
                     "uuid": "dae90093-ae96-4bb2-824d-c92b61585096"
                 }
@@ -335,12 +335,12 @@
             "uuid": "95440a74-31d3-4b9c-8c8f-4e91fd54cf01", 
             "workflow_outputs": [
                 {
-                    "label": null, 
+                    "label": "multiqc_stats", 
                     "output_name": "stats", 
                     "uuid": "85e3704a-859d-4657-b3d7-9b67e4981d21"
                 }, 
                 {
-                    "label": null, 
+                    "label": "multiqc_report", 
                     "output_name": "html_report", 
                     "uuid": "fab7e06a-604e-4432-b0ed-b63157a8643b"
                 }
@@ -384,7 +384,7 @@
             "uuid": "f98f0453-b473-4407-82da-8348aff285dd", 
             "workflow_outputs": [
                 {
-                    "label": null, 
+                    "label": "velveth_out", 
                     "output_name": "out_file1", 
                     "uuid": "607a214d-9137-4e73-9b73-954c79678937"
                 }
@@ -432,12 +432,12 @@
             "uuid": "c34bb33c-0e8a-4698-a370-f8d8f96f0921", 
             "workflow_outputs": [
                 {
-                    "label": null, 
+                    "label": "velvet_contigs",
                     "output_name": "contigs", 
                     "uuid": "b0cf3779-6199-42c9-963f-a733559f90bb"
                 }, 
                 {
-                    "label": null, 
+                    "label": "velvet_stats",
                     "output_name": "stats", 
                     "uuid": "54926701-ccae-4143-b649-b7e08e1c6a8e"
                 }
@@ -526,12 +526,12 @@
             "uuid": "80922e53-cb63-4bba-8fd6-d53e48b17327", 
             "workflow_outputs": [
                 {
-                    "label": null, 
+                    "label": "quast_report_html", 
                     "output_name": "report_html", 
                     "uuid": "0babe959-4d63-4838-9e18-4526b3dd0db5"
                 }, 
                 {
-                    "label": null, 
+                    "label": "quast_report_pdf", 
                     "output_name": "report_pdf", 
                     "uuid": "f41c43c4-763c-42bc-b36e-9ea76e7752c2"
                 }


### PR DESCRIPTION
Both passing on usegalaxy.org.au.  The debruijn-graph-assembly one was generated with `planemo workflow_test_init` from https://github.com/galaxyproject/planemo/pull/1028 (thank you @mvdbeek for putting me on to this)

