### PR TITLE
Sort tutorials case-insensitively on topic page

### DIFF
--- a/_plugins/jekyll-topic-filter.rb
+++ b/_plugins/jekyll-topic-filter.rb
@@ -168,7 +168,7 @@ module Jekyll
 
       # The complete resources we'll return is the introduction slides first
       # (regardless of alphabetisation), and then the rest of the pages.
-      resource_pages = resource_intro + resource_pages.sort_by{ |k| k["title"] }
+      resource_pages = resource_intro + resource_pages.sort_by{ |k| k["title"].downcase}
 
       if resource_pages.length == 0 then
         puts "Error? Could not find any relevant pages for #{topic_name}"


### PR DESCRIPTION
for example to fix this ordering (in proteomics topic):

![image](https://user-images.githubusercontent.com/2563865/96848790-275b4280-1455-11eb-872f-66f3e376bed6.png)
