### PR TITLE
Add tool link for tbvcfreport

### DIFF
--- a/topics/variant-analysis/tutorials/tb-variant-analysis/tutorial.md
+++ b/topics/variant-analysis/tutorials/tb-variant-analysis/tutorial.md
@@ -274,7 +274,7 @@ Finally, TB Variant Report use the COMBAT-TB [eXplorer](https://explorer.sanbi.a
 >       **TB Profiler** produces 3 output files, it's own VCF file, a report about the sample including it's likely lineages and any AMR found. There is also a `.json` formatted results file.
 >
 >
-> 2. **TB Variant Report**: {% icon tool %} with the following parameters
+> 2. {% tool [TB Variant Report](toolshed.g2.bx.psu.edu/repos/iuc/tbvcfreport/tbvcfreport/0.1.7+galaxy0) %}: {% icon tool %} with the following parameters
 >   - *"Input SnpEff annotated M.tuberculosis VCF(s)"*: `TB-Profiler Profile VCF on data XX`
 >   - *"TBProfiler Drug Resistance Report (Optional)"*: `TB-Profiler Profile on data XX: Results.json`
 >


### PR DESCRIPTION
Minor change to add tool link for tbvcfreport tool to M. tuberculosis variant annotation tutorial