### PR TITLE
change expected test output for tbvcfreport

### DIFF
--- a/topics/variant-analysis/tutorials/tb-variant-analysis/workflows/tb-variant-analysis-test.yml
+++ b/topics/variant-analysis/tutorials/tb-variant-analysis/workflows/tb-variant-analysis-test.yml
@@ -37,7 +37,7 @@
     mtbva_tb_variant_report_html:
       asserts:
         has_text:
-          text: 'c.481C>T'
+          text: 'Leu161Leu'
     mtbva_tb_variant_dr_report_html:
       asserts:
         has_text:


### PR DESCRIPTION
The current test fails on usegalaxy.org.au because it looks for 'c.481C>T' which gets rendered as 'c.481C&gt;T' there. This PR updates that test to look for 'Leu161Leu' instead (part of the same output row) to avoid problems with HTML escapes.