### PR TITLE
The final redirect

### DIFF
--- a/_layouts/base.html
+++ b/_layouts/base.html
@@ -59,4 +59,17 @@
     <script type="text/javascript" src="{{ site.baseurl }}/assets/js/list.min.js"></script>
     <script type="text/javascript" src="{{ site.baseurl }}/assets/js/topic.js"></script>
     {% endif %}
+
+    <script type="text/javascript">
+        if(window.location.hostname === "galaxyproject.github.io") {
+            // Redirect
+            var redirect = "https://training.galaxyproject.org" + window.location.pathname + window.location.search;
+            $('div.container.main-content').prepend("<div class='alert alert-warning'><strong>Note: </strong>This content has a new home at <a href=\"" + redirect + "\">" + redirect + "</a>, which you will be redirected to in 5 seconds.</div>");
+
+            window.setTimeout(function(){
+                window.location.href = redirect;
+            }, 5000)
+
+        }
+    </script>
 </html>

--- a/_layouts/base_slides.html
+++ b/_layouts/base_slides.html
@@ -131,5 +131,19 @@ This material is licensed under the <a rel="license" href="https://creativecommo
         target:function(trigger){return trigger.parentElement;
       }});
     </script>
+
+    <script type="text/javascript">
+        if(window.location.hostname === "galaxyproject.github.io") {
+            // Redirect
+            var redirect = "https://training.galaxyproject.org" + window.location.pathname + window.location.search;
+            $('body').prepend("<div style='text-align: center'><strong>Note: </strong>This content has a new home at <a href=\"" + redirect + "\">" + redirect + "</a>, which you will be redirected to in 5 seconds.</div>");
+
+            window.setTimeout(function(){
+                window.location.href = redirect;
+            }, 5000)
+
+        }
+    </script>
+
   </body>
 </html>


### PR DESCRIPTION
So we did a partial move to the new domain (training.galaxyproject.org) from our old galaxyproject.github.io address and let people update their address books when they felt like it.

This is the next part of that move: now all traffic going to galaxyproject.github.io will be redirected automatically to the new domain.

I had avoided this during the original move because I didn't have a clean solution for it (I was thinking we would have to add redirects to each html page or something crazy, and that was going to be very difficult to make work.) Thanks to @dannon for the idea, this is a lot simpler. We add some JS to do the redirection, if and only if they're on that domain. (@Dannon I've requested a review, can you do a sanity check for me? Does this look ok?)


In the future we can discuss if we want:
- to continue using the galaxyproject proxy, or to use github custom domains
- if we want it to point to the gh-pages deployed site, or if we want to push everything to s3, and proxy to that.
- etc.

But those don't need to be decided now.