### PR TITLE
Galaxy paper-cut: fix missing link for zenodo (input data) in climate101

### DIFF
--- a/topics/climate/tutorials/climate-101/tutorial.md
+++ b/topics/climate/tutorials/climate-101/tutorial.md
@@ -68,7 +68,7 @@ Freiburg). The data format may also have been changed (for instance to tabular) 
 >
 > 1. Create a new history for this tutorial. If you are not inspired, you can name it *climate101*.
 >    {% include snippets/create_new_history.md %}
-> 2. Import the files from [Zenodo]() or from the shared data library
+> 2. Import the files from [Zenodo](https://doi.org/10.5281/zenodo.3776500) or from the shared data library
 >
 >    ```
 >    https://zenodo.org/record/3776500/files/tg_ens_mean_0.1deg_reg_v20.0e_Paris_daily.csv


### PR DESCRIPTION
Found a missing link in climate 101 tutorial.