### PR TITLE
Tweak dockstore YAML (just trying to trigger a Dockstore update)

### DIFF
--- a/.dockstore.yml
+++ b/.dockstore.yml
@@ -1,3 +1,4 @@
+# Register workflows for Dockstore (https://dockstore.org/)
 version: 1.2
 workflows:
   - name: intro-short


### PR DESCRIPTION
My admin powers have been defeated. 

```
remote: Resolving deltas: 100% (2/2), completed with 2 local objects.
remote: error: GH006: Protected branch update failed for refs/heads/master.
remote: error: At least 1 approving review is required by reviewers with write access.
To github.com:galaxyproject/training-material.git
 ! [remote rejected]     master -> master (protected branch hook declined)
error: failed to push some refs to 'git@github.com:galaxyproject/training-material.git'
```