### PR TITLE
htmlproofer: do not check anchors on remark slides

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -116,7 +116,7 @@ check-html-internal: build ## validate HTML (internal links only)
 		htmlproofer \
 	      	--assume-extension \
 	      	--http-status-ignore 405,503,999 \
-	      	--url-ignore "/.*localhost.*/","/.*vimeo\.com.*/","/.*gitter\.im.*/","/.*drmaa\.org.*/" \
+	      	--url-ignore "/.*localhost.*/","/.*vimeo\.com.*/","/.*gitter\.im.*/","/.*drmaa\.org.*/","/.*slides.html#/" \
 	      	--url-swap "github.com/galaxyproject/training-material/tree/master:github.com/${REPO}/tree/${BRANCH}" \
 	      	--file-ignore "/.*\/files\/.*/","/.*\/node_modules\/.*/" \
 	      	--disable-external \


### PR DESCRIPTION
Named slides in remark allow for referencing specific slides via anchors, but htmlproofer will fail on such links because the html for the slides is rendered on the fly, so this ignores these anchors on `slides.html`, should fix the errors on https://github.com/galaxyproject/training-material/pull/2014

