### PR TITLE
Contributing fixes

### DIFF
--- a/topics/contributing/tutorials/github-command-line-contribution/tutorial.md
+++ b/topics/contributing/tutorials/github-command-line-contribution/tutorial.md
@@ -62,7 +62,7 @@ Forking a repository is a simple two-step process:
 
 > ### {% icon hands_on %} Hands-on: Fork the repository
 >
-> 1. Go on the GitHub repository: [{{ site.github_repository }}]({{ site.github.repository }})
+> 1. Go on the GitHub repository: [{{ site.github_repository }}]({{ site.github_repository }})
 > 2. Click on **Fork** (top-right corner of the page)
 >
 >    ![Fork](../../images/PR_fork.jpg)

--- a/topics/contributing/tutorials/github-command-line-contribution/tutorial.md
+++ b/topics/contributing/tutorials/github-command-line-contribution/tutorial.md
@@ -28,7 +28,7 @@ contributors:
 # Introduction
 {:.no_toc}
 
-Most of the content is written in [GitHub Flavored Markdown](https://guides.github.com/features/mastering-markdown/) with some metadata (or variables) found in [YAML](http://yaml.org/) files. Everything is stored on a [GitHub](https://github.com) repository: [{{ site.github_repository }}]({{ site.github.repository_url }}).
+Most of the content is written in [GitHub Flavored Markdown](https://guides.github.com/features/mastering-markdown/) with some metadata (or variables) found in [YAML](http://yaml.org/) files. Everything is stored on a [GitHub](https://github.com) repository: [{{ site.github_repository }}]({{ site.github_repository }}).
 
 The process of development of new content is open and transparent, using git and following the [GitHub flow](https://guides.github.com/introduction/flow/):
 
@@ -62,7 +62,7 @@ Forking a repository is a simple two-step process:
 
 > ### {% icon hands_on %} Hands-on: Fork the repository
 >
-> 1. Go on the GitHub repository: [{{ site.github_repository }}]({{ site.github.repository_url }})
+> 1. Go on the GitHub repository: [{{ site.github_repository }}]({{ site.github.repository }})
 > 2. Click on **Fork** (top-right corner of the page)
 >
 >    ![Fork](../../images/PR_fork.jpg)


### PR DESCRIPTION
Some of the links to the github repo went instead to the training website - I removed the .url extension on these (and added in underscore) so that they link to the actual github repo. (I think this should work?) 
