### PR TITLE
GALAXY

### DIFF
--- a/.dockstore.yml
+++ b/.dockstore.yml
@@ -1,17 +1,17 @@
 version: 1.2
 workflows:
   - name: intro-short
-    subclass: GXFORMAT2
+    subclass: GALAXY
     primaryDescriptorPath: topics/introduction/tutorials/galaxy-intro-short/workflows/Galaxy-Workflow-galaxy-intro-short.ga
   - name: intro-everyone
-    subclass: GXFORMAT2
+    subclass: GALAXY
     primaryDescriptorPath: topics/introduction/tutorials/galaxy-intro-101-everyone/workflows/main_workflow.ga
   - name: de-novo
-    subclass: GXFORMAT2
+    subclass: GALAXY
     primaryDescriptorPath: topics/transcriptomics/tutorials/full-de-novo/workflows/main_workflow.ga
   - name: dip
-    subclass: GXFORMAT2
+    subclass: GALAXY
     primaryDescriptorPath: topics/variant-analysis/tutorials/dip/workflows/diploid.ga
   - name: genome-annotation
-    subclass: GXFORMAT2
+    subclass: GALAXY
     primaryDescriptorPath: topics/genome-annotation/tutorials/annotation-with-prokka/workflows/Galaxy-Workflow-Workflow_constructed_from_history__prokka-workflow_.ga


### PR DESCRIPTION
dockstore/dockstore#3186
Dockstore has updated the subclass to be `GALAXY` so this change is needed to register these workflows on Dockstore using GitHub Apps. Once merged, who can I talk to about getting these workflows registered on Dockstore?