### PR TITLE
[Mapping slides] alignment game broken, use waybackmachine link until fixed

### DIFF
--- a/topics/sequence-analysis/tutorials/mapping/slides.html
+++ b/topics/sequence-analysis/tutorials/mapping/slides.html
@@ -491,7 +491,8 @@ These different mappings led to different variants, and hard to tell they are eq
 
 - Lego time! Who wants to volunteer?
 
-- Or try this [online sequence alignment game](http://teacheng.illinois.edu/SequenceAlignment/):
+- Or try this [online sequence alignment game](http://web.archive.org/web/20200411075748/https://teacheng.illinois.edu/SequenceAlignment/):
+<!-- using webarchive version because game seems broken, once fixed we can update the link back to: http://teacheng.illinois.edu/SequenceAlignment/ -->
 
 .image-75[![Recording of alignment game](../../images/mapping/alignment.gif)]
 


### PR DESCRIPTION
We were teaching this today and noticed the alignment game linked from the slides was not working properly. But a version cached by waybackmachine still worked, so updating the link temporarily until the game works again