### PR TITLE
Data library update

### DIFF
--- a/bin/schema-tutorial.yaml
+++ b/bin/schema-tutorial.yaml
@@ -45,6 +45,7 @@ mapping:
     zenodo_link:
         type: str
         required: false
+        pattern: /^https:\/\/(zenodo.org\/record\/|doi.org\/10.5281\/zenodo\.)[0-9]{4,}$/
     tags:
         type: seq
         required: false

--- a/topics/admin/slides/introduction.html
+++ b/topics/admin/slides/introduction.html
@@ -4,7 +4,6 @@ logo: "GTN"
 
 title: "Galaxy from an administrator's point of view"
 type: "introduction"
-zenodo_link: ""
 questions:
   - What options to deploy Galaxy do I have?
   - Which platforms are supported by Galaxy?

--- a/topics/admin/tutorials/ansible/tutorial.md
+++ b/topics/admin/tutorials/ansible/tutorial.md
@@ -2,7 +2,6 @@
 layout: tutorial_hands_on
 
 title: "Ansible"
-zenodo_link: ""
 questions:
   - Why Ansible?
   - How and when to use Ansible?

--- a/topics/admin/tutorials/cvmfs-manual/tutorial.md
+++ b/topics/admin/tutorials/cvmfs-manual/tutorial.md
@@ -2,7 +2,6 @@
 layout: tutorial_hands_on
 
 title: "Reference Data with CVMFS without Ansible"
-zenodo_link: ""
 questions:
 objectives:
   - Have an understanding of what CVMFS is and how it works

--- a/topics/admin/tutorials/cvmfs/tutorial.md
+++ b/topics/admin/tutorials/cvmfs/tutorial.md
@@ -2,7 +2,6 @@
 layout: tutorial_hands_on
 
 title: "Reference Data with CVMFS"
-zenodo_link: ""
 questions:
 objectives:
   - Have an understanding of what CVMFS is and how it works

--- a/topics/admin/tutorials/database-schema/tutorial.md
+++ b/topics/admin/tutorials/database-schema/tutorial.md
@@ -2,7 +2,6 @@
 layout: tutorial_hands_on
 
 title: "Galaxy Database schema"
-zenodo_link: ""
 questions:
   - "Running a production Galaxy server, you some times end up in with a situation, where you manually need to interact with the Galaxy database: how do you do that"
   - "How to extract usage information, which can not be gathered using the given report tools"

--- a/topics/admin/tutorials/gxadmin/tutorial.md
+++ b/topics/admin/tutorials/gxadmin/tutorial.md
@@ -2,7 +2,6 @@
 layout: tutorial_hands_on
 
 title: "Galaxy Monitoring with gxadmin"
-zenodo_link: ""
 questions:
   - What is gxadmin
   - What can it do?

--- a/topics/admin/tutorials/interactive-tools/tutorial.md
+++ b/topics/admin/tutorials/interactive-tools/tutorial.md
@@ -2,7 +2,6 @@
 layout: tutorial_hands_on
 
 title: "Galaxy Interactive Tools"
-zenodo_link: ""
 questions:
 objectives:
   - Understand what Galaxy Interactive Tools are and how they work

--- a/topics/admin/tutorials/job-metrics/tutorial.md
+++ b/topics/admin/tutorials/job-metrics/tutorial.md
@@ -2,7 +2,6 @@
 layout: tutorial_hands_on
 
 title: "Recording Job Metrics"
-zenodo_link: ""
 questions:
 objectives:
   - What are job metrics?

--- a/topics/admin/tutorials/maintenance/slides.html
+++ b/topics/admin/tutorials/maintenance/slides.html
@@ -3,7 +3,6 @@ layout: tutorial_slides
 logo: "GTN"
 
 title: "Server Maintenance and Backups"
-zenodo_link: ""
 questions:
   - How do I maintain a Galaxy server?
   - What happens if I lose everything?

--- a/topics/admin/tutorials/reports/tutorial.md
+++ b/topics/admin/tutorials/reports/tutorial.md
@@ -2,7 +2,6 @@
 layout: tutorial_hands_on
 
 title: "Galaxy Monitoring with Reports"
-zenodo_link: ""
 questions:
   - How to monitor a Galaxy service with the Reports application?
 objectives:

--- a/topics/admin/tutorials/stuff/slides.html
+++ b/topics/admin/tutorials/stuff/slides.html
@@ -4,7 +4,6 @@ logo: "GTN"
 
 title: "Server: Other"
 enable: false
-zenodo_link: ""
 questions:
   - How to monitor a Galaxy service?
 objectives:

--- a/topics/admin/tutorials/terraform/tutorial.md
+++ b/topics/admin/tutorials/terraform/tutorial.md
@@ -2,7 +2,6 @@
 layout: tutorial_hands_on
 
 title: "Deploying a compute cluster in OpenStack via Terraform"
-zenodo_link: ""
 questions:
   - What is Terraform?
   - In which situations is it good/bad?

--- a/topics/admin/tutorials/tiaas/tutorial.md
+++ b/topics/admin/tutorials/tiaas/tutorial.md
@@ -2,7 +2,6 @@
 layout: tutorial_hands_on
 
 title: "Training Infrastructure as a Service (TIaaS)"
-zenodo_link: ""
 questions:
   - How to deploy EU's TIaaS
 objectives:

--- a/topics/admin/tutorials/upgrading/slides.html
+++ b/topics/admin/tutorials/upgrading/slides.html
@@ -3,7 +3,6 @@ layout: tutorial_slides
 logo: "GTN"
 
 title: "Upgrading Galaxy"
-zenodo_link: ""
 questions:
   - What is the release cycle of Galaxy?
   - What do I need to do before updating my Galaxy server?

--- a/topics/admin/tutorials/users-groups-quotas/slides.html
+++ b/topics/admin/tutorials/users-groups-quotas/slides.html
@@ -3,7 +3,6 @@ layout: tutorial_slides
 logo: "GTN"
 
 title: "User, Group and Quota managment"
-zenodo_link: ""
 questions:
   - How does Galaxy manage users and groups?
   - How can I assign Quotas to specific users/groups?

--- a/topics/assembly/tutorials/assembly-with-preprocessing/data-library.yaml
+++ b/topics/assembly/tutorials/assembly-with-preprocessing/data-library.yaml
@@ -1,0 +1,56 @@
+---
+destination:
+  type: library
+  name: GTN - Material
+  description: Galaxy Training Network Material
+  synopsis: Galaxy Training Network Material. See https://training.galaxyproject.org
+items:
+- name: Assembly
+  description: DNA sequence data has become an indispensable tool for Molecular Biology
+    & Evolutionary Biology. Study in these fields now require a genome sequence to
+    work from. We call this a 'Reference Sequence.' We need to build a reference for
+    each species. We do this by Genome Assembly. De novo Genome Assembly is the process
+    of reconstructing the original DNA sequence from the fragment reads alone.
+  items:
+  - name: Unicycler assembly of SARS-CoV-2 genome with preprocessing to remove human
+      genome reads
+    items:
+    - name: 'DOI: 10.5281/zenodo.3732358'
+      description: latest
+      items:
+      - url: https://zenodo.org/api/files/28b4a623-35a4-428d-a3dd-77d26f9eb4b6/SRR10902284_ONT.fq.gz
+        src: url
+        ext: gz
+        info: https://doi.org/10.5281/zenodo.3732358
+      - url: https://zenodo.org/api/files/28b4a623-35a4-428d-a3dd-77d26f9eb4b6/SRR10903401_r1.fq.gz
+        src: url
+        ext: gz
+        info: https://doi.org/10.5281/zenodo.3732358
+      - url: https://zenodo.org/api/files/28b4a623-35a4-428d-a3dd-77d26f9eb4b6/SRR10903401_r2.fq.gz
+        src: url
+        ext: gz
+        info: https://doi.org/10.5281/zenodo.3732358
+      - url: https://zenodo.org/api/files/28b4a623-35a4-428d-a3dd-77d26f9eb4b6/SRR10903402_r1.fq.gz
+        src: url
+        ext: gz
+        info: https://doi.org/10.5281/zenodo.3732358
+      - url: https://zenodo.org/api/files/28b4a623-35a4-428d-a3dd-77d26f9eb4b6/SRR10903402_r2.fq.gz
+        src: url
+        ext: gz
+        info: https://doi.org/10.5281/zenodo.3732358
+      - url: https://zenodo.org/api/files/28b4a623-35a4-428d-a3dd-77d26f9eb4b6/SRR10948474_ONT.fq.gz
+        src: url
+        ext: gz
+        info: https://doi.org/10.5281/zenodo.3732358
+      - url: https://zenodo.org/api/files/28b4a623-35a4-428d-a3dd-77d26f9eb4b6/SRR10948550_ONT.fq.gz
+        src: url
+        ext: gz
+        info: https://doi.org/10.5281/zenodo.3732358
+      - url: https://zenodo.org/api/files/28b4a623-35a4-428d-a3dd-77d26f9eb4b6/SRR10971381_r1.fq.gz
+        src: url
+        ext: gz
+        info: https://doi.org/10.5281/zenodo.3732358
+      - url: https://zenodo.org/api/files/28b4a623-35a4-428d-a3dd-77d26f9eb4b6/SRR10971381_r2.fq.gz
+        src: url
+        ext: gz
+        info: https://doi.org/10.5281/zenodo.3732358

--- a/topics/assembly/tutorials/general-introduction/data-library.yaml
+++ b/topics/assembly/tutorials/general-introduction/data-library.yaml
@@ -29,3 +29,11 @@ items:
         src: url
         ext: fasta
         info: https://doi.org/10.5281/zenodo.582600
+      - url: https://zenodo.org/api/files/287966da-5411-4f79-8cfb-0ffa84d0d6cc/wildtype.gbk
+        src: url
+        ext: gbk
+        info: https://doi.org/10.5281/zenodo.582600
+      - url: https://zenodo.org/api/files/287966da-5411-4f79-8cfb-0ffa84d0d6cc/wildtype.gff
+        src: url
+        ext: gff
+        info: https://doi.org/10.5281/zenodo.582600

--- a/topics/climate/tutorials/climate-101/data-library.yaml
+++ b/topics/climate/tutorials/climate-101/data-library.yaml
@@ -1,0 +1,23 @@
+---
+destination:
+  type: library
+  name: GTN - Material
+  description: Galaxy Training Network Material
+  synopsis: Galaxy Training Network Material. See https://training.galaxyproject.org
+items:
+- name: Climate
+  description: Learn to analyze climate data through Galaxy.
+  items:
+  - name: Getting your hands-on climate data
+    items:
+    - name: 'DOI: 10.5281/zenodo.3776499'
+      description: latest
+      items:
+      - url: https://zenodo.org/api/files/c48b8155-3012-463c-b04f-74337a0905b8/tg_ens_mean_0.1deg_reg_v20.0e_Paris_daily.csv
+        src: url
+        ext: csv
+        info: https://doi.org/10.5281/zenodo.3776499
+      - url: https://zenodo.org/api/files/c48b8155-3012-463c-b04f-74337a0905b8/ts_cities.csv
+        src: url
+        ext: csv
+        info: https://doi.org/10.5281/zenodo.3776499

--- a/topics/climate/tutorials/fates-jupyterlab/data-library.yaml
+++ b/topics/climate/tutorials/fates-jupyterlab/data-library.yaml
@@ -1,0 +1,20 @@
+---
+destination:
+  type: library
+  name: GTN - Material
+  description: Galaxy Training Network Material
+  synopsis: Galaxy Training Network Material. See https://training.galaxyproject.org
+items:
+- name: Climate
+  description: Learn to analyze climate data through Galaxy.
+  items:
+  - name: Functionally Assembled Terrestrial Ecosystem Simulator (FATES) with Galaxy
+      Climate JupyterLab
+    items:
+    - name: 'DOI: 10.5281/zenodo.4108341'
+      description: latest
+      items:
+      - url: https://zenodo.org/api/files/d8b1447d-d45d-4c01-a2ea-8af0961b3c27/inputdata_version2.0.0_ALP1.tar
+        src: url
+        ext: '# Please add a Galaxy datatype or update the shared/datatypes.yaml file'
+        info: https://doi.org/10.5281/zenodo.4108341

--- a/topics/climate/tutorials/fates/data-library.yaml
+++ b/topics/climate/tutorials/fates/data-library.yaml
@@ -1,0 +1,19 @@
+---
+destination:
+  type: library
+  name: GTN - Material
+  description: Galaxy Training Network Material
+  synopsis: Galaxy Training Network Material. See https://training.galaxyproject.org
+items:
+- name: Climate
+  description: Learn to analyze climate data through Galaxy.
+  items:
+  - name: Functionally Assembled Terrestrial Ecosystem Simulator (FATES)
+    items:
+    - name: 'DOI: 10.5281/zenodo.4108341'
+      description: latest
+      items:
+      - url: https://zenodo.org/api/files/d8b1447d-d45d-4c01-a2ea-8af0961b3c27/inputdata_version2.0.0_ALP1.tar
+        src: url
+        ext: '# Please add a Galaxy datatype or update the shared/datatypes.yaml file'
+        info: https://doi.org/10.5281/zenodo.4108341

--- a/topics/climate/tutorials/panoply/data-library.yaml
+++ b/topics/climate/tutorials/panoply/data-library.yaml
@@ -1,0 +1,19 @@
+---
+destination:
+  type: library
+  name: GTN - Material
+  description: Galaxy Training Network Material
+  synopsis: Galaxy Training Network Material. See https://training.galaxyproject.org
+items:
+- name: Climate
+  description: Learn to analyze climate data through Galaxy.
+  items:
+  - name: Visualize Climate data with Panoply netCDF viewer
+    items:
+    - name: 'DOI: 10.5281/zenodo.3695482'
+      description: latest
+      items:
+      - url: https://zenodo.org/api/files/2c5972cb-4938-4604-97c2-75230d319708/era5-land.nc
+        src: url
+        ext: '# Please add a Galaxy datatype or update the shared/datatypes.yaml file'
+        info: https://doi.org/10.5281/zenodo.3695482

--- a/topics/computational-chemistry/tutorials/analysis-md-simulations/data-library.yaml
+++ b/topics/computational-chemistry/tutorials/analysis-md-simulations/data-library.yaml
@@ -1,0 +1,23 @@
+---
+destination:
+  type: library
+  name: GTN - Material
+  description: Galaxy Training Network Material
+  synopsis: Galaxy Training Network Material. See https://training.galaxyproject.org
+items:
+- name: Computational chemistry
+  description: Modelling, simulation and analysis of biomolecular systems
+  items:
+  - name: Analysis of molecular dynamics simulations
+    items:
+    - name: 'DOI: 10.5281/zenodo.2537734'
+      description: latest
+      items:
+      - url: https://zenodo.org/api/files/0e28549d-316f-4cca-9352-675f7b8f451d/cbh1test.dcd
+        src: url
+        ext: '# Please add a Galaxy datatype or update the shared/datatypes.yaml file'
+        info: https://zenodo.org/record/2537734
+      - url: https://zenodo.org/api/files/0e28549d-316f-4cca-9352-675f7b8f451d/cbh1test.pdb
+        src: url
+        ext: '# Please add a Galaxy datatype or update the shared/datatypes.yaml file'
+        info: https://zenodo.org/record/2537734

--- a/topics/computational-chemistry/tutorials/cheminformatics/tutorial.md
+++ b/topics/computational-chemistry/tutorials/cheminformatics/tutorial.md
@@ -3,7 +3,6 @@ layout: tutorial_hands_on
 
 title: Protein-ligand docking
 level: Intermediate
-zenodo_link: ''
 questions:
 - What is cheminformatics?
 - What is protein-ligand docking?

--- a/topics/computational-chemistry/tutorials/covid19-docking/data-library.yaml
+++ b/topics/computational-chemistry/tutorials/covid19-docking/data-library.yaml
@@ -1,0 +1,31 @@
+---
+destination:
+  type: library
+  name: GTN - Material
+  description: Galaxy Training Network Material
+  synopsis: Galaxy Training Network Material. See https://training.galaxyproject.org
+items:
+- name: Computational chemistry
+  description: Modelling, simulation and analysis of biomolecular systems
+  items:
+  - name: Virtual screening of the SARS-CoV-2 main protease with rDock and pose scoring
+    items:
+    - name: 'DOI: 10.5281/zenodo.3730474'
+      description: latest
+      items:
+      - url: https://zenodo.org/api/files/8c7cbf84-57cd-43d5-b96e-1316326c8cc5/candidates.smi
+        src: url
+        ext: '# Please add a Galaxy datatype or update the shared/datatypes.yaml file'
+        info: https://zenodo.org/record/3730474
+      - url: https://zenodo.org/api/files/8c7cbf84-57cd-43d5-b96e-1316326c8cc5/frankenstein.sdf
+        src: url
+        ext: '# Please add a Galaxy datatype or update the shared/datatypes.yaml file'
+        info: https://zenodo.org/record/3730474
+      - url: https://zenodo.org/api/files/8c7cbf84-57cd-43d5-b96e-1316326c8cc5/hits.sdf
+        src: url
+        ext: '# Please add a Galaxy datatype or update the shared/datatypes.yaml file'
+        info: https://zenodo.org/record/3730474
+      - url: https://zenodo.org/api/files/8c7cbf84-57cd-43d5-b96e-1316326c8cc5/Mpro-x0195_0_apo-desolv.pdb
+        src: url
+        ext: '# Please add a Galaxy datatype or update the shared/datatypes.yaml file'
+        info: https://zenodo.org/record/3730474

--- a/topics/computational-chemistry/tutorials/htmd-analysis/data-library.yaml
+++ b/topics/computational-chemistry/tutorials/htmd-analysis/data-library.yaml
@@ -1,0 +1,12 @@
+---
+destination:
+  type: library
+  name: GTN - Material
+  description: Galaxy Training Network Material
+  synopsis: Galaxy Training Network Material. See https://training.galaxyproject.org
+items:
+- name: Computational chemistry
+  description: Modelling, simulation and analysis of biomolecular systems
+  items:
+  - name: High Throughput Molecular Dynamics and Analysis
+    items: []

--- a/topics/computational-chemistry/tutorials/htmd-analysis/tutorial.md
+++ b/topics/computational-chemistry/tutorials/htmd-analysis/tutorial.md
@@ -3,7 +3,7 @@ layout: tutorial_hands_on
 
 title: High Throughput Molecular Dynamics and Analysis
 level: Advanced
-zenodo_link: 'https://zenodo.org/badge/latestdoi/260474701'
+zenodo_link: 'https://zenodo.org/record/3813283'
 questions:
 - How are protein-ligand systems parameterized for molecular dynamics simulation?
 - What kind of analysis can be carried out on molecular trajectories?

--- a/topics/computational-chemistry/tutorials/md-simulation-gromacs/data-library.yaml
+++ b/topics/computational-chemistry/tutorials/md-simulation-gromacs/data-library.yaml
@@ -1,0 +1,19 @@
+---
+destination:
+  type: library
+  name: GTN - Material
+  description: Galaxy Training Network Material
+  synopsis: Galaxy Training Network Material. See https://training.galaxyproject.org
+items:
+- name: Computational chemistry
+  description: Modelling, simulation and analysis of biomolecular systems
+  items:
+  - name: Running molecular dynamics simulations using GROMACS
+    items:
+    - name: 'DOI: 10.5281/zenodo.2598415'
+      description: latest
+      items:
+      - url: https://zenodo.org/api/files/5ea22a57-0cb0-4bc8-b79c-545647b67f5f/1AKI_clean.pdb
+        src: url
+        ext: '# Please add a Galaxy datatype or update the shared/datatypes.yaml file'
+        info: https://zenodo.org/record/2598415

--- a/topics/computational-chemistry/tutorials/md-simulation-namd/data-library.yaml
+++ b/topics/computational-chemistry/tutorials/md-simulation-namd/data-library.yaml
@@ -1,0 +1,23 @@
+---
+destination:
+  type: library
+  name: GTN - Material
+  description: Galaxy Training Network Material
+  synopsis: Galaxy Training Network Material. See https://training.galaxyproject.org
+items:
+- name: Computational chemistry
+  description: Modelling, simulation and analysis of biomolecular systems
+  items:
+  - name: Running molecular dynamics simulations using NAMD
+    items:
+    - name: 'DOI: 10.5281/zenodo.3234841'
+      description: latest
+      items:
+      - url: https://zenodo.org/api/files/037b9077-6878-4d36-9553-5575257e9e73/cbh1test.crd
+        src: url
+        ext: '# Please add a Galaxy datatype or update the shared/datatypes.yaml file'
+        info: https://zenodo.org/record/3234841
+      - url: https://zenodo.org/api/files/037b9077-6878-4d36-9553-5575257e9e73/cbh1test.psf
+        src: url
+        ext: '# Please add a Galaxy datatype or update the shared/datatypes.yaml file'
+        info: https://zenodo.org/record/3234841

--- a/topics/computational-chemistry/tutorials/setting-up-molecular-systems/data-library.yaml
+++ b/topics/computational-chemistry/tutorials/setting-up-molecular-systems/data-library.yaml
@@ -1,0 +1,19 @@
+---
+destination:
+  type: library
+  name: GTN - Material
+  description: Galaxy Training Network Material
+  synopsis: Galaxy Training Network Material. See https://training.galaxyproject.org
+items:
+- name: Computational chemistry
+  description: Modelling, simulation and analysis of biomolecular systems
+  items:
+  - name: Setting up molecular systems
+    items:
+    - name: 'DOI: 10.5281/zenodo.2600690'
+      description: latest
+      items:
+      - url: https://zenodo.org/api/files/07c47602-3c27-4790-803b-bd3ff7ecc305/7cel_modeled.pdb
+        src: url
+        ext: '# Please add a Galaxy datatype or update the shared/datatypes.yaml file'
+        info: https://zenodo.org/record/2600690

--- a/topics/contributing/tutorials/create-new-tutorial-content/tutorial.md
+++ b/topics/contributing/tutorials/create-new-tutorial-content/tutorial.md
@@ -41,7 +41,6 @@ The tutorial's content should be placed in the file `tutorial.md`. Its syntax an
 layout: tutorial_hands_on
 
 title: Title of the tutorial
-zenodo_link: ''
 questions:
 - Which biological questions are addressed by the tutorial?
 - Which bioinformatics techniques are important to know for this type of data?

--- a/topics/ecology/tutorials/genetic-map-rad-seq/data-library.yaml
+++ b/topics/ecology/tutorials/genetic-map-rad-seq/data-library.yaml
@@ -15,89 +15,89 @@ items:
       items:
       - url: https://zenodo.org/api/files/af88bbbe-43a7-4c6b-8e12-3477cd3106ad/female
         src: url
-        ext: fasta
+        ext: '# Please add a Galaxy datatype or update the shared/datatypes.yaml file'
         info: https://doi.org/10.5281/zenodo.1219888
       - url: https://zenodo.org/api/files/af88bbbe-43a7-4c6b-8e12-3477cd3106ad/male
         src: url
-        ext: fasta
+        ext: '# Please add a Galaxy datatype or update the shared/datatypes.yaml file'
         info: https://doi.org/10.5281/zenodo.1219888
       - url: https://zenodo.org/api/files/af88bbbe-43a7-4c6b-8e12-3477cd3106ad/progeny_1
         src: url
-        ext: fasta
+        ext: '# Please add a Galaxy datatype or update the shared/datatypes.yaml file'
         info: https://doi.org/10.5281/zenodo.1219888
       - url: https://zenodo.org/api/files/af88bbbe-43a7-4c6b-8e12-3477cd3106ad/progeny_10
         src: url
-        ext: fasta
+        ext: '# Please add a Galaxy datatype or update the shared/datatypes.yaml file'
         info: https://doi.org/10.5281/zenodo.1219888
       - url: https://zenodo.org/api/files/af88bbbe-43a7-4c6b-8e12-3477cd3106ad/progeny_11
         src: url
-        ext: fasta
+        ext: '# Please add a Galaxy datatype or update the shared/datatypes.yaml file'
         info: https://doi.org/10.5281/zenodo.1219888
       - url: https://zenodo.org/api/files/af88bbbe-43a7-4c6b-8e12-3477cd3106ad/progeny_12
         src: url
-        ext: fasta
+        ext: '# Please add a Galaxy datatype or update the shared/datatypes.yaml file'
         info: https://doi.org/10.5281/zenodo.1219888
       - url: https://zenodo.org/api/files/af88bbbe-43a7-4c6b-8e12-3477cd3106ad/progeny_13
         src: url
-        ext: fasta
+        ext: '# Please add a Galaxy datatype or update the shared/datatypes.yaml file'
         info: https://doi.org/10.5281/zenodo.1219888
       - url: https://zenodo.org/api/files/af88bbbe-43a7-4c6b-8e12-3477cd3106ad/progeny_14
         src: url
-        ext: fasta
+        ext: '# Please add a Galaxy datatype or update the shared/datatypes.yaml file'
         info: https://doi.org/10.5281/zenodo.1219888
       - url: https://zenodo.org/api/files/af88bbbe-43a7-4c6b-8e12-3477cd3106ad/progeny_15
         src: url
-        ext: fasta
+        ext: '# Please add a Galaxy datatype or update the shared/datatypes.yaml file'
         info: https://doi.org/10.5281/zenodo.1219888
       - url: https://zenodo.org/api/files/af88bbbe-43a7-4c6b-8e12-3477cd3106ad/progeny_16
         src: url
-        ext: fasta
+        ext: '# Please add a Galaxy datatype or update the shared/datatypes.yaml file'
         info: https://doi.org/10.5281/zenodo.1219888
       - url: https://zenodo.org/api/files/af88bbbe-43a7-4c6b-8e12-3477cd3106ad/progeny_17
         src: url
-        ext: fasta
+        ext: '# Please add a Galaxy datatype or update the shared/datatypes.yaml file'
         info: https://doi.org/10.5281/zenodo.1219888
       - url: https://zenodo.org/api/files/af88bbbe-43a7-4c6b-8e12-3477cd3106ad/progeny_18
         src: url
-        ext: fasta
+        ext: '# Please add a Galaxy datatype or update the shared/datatypes.yaml file'
         info: https://doi.org/10.5281/zenodo.1219888
       - url: https://zenodo.org/api/files/af88bbbe-43a7-4c6b-8e12-3477cd3106ad/progeny_19
         src: url
-        ext: fasta
+        ext: '# Please add a Galaxy datatype or update the shared/datatypes.yaml file'
         info: https://doi.org/10.5281/zenodo.1219888
       - url: https://zenodo.org/api/files/af88bbbe-43a7-4c6b-8e12-3477cd3106ad/progeny_2
         src: url
-        ext: fasta
+        ext: '# Please add a Galaxy datatype or update the shared/datatypes.yaml file'
         info: https://doi.org/10.5281/zenodo.1219888
       - url: https://zenodo.org/api/files/af88bbbe-43a7-4c6b-8e12-3477cd3106ad/progeny_20
         src: url
-        ext: fasta
+        ext: '# Please add a Galaxy datatype or update the shared/datatypes.yaml file'
         info: https://doi.org/10.5281/zenodo.1219888
       - url: https://zenodo.org/api/files/af88bbbe-43a7-4c6b-8e12-3477cd3106ad/progeny_3
         src: url
-        ext: fasta
+        ext: '# Please add a Galaxy datatype or update the shared/datatypes.yaml file'
         info: https://doi.org/10.5281/zenodo.1219888
       - url: https://zenodo.org/api/files/af88bbbe-43a7-4c6b-8e12-3477cd3106ad/progeny_4
         src: url
-        ext: fasta
+        ext: '# Please add a Galaxy datatype or update the shared/datatypes.yaml file'
         info: https://doi.org/10.5281/zenodo.1219888
       - url: https://zenodo.org/api/files/af88bbbe-43a7-4c6b-8e12-3477cd3106ad/progeny_5
         src: url
-        ext: fasta
+        ext: '# Please add a Galaxy datatype or update the shared/datatypes.yaml file'
         info: https://doi.org/10.5281/zenodo.1219888
       - url: https://zenodo.org/api/files/af88bbbe-43a7-4c6b-8e12-3477cd3106ad/progeny_6
         src: url
-        ext: fasta
+        ext: '# Please add a Galaxy datatype or update the shared/datatypes.yaml file'
         info: https://doi.org/10.5281/zenodo.1219888
       - url: https://zenodo.org/api/files/af88bbbe-43a7-4c6b-8e12-3477cd3106ad/progeny_7
         src: url
-        ext: fasta
+        ext: '# Please add a Galaxy datatype or update the shared/datatypes.yaml file'
         info: https://doi.org/10.5281/zenodo.1219888
       - url: https://zenodo.org/api/files/af88bbbe-43a7-4c6b-8e12-3477cd3106ad/progeny_8
         src: url
-        ext: fasta
+        ext: '# Please add a Galaxy datatype or update the shared/datatypes.yaml file'
         info: https://doi.org/10.5281/zenodo.1219888
       - url: https://zenodo.org/api/files/af88bbbe-43a7-4c6b-8e12-3477cd3106ad/progeny_9
         src: url
-        ext: fasta
+        ext: '# Please add a Galaxy datatype or update the shared/datatypes.yaml file'
         info: https://doi.org/10.5281/zenodo.1219888

--- a/topics/ecology/tutorials/regionalGAM/data-library.yaml
+++ b/topics/ecology/tutorials/regionalGAM/data-library.yaml
@@ -10,8 +10,23 @@ items:
   items:
   - name: Regional GAM
     items:
-    - name: 'DOI: 10.5281/zenodo.1324204'
+    - name: 'DOI: 10.5281/zenodo.1324204#.W2BmRn7fNE4'
       description: latest
+      items:
+      - url: https://zenodo.org/api/files/65ae2c8c-3d4c-4e16-b485-883c58a16573/Dataset%20multispecies%20Regional%20GAM.csv
+        src: url
+        ext: csv
+        info: https://zenodo.org/record/1324204#.W2BmRn7fNE4
+      - url: https://zenodo.org/api/files/65ae2c8c-3d4c-4e16-b485-883c58a16573/gatekeeper_CM%20.RData
+        src: url
+        ext: '# Please add a Galaxy datatype or update the shared/datatypes.yaml file'
+        info: https://zenodo.org/record/1324204#.W2BmRn7fNE4
+      - url: https://zenodo.org/api/files/65ae2c8c-3d4c-4e16-b485-883c58a16573/regional%20GAM%20data.csv
+        src: url
+        ext: csv
+        info: https://zenodo.org/record/1324204#.W2BmRn7fNE4
+    - name: 'DOI: 10.5281/zenodo.1324204'
+      description: ''
       items:
       - url: https://zenodo.org/api/files/65ae2c8c-3d4c-4e16-b485-883c58a16573/regional%20GAM%20data.csv
         src: url

--- a/topics/ecology/tutorials/regionalGAM/tutorial.md
+++ b/topics/ecology/tutorials/regionalGAM/tutorial.md
@@ -1,7 +1,7 @@
 ---
 layout: tutorial_hands_on
 title: Regional GAM
-zenodo_link: "https://zenodo.org/record/1324204#.W2BmRn7fNE4"
+zenodo_link: "https://zenodo.org/record/1324204"
 edam_ontology: "topic_0610"
 questions:
     - "What are abundance and trends of a butterfly species?"

--- a/topics/epigenetics/tutorials/atac-seq/data-library.yaml
+++ b/topics/epigenetics/tutorials/atac-seq/data-library.yaml
@@ -17,13 +17,13 @@ items:
       items:
       - url: https://zenodo.org/api/files/b205aa3d-919b-4fbb-a8dd-3ae01d5daa91/ENCFF933NTR.bed.gz
         src: url
-        ext: bed
+        ext: gz
         info: https://zenodo.org/record/3862793
       - url: https://zenodo.org/api/files/b205aa3d-919b-4fbb-a8dd-3ae01d5daa91/SRR891268_chr22_enriched_R1.fastq.gz
         src: url
-        ext: fastqsanger.gz
+        ext: gz
         info: https://zenodo.org/record/3862793
       - url: https://zenodo.org/api/files/b205aa3d-919b-4fbb-a8dd-3ae01d5daa91/SRR891268_chr22_enriched_R2.fastq.gz
         src: url
-        ext: fastqsanger.gz
+        ext: gz
         info: https://zenodo.org/record/3862793

--- a/topics/epigenetics/tutorials/ewas-suite/tutorial.md
+++ b/topics/epigenetics/tutorials/ewas-suite/tutorial.md
@@ -2,7 +2,7 @@
 layout: tutorial_hands_on
 
 title: "Infinium Human Methylation BeadChip"
-zenodo_link: "https://zenodo.org/record/1251211#.WwREQ1Mvz-Y"
+zenodo_link: "https://zenodo.org/record/1251211"
 questions:
   - "Which DNA regions and positions are diffrentialy methylated in pre MAPKi treatment and post MAPKi resistance Melanomas GSE65183?"
   - "How to analyse and visualise Infinium Human Methylation BeadChip's?"

--- a/topics/epigenetics/tutorials/formation_of_super-structures_on_xi/data-library.yaml
+++ b/topics/epigenetics/tutorials/formation_of_super-structures_on_xi/data-library.yaml
@@ -97,3 +97,53 @@ items:
         src: url
         ext: bam
         info: https://doi.org/10.5281/zenodo.1321974
+- name: Epigenetics
+  description: DNA methylation is an epigenetic mechanism used by higher eukaryotes
+    and involved in e.g. gene expression, X-Chromosome inactivating, imprinting, and
+    gene silencing of germline specific gene and repetitive elements.
+  items:
+  - name: Formation of the Super-Structures on the Inactive X
+    items:
+    - name: 'DOI: 10.5281/zenodo.1324070'
+      description: latest
+      items:
+      - url: https://zenodo.org/api/files/67d95c38-5a06-4184-b3a0-a6d3c9f25268/wt_CTCF_rep1.bam
+        src: url
+        ext: bam
+        info: https://zenodo.org/record/1324070
+      - url: https://zenodo.org/api/files/67d95c38-5a06-4184-b3a0-a6d3c9f25268/wt_CTCF_rep2.bam
+        src: url
+        ext: bam
+        info: https://zenodo.org/record/1324070
+      - url: https://zenodo.org/api/files/67d95c38-5a06-4184-b3a0-a6d3c9f25268/wt_H3K27me3_rep1.bam
+        src: url
+        ext: bam
+        info: https://zenodo.org/record/1324070
+      - url: https://zenodo.org/api/files/67d95c38-5a06-4184-b3a0-a6d3c9f25268/wt_H3K27me3_rep2.bam
+        src: url
+        ext: bam
+        info: https://zenodo.org/record/1324070
+      - url: https://zenodo.org/api/files/67d95c38-5a06-4184-b3a0-a6d3c9f25268/wt_H3K4me3_read1.fastq.gz
+        src: url
+        ext: gz
+        info: https://zenodo.org/record/1324070
+      - url: https://zenodo.org/api/files/67d95c38-5a06-4184-b3a0-a6d3c9f25268/wt_H3K4me3_read2.fastq.gz
+        src: url
+        ext: gz
+        info: https://zenodo.org/record/1324070
+      - url: https://zenodo.org/api/files/67d95c38-5a06-4184-b3a0-a6d3c9f25268/wt_H3K4me3_rep1.bam
+        src: url
+        ext: bam
+        info: https://zenodo.org/record/1324070
+      - url: https://zenodo.org/api/files/67d95c38-5a06-4184-b3a0-a6d3c9f25268/wt_H3K4me3_rep2.bam
+        src: url
+        ext: bam
+        info: https://zenodo.org/record/1324070
+      - url: https://zenodo.org/api/files/67d95c38-5a06-4184-b3a0-a6d3c9f25268/wt_input_rep1.bam
+        src: url
+        ext: bam
+        info: https://zenodo.org/record/1324070
+      - url: https://zenodo.org/api/files/67d95c38-5a06-4184-b3a0-a6d3c9f25268/wt_input_rep2.bam
+        src: url
+        ext: bam
+        info: https://zenodo.org/record/1324070

--- a/topics/epigenetics/tutorials/formation_of_super-structures_on_xi/slides.html
+++ b/topics/epigenetics/tutorials/formation_of_super-structures_on_xi/slides.html
@@ -4,7 +4,6 @@ logo: "GTN"
 class: enlarge120
 
 title: "ChIP-seq data analysis"
-zenodo_link: ""
 questions:
   - "What is ChIP-seq?"
 objectives:

--- a/topics/epigenetics/tutorials/tal1-binding-site-identification/data-library.yaml
+++ b/topics/epigenetics/tutorials/tal1-binding-site-identification/data-library.yaml
@@ -55,3 +55,54 @@ items:
         src: url
         ext: bed
         info: https://doi.org/10.5281/zenodo.197100
+- name: Epigenetics
+  description: DNA methylation is an epigenetic mechanism used by higher eukaryotes
+    and involved in e.g. gene expression, X-Chromosome inactivating, imprinting, and
+    gene silencing of germline specific gene and repetitive elements.
+  items:
+  - name: Identification of the binding sites of the T-cell acute lymphocytic leukemia
+      protein 1 (TAL1)
+    items:
+    - name: 'DOI: 10.5281/zenodo.197100'
+      description: latest
+      items:
+      - url: https://zenodo.org/api/files/20ff737e-c485-45e9-99dc-8bfb6a776478/ChIPseq_regions_of_interest_v4.bed
+        src: url
+        ext: bed
+        info: https://doi.org/10.5281/zenodo.197100
+      - url: https://zenodo.org/api/files/20ff737e-c485-45e9-99dc-8bfb6a776478/G1E_input_R1_downsampled_SRR507859.fastqsanger
+        src: url
+        ext: fastqsanger
+        info: https://doi.org/10.5281/zenodo.197100
+      - url: https://zenodo.org/api/files/20ff737e-c485-45e9-99dc-8bfb6a776478/G1E_input_R2_downsampled_SRR507860.fastqsanger
+        src: url
+        ext: fastqsanger
+        info: https://doi.org/10.5281/zenodo.197100
+      - url: https://zenodo.org/api/files/20ff737e-c485-45e9-99dc-8bfb6a776478/G1E_Tal1_R1_downsampled_SRR492444.fastqsanger
+        src: url
+        ext: fastqsanger
+        info: https://doi.org/10.5281/zenodo.197100
+      - url: https://zenodo.org/api/files/20ff737e-c485-45e9-99dc-8bfb6a776478/G1E_Tal1_R2_downsampled_SRR492445.fastqsanger
+        src: url
+        ext: fastqsanger
+        info: https://doi.org/10.5281/zenodo.197100
+      - url: https://zenodo.org/api/files/20ff737e-c485-45e9-99dc-8bfb6a776478/Megakaryocyte_input_R1_downsampled_SRR492453.fastqsanger
+        src: url
+        ext: fastqsanger
+        info: https://doi.org/10.5281/zenodo.197100
+      - url: https://zenodo.org/api/files/20ff737e-c485-45e9-99dc-8bfb6a776478/Megakaryocyte_input_R2_downsampled_SRR492454.fastqsanger
+        src: url
+        ext: fastqsanger
+        info: https://doi.org/10.5281/zenodo.197100
+      - url: https://zenodo.org/api/files/20ff737e-c485-45e9-99dc-8bfb6a776478/Megakaryocytes_Tal1_R2_downsampled_SRR549007.fastqsanger
+        src: url
+        ext: fastqsanger
+        info: https://doi.org/10.5281/zenodo.197100
+      - url: https://zenodo.org/api/files/20ff737e-c485-45e9-99dc-8bfb6a776478/Megakaryocyte_Tal1_R1_downsampled_SRR549006.fastqsanger
+        src: url
+        ext: fastqsanger
+        info: https://doi.org/10.5281/zenodo.197100
+      - url: https://zenodo.org/api/files/20ff737e-c485-45e9-99dc-8bfb6a776478/RefSeq_gene_annotations_mm10.bed
+        src: url
+        ext: bed
+        info: https://doi.org/10.5281/zenodo.197100

--- a/topics/galaxy-interface/tutorials/collections/tutorial.md
+++ b/topics/galaxy-interface/tutorials/collections/tutorial.md
@@ -6,7 +6,6 @@ redirect_from:
 title: "Using dataset collections"
 tags:
 - collections
-zenodo_link: ""
 level: Intermediate
 questions:
   - "How to manipulate large numbers of datasets at once?"

--- a/topics/galaxy-interface/tutorials/download-delete-data/tutorial.md
+++ b/topics/galaxy-interface/tutorials/download-delete-data/tutorial.md
@@ -4,7 +4,6 @@ redirect_from:
   - /topics/galaxy-data-manipulation/tutorials/download-delete-data/tutorial
 
 title: 'Downloading and Deleting Data in Galaxy'
-zenodo_link: ''
 level: Introductory
 questions:
 - How can I efficiently download my data from Galaxy once I've completed my analyses?

--- a/topics/galaxy-interface/tutorials/galaxy-intro-jupyter/tutorial.md
+++ b/topics/galaxy-interface/tutorials/galaxy-intro-jupyter/tutorial.md
@@ -4,7 +4,7 @@ redirect_from:
   - /topics/galaxy-ui/tutorials/galaxy-intro-jupyter/tutorial
 
 title: "Use Jupyter notebooks in Galaxy"
-zenodo_link: "https://zenodo.org/record/1185122/files/GSM461176_untreat_single.counts"
+zenodo_link: "https://zenodo.org/record/1185122"
 questions:
   - "How to use a Jupyter Notebook in Galaxy"
 objectives:
@@ -25,7 +25,7 @@ subtopic: analyse
 {:.no_toc}
 
 In this tutorial we are going to explore the basics of using Jupyter in Galaxy. We will use a RNA seq count file as a test set to get a hang of the Jupyter notebooks.
-The file is available in [Zenodo](https://zenodo.org/record/1185122#.WzlCQNhKgWo) or in the *Tutorial* section of *Data Libraries*.
+The file is available in [Zenodo](https://zenodo.org/record/1185122) or in the *Tutorial* section of *Data Libraries*.
 Select a file ending with `.count` and upload it in your history (If you want to know how to upload data in galaxy, see [Getting Data into Galaxy](http://galaxyproject.github.io/training-material/topics/galaxy-interface/tutorials/get-data/slides.html#1) tutorial)
 
 > ### Agenda

--- a/topics/galaxy-interface/tutorials/get-data/slides.html
+++ b/topics/galaxy-interface/tutorials/get-data/slides.html
@@ -5,7 +5,6 @@ redirect_from:
   - /topics/galaxy-data-manipulation/tutorials/get-data/slides
 
 title: "Getting data into Galaxy"
-zenodo_link: ""
 questions:
   - "How do I get my data into Galaxy?"
   - "How do I get public data into Galaxy?"

--- a/topics/galaxy-interface/tutorials/group-tags/tutorial.md
+++ b/topics/galaxy-interface/tutorials/group-tags/tutorial.md
@@ -4,7 +4,6 @@ redirect_from:
   - /topics/galaxy-data-manipulation/tutorials/group-tags/tutorial
 
 title: Group tags for complex experimental designs
-zenodo_link: ''
 questions:
 - What are group tags?
 - How can I use group tags to perform multi-factor analyses with collections

--- a/topics/galaxy-interface/tutorials/history-to-workflow/tutorial.md
+++ b/topics/galaxy-interface/tutorials/history-to-workflow/tutorial.md
@@ -6,7 +6,6 @@ redirect_from:
 title: "Extracting Workflows from Histories"
 tags:
   - workflows
-zenodo_link: ""
 questions:
   - "What is a workflow?"
   - "How can I create a workflow based on my analysis history?"

--- a/topics/galaxy-interface/tutorials/history/tutorial.md
+++ b/topics/galaxy-interface/tutorials/history/tutorial.md
@@ -4,7 +4,6 @@ redirect_from:
   - /topics/galaxy-ui/tutorials/history/tutorial
 
 title: "Understanding Galaxy history system"
-zenodo_link: ""
 questions:
   - "How do Galaxy histories work?"
 objectives:

--- a/topics/galaxy-interface/tutorials/jupyterlab/tutorial.md
+++ b/topics/galaxy-interface/tutorials/jupyterlab/tutorial.md
@@ -4,7 +4,6 @@ redirect_from:
   - /topics/galaxy-ui/tutorials/jupyterlab/tutorial
 
 title: JupyterLab in Galaxy
-zenodo_link: ""
 questions:
 - How can I manipulate data using JupyterLab in Galaxy?
 - How can I start a notebook in JupyterLab?

--- a/topics/galaxy-interface/tutorials/name-tags/tutorial.md
+++ b/topics/galaxy-interface/tutorials/name-tags/tutorial.md
@@ -4,7 +4,6 @@ redirect_from:
   - /topics/galaxy-data-manipulation/tutorials/name-tags/tutorial
 
 title: Name tags for following complex histories
-zenodo_link: ''
 questions:
 - What are name tags or hash tags?
 - How can I use them to keep track of my data?

--- a/topics/galaxy-interface/tutorials/processing-many-samples-at-once/tutorial.md
+++ b/topics/galaxy-interface/tutorials/processing-many-samples-at-once/tutorial.md
@@ -6,7 +6,6 @@ redirect_from:
 title: "Multisample Analysis"
 tags:
   - collections
-zenodo_link: ""
 level: Advanced
 questions:
 objectives:

--- a/topics/galaxy-interface/tutorials/rstudio/tutorial.md
+++ b/topics/galaxy-interface/tutorials/rstudio/tutorial.md
@@ -4,7 +4,6 @@ redirect_from:
   - /topics/galaxy-ui/tutorials/rstudio/tutorial
 
 title: RStudio in Galaxy
-zenodo_link: ""
 questions:
 - How can I manipulate data using R in Galaxy?
 objectives:

--- a/topics/galaxy-interface/tutorials/search/tutorial.md
+++ b/topics/galaxy-interface/tutorials/search/tutorial.md
@@ -2,7 +2,6 @@
 layout: tutorial_hands_on
 
 title: "Searching Your History"
-zenodo_link: ""
 level: Introductory
 questions:
   - How can you find your datasets?

--- a/topics/galaxy-interface/tutorials/upload-rules-advanced/tutorial.md
+++ b/topics/galaxy-interface/tutorials/upload-rules-advanced/tutorial.md
@@ -2,7 +2,6 @@
 layout: tutorial_hands_on
 
 title: "Rule Based Uploader: Advanced"
-zenodo_link: ""
 level: Advanced
 questions:
   - "How to use the rule based uploader to create complex collections"

--- a/topics/galaxy-interface/tutorials/upload-rules/tutorial.md
+++ b/topics/galaxy-interface/tutorials/upload-rules/tutorial.md
@@ -4,7 +4,6 @@ redirect_from:
   - /topics/galaxy-data-manipulation/tutorials/upload-rules/tutorial
 
 title: "Rule Based Uploader"
-zenodo_link: ""
 level: Intermediate
 questions:
   - "How to use the rule based uploader to create complex collections"

--- a/topics/galaxy-interface/tutorials/workflow-editor/tutorial.md
+++ b/topics/galaxy-interface/tutorials/workflow-editor/tutorial.md
@@ -4,7 +4,6 @@ layout: tutorial_hands_on
 title: Creating, Editing and Importing Galaxy Workflows
 tags:
 - workflows
-zenodo_link: ''
 questions:
 - How can you construct Galaxy workflows from scratch?
 - How can you label outputs?

--- a/topics/galaxy-interface/tutorials/workflow-parameters/tutorial.md
+++ b/topics/galaxy-interface/tutorials/workflow-parameters/tutorial.md
@@ -6,7 +6,6 @@ redirect_from:
 title: 'Using Workflow Parameters'
 tags:
 - workflows
-zenodo_link: ''
 questions:
 - What are Workflow Parameters
 - How can I define and use Workflow Parameters

--- a/topics/genome-annotation/tutorials/annotation-with-maker/data-library.yaml
+++ b/topics/genome-annotation/tutorials/annotation-with-maker/data-library.yaml
@@ -18,11 +18,11 @@ items:
       items:
       - url: https://zenodo.org/api/files/4385871d-9632-4fae-9aaf-f8ed692163d1/augustus_training_1.tar.gz
         src: url
-        ext: augustus
+        ext: gz
         info: https://doi.org/10.5281/zenodo.1488687
       - url: https://zenodo.org/api/files/4385871d-9632-4fae-9aaf-f8ed692163d1/augustus_training_2.tar.gz
         src: url
-        ext: augustus
+        ext: gz
         info: https://doi.org/10.5281/zenodo.1488687
       - url: https://zenodo.org/api/files/4385871d-9632-4fae-9aaf-f8ed692163d1/S_pombe_chrIII.fasta
         src: url

--- a/topics/genome-annotation/tutorials/tnseq/data-library.yaml
+++ b/topics/genome-annotation/tutorials/tnseq/data-library.yaml
@@ -13,8 +13,31 @@ items:
   items:
   - name: Essential genes detection with Transposon insertion sequencing
     items:
-    - name: 'DOI: 10.5281/zenodo.940733'
+    - name: 'DOI: 10.5281/zenodo.2579335'
       description: latest
+      items:
+      - url: https://zenodo.org/api/files/969c6811-d3c0-4ba7-9320-2310a859d5eb/condition_barcodes.fasta
+        src: url
+        ext: fasta
+        info: https://doi.org/10.5281/zenodo.2579335
+      - url: https://zenodo.org/api/files/969c6811-d3c0-4ba7-9320-2310a859d5eb/construct_barcodes.fasta
+        src: url
+        ext: fasta
+        info: https://doi.org/10.5281/zenodo.2579335
+      - url: https://zenodo.org/api/files/969c6811-d3c0-4ba7-9320-2310a859d5eb/staph_aur.fasta
+        src: url
+        ext: fasta
+        info: https://doi.org/10.5281/zenodo.2579335
+      - url: https://zenodo.org/api/files/969c6811-d3c0-4ba7-9320-2310a859d5eb/staph_aur.gff3
+        src: url
+        ext: gff3
+        info: https://doi.org/10.5281/zenodo.2579335
+      - url: https://zenodo.org/api/files/969c6811-d3c0-4ba7-9320-2310a859d5eb/Tnseq-Tutorial-reads.fastqsanger.gz
+        src: url
+        ext: gz
+        info: https://doi.org/10.5281/zenodo.2579335
+    - name: 'DOI: 10.5281/zenodo.940733'
+      description: ''
       items:
       - url: https://zenodo.org/api/files/0b6b7422-42dc-489e-9567-a9de12c6972e/illumina_f.fq
         src: url

--- a/topics/imaging/tutorials/hela-screen-analysis/data-library.yaml
+++ b/topics/imaging/tutorials/hela-screen-analysis/data-library.yaml
@@ -23,4 +23,181 @@ items:
       - url: https://zenodo.org/record/3362976/files/B3.zip
         src: url
         ext: zip
-        info: https://zenodo.org/record/3362976       
+        info: https://zenodo.org/record/3362976
+  - name: Analyse HeLa fluorescence siRNA screen
+    items:
+    - name: 'DOI: 10.5281/zenodo.3362976'
+      description: latest
+      items:
+      - url: https://zenodo.org/api/files/45b0ab7e-7054-4944-a6fe-0c70b729b4a6/B2.zip
+        src: url
+        ext: zip
+        info: https://zenodo.org/record/3362976
+      - url: https://zenodo.org/api/files/45b0ab7e-7054-4944-a6fe-0c70b729b4a6/B3.zip
+        src: url
+        ext: zip
+        info: https://zenodo.org/record/3362976
+      - url: https://zenodo.org/api/files/45b0ab7e-7054-4944-a6fe-0c70b729b4a6/B4.zip
+        src: url
+        ext: zip
+        info: https://zenodo.org/record/3362976
+      - url: https://zenodo.org/api/files/45b0ab7e-7054-4944-a6fe-0c70b729b4a6/B5.zip
+        src: url
+        ext: zip
+        info: https://zenodo.org/record/3362976
+      - url: https://zenodo.org/api/files/45b0ab7e-7054-4944-a6fe-0c70b729b4a6/B6.zip
+        src: url
+        ext: zip
+        info: https://zenodo.org/record/3362976
+      - url: https://zenodo.org/api/files/45b0ab7e-7054-4944-a6fe-0c70b729b4a6/B7.zip
+        src: url
+        ext: zip
+        info: https://zenodo.org/record/3362976
+      - url: https://zenodo.org/api/files/45b0ab7e-7054-4944-a6fe-0c70b729b4a6/C2.zip
+        src: url
+        ext: zip
+        info: https://zenodo.org/record/3362976
+      - url: https://zenodo.org/api/files/45b0ab7e-7054-4944-a6fe-0c70b729b4a6/C3.zip
+        src: url
+        ext: zip
+        info: https://zenodo.org/record/3362976
+      - url: https://zenodo.org/api/files/45b0ab7e-7054-4944-a6fe-0c70b729b4a6/C4.zip
+        src: url
+        ext: zip
+        info: https://zenodo.org/record/3362976
+      - url: https://zenodo.org/api/files/45b0ab7e-7054-4944-a6fe-0c70b729b4a6/C5.zip
+        src: url
+        ext: zip
+        info: https://zenodo.org/record/3362976
+      - url: https://zenodo.org/api/files/45b0ab7e-7054-4944-a6fe-0c70b729b4a6/C6.zip
+        src: url
+        ext: zip
+        info: https://zenodo.org/record/3362976
+      - url: https://zenodo.org/api/files/45b0ab7e-7054-4944-a6fe-0c70b729b4a6/C7.zip
+        src: url
+        ext: zip
+        info: https://zenodo.org/record/3362976
+      - url: https://zenodo.org/api/files/45b0ab7e-7054-4944-a6fe-0c70b729b4a6/D2.zip
+        src: url
+        ext: zip
+        info: https://zenodo.org/record/3362976
+      - url: https://zenodo.org/api/files/45b0ab7e-7054-4944-a6fe-0c70b729b4a6/D3.zip
+        src: url
+        ext: zip
+        info: https://zenodo.org/record/3362976
+      - url: https://zenodo.org/api/files/45b0ab7e-7054-4944-a6fe-0c70b729b4a6/D4.zip
+        src: url
+        ext: zip
+        info: https://zenodo.org/record/3362976
+      - url: https://zenodo.org/api/files/45b0ab7e-7054-4944-a6fe-0c70b729b4a6/D5.zip
+        src: url
+        ext: zip
+        info: https://zenodo.org/record/3362976
+      - url: https://zenodo.org/api/files/45b0ab7e-7054-4944-a6fe-0c70b729b4a6/D6.zip
+        src: url
+        ext: zip
+        info: https://zenodo.org/record/3362976
+      - url: https://zenodo.org/api/files/45b0ab7e-7054-4944-a6fe-0c70b729b4a6/D7.zip
+        src: url
+        ext: zip
+        info: https://zenodo.org/record/3362976
+      - url: https://zenodo.org/api/files/45b0ab7e-7054-4944-a6fe-0c70b729b4a6/E2.zip
+        src: url
+        ext: zip
+        info: https://zenodo.org/record/3362976
+      - url: https://zenodo.org/api/files/45b0ab7e-7054-4944-a6fe-0c70b729b4a6/E3.zip
+        src: url
+        ext: zip
+        info: https://zenodo.org/record/3362976
+      - url: https://zenodo.org/api/files/45b0ab7e-7054-4944-a6fe-0c70b729b4a6/E4.zip
+        src: url
+        ext: zip
+        info: https://zenodo.org/record/3362976
+      - url: https://zenodo.org/api/files/45b0ab7e-7054-4944-a6fe-0c70b729b4a6/E5.zip
+        src: url
+        ext: zip
+        info: https://zenodo.org/record/3362976
+      - url: https://zenodo.org/api/files/45b0ab7e-7054-4944-a6fe-0c70b729b4a6/E6.zip
+        src: url
+        ext: zip
+        info: https://zenodo.org/record/3362976
+      - url: https://zenodo.org/api/files/45b0ab7e-7054-4944-a6fe-0c70b729b4a6/E7.zip
+        src: url
+        ext: zip
+        info: https://zenodo.org/record/3362976
+      - url: https://zenodo.org/api/files/45b0ab7e-7054-4944-a6fe-0c70b729b4a6/F2.zip
+        src: url
+        ext: zip
+        info: https://zenodo.org/record/3362976
+      - url: https://zenodo.org/api/files/45b0ab7e-7054-4944-a6fe-0c70b729b4a6/F3.zip
+        src: url
+        ext: zip
+        info: https://zenodo.org/record/3362976
+      - url: https://zenodo.org/api/files/45b0ab7e-7054-4944-a6fe-0c70b729b4a6/F4.zip
+        src: url
+        ext: zip
+        info: https://zenodo.org/record/3362976
+      - url: https://zenodo.org/api/files/45b0ab7e-7054-4944-a6fe-0c70b729b4a6/F5.zip
+        src: url
+        ext: zip
+        info: https://zenodo.org/record/3362976
+      - url: https://zenodo.org/api/files/45b0ab7e-7054-4944-a6fe-0c70b729b4a6/F6.zip
+        src: url
+        ext: zip
+        info: https://zenodo.org/record/3362976
+      - url: https://zenodo.org/api/files/45b0ab7e-7054-4944-a6fe-0c70b729b4a6/F7.zip
+        src: url
+        ext: zip
+        info: https://zenodo.org/record/3362976
+      - url: https://zenodo.org/api/files/45b0ab7e-7054-4944-a6fe-0c70b729b4a6/G2.zip
+        src: url
+        ext: zip
+        info: https://zenodo.org/record/3362976
+      - url: https://zenodo.org/api/files/45b0ab7e-7054-4944-a6fe-0c70b729b4a6/G3.zip
+        src: url
+        ext: zip
+        info: https://zenodo.org/record/3362976
+      - url: https://zenodo.org/api/files/45b0ab7e-7054-4944-a6fe-0c70b729b4a6/G4.zip
+        src: url
+        ext: zip
+        info: https://zenodo.org/record/3362976
+      - url: https://zenodo.org/api/files/45b0ab7e-7054-4944-a6fe-0c70b729b4a6/G5.zip
+        src: url
+        ext: zip
+        info: https://zenodo.org/record/3362976
+      - url: https://zenodo.org/api/files/45b0ab7e-7054-4944-a6fe-0c70b729b4a6/G6.zip
+        src: url
+        ext: zip
+        info: https://zenodo.org/record/3362976
+      - url: https://zenodo.org/api/files/45b0ab7e-7054-4944-a6fe-0c70b729b4a6/G7.zip
+        src: url
+        ext: zip
+        info: https://zenodo.org/record/3362976
+      - url: https://zenodo.org/api/files/45b0ab7e-7054-4944-a6fe-0c70b729b4a6/H2.zip
+        src: url
+        ext: zip
+        info: https://zenodo.org/record/3362976
+      - url: https://zenodo.org/api/files/45b0ab7e-7054-4944-a6fe-0c70b729b4a6/H3.zip
+        src: url
+        ext: zip
+        info: https://zenodo.org/record/3362976
+      - url: https://zenodo.org/api/files/45b0ab7e-7054-4944-a6fe-0c70b729b4a6/H4.zip
+        src: url
+        ext: zip
+        info: https://zenodo.org/record/3362976
+      - url: https://zenodo.org/api/files/45b0ab7e-7054-4944-a6fe-0c70b729b4a6/H5.zip
+        src: url
+        ext: zip
+        info: https://zenodo.org/record/3362976
+      - url: https://zenodo.org/api/files/45b0ab7e-7054-4944-a6fe-0c70b729b4a6/H6.zip
+        src: url
+        ext: zip
+        info: https://zenodo.org/record/3362976
+      - url: https://zenodo.org/api/files/45b0ab7e-7054-4944-a6fe-0c70b729b4a6/H7.zip
+        src: url
+        ext: zip
+        info: https://zenodo.org/record/3362976
+      - url: https://zenodo.org/api/files/45b0ab7e-7054-4944-a6fe-0c70b729b4a6/Layout_Course_Data_2019.xlsx
+        src: url
+        ext: '# Please add a Galaxy datatype or update the shared/datatypes.yaml file'
+        info: https://zenodo.org/record/3362976

--- a/topics/imaging/tutorials/imaging-introduction/data-library.yaml
+++ b/topics/imaging/tutorials/imaging-introduction/data-library.yaml
@@ -17,3 +17,180 @@ items:
         src: url
         ext: zip
         info: https://zenodo.org/record/3362976
+  - name: Introduction to image analysis using Galaxy
+    items:
+    - name: 'DOI: 10.5281/zenodo.3362976'
+      description: latest
+      items:
+      - url: https://zenodo.org/api/files/45b0ab7e-7054-4944-a6fe-0c70b729b4a6/B2.zip
+        src: url
+        ext: zip
+        info: https://zenodo.org/record/3362976
+      - url: https://zenodo.org/api/files/45b0ab7e-7054-4944-a6fe-0c70b729b4a6/B3.zip
+        src: url
+        ext: zip
+        info: https://zenodo.org/record/3362976
+      - url: https://zenodo.org/api/files/45b0ab7e-7054-4944-a6fe-0c70b729b4a6/B4.zip
+        src: url
+        ext: zip
+        info: https://zenodo.org/record/3362976
+      - url: https://zenodo.org/api/files/45b0ab7e-7054-4944-a6fe-0c70b729b4a6/B5.zip
+        src: url
+        ext: zip
+        info: https://zenodo.org/record/3362976
+      - url: https://zenodo.org/api/files/45b0ab7e-7054-4944-a6fe-0c70b729b4a6/B6.zip
+        src: url
+        ext: zip
+        info: https://zenodo.org/record/3362976
+      - url: https://zenodo.org/api/files/45b0ab7e-7054-4944-a6fe-0c70b729b4a6/B7.zip
+        src: url
+        ext: zip
+        info: https://zenodo.org/record/3362976
+      - url: https://zenodo.org/api/files/45b0ab7e-7054-4944-a6fe-0c70b729b4a6/C2.zip
+        src: url
+        ext: zip
+        info: https://zenodo.org/record/3362976
+      - url: https://zenodo.org/api/files/45b0ab7e-7054-4944-a6fe-0c70b729b4a6/C3.zip
+        src: url
+        ext: zip
+        info: https://zenodo.org/record/3362976
+      - url: https://zenodo.org/api/files/45b0ab7e-7054-4944-a6fe-0c70b729b4a6/C4.zip
+        src: url
+        ext: zip
+        info: https://zenodo.org/record/3362976
+      - url: https://zenodo.org/api/files/45b0ab7e-7054-4944-a6fe-0c70b729b4a6/C5.zip
+        src: url
+        ext: zip
+        info: https://zenodo.org/record/3362976
+      - url: https://zenodo.org/api/files/45b0ab7e-7054-4944-a6fe-0c70b729b4a6/C6.zip
+        src: url
+        ext: zip
+        info: https://zenodo.org/record/3362976
+      - url: https://zenodo.org/api/files/45b0ab7e-7054-4944-a6fe-0c70b729b4a6/C7.zip
+        src: url
+        ext: zip
+        info: https://zenodo.org/record/3362976
+      - url: https://zenodo.org/api/files/45b0ab7e-7054-4944-a6fe-0c70b729b4a6/D2.zip
+        src: url
+        ext: zip
+        info: https://zenodo.org/record/3362976
+      - url: https://zenodo.org/api/files/45b0ab7e-7054-4944-a6fe-0c70b729b4a6/D3.zip
+        src: url
+        ext: zip
+        info: https://zenodo.org/record/3362976
+      - url: https://zenodo.org/api/files/45b0ab7e-7054-4944-a6fe-0c70b729b4a6/D4.zip
+        src: url
+        ext: zip
+        info: https://zenodo.org/record/3362976
+      - url: https://zenodo.org/api/files/45b0ab7e-7054-4944-a6fe-0c70b729b4a6/D5.zip
+        src: url
+        ext: zip
+        info: https://zenodo.org/record/3362976
+      - url: https://zenodo.org/api/files/45b0ab7e-7054-4944-a6fe-0c70b729b4a6/D6.zip
+        src: url
+        ext: zip
+        info: https://zenodo.org/record/3362976
+      - url: https://zenodo.org/api/files/45b0ab7e-7054-4944-a6fe-0c70b729b4a6/D7.zip
+        src: url
+        ext: zip
+        info: https://zenodo.org/record/3362976
+      - url: https://zenodo.org/api/files/45b0ab7e-7054-4944-a6fe-0c70b729b4a6/E2.zip
+        src: url
+        ext: zip
+        info: https://zenodo.org/record/3362976
+      - url: https://zenodo.org/api/files/45b0ab7e-7054-4944-a6fe-0c70b729b4a6/E3.zip
+        src: url
+        ext: zip
+        info: https://zenodo.org/record/3362976
+      - url: https://zenodo.org/api/files/45b0ab7e-7054-4944-a6fe-0c70b729b4a6/E4.zip
+        src: url
+        ext: zip
+        info: https://zenodo.org/record/3362976
+      - url: https://zenodo.org/api/files/45b0ab7e-7054-4944-a6fe-0c70b729b4a6/E5.zip
+        src: url
+        ext: zip
+        info: https://zenodo.org/record/3362976
+      - url: https://zenodo.org/api/files/45b0ab7e-7054-4944-a6fe-0c70b729b4a6/E6.zip
+        src: url
+        ext: zip
+        info: https://zenodo.org/record/3362976
+      - url: https://zenodo.org/api/files/45b0ab7e-7054-4944-a6fe-0c70b729b4a6/E7.zip
+        src: url
+        ext: zip
+        info: https://zenodo.org/record/3362976
+      - url: https://zenodo.org/api/files/45b0ab7e-7054-4944-a6fe-0c70b729b4a6/F2.zip
+        src: url
+        ext: zip
+        info: https://zenodo.org/record/3362976
+      - url: https://zenodo.org/api/files/45b0ab7e-7054-4944-a6fe-0c70b729b4a6/F3.zip
+        src: url
+        ext: zip
+        info: https://zenodo.org/record/3362976
+      - url: https://zenodo.org/api/files/45b0ab7e-7054-4944-a6fe-0c70b729b4a6/F4.zip
+        src: url
+        ext: zip
+        info: https://zenodo.org/record/3362976
+      - url: https://zenodo.org/api/files/45b0ab7e-7054-4944-a6fe-0c70b729b4a6/F5.zip
+        src: url
+        ext: zip
+        info: https://zenodo.org/record/3362976
+      - url: https://zenodo.org/api/files/45b0ab7e-7054-4944-a6fe-0c70b729b4a6/F6.zip
+        src: url
+        ext: zip
+        info: https://zenodo.org/record/3362976
+      - url: https://zenodo.org/api/files/45b0ab7e-7054-4944-a6fe-0c70b729b4a6/F7.zip
+        src: url
+        ext: zip
+        info: https://zenodo.org/record/3362976
+      - url: https://zenodo.org/api/files/45b0ab7e-7054-4944-a6fe-0c70b729b4a6/G2.zip
+        src: url
+        ext: zip
+        info: https://zenodo.org/record/3362976
+      - url: https://zenodo.org/api/files/45b0ab7e-7054-4944-a6fe-0c70b729b4a6/G3.zip
+        src: url
+        ext: zip
+        info: https://zenodo.org/record/3362976
+      - url: https://zenodo.org/api/files/45b0ab7e-7054-4944-a6fe-0c70b729b4a6/G4.zip
+        src: url
+        ext: zip
+        info: https://zenodo.org/record/3362976
+      - url: https://zenodo.org/api/files/45b0ab7e-7054-4944-a6fe-0c70b729b4a6/G5.zip
+        src: url
+        ext: zip
+        info: https://zenodo.org/record/3362976
+      - url: https://zenodo.org/api/files/45b0ab7e-7054-4944-a6fe-0c70b729b4a6/G6.zip
+        src: url
+        ext: zip
+        info: https://zenodo.org/record/3362976
+      - url: https://zenodo.org/api/files/45b0ab7e-7054-4944-a6fe-0c70b729b4a6/G7.zip
+        src: url
+        ext: zip
+        info: https://zenodo.org/record/3362976
+      - url: https://zenodo.org/api/files/45b0ab7e-7054-4944-a6fe-0c70b729b4a6/H2.zip
+        src: url
+        ext: zip
+        info: https://zenodo.org/record/3362976
+      - url: https://zenodo.org/api/files/45b0ab7e-7054-4944-a6fe-0c70b729b4a6/H3.zip
+        src: url
+        ext: zip
+        info: https://zenodo.org/record/3362976
+      - url: https://zenodo.org/api/files/45b0ab7e-7054-4944-a6fe-0c70b729b4a6/H4.zip
+        src: url
+        ext: zip
+        info: https://zenodo.org/record/3362976
+      - url: https://zenodo.org/api/files/45b0ab7e-7054-4944-a6fe-0c70b729b4a6/H5.zip
+        src: url
+        ext: zip
+        info: https://zenodo.org/record/3362976
+      - url: https://zenodo.org/api/files/45b0ab7e-7054-4944-a6fe-0c70b729b4a6/H6.zip
+        src: url
+        ext: zip
+        info: https://zenodo.org/record/3362976
+      - url: https://zenodo.org/api/files/45b0ab7e-7054-4944-a6fe-0c70b729b4a6/H7.zip
+        src: url
+        ext: zip
+        info: https://zenodo.org/record/3362976
+      - url: https://zenodo.org/api/files/45b0ab7e-7054-4944-a6fe-0c70b729b4a6/Layout_Course_Data_2019.xlsx
+        src: url
+        ext: '# Please add a Galaxy datatype or update the shared/datatypes.yaml file'
+        info: https://zenodo.org/record/3362976

--- a/topics/imaging/tutorials/tutorial-CP/slides.html
+++ b/topics/imaging/tutorials/tutorial-CP/slides.html
@@ -3,7 +3,6 @@ layout: tutorial_slides
 logo: "GTN"
 
 title: Nucleoli Segmentation <br> & <br> Feature Extraction <br> using CellProfiler
-zenodo_link: ''
 questions:
 - How do I run an image analysis pipeline on public data using CellProfiler?
 - How do I analyse the DNA channel of fluorescence siRNA screens?

--- a/topics/imaging/tutorials/tutorial-CP/tutorial.md
+++ b/topics/imaging/tutorials/tutorial-CP/tutorial.md
@@ -27,7 +27,6 @@ key_points:
 contributors:
 - beatrizserrano
 - jkh1
-zenodo_link: ''
 ---
 
 

--- a/topics/introduction/tutorials/galaxy-intro-101-everyone/tutorial.md
+++ b/topics/introduction/tutorials/galaxy-intro-101-everyone/tutorial.md
@@ -2,7 +2,7 @@
 layout: tutorial_hands_on
 
 title: "Galaxy 101 for everyone"
-zenodo_link: https://zenodo.org/record/1319069/files/iris.csv
+zenodo_link: "https://zenodo.org/record/1319069"
 level: Introductory
 questions:
   - "What are the differences between the Iris species?"

--- a/topics/introduction/tutorials/galaxy-intro-ngs-data-managment/tutorial.md
+++ b/topics/introduction/tutorials/galaxy-intro-ngs-data-managment/tutorial.md
@@ -2,7 +2,6 @@
 layout: tutorial_hands_on
 
 title: "NGS data logistics"
-zenodo_link: ""
 questions:
   - "How to manipulate and process NGS data"
 objectives:

--- a/topics/introduction/tutorials/galaxy-intro-short/slides.html
+++ b/topics/introduction/tutorials/galaxy-intro-short/slides.html
@@ -3,7 +3,6 @@ layout: tutorial_slides
 logo: GTN
 video: true
 title: "A Short Introduction to Galaxy"
-zenodo_link: ""
 questions:
   - "What is Galaxy?"
   - "Why should I use Galaxy?"

--- a/topics/introduction/tutorials/galaxy-intro-strands/tutorial.md
+++ b/topics/introduction/tutorials/galaxy-intro-strands/tutorial.md
@@ -2,7 +2,6 @@
 layout: tutorial_hands_on
 
 title: "Introduction to Genomics and Galaxy"
-zenodo_link: ""
 level: Introductory
 questions:
   - "Do genes on opposite strands ever overlap?  If so, how often?"

--- a/topics/introduction/tutorials/igv-introduction/tutorial.md
+++ b/topics/introduction/tutorials/igv-introduction/tutorial.md
@@ -2,7 +2,6 @@
 layout: tutorial_hands_on
 
 title: "IGV Introduction"
-zenodo_link: ""
 questions:
 objectives:
 time_estimation: "2H"

--- a/topics/introduction/tutorials/options-for-using-galaxy/slides.html
+++ b/topics/introduction/tutorials/options-for-using-galaxy/slides.html
@@ -3,7 +3,6 @@ layout: tutorial_slides
 logo: GTN
 
 title: "Options for using Galaxy"
-zenodo_link: ""
 questions:
   - "Which Galaxy instance should I use?"
 objectives:

--- a/topics/introduction/tutorials/r-advanced/tutorial.md
+++ b/topics/introduction/tutorials/r-advanced/tutorial.md
@@ -3,7 +3,6 @@ layout: tutorial_hands_on
 
 title: Advanced R in Galaxy
 level: Intermediate
-zenodo_link: ""
 requirements:
   -
     type: "internal"

--- a/topics/introduction/tutorials/r-basics/tutorial.md
+++ b/topics/introduction/tutorials/r-basics/tutorial.md
@@ -3,7 +3,6 @@ layout: tutorial_hands_on
 
 title: R basics in Galaxy
 level: Introductory
-zenodo_link: ""
 requirements:
   -
     type: "internal"

--- a/topics/metabolomics/tutorials/lcms-preprocessing/data-library.yaml
+++ b/topics/metabolomics/tutorials/lcms-preprocessing/data-library.yaml
@@ -54,3 +54,64 @@ items:
         src: url
         ext: tsv
         info: https://zenodo.org/record/3244991
+  - name: 'Mass spectrometry: LC-MS preprocessing with XCMS'
+    items:
+    - name: 'DOI: 10.5281/zenodo.3757956'
+      description: latest
+      items:
+      - url: https://zenodo.org/api/files/275fba6b-c35a-48ac-9197-7954b12eca83/Blanc05.mzML
+        src: url
+        ext: mzml
+        info: https://zenodo.org/record/3757956
+      - url: https://zenodo.org/api/files/275fba6b-c35a-48ac-9197-7954b12eca83/Blanc10.mzML
+        src: url
+        ext: mzml
+        info: https://zenodo.org/record/3757956
+      - url: https://zenodo.org/api/files/275fba6b-c35a-48ac-9197-7954b12eca83/Blanc16.mzML
+        src: url
+        ext: mzml
+        info: https://zenodo.org/record/3757956
+      - url: https://zenodo.org/api/files/275fba6b-c35a-48ac-9197-7954b12eca83/HU_neg_048.mzML
+        src: url
+        ext: mzml
+        info: https://zenodo.org/record/3757956
+      - url: https://zenodo.org/api/files/275fba6b-c35a-48ac-9197-7954b12eca83/HU_neg_090.mzML
+        src: url
+        ext: mzml
+        info: https://zenodo.org/record/3757956
+      - url: https://zenodo.org/api/files/275fba6b-c35a-48ac-9197-7954b12eca83/HU_neg_123.mzML
+        src: url
+        ext: mzml
+        info: https://zenodo.org/record/3757956
+      - url: https://zenodo.org/api/files/275fba6b-c35a-48ac-9197-7954b12eca83/HU_neg_157.mzML
+        src: url
+        ext: mzml
+        info: https://zenodo.org/record/3757956
+      - url: https://zenodo.org/api/files/275fba6b-c35a-48ac-9197-7954b12eca83/HU_neg_173.mzML
+        src: url
+        ext: mzml
+        info: https://zenodo.org/record/3757956
+      - url: https://zenodo.org/api/files/275fba6b-c35a-48ac-9197-7954b12eca83/HU_neg_192.mzML
+        src: url
+        ext: mzml
+        info: https://zenodo.org/record/3757956
+      - url: https://zenodo.org/api/files/275fba6b-c35a-48ac-9197-7954b12eca83/QC1_002.mzML
+        src: url
+        ext: mzml
+        info: https://zenodo.org/record/3757956
+      - url: https://zenodo.org/api/files/275fba6b-c35a-48ac-9197-7954b12eca83/QC1_008.mzML
+        src: url
+        ext: mzml
+        info: https://zenodo.org/record/3757956
+      - url: https://zenodo.org/api/files/275fba6b-c35a-48ac-9197-7954b12eca83/QC1_014.mzML
+        src: url
+        ext: mzml
+        info: https://zenodo.org/record/3757956
+      - url: https://zenodo.org/api/files/275fba6b-c35a-48ac-9197-7954b12eca83/sampleMetadata_12samp_completed.tsv
+        src: url
+        ext: tsv
+        info: https://zenodo.org/record/3757956
+      - url: https://zenodo.org/api/files/275fba6b-c35a-48ac-9197-7954b12eca83/sampleMetadata_9samp_completed.tsv
+        src: url
+        ext: tsv
+        info: https://zenodo.org/record/3757956

--- a/topics/metabolomics/tutorials/msi-analyte-distribution/data-library.yaml
+++ b/topics/metabolomics/tutorials/msi-analyte-distribution/data-library.yaml
@@ -6,19 +6,51 @@ destination:
   synopsis: Galaxy Training Network Material. See https://training.galaxyproject.org
 items:
 - name: Metabolomics
-  description: 'Training material for Mass spectrometry imaging workflows in Galaxy'
+  description: Training material for Mass spectrometry imaging workflows in Galaxy
   items:
   - name: Msi analyte distribution
     items:
     - name: 'DOI: 10.5281/zenodo.484496'
       description: latest
       items:
-      # Commented until composite dataset upload is possible (https://github.com/galaxyproject/galaxy/issues/8909)
-      # - url: https://zenodo.org/api/files/853abf60-5799-4ab5-bed6-f9d6acde9bda/ltpmsi-chilli.ibd
-      #  src: url
-      #  ext: 'ibd'
-      #  info: https://zenodo.org/record/484496
       - url: https://zenodo.org/api/files/853abf60-5799-4ab5-bed6-f9d6acde9bda/ltpmsi-chilli.imzML
         src: url
-        ext: 'imzml'
+        ext: imzml
+        info: https://zenodo.org/record/484496
+  - name: 'Mass spectrometry imaging: Examining the spatial distribution of analytes'
+    items:
+    - name: 'DOI: 10.5281/zenodo.484496'
+      description: latest
+      items:
+      - url: https://zenodo.org/api/files/853abf60-5799-4ab5-bed6-f9d6acde9bda/130704_IMGCHJ2.mzML
+        src: url
+        ext: mzml
+        info: https://zenodo.org/record/484496
+      - url: https://zenodo.org/api/files/853abf60-5799-4ab5-bed6-f9d6acde9bda/130704_IMGCHJ2.mzXML
+        src: url
+        ext: '# Please add a Galaxy datatype or update the shared/datatypes.yaml file'
+        info: https://zenodo.org/record/484496
+      - url: https://zenodo.org/api/files/853abf60-5799-4ab5-bed6-f9d6acde9bda/130704%20IMGCHJ2.txt
+        src: url
+        ext: txt
+        info: https://zenodo.org/record/484496
+      - url: https://zenodo.org/api/files/853abf60-5799-4ab5-bed6-f9d6acde9bda/Imaging1.toppas
+        src: url
+        ext: '# Please add a Galaxy datatype or update the shared/datatypes.yaml file'
+        info: https://zenodo.org/record/484496
+      - url: https://zenodo.org/api/files/853abf60-5799-4ab5-bed6-f9d6acde9bda/ltpmsi-chilli.ibd
+        src: url
+        ext: ibd
+        info: https://zenodo.org/record/484496
+      - url: https://zenodo.org/api/files/853abf60-5799-4ab5-bed6-f9d6acde9bda/ltpmsi-chilli.imzML
+        src: url
+        ext: '# Please add a Galaxy datatype or update the shared/datatypes.yaml file'
+        info: https://zenodo.org/record/484496
+      - url: https://zenodo.org/api/files/853abf60-5799-4ab5-bed6-f9d6acde9bda/MSVs2D.V1.R
+        src: url
+        ext: '# Please add a Galaxy datatype or update the shared/datatypes.yaml file'
+        info: https://zenodo.org/record/484496
+      - url: https://zenodo.org/api/files/853abf60-5799-4ab5-bed6-f9d6acde9bda/TOPPAS.log
+        src: url
+        ext: '# Please add a Galaxy datatype or update the shared/datatypes.yaml file'
         info: https://zenodo.org/record/484496

--- a/topics/metabolomics/tutorials/msi-finding-nglycans/data-library.yaml
+++ b/topics/metabolomics/tutorials/msi-finding-nglycans/data-library.yaml
@@ -1,0 +1,52 @@
+---
+destination:
+  type: library
+  name: GTN - Material
+  description: Galaxy Training Network Material
+  synopsis: Galaxy Training Network Material. See https://training.galaxyproject.org
+items:
+- name: Metabolomics
+  description: 'Training material to analyse Mass spectrometry data in Galaxy: Metabolomics
+    (LCMS, FIAMS, GCMS, NMR) and imaging.'
+  items:
+  - name: 'Mass spectrometry imaging: Finding differential analytes'
+    items:
+    - name: 'DOI: 10.5281/zenodo.2628280'
+      description: latest
+      items:
+      - url: https://zenodo.org/api/files/46ecaadd-df32-462d-bc33-404d0ec042a4/all_files_annotation.tabular
+        src: url
+        ext: tabular
+        info: https://zenodo.org/record/2628280
+      - url: https://zenodo.org/api/files/46ecaadd-df32-462d-bc33-404d0ec042a4/all_files.ibd
+        src: url
+        ext: ibd
+        info: https://zenodo.org/record/2628280
+      - url: https://zenodo.org/api/files/46ecaadd-df32-462d-bc33-404d0ec042a4/all_files.imzml
+        src: url
+        ext: '# Please add a Galaxy datatype or update the shared/datatypes.yaml file'
+        info: https://zenodo.org/record/2628280
+      - url: https://zenodo.org/api/files/46ecaadd-df32-462d-bc33-404d0ec042a4/combined_image_all_files.pdf
+        src: url
+        ext: '# Please add a Galaxy datatype or update the shared/datatypes.yaml file'
+        info: https://zenodo.org/record/2628280
+      - url: https://zenodo.org/api/files/46ecaadd-df32-462d-bc33-404d0ec042a4/conrol.imzml
+        src: url
+        ext: '# Please add a Galaxy datatype or update the shared/datatypes.yaml file'
+        info: https://zenodo.org/record/2628280
+      - url: https://zenodo.org/api/files/46ecaadd-df32-462d-bc33-404d0ec042a4/control.ibd
+        src: url
+        ext: ibd
+        info: https://zenodo.org/record/2628280
+      - url: https://zenodo.org/api/files/46ecaadd-df32-462d-bc33-404d0ec042a4/Glycan_IDs.tabular
+        src: url
+        ext: tabular
+        info: https://zenodo.org/record/2628280
+      - url: https://zenodo.org/api/files/46ecaadd-df32-462d-bc33-404d0ec042a4/treated1.ibd
+        src: url
+        ext: ibd
+        info: https://zenodo.org/record/2628280
+      - url: https://zenodo.org/api/files/46ecaadd-df32-462d-bc33-404d0ec042a4/treated1.imzml
+        src: url
+        ext: '# Please add a Galaxy datatype or update the shared/datatypes.yaml file'
+        info: https://zenodo.org/record/2628280

--- a/topics/metagenomics/tutorials/metatranscriptomics-short/data-library.yaml
+++ b/topics/metagenomics/tutorials/metatranscriptomics-short/data-library.yaml
@@ -1,0 +1,36 @@
+---
+destination:
+  type: library
+  name: GTN - Material
+  description: Galaxy Training Network Material
+  synopsis: Galaxy Training Network Material. See https://training.galaxyproject.org
+items:
+- name: Metagenomics
+  description: Metagenomics is a discipline that enables the genomic study of uncultured
+    microorganisms
+  items:
+  - name: Metatranscriptomics analysis using microbiome RNA-seq data (short)
+    items:
+    - name: 'DOI: 10.5281/zenodo.3362849'
+      description: latest
+      items:
+      - url: https://zenodo.org/api/files/9659a01c-495d-4f41-ae8a-f6e4a9ed7b6c/T1A_forward.fastqsanger
+        src: url
+        ext: fastqsanger
+        info: https://zenodo.org/record/3362849
+      - url: https://zenodo.org/api/files/9659a01c-495d-4f41-ae8a-f6e4a9ed7b6c/T1A_humann2_gene_family_abundances.tsv
+        src: url
+        ext: tsv
+        info: https://zenodo.org/record/3362849
+      - url: https://zenodo.org/api/files/9659a01c-495d-4f41-ae8a-f6e4a9ed7b6c/T1A_humann2_pathway_abundances.tsv
+        src: url
+        ext: tsv
+        info: https://zenodo.org/record/3362849
+      - url: https://zenodo.org/api/files/9659a01c-495d-4f41-ae8a-f6e4a9ed7b6c/T1A_metaphlan2_community_profile.tabular
+        src: url
+        ext: tabular
+        info: https://zenodo.org/record/3362849
+      - url: https://zenodo.org/api/files/9659a01c-495d-4f41-ae8a-f6e4a9ed7b6c/T1A_reverse.fastqsanger
+        src: url
+        ext: fastqsanger
+        info: https://zenodo.org/record/3362849

--- a/topics/metagenomics/tutorials/mothur-miseq-sop-short/data-library.yaml
+++ b/topics/metagenomics/tutorials/mothur-miseq-sop-short/data-library.yaml
@@ -1,0 +1,200 @@
+---
+destination:
+  type: library
+  name: GTN - Material
+  description: Galaxy Training Network Material
+  synopsis: Galaxy Training Network Material. See https://training.galaxyproject.org
+items:
+- name: Metagenomics
+  description: Metagenomics is a discipline that enables the genomic study of uncultured
+    microorganisms
+  items:
+  - name: 16S Microbial Analysis with mothur (short)
+    items:
+    - name: 'DOI: 10.5281/zenodo.800651'
+      description: latest
+      items:
+      - url: https://zenodo.org/api/files/111d2e4e-285b-49a7-b6e8-1a6ededc588f/F3D0_R1.fastq
+        src: url
+        ext: fastqsanger
+        info: https://doi.org/10.5281/zenodo.800651
+      - url: https://zenodo.org/api/files/111d2e4e-285b-49a7-b6e8-1a6ededc588f/F3D0_R2.fastq
+        src: url
+        ext: fastqsanger
+        info: https://doi.org/10.5281/zenodo.800651
+      - url: https://zenodo.org/api/files/111d2e4e-285b-49a7-b6e8-1a6ededc588f/F3D141_R1.fastq
+        src: url
+        ext: fastqsanger
+        info: https://doi.org/10.5281/zenodo.800651
+      - url: https://zenodo.org/api/files/111d2e4e-285b-49a7-b6e8-1a6ededc588f/F3D141_R2.fastq
+        src: url
+        ext: fastqsanger
+        info: https://doi.org/10.5281/zenodo.800651
+      - url: https://zenodo.org/api/files/111d2e4e-285b-49a7-b6e8-1a6ededc588f/F3D142_R1.fastq
+        src: url
+        ext: fastqsanger
+        info: https://doi.org/10.5281/zenodo.800651
+      - url: https://zenodo.org/api/files/111d2e4e-285b-49a7-b6e8-1a6ededc588f/F3D142_R2.fastq
+        src: url
+        ext: fastqsanger
+        info: https://doi.org/10.5281/zenodo.800651
+      - url: https://zenodo.org/api/files/111d2e4e-285b-49a7-b6e8-1a6ededc588f/F3D143_R1.fastq
+        src: url
+        ext: fastqsanger
+        info: https://doi.org/10.5281/zenodo.800651
+      - url: https://zenodo.org/api/files/111d2e4e-285b-49a7-b6e8-1a6ededc588f/F3D143_R2.fastq
+        src: url
+        ext: fastqsanger
+        info: https://doi.org/10.5281/zenodo.800651
+      - url: https://zenodo.org/api/files/111d2e4e-285b-49a7-b6e8-1a6ededc588f/F3D144_R1.fastq
+        src: url
+        ext: fastqsanger
+        info: https://doi.org/10.5281/zenodo.800651
+      - url: https://zenodo.org/api/files/111d2e4e-285b-49a7-b6e8-1a6ededc588f/F3D144_R2.fastq
+        src: url
+        ext: fastqsanger
+        info: https://doi.org/10.5281/zenodo.800651
+      - url: https://zenodo.org/api/files/111d2e4e-285b-49a7-b6e8-1a6ededc588f/F3D145_R1.fastq
+        src: url
+        ext: fastqsanger
+        info: https://doi.org/10.5281/zenodo.800651
+      - url: https://zenodo.org/api/files/111d2e4e-285b-49a7-b6e8-1a6ededc588f/F3D145_R2.fastq
+        src: url
+        ext: fastqsanger
+        info: https://doi.org/10.5281/zenodo.800651
+      - url: https://zenodo.org/api/files/111d2e4e-285b-49a7-b6e8-1a6ededc588f/F3D146_R1.fastq
+        src: url
+        ext: fastqsanger
+        info: https://doi.org/10.5281/zenodo.800651
+      - url: https://zenodo.org/api/files/111d2e4e-285b-49a7-b6e8-1a6ededc588f/F3D146_R2.fastq
+        src: url
+        ext: fastqsanger
+        info: https://doi.org/10.5281/zenodo.800651
+      - url: https://zenodo.org/api/files/111d2e4e-285b-49a7-b6e8-1a6ededc588f/F3D147_R1.fastq
+        src: url
+        ext: fastqsanger
+        info: https://doi.org/10.5281/zenodo.800651
+      - url: https://zenodo.org/api/files/111d2e4e-285b-49a7-b6e8-1a6ededc588f/F3D147_R2.fastq
+        src: url
+        ext: fastqsanger
+        info: https://doi.org/10.5281/zenodo.800651
+      - url: https://zenodo.org/api/files/111d2e4e-285b-49a7-b6e8-1a6ededc588f/F3D148_R1.fastq
+        src: url
+        ext: fastqsanger
+        info: https://doi.org/10.5281/zenodo.800651
+      - url: https://zenodo.org/api/files/111d2e4e-285b-49a7-b6e8-1a6ededc588f/F3D148_R2.fastq
+        src: url
+        ext: fastqsanger
+        info: https://doi.org/10.5281/zenodo.800651
+      - url: https://zenodo.org/api/files/111d2e4e-285b-49a7-b6e8-1a6ededc588f/F3D149_R1.fastq
+        src: url
+        ext: fastqsanger
+        info: https://doi.org/10.5281/zenodo.800651
+      - url: https://zenodo.org/api/files/111d2e4e-285b-49a7-b6e8-1a6ededc588f/F3D149_R2.fastq
+        src: url
+        ext: fastqsanger
+        info: https://doi.org/10.5281/zenodo.800651
+      - url: https://zenodo.org/api/files/111d2e4e-285b-49a7-b6e8-1a6ededc588f/F3D150_R1.fastq
+        src: url
+        ext: fastqsanger
+        info: https://doi.org/10.5281/zenodo.800651
+      - url: https://zenodo.org/api/files/111d2e4e-285b-49a7-b6e8-1a6ededc588f/F3D150_R2.fastq
+        src: url
+        ext: fastqsanger
+        info: https://doi.org/10.5281/zenodo.800651
+      - url: https://zenodo.org/api/files/111d2e4e-285b-49a7-b6e8-1a6ededc588f/F3D1_R1.fastq
+        src: url
+        ext: fastqsanger
+        info: https://doi.org/10.5281/zenodo.800651
+      - url: https://zenodo.org/api/files/111d2e4e-285b-49a7-b6e8-1a6ededc588f/F3D1_R2.fastq
+        src: url
+        ext: fastqsanger
+        info: https://doi.org/10.5281/zenodo.800651
+      - url: https://zenodo.org/api/files/111d2e4e-285b-49a7-b6e8-1a6ededc588f/F3D2_R1.fastq
+        src: url
+        ext: fastqsanger
+        info: https://doi.org/10.5281/zenodo.800651
+      - url: https://zenodo.org/api/files/111d2e4e-285b-49a7-b6e8-1a6ededc588f/F3D2_R2.fastq
+        src: url
+        ext: fastqsanger
+        info: https://doi.org/10.5281/zenodo.800651
+      - url: https://zenodo.org/api/files/111d2e4e-285b-49a7-b6e8-1a6ededc588f/F3D3_R1.fastq
+        src: url
+        ext: fastqsanger
+        info: https://doi.org/10.5281/zenodo.800651
+      - url: https://zenodo.org/api/files/111d2e4e-285b-49a7-b6e8-1a6ededc588f/F3D3_R2.fastq
+        src: url
+        ext: fastqsanger
+        info: https://doi.org/10.5281/zenodo.800651
+      - url: https://zenodo.org/api/files/111d2e4e-285b-49a7-b6e8-1a6ededc588f/F3D5_R1.fastq
+        src: url
+        ext: fastqsanger
+        info: https://doi.org/10.5281/zenodo.800651
+      - url: https://zenodo.org/api/files/111d2e4e-285b-49a7-b6e8-1a6ededc588f/F3D5_R2.fastq
+        src: url
+        ext: fastqsanger
+        info: https://doi.org/10.5281/zenodo.800651
+      - url: https://zenodo.org/api/files/111d2e4e-285b-49a7-b6e8-1a6ededc588f/F3D6_R1.fastq
+        src: url
+        ext: fastqsanger
+        info: https://doi.org/10.5281/zenodo.800651
+      - url: https://zenodo.org/api/files/111d2e4e-285b-49a7-b6e8-1a6ededc588f/F3D6_R2.fastq
+        src: url
+        ext: fastqsanger
+        info: https://doi.org/10.5281/zenodo.800651
+      - url: https://zenodo.org/api/files/111d2e4e-285b-49a7-b6e8-1a6ededc588f/F3D7_R1.fastq
+        src: url
+        ext: fastqsanger
+        info: https://doi.org/10.5281/zenodo.800651
+      - url: https://zenodo.org/api/files/111d2e4e-285b-49a7-b6e8-1a6ededc588f/F3D7_R2.fastq
+        src: url
+        ext: fastqsanger
+        info: https://doi.org/10.5281/zenodo.800651
+      - url: https://zenodo.org/api/files/111d2e4e-285b-49a7-b6e8-1a6ededc588f/F3D8_R1.fastq
+        src: url
+        ext: fastqsanger
+        info: https://doi.org/10.5281/zenodo.800651
+      - url: https://zenodo.org/api/files/111d2e4e-285b-49a7-b6e8-1a6ededc588f/F3D8_R2.fastq
+        src: url
+        ext: fastqsanger
+        info: https://doi.org/10.5281/zenodo.800651
+      - url: https://zenodo.org/api/files/111d2e4e-285b-49a7-b6e8-1a6ededc588f/F3D9_R1.fastq
+        src: url
+        ext: fastqsanger
+        info: https://doi.org/10.5281/zenodo.800651
+      - url: https://zenodo.org/api/files/111d2e4e-285b-49a7-b6e8-1a6ededc588f/F3D9_R2.fastq
+        src: url
+        ext: fastqsanger
+        info: https://doi.org/10.5281/zenodo.800651
+      - url: https://zenodo.org/api/files/111d2e4e-285b-49a7-b6e8-1a6ededc588f/HMP_MOCK.v35.fasta
+        src: url
+        ext: fasta
+        info: https://doi.org/10.5281/zenodo.800651
+      - url: https://zenodo.org/api/files/111d2e4e-285b-49a7-b6e8-1a6ededc588f/Mock_R1.fastq
+        src: url
+        ext: fastqsanger
+        info: https://doi.org/10.5281/zenodo.800651
+      - url: https://zenodo.org/api/files/111d2e4e-285b-49a7-b6e8-1a6ededc588f/Mock_R2.fastq
+        src: url
+        ext: fastqsanger
+        info: https://doi.org/10.5281/zenodo.800651
+      - url: https://zenodo.org/api/files/111d2e4e-285b-49a7-b6e8-1a6ededc588f/mouse.dpw.metadata
+        src: url
+        ext: tabular
+        info: https://doi.org/10.5281/zenodo.800651
+      - url: https://zenodo.org/api/files/111d2e4e-285b-49a7-b6e8-1a6ededc588f/mouse.time.design
+        src: url
+        ext: mothur.design
+        info: https://doi.org/10.5281/zenodo.800651
+      - url: https://zenodo.org/api/files/111d2e4e-285b-49a7-b6e8-1a6ededc588f/silva.v4.fasta
+        src: url
+        ext: fasta
+        info: https://doi.org/10.5281/zenodo.800651
+      - url: https://zenodo.org/api/files/111d2e4e-285b-49a7-b6e8-1a6ededc588f/trainset9_032012.pds.fasta
+        src: url
+        ext: fasta
+        info: https://doi.org/10.5281/zenodo.800651
+      - url: https://zenodo.org/api/files/111d2e4e-285b-49a7-b6e8-1a6ededc588f/trainset9_032012.pds.tax
+        src: url
+        ext: mothur.seq.taxonomy
+        info: https://doi.org/10.5281/zenodo.800651

--- a/topics/metagenomics/tutorials/mothur-miseq-sop/data-library.yaml
+++ b/topics/metagenomics/tutorials/mothur-miseq-sop/data-library.yaml
@@ -209,3 +209,192 @@ items:
         src: url
         ext: zip
         info: https://doi.org/10.5281/zenodo.165147
+  - name: 16S Microbial Analysis with mothur (extended)
+    items:
+    - name: 'DOI: 10.5281/zenodo.800651'
+      description: latest
+      items:
+      - url: https://zenodo.org/api/files/111d2e4e-285b-49a7-b6e8-1a6ededc588f/F3D0_R1.fastq
+        src: url
+        ext: fastqsanger
+        info: https://doi.org/10.5281/zenodo.800651
+      - url: https://zenodo.org/api/files/111d2e4e-285b-49a7-b6e8-1a6ededc588f/F3D0_R2.fastq
+        src: url
+        ext: fastqsanger
+        info: https://doi.org/10.5281/zenodo.800651
+      - url: https://zenodo.org/api/files/111d2e4e-285b-49a7-b6e8-1a6ededc588f/F3D141_R1.fastq
+        src: url
+        ext: fastqsanger
+        info: https://doi.org/10.5281/zenodo.800651
+      - url: https://zenodo.org/api/files/111d2e4e-285b-49a7-b6e8-1a6ededc588f/F3D141_R2.fastq
+        src: url
+        ext: fastqsanger
+        info: https://doi.org/10.5281/zenodo.800651
+      - url: https://zenodo.org/api/files/111d2e4e-285b-49a7-b6e8-1a6ededc588f/F3D142_R1.fastq
+        src: url
+        ext: fastqsanger
+        info: https://doi.org/10.5281/zenodo.800651
+      - url: https://zenodo.org/api/files/111d2e4e-285b-49a7-b6e8-1a6ededc588f/F3D142_R2.fastq
+        src: url
+        ext: fastqsanger
+        info: https://doi.org/10.5281/zenodo.800651
+      - url: https://zenodo.org/api/files/111d2e4e-285b-49a7-b6e8-1a6ededc588f/F3D143_R1.fastq
+        src: url
+        ext: fastqsanger
+        info: https://doi.org/10.5281/zenodo.800651
+      - url: https://zenodo.org/api/files/111d2e4e-285b-49a7-b6e8-1a6ededc588f/F3D143_R2.fastq
+        src: url
+        ext: fastqsanger
+        info: https://doi.org/10.5281/zenodo.800651
+      - url: https://zenodo.org/api/files/111d2e4e-285b-49a7-b6e8-1a6ededc588f/F3D144_R1.fastq
+        src: url
+        ext: fastqsanger
+        info: https://doi.org/10.5281/zenodo.800651
+      - url: https://zenodo.org/api/files/111d2e4e-285b-49a7-b6e8-1a6ededc588f/F3D144_R2.fastq
+        src: url
+        ext: fastqsanger
+        info: https://doi.org/10.5281/zenodo.800651
+      - url: https://zenodo.org/api/files/111d2e4e-285b-49a7-b6e8-1a6ededc588f/F3D145_R1.fastq
+        src: url
+        ext: fastqsanger
+        info: https://doi.org/10.5281/zenodo.800651
+      - url: https://zenodo.org/api/files/111d2e4e-285b-49a7-b6e8-1a6ededc588f/F3D145_R2.fastq
+        src: url
+        ext: fastqsanger
+        info: https://doi.org/10.5281/zenodo.800651
+      - url: https://zenodo.org/api/files/111d2e4e-285b-49a7-b6e8-1a6ededc588f/F3D146_R1.fastq
+        src: url
+        ext: fastqsanger
+        info: https://doi.org/10.5281/zenodo.800651
+      - url: https://zenodo.org/api/files/111d2e4e-285b-49a7-b6e8-1a6ededc588f/F3D146_R2.fastq
+        src: url
+        ext: fastqsanger
+        info: https://doi.org/10.5281/zenodo.800651
+      - url: https://zenodo.org/api/files/111d2e4e-285b-49a7-b6e8-1a6ededc588f/F3D147_R1.fastq
+        src: url
+        ext: fastqsanger
+        info: https://doi.org/10.5281/zenodo.800651
+      - url: https://zenodo.org/api/files/111d2e4e-285b-49a7-b6e8-1a6ededc588f/F3D147_R2.fastq
+        src: url
+        ext: fastqsanger
+        info: https://doi.org/10.5281/zenodo.800651
+      - url: https://zenodo.org/api/files/111d2e4e-285b-49a7-b6e8-1a6ededc588f/F3D148_R1.fastq
+        src: url
+        ext: fastqsanger
+        info: https://doi.org/10.5281/zenodo.800651
+      - url: https://zenodo.org/api/files/111d2e4e-285b-49a7-b6e8-1a6ededc588f/F3D148_R2.fastq
+        src: url
+        ext: fastqsanger
+        info: https://doi.org/10.5281/zenodo.800651
+      - url: https://zenodo.org/api/files/111d2e4e-285b-49a7-b6e8-1a6ededc588f/F3D149_R1.fastq
+        src: url
+        ext: fastqsanger
+        info: https://doi.org/10.5281/zenodo.800651
+      - url: https://zenodo.org/api/files/111d2e4e-285b-49a7-b6e8-1a6ededc588f/F3D149_R2.fastq
+        src: url
+        ext: fastqsanger
+        info: https://doi.org/10.5281/zenodo.800651
+      - url: https://zenodo.org/api/files/111d2e4e-285b-49a7-b6e8-1a6ededc588f/F3D150_R1.fastq
+        src: url
+        ext: fastqsanger
+        info: https://doi.org/10.5281/zenodo.800651
+      - url: https://zenodo.org/api/files/111d2e4e-285b-49a7-b6e8-1a6ededc588f/F3D150_R2.fastq
+        src: url
+        ext: fastqsanger
+        info: https://doi.org/10.5281/zenodo.800651
+      - url: https://zenodo.org/api/files/111d2e4e-285b-49a7-b6e8-1a6ededc588f/F3D1_R1.fastq
+        src: url
+        ext: fastqsanger
+        info: https://doi.org/10.5281/zenodo.800651
+      - url: https://zenodo.org/api/files/111d2e4e-285b-49a7-b6e8-1a6ededc588f/F3D1_R2.fastq
+        src: url
+        ext: fastqsanger
+        info: https://doi.org/10.5281/zenodo.800651
+      - url: https://zenodo.org/api/files/111d2e4e-285b-49a7-b6e8-1a6ededc588f/F3D2_R1.fastq
+        src: url
+        ext: fastqsanger
+        info: https://doi.org/10.5281/zenodo.800651
+      - url: https://zenodo.org/api/files/111d2e4e-285b-49a7-b6e8-1a6ededc588f/F3D2_R2.fastq
+        src: url
+        ext: fastqsanger
+        info: https://doi.org/10.5281/zenodo.800651
+      - url: https://zenodo.org/api/files/111d2e4e-285b-49a7-b6e8-1a6ededc588f/F3D3_R1.fastq
+        src: url
+        ext: fastqsanger
+        info: https://doi.org/10.5281/zenodo.800651
+      - url: https://zenodo.org/api/files/111d2e4e-285b-49a7-b6e8-1a6ededc588f/F3D3_R2.fastq
+        src: url
+        ext: fastqsanger
+        info: https://doi.org/10.5281/zenodo.800651
+      - url: https://zenodo.org/api/files/111d2e4e-285b-49a7-b6e8-1a6ededc588f/F3D5_R1.fastq
+        src: url
+        ext: fastqsanger
+        info: https://doi.org/10.5281/zenodo.800651
+      - url: https://zenodo.org/api/files/111d2e4e-285b-49a7-b6e8-1a6ededc588f/F3D5_R2.fastq
+        src: url
+        ext: fastqsanger
+        info: https://doi.org/10.5281/zenodo.800651
+      - url: https://zenodo.org/api/files/111d2e4e-285b-49a7-b6e8-1a6ededc588f/F3D6_R1.fastq
+        src: url
+        ext: fastqsanger
+        info: https://doi.org/10.5281/zenodo.800651
+      - url: https://zenodo.org/api/files/111d2e4e-285b-49a7-b6e8-1a6ededc588f/F3D6_R2.fastq
+        src: url
+        ext: fastqsanger
+        info: https://doi.org/10.5281/zenodo.800651
+      - url: https://zenodo.org/api/files/111d2e4e-285b-49a7-b6e8-1a6ededc588f/F3D7_R1.fastq
+        src: url
+        ext: fastqsanger
+        info: https://doi.org/10.5281/zenodo.800651
+      - url: https://zenodo.org/api/files/111d2e4e-285b-49a7-b6e8-1a6ededc588f/F3D7_R2.fastq
+        src: url
+        ext: fastqsanger
+        info: https://doi.org/10.5281/zenodo.800651
+      - url: https://zenodo.org/api/files/111d2e4e-285b-49a7-b6e8-1a6ededc588f/F3D8_R1.fastq
+        src: url
+        ext: fastqsanger
+        info: https://doi.org/10.5281/zenodo.800651
+      - url: https://zenodo.org/api/files/111d2e4e-285b-49a7-b6e8-1a6ededc588f/F3D8_R2.fastq
+        src: url
+        ext: fastqsanger
+        info: https://doi.org/10.5281/zenodo.800651
+      - url: https://zenodo.org/api/files/111d2e4e-285b-49a7-b6e8-1a6ededc588f/F3D9_R1.fastq
+        src: url
+        ext: fastqsanger
+        info: https://doi.org/10.5281/zenodo.800651
+      - url: https://zenodo.org/api/files/111d2e4e-285b-49a7-b6e8-1a6ededc588f/F3D9_R2.fastq
+        src: url
+        ext: fastqsanger
+        info: https://doi.org/10.5281/zenodo.800651
+      - url: https://zenodo.org/api/files/111d2e4e-285b-49a7-b6e8-1a6ededc588f/HMP_MOCK.v35.fasta
+        src: url
+        ext: fasta
+        info: https://doi.org/10.5281/zenodo.800651
+      - url: https://zenodo.org/api/files/111d2e4e-285b-49a7-b6e8-1a6ededc588f/Mock_R1.fastq
+        src: url
+        ext: fastqsanger
+        info: https://doi.org/10.5281/zenodo.800651
+      - url: https://zenodo.org/api/files/111d2e4e-285b-49a7-b6e8-1a6ededc588f/Mock_R2.fastq
+        src: url
+        ext: fastqsanger
+        info: https://doi.org/10.5281/zenodo.800651
+      - url: https://zenodo.org/api/files/111d2e4e-285b-49a7-b6e8-1a6ededc588f/mouse.dpw.metadata
+        src: url
+        ext: tabular
+        info: https://doi.org/10.5281/zenodo.800651
+      - url: https://zenodo.org/api/files/111d2e4e-285b-49a7-b6e8-1a6ededc588f/mouse.time.design
+        src: url
+        ext: mothur.design
+        info: https://doi.org/10.5281/zenodo.800651
+      - url: https://zenodo.org/api/files/111d2e4e-285b-49a7-b6e8-1a6ededc588f/silva.v4.fasta
+        src: url
+        ext: fasta
+        info: https://doi.org/10.5281/zenodo.800651
+      - url: https://zenodo.org/api/files/111d2e4e-285b-49a7-b6e8-1a6ededc588f/trainset9_032012.pds.fasta
+        src: url
+        ext: fasta
+        info: https://doi.org/10.5281/zenodo.800651
+      - url: https://zenodo.org/api/files/111d2e4e-285b-49a7-b6e8-1a6ededc588f/trainset9_032012.pds.tax
+        src: url
+        ext: mothur.seq.taxonomy
+        info: https://doi.org/10.5281/zenodo.800651

--- a/topics/metagenomics/tutorials/plasmid-metagenomics-nanopore/data-library.yaml
+++ b/topics/metagenomics/tutorials/plasmid-metagenomics-nanopore/data-library.yaml
@@ -9,56 +9,56 @@ items:
   description: Metagenomics is a discipline that enables the genomic study of uncultured
     microorganisms
   items:
-  - name: Antibiotic resistance detection 
+  - name: Antibiotic resistance detection
     items:
     - name: 'DOI: 10.5281/zenodo.3247504'
       description: latest
       items:
-      - url: https://zenodo.org/record/3247504/files/RB01.fasta
+      - url: https://zenodo.org/api/files/51c8f3dc-61fa-4bb2-a014-a65aadfaf64a/RB01.fasta
         src: url
         ext: fasta
         info: https://doi.org/10.5281/zenodo.3247504
-      - url: https://zenodo.org/record/3247504/files/RB02.fasta
+      - url: https://zenodo.org/api/files/51c8f3dc-61fa-4bb2-a014-a65aadfaf64a/RB02.fasta
         src: url
         ext: fasta
         info: https://doi.org/10.5281/zenodo.3247504
-      - url: https://zenodo.org/record/3247504/files/RB03.fasta
+      - url: https://zenodo.org/api/files/51c8f3dc-61fa-4bb2-a014-a65aadfaf64a/RB03.fasta
         src: url
         ext: fasta
         info: https://doi.org/10.5281/zenodo.3247504
-      - url: https://zenodo.org/record/3247504/files/RB04.fasta
+      - url: https://zenodo.org/api/files/51c8f3dc-61fa-4bb2-a014-a65aadfaf64a/RB04.fasta
         src: url
         ext: fasta
         info: https://doi.org/10.5281/zenodo.3247504
-      - url: https://zenodo.org/record/3247504/files/RB05.fasta
+      - url: https://zenodo.org/api/files/51c8f3dc-61fa-4bb2-a014-a65aadfaf64a/RB05.fasta
         src: url
         ext: fasta
         info: https://doi.org/10.5281/zenodo.3247504
-      - url: https://zenodo.org/record/3247504/files/RB06.fasta
+      - url: https://zenodo.org/api/files/51c8f3dc-61fa-4bb2-a014-a65aadfaf64a/RB06.fasta
         src: url
         ext: fasta
         info: https://doi.org/10.5281/zenodo.3247504
-      - url: https://zenodo.org/record/3247504/files/RB07.fasta
+      - url: https://zenodo.org/api/files/51c8f3dc-61fa-4bb2-a014-a65aadfaf64a/RB07.fasta
         src: url
         ext: fasta
         info: https://doi.org/10.5281/zenodo.3247504
-      - url: https://zenodo.org/record/3247504/files/RB08.fasta
+      - url: https://zenodo.org/api/files/51c8f3dc-61fa-4bb2-a014-a65aadfaf64a/RB08.fasta
         src: url
         ext: fasta
         info: https://doi.org/10.5281/zenodo.3247504
-      - url: https://zenodo.org/record/3247504/files/RB09.fasta
+      - url: https://zenodo.org/api/files/51c8f3dc-61fa-4bb2-a014-a65aadfaf64a/RB09.fasta
         src: url
         ext: fasta
         info: https://doi.org/10.5281/zenodo.3247504
-      - url: https://zenodo.org/record/3247504/files/RB10.fasta
+      - url: https://zenodo.org/api/files/51c8f3dc-61fa-4bb2-a014-a65aadfaf64a/RB10.fasta
         src: url
         ext: fasta
         info: https://doi.org/10.5281/zenodo.3247504
-      - url: https://zenodo.org/record/3247504/files/RB11.fasta
+      - url: https://zenodo.org/api/files/51c8f3dc-61fa-4bb2-a014-a65aadfaf64a/RB11.fasta
         src: url
         ext: fasta
         info: https://doi.org/10.5281/zenodo.3247504
-      - url: https://zenodo.org/record/3247504/files/RB12.fasta
+      - url: https://zenodo.org/api/files/51c8f3dc-61fa-4bb2-a014-a65aadfaf64a/RB12.fasta
         src: url
         ext: fasta
         info: https://doi.org/10.5281/zenodo.3247504

--- a/topics/proteomics/tutorials/biomarker_selection/tutorial.md
+++ b/topics/proteomics/tutorials/biomarker_selection/tutorial.md
@@ -2,7 +2,6 @@
 layout: tutorial_hands_on
 
 title:  Biomarker candidate identification
-zenodo_link: ''
 questions:
 - How to mine public databases to retrieve info?
 - How to build a selection strategy by applying

--- a/topics/proteomics/tutorials/database-handling/tutorial.md
+++ b/topics/proteomics/tutorials/database-handling/tutorial.md
@@ -3,7 +3,6 @@ layout: tutorial_hands_on
 
 title: "Protein FASTA Database Handling"
 edam_ontology: "topic_0121"
-zenodo_link: ""
 level: Introductory
 questions:
   - "How to download protein FASTA databases of a certain organism?"

--- a/topics/proteomics/tutorials/labelfree-vs-labelled/tutorial.md
+++ b/topics/proteomics/tutorials/labelfree-vs-labelled/tutorial.md
@@ -2,7 +2,6 @@
 layout: tutorial_hands_on
 
 title: "Label-free versus Labelled - How to Choose Your Quantitation Method"
-zenodo_link: ""
 level: Introductory
 questions:
   - "What are benefits and drawbacks of different quantitation methods?"

--- a/topics/proteomics/tutorials/mass-spectrometry-imaging-loading-exploring-data/data-library.yaml
+++ b/topics/proteomics/tutorials/mass-spectrometry-imaging-loading-exploring-data/data-library.yaml
@@ -13,12 +13,20 @@ items:
     - name: 'DOI: 10.5281/zenodo.1560645'
       description: latest
       items:
-      # Commented until composite dataset upload is possible (https://github.com/galaxyproject/galaxy/issues/8909)
-      # - url: https://zenodo.org/api/files/463f6b73-0c42-4be4-8b52-181a8e093abd/mouse_kidney_cut.ibd
-      #  src: url
-      #  ext: ibd
-      #  info: https://doi.org/10.5281/zenodo.1560645
       - url: https://zenodo.org/api/files/463f6b73-0c42-4be4-8b52-181a8e093abd/mouse_kidney_cut.imzML
         src: url
         ext: imzml
+        info: https://doi.org/10.5281/zenodo.1560645
+  - name: 'Mass spectrometry imaging: Loading and exploring MSI data'
+    items:
+    - name: 'DOI: 10.5281/zenodo.1560645'
+      description: latest
+      items:
+      - url: https://zenodo.org/api/files/463f6b73-0c42-4be4-8b52-181a8e093abd/mouse_kidney_cut.ibd
+        src: url
+        ext: ibd
+        info: https://doi.org/10.5281/zenodo.1560645
+      - url: https://zenodo.org/api/files/463f6b73-0c42-4be4-8b52-181a8e093abd/mouse_kidney_cut.imzML
+        src: url
+        ext: '# Please add a Galaxy datatype or update the shared/datatypes.yaml file'
         info: https://doi.org/10.5281/zenodo.1560645

--- a/topics/proteomics/tutorials/maxquant-label-free/data-library.yaml
+++ b/topics/proteomics/tutorials/maxquant-label-free/data-library.yaml
@@ -10,8 +10,39 @@ items:
   items:
   - name: Label-free data analysis using MaxQuant
     items:
-    - name: '10.5281/zenodo.3774452'
+    - name: 'DOI: 10.5281/zenodo.3774452'
       description: latest
+      items:
+      - url: https://zenodo.org/api/files/7eeb171b-1d37-475b-ad3f-0aae418b590b/MaxQuant_mqpar.xml
+        src: url
+        ext: '# Please add a Galaxy datatype or update the shared/datatypes.yaml file'
+        info: https://zenodo.org/record/3774452
+      - url: https://zenodo.org/api/files/7eeb171b-1d37-475b-ad3f-0aae418b590b/MaxQuant_Peptides.tabular
+        src: url
+        ext: tabular
+        info: https://zenodo.org/record/3774452
+      - url: https://zenodo.org/api/files/7eeb171b-1d37-475b-ad3f-0aae418b590b/MaxQuant_Protein_Groups.tabular
+        src: url
+        ext: tabular
+        info: https://zenodo.org/record/3774452
+      - url: https://zenodo.org/api/files/7eeb171b-1d37-475b-ad3f-0aae418b590b/Protein_database.fasta
+        src: url
+        ext: fasta
+        info: https://zenodo.org/record/3774452
+      - url: https://zenodo.org/api/files/7eeb171b-1d37-475b-ad3f-0aae418b590b/PTXQC_report.pdf
+        src: url
+        ext: '# Please add a Galaxy datatype or update the shared/datatypes.yaml file'
+        info: https://zenodo.org/record/3774452
+      - url: https://zenodo.org/api/files/7eeb171b-1d37-475b-ad3f-0aae418b590b/Sample1.raw
+        src: url
+        ext: thermo.raw
+        info: https://zenodo.org/record/3774452
+      - url: https://zenodo.org/api/files/7eeb171b-1d37-475b-ad3f-0aae418b590b/Sample2.raw
+        src: url
+        ext: thermo.raw
+        info: https://zenodo.org/record/3774452
+    - name: 10.5281/zenodo.3774452
+      description: ''
       items:
       - url: https://zenodo.org/record/3774452/files/Sample1.raw
         src: url

--- a/topics/proteomics/tutorials/metaquantome-data-creation/data-library.yaml
+++ b/topics/proteomics/tutorials/metaquantome-data-creation/data-library.yaml
@@ -1,0 +1,39 @@
+---
+destination:
+  type: library
+  name: GTN - Material
+  description: Galaxy Training Network Material
+  synopsis: Galaxy Training Network Material. See https://training.galaxyproject.org
+items:
+- name: Proteomics
+  description: Training material for proteomics workflows in Galaxy
+  items:
+  - name: 'metaQuantome 1: Data creation'
+    items:
+    - name: 'DOI: 10.5281/zenodo.4037137'
+      description: latest
+      items:
+      - url: https://zenodo.org/api/files/ae1f8058-590e-4326-955a-65f9cd32a7d0/ExperimentalDesign.tsv
+        src: url
+        ext: tsv
+        info: https://doi.org/10.5281/zenodo.4037137
+      - url: https://zenodo.org/api/files/ae1f8058-590e-4326-955a-65f9cd32a7d0/ProteinDB_cRAP.fasta
+        src: url
+        ext: fasta
+        info: https://doi.org/10.5281/zenodo.4037137
+      - url: https://zenodo.org/api/files/ae1f8058-590e-4326-955a-65f9cd32a7d0/T2_A1.mzml
+        src: url
+        ext: mzml
+        info: https://doi.org/10.5281/zenodo.4037137
+      - url: https://zenodo.org/api/files/ae1f8058-590e-4326-955a-65f9cd32a7d0/T2_B1.mzml
+        src: url
+        ext: mzml
+        info: https://doi.org/10.5281/zenodo.4037137
+      - url: https://zenodo.org/api/files/ae1f8058-590e-4326-955a-65f9cd32a7d0/T7A_1.mzml
+        src: url
+        ext: mzml
+        info: https://doi.org/10.5281/zenodo.4037137
+      - url: https://zenodo.org/api/files/ae1f8058-590e-4326-955a-65f9cd32a7d0/T7B_1.mzml
+        src: url
+        ext: mzml
+        info: https://doi.org/10.5281/zenodo.4037137

--- a/topics/proteomics/tutorials/metaquantome-function/data-library.yaml
+++ b/topics/proteomics/tutorials/metaquantome-function/data-library.yaml
@@ -1,0 +1,27 @@
+---
+destination:
+  type: library
+  name: GTN - Material
+  description: Galaxy Training Network Material
+  synopsis: Galaxy Training Network Material. See https://training.galaxyproject.org
+items:
+- name: Proteomics
+  description: Training material for proteomics workflows in Galaxy
+  items:
+  - name: 'metaQuantome 2: Function'
+    items:
+    - name: 'DOI: 10.5281/zenodo.4110725'
+      description: latest
+      items:
+      - url: https://zenodo.org/api/files/50ece8a4-f12e-4bb0-8b25-e9f0d4325e04/Function-File.tabular
+        src: url
+        ext: tabular
+        info: https://doi.org/10.5281/zenodo.4110725
+      - url: https://zenodo.org/api/files/50ece8a4-f12e-4bb0-8b25-e9f0d4325e04/Intensity-File.tabular
+        src: url
+        ext: tabular
+        info: https://doi.org/10.5281/zenodo.4110725
+      - url: https://zenodo.org/api/files/50ece8a4-f12e-4bb0-8b25-e9f0d4325e04/Taxonomy-File.tabular
+        src: url
+        ext: tabular
+        info: https://doi.org/10.5281/zenodo.4110725

--- a/topics/proteomics/tutorials/metaquantome-taxonomy/data-library.yaml
+++ b/topics/proteomics/tutorials/metaquantome-taxonomy/data-library.yaml
@@ -1,0 +1,27 @@
+---
+destination:
+  type: library
+  name: GTN - Material
+  description: Galaxy Training Network Material
+  synopsis: Galaxy Training Network Material. See https://training.galaxyproject.org
+items:
+- name: Proteomics
+  description: Training material for proteomics workflows in Galaxy
+  items:
+  - name: 'metaQuantome 3: Taxonomy'
+    items:
+    - name: 'DOI: 10.5281/zenodo.4110725'
+      description: latest
+      items:
+      - url: https://zenodo.org/api/files/50ece8a4-f12e-4bb0-8b25-e9f0d4325e04/Function-File.tabular
+        src: url
+        ext: tabular
+        info: https://doi.org/10.5281/zenodo.4110725
+      - url: https://zenodo.org/api/files/50ece8a4-f12e-4bb0-8b25-e9f0d4325e04/Intensity-File.tabular
+        src: url
+        ext: tabular
+        info: https://doi.org/10.5281/zenodo.4110725
+      - url: https://zenodo.org/api/files/50ece8a4-f12e-4bb0-8b25-e9f0d4325e04/Taxonomy-File.tabular
+        src: url
+        ext: tabular
+        info: https://doi.org/10.5281/zenodo.4110725

--- a/topics/proteomics/tutorials/ntails/tutorial.md
+++ b/topics/proteomics/tutorials/ntails/tutorial.md
@@ -3,7 +3,6 @@ layout: tutorial_hands_on
 
 title: "Detection and quantitation of N-termini (degradomics) via N-TAILS"
 edam_ontology: "topic_0121"
-zenodo_link: ""
 level: Intermediate
 questions:
   - "How can protein N-termini be enriched for LC-MS/MS?"

--- a/topics/proteomics/tutorials/proteome_annotation/data-library.yaml
+++ b/topics/proteomics/tutorials/proteome_annotation/data-library.yaml
@@ -1,0 +1,27 @@
+---
+destination:
+  type: library
+  name: GTN - Material
+  description: Galaxy Training Network Material
+  synopsis: Galaxy Training Network Material. See https://training.galaxyproject.org
+items:
+- name: Proteomics
+  description: Training material for proteomics workflows in Galaxy
+  items:
+  - name: Annotating a protein list identified by LC-MS/MS experiments
+    items:
+    - name: 'DOI: 10.5281/zenodo.3405119'
+      description: latest
+      items:
+      - url: https://zenodo.org/api/files/4c5e2fad-f1b7-4bc2-baa9-58c7ee7db673/Bredberg.txt
+        src: url
+        ext: txt
+        info: https://zenodo.org/record/3405119
+      - url: https://zenodo.org/api/files/4c5e2fad-f1b7-4bc2-baa9-58c7ee7db673/Lacombe_2018.txt
+        src: url
+        ext: txt
+        info: https://zenodo.org/record/3405119
+      - url: https://zenodo.org/api/files/4c5e2fad-f1b7-4bc2-baa9-58c7ee7db673/Mucilli.txt
+        src: url
+        ext: txt
+        info: https://zenodo.org/record/3405119

--- a/topics/sequence-analysis/tutorials/mapping/data-library.yaml
+++ b/topics/sequence-analysis/tutorials/mapping/data-library.yaml
@@ -31,11 +31,11 @@ items:
         info: https://doi.org/10.5281/zenodo.1324070
       - url: https://zenodo.org/api/files/67d95c38-5a06-4184-b3a0-a6d3c9f25268/wt_H3K4me3_read1.fastq.gz
         src: url
-        ext: fastqsanger.gz
+        ext: gz
         info: https://doi.org/10.5281/zenodo.1324070
       - url: https://zenodo.org/api/files/67d95c38-5a06-4184-b3a0-a6d3c9f25268/wt_H3K4me3_read2.fastq.gz
         src: url
-        ext: fastqsanger.gz
+        ext: gz
         info: https://doi.org/10.5281/zenodo.1324070
       - url: https://zenodo.org/api/files/67d95c38-5a06-4184-b3a0-a6d3c9f25268/wt_H3K4me3_rep1.bam
         src: url

--- a/topics/statistics/tutorials/age-prediction-with-ml/tutorial.md
+++ b/topics/statistics/tutorials/age-prediction-with-ml/tutorial.md
@@ -2,7 +2,7 @@
 layout: tutorial_hands_on
 
 title: Age prediction using machine learning
-zenodo_link: https://zenodo.org/record/2545213#.XEWTJ9-YVa0
+zenodo_link: "https://zenodo.org/record/2545213"
 questions:
 - How to use machine learning to create predictive models from biological datasets (RNA-seq and DNA methylation)?
 objectives:
@@ -236,7 +236,7 @@ The output plot has the following legend: the colour-coding is based on the `mea
 >
 > > ### {% icon solution %} Solution
 > >
-> > Worst four: 
+> > Worst four:
 > >    - alpha: 0.00001, normalize: False, k: 5880
 > >    - alpha: 0.00001, normalize: False, k: 5890
 > >    - alpha: 0.00001, normalize: False, k: 5895
@@ -300,7 +300,7 @@ We will create a pipeline with **Pipeline builder** tool, but this time, we just
 >            - *"Choose estimator class"*: `GradientBoostingRegressor`
 >            - *"Type in parameter settings if different from default"*: `random_state=42`
 >    - In *"Output parameters for searchCV?"*: `Yes`
-> 
+>
 >
 {: .hands_on}
 

--- a/topics/statistics/tutorials/classification_machinelearning/data-library.yaml
+++ b/topics/statistics/tutorials/classification_machinelearning/data-library.yaml
@@ -6,13 +6,27 @@ destination:
   synopsis: Galaxy Training Network Material. See https://training.galaxyproject.org
 items:
 - name: Statistics and machine learning
-  description: Classification algorithms in machine learning using Galaxy
-    tools
+  description: Classification algorithms in machine learning using Galaxy tools
   items:
   - name: Classification in Machine Learning
     items:
-    - name: 'DOI:10.5281/zenodo.3738729'
+    - name: 'DOI: 10.5281/zenodo.3738729#.XoZyHXUzaV4'
       description: latest
+      items:
+      - url: https://zenodo.org/api/files/e2310a01-d2f0-44bb-9a82-26eb769ce979/test_rows.csv
+        src: url
+        ext: csv
+        info: https://zenodo.org/record/3738729#.XoZyHXUzaV4
+      - url: https://zenodo.org/api/files/e2310a01-d2f0-44bb-9a82-26eb769ce979/test_rows_labels.csv
+        src: url
+        ext: csv
+        info: https://zenodo.org/record/3738729#.XoZyHXUzaV4
+      - url: https://zenodo.org/api/files/e2310a01-d2f0-44bb-9a82-26eb769ce979/train_rows.csv
+        src: url
+        ext: csv
+        info: https://zenodo.org/record/3738729#.XoZyHXUzaV4
+    - name: DOI:10.5281/zenodo.3738729
+      description: ''
       items:
       - url: https://zenodo.org/record/3738729/files/train_rows.csv
         src: url

--- a/topics/statistics/tutorials/classification_machinelearning/tutorial.md
+++ b/topics/statistics/tutorials/classification_machinelearning/tutorial.md
@@ -2,7 +2,7 @@
 layout: tutorial_hands_on
 
 title: 'Classification in Machine Learning'
-zenodo_link: https://zenodo.org/record/3738729#.XoZyHXUzaV4
+zenodo_link: "https://zenodo.org/record/3738729"
 questions:
 - What is classification and how we can use classification techniques?
 objectives:
@@ -136,7 +136,7 @@ The second thing we need is an optimization algorithm for iteratively updating t
 > > ### {% icon solution %} Solution
 > >
 > > In the logistic regressoion model, the coefficients of the logistic regression algorithm have be estimated from our training data. This is done using [maximum-likelihood estimation](https://en.wikipedia.org/wiki/Maximum_likelihood_estimation).
-> > 
+> >
 > {: .solution}
 >
 {: .question}
@@ -161,7 +161,7 @@ Now, we will predict the class in the test dataset using this classifier in orde
 
 ## Visualize the logistic regression classification results
 
-We will evaluate the classification by comparing the predicted with the expected classes. In the previous step, we classified the test dataset (`LogisticRegression_result`). We have one more dataset (`test_rows_labels`) which contains the true class label of the test set. Using the true and predicted class labels in the test set, we will verify the performance by analyzing the plots. As you can see, `LogisticRegression_result` has no header, so first we should remove the header from `test_rows_labels` to compare. 
+We will evaluate the classification by comparing the predicted with the expected classes. In the previous step, we classified the test dataset (`LogisticRegression_result`). We have one more dataset (`test_rows_labels`) which contains the true class label of the test set. Using the true and predicted class labels in the test set, we will verify the performance by analyzing the plots. As you can see, `LogisticRegression_result` has no header, so first we should remove the header from `test_rows_labels` to compare.
 
 > ### {% icon hands_on %} Hands-on: Remove the header
 >
@@ -204,7 +204,7 @@ These plots are important to visualize the quality of the classifier and the tru
 >
 > > ### {% icon solution %} Solution
 > >
-> > Figures 2,3 and 4 show that the classification is acceptable, but as you will see in the next steps, the results can be improved. 
+> > Figures 2,3 and 4 show that the classification is acceptable, but as you will see in the next steps, the results can be improved.
 > >
 > {: .solution}
 {: .question}
@@ -267,12 +267,12 @@ At the second step, we will use k-nearest neighbor classifier. In the [k-nearest
 > What is the value of k (number of neighbors) for the model?
 >
 > > ### {% icon solution %} Solution
-> > As you can see in the Advanced Options, the default value for the number of neighbors is 5, and we used the default value. You can set this parameter based on your problem and data. 
+> > As you can see in the Advanced Options, the default value for the number of neighbors is 5, and we used the default value. You can set this parameter based on your problem and data.
 > >
 > {: .solution}
 {: .question}
 
-Now, we should evaluate the performance on the test dataset to find out whether the KNN classifier is a good model from the training dataset or not. 
+Now, we should evaluate the performance on the test dataset to find out whether the KNN classifier is a good model from the training dataset or not.
 
 > ### {% icon hands_on %} Hands-on: Predict class using the k-nearest neighbor classifier
 >
@@ -286,7 +286,7 @@ Now, we should evaluate the performance on the test dataset to find out whether 
 {: .hands_on}
 
 
-Now we visualize and analyze the classification. As you can see, `NearestNeighbors_result` has a header, so use `test_rows_labels` to compare. 
+Now we visualize and analyze the classification. As you can see, `NearestNeighbors_result` has a header, so use `test_rows_labels` to compare.
 
 > ### {% icon hands_on %} Hands-on: Check and visualize the classification
 > 1. **Plot confusion matrix, precision, recall and ROC and AUC curves** {% icon tool %} with the following parameters to visualize the classification:
@@ -311,7 +311,7 @@ The visualization tool creates diagrams for the Confusion matrix, Precision, rec
 To solve this problem, SVM uses kernel functions to map the input to a high dimension feature space, i.e hyperplane, where a linear decision boundary is constructed in such a manner that the boundary maximises the margin between two classes. The kernel approach is simply an efficient computational approach for accommodating a non-linear boundary between classes.
 
 Without going into technical details, a kernel is a function that quantifies the similarity of two observations. Two special properties of SVMs are that SVMs achieve (1) high generalization by maximizing the margin and (2) support an efficient learning of nonlinear functions by
-kernel trick. In the next step, we will build a SVM classifier with our data. 
+kernel trick. In the next step, we will build a SVM classifier with our data.
 
 > ### {% icon hands_on %} Hands-on: Train a SVM classifier
 >
@@ -337,7 +337,7 @@ kernel trick. In the next step, we will build a SVM classifier with our data.
 > > ### {% icon solution %} Solution
 > >
 > > The coefficients of the line with the maximal margin in the kernel space is learned in the training phase.
-> > 
+> >
 > {: .solution}
 >
 {: .question}
@@ -447,7 +447,7 @@ At the last step, we will create a bagging classifier by using  the **Pipeline b
 >        - *"Choose the module that contains target estimator"*: `sklearn.ensemble`
 >            - *"Choose estimator class"*: `BaggingClassifier`
 >    - In *"Output parameters for searchCV?"*: `Yes`
-> 
+>
 >      We choose `Final Estimator` as we have only the estimator and no preprocessor and need the parameters of only the estimator.
 >
 {: .hands_on}
@@ -491,7 +491,7 @@ After extracting the parameter names from the **Pipeline builder** file, we will
 >
 > > ### {% icon solution %} Solution
 > >
-> > 20 - even though the default value of the number of estimators for Bagging Classifier is `10`, `20` gives the best accuracy. That's why it is important to perform hyperparameter search to tune these parameters for any dataset. 
+> > 20 - even though the default value of the number of estimators for Bagging Classifier is `10`, `20` gives the best accuracy. That's why it is important to perform hyperparameter search to tune these parameters for any dataset.
 > >
 > {: .solution}
 >

--- a/topics/statistics/tutorials/classification_regression/data-library.yaml
+++ b/topics/statistics/tutorials/classification_regression/data-library.yaml
@@ -11,8 +11,35 @@ items:
   items:
   - name: 'Machine learning: classification and regression'
     items:
-    - name: 'DOI: https://zenodo.org/record/3248907'
+    - name: 'DOI: 10.5281/zenodo.2579649#.XHep39F7mL4'
       description: latest
+      items:
+      - url: https://zenodo.org/api/files/efd372b1-4d11-4f43-bba6-66e75a0b4d15/breast-w_targets.tsv
+        src: url
+        ext: tsv
+        info: https://zenodo.org/record/2579649#.XHep39F7mL4
+      - url: https://zenodo.org/api/files/efd372b1-4d11-4f43-bba6-66e75a0b4d15/breast-w_test.tsv
+        src: url
+        ext: tsv
+        info: https://zenodo.org/record/2579649#.XHep39F7mL4
+      - url: https://zenodo.org/api/files/efd372b1-4d11-4f43-bba6-66e75a0b4d15/breast-w_train.tsv
+        src: url
+        ext: tsv
+        info: https://zenodo.org/record/2579649#.XHep39F7mL4
+      - url: https://zenodo.org/api/files/efd372b1-4d11-4f43-bba6-66e75a0b4d15/test_data.tabular
+        src: url
+        ext: tabular
+        info: https://zenodo.org/record/2579649#.XHep39F7mL4
+      - url: https://zenodo.org/api/files/efd372b1-4d11-4f43-bba6-66e75a0b4d15/test_target.tabular
+        src: url
+        ext: tabular
+        info: https://zenodo.org/record/2579649#.XHep39F7mL4
+      - url: https://zenodo.org/api/files/efd372b1-4d11-4f43-bba6-66e75a0b4d15/train_data.tabular
+        src: url
+        ext: tabular
+        info: https://zenodo.org/record/2579649#.XHep39F7mL4
+    - name: 'DOI: https://zenodo.org/record/3248907'
+      description: ''
       items:
       - info: https://zenodo.org/record/3248907
         ext: tsv

--- a/topics/statistics/tutorials/classification_regression/tutorial.md
+++ b/topics/statistics/tutorials/classification_regression/tutorial.md
@@ -2,7 +2,7 @@
 layout: tutorial_hands_on
 
 title: 'Machine learning: classification and regression'
-zenodo_link: https://zenodo.org/record/2579649#.XHep39F7mL4
+zenodo_link: "https://zenodo.org/record/2579649"
 questions:
 - what are classification and regression techniques?
 - How they can be used for prediction?
@@ -123,7 +123,7 @@ The training dataset is used for learning the associations between features and 
 > > Two attributes **coef_** and **intercept_** are learned by the classifier using the training dataset. The **coef_** contains importance weight for each feature and **intercept_** is just a
 > > constant scalar. However, for different classifiers, these attributes are different. The attributes shown here are specific to the **Linear support vector** classifier.
 > > These attributes are stored in the trained model and can be accessed by reading this file.
-> > 
+> >
 > {: .solution}
 >
 {: .question}
@@ -239,7 +239,7 @@ the [Gradient boosting regressor](http://scikit-learn.org/stable/modules/ensembl
 > > the **Gradient boosting** regressor learns multiple attributes such as **feature_importances_** (weight for each feature/column),
 > > **oob_improvement_** (which stores incremental improvements in learning), **estimators_** (collection of weak learners) and a few more.
 > > These attributes are used to predict the target for a new sample and are stored in the trained model. They can be accessed by reading this file.
-> > 
+> >
 > {: .solution}
 >
 {: .question}

--- a/topics/statistics/tutorials/clustering_machinelearning/data-library.yaml
+++ b/topics/statistics/tutorials/clustering_machinelearning/data-library.yaml
@@ -6,22 +6,23 @@ destination:
   synopsis: Galaxy Training Network Material. See https://training.galaxyproject.org
 items:
 - name: Statistics and machine learning
-  description: Using clustering algorithms as an unsupervised machine learning methods using Galaxy tools
+  description: Using clustering algorithms as an unsupervised machine learning methods
+    using Galaxy tools
   items:
   - name: Clustering in Machine Learning
     items:
     - name: 'DOI: 10.5281/zenodo.3813447'
       description: latest
       items:
-      - url: https://zenodo.org/api/files/4cc718d4-8a36-4d05-a211-b954fbc015f7/iris.csv
-        src: url
-        ext: csv
-        info: https://doi.org/10.5281/zenodo.3813447
       - url: https://zenodo.org/api/files/4cc718d4-8a36-4d05-a211-b954fbc015f7/circles.csv
         src: url
         ext: csv
-        info: https://doi.org/10.5281/zenodo.3813447
+        info: https://zenodo.org/record/3813447
+      - url: https://zenodo.org/api/files/4cc718d4-8a36-4d05-a211-b954fbc015f7/iris.csv
+        src: url
+        ext: csv
+        info: https://zenodo.org/record/3813447
       - url: https://zenodo.org/api/files/4cc718d4-8a36-4d05-a211-b954fbc015f7/moon.csv
         src: url
         ext: csv
-        info: https://doi.org/10.5281/zenodo.3813447
+        info: https://zenodo.org/record/3813447

--- a/topics/statistics/tutorials/intro_deep_learning/data-library.yaml
+++ b/topics/statistics/tutorials/intro_deep_learning/data-library.yaml
@@ -11,8 +11,27 @@ items:
   items:
   - name: Introduction to deep learning
     items:
-    - name: 'DOI: 10.5281/zenodo.3706539'
+    - name: 'DOI: 10.5281/zenodo.3706539#.XmjDYHVKg5k'
       description: latest
+      items:
+      - url: https://zenodo.org/api/files/a8d0d406-fb16-457f-a218-618f95b3e172/X_test.tsv
+        src: url
+        ext: tsv
+        info: https://zenodo.org/record/3706539#.XmjDYHVKg5k
+      - url: https://zenodo.org/api/files/a8d0d406-fb16-457f-a218-618f95b3e172/X_train.tsv
+        src: url
+        ext: tsv
+        info: https://zenodo.org/record/3706539#.XmjDYHVKg5k
+      - url: https://zenodo.org/api/files/a8d0d406-fb16-457f-a218-618f95b3e172/y_test.tsv
+        src: url
+        ext: tsv
+        info: https://zenodo.org/record/3706539#.XmjDYHVKg5k
+      - url: https://zenodo.org/api/files/a8d0d406-fb16-457f-a218-618f95b3e172/y_train.tsv
+        src: url
+        ext: tsv
+        info: https://zenodo.org/record/3706539#.XmjDYHVKg5k
+    - name: 'DOI: 10.5281/zenodo.3706539'
+      description: ''
       items:
       - url: https://zenodo.org/record/3706539/files/X_test.tsv
         src: url

--- a/topics/statistics/tutorials/intro_deep_learning/tutorial.md
+++ b/topics/statistics/tutorials/intro_deep_learning/tutorial.md
@@ -2,7 +2,7 @@
 layout: tutorial_hands_on
 
 title: Introduction to deep learning
-zenodo_link: https://zenodo.org/record/3706539#.XmjDYHVKg5k
+zenodo_link: "https://zenodo.org/record/3706539"
 questions:
 - What are deep learning and neural networks?
 - Why is it useful?
@@ -138,7 +138,7 @@ Defining a neural network architecture needs to ascertain the types and number o
 > 1. **Create a deep learning model architecture using Keras** {% icon tool %} with the following parameters:
 >    - *"Select keras model type"*: `Sequential`
 >    - *"input_shape"*: `(7129, )`
->       
+>
 >    - In *"LAYER"*:
 >        - {% icon param-repeat %} *"1: LAYER"*:
 >            - *"Choose the type of layer"*: `Core -- Dense`
@@ -152,7 +152,7 @@ Defining a neural network architecture needs to ascertain the types and number o
 >            - *"Choose the type of layer"*: `Core -- Dense`
 >                - *"units"*: `1`
 >                - *"Activation function"*: `sigmoid`
-> 
+>
 >
 {: .hands_on}
 
@@ -166,17 +166,17 @@ The tool returns a JSON output file containing data about the neural network lay
 >    - *"Choose a building mode"*: `Build a training model`
 >    - *"Select the dataset containing model configurations (JSON)"*: `Keras model config` (output of **Create a deep learning model architecture using Keras** {% icon tool %})
 >    - *"Do classification or regression?"*: `KerasGClassifier`
-> 
+>
 >    `KerasGClassifier` is chosen because the learning task is classfication i.e. assigning each patient a type of cancer.
 >    - In *"Compile Parameters"*:
 >        - *"Select a loss function"*: `binary_crossentropy`
-> 
+>
 >        The loss function is `binary_crossentropy` because the labels are discrete and binary (0 and 1).
 >        - *"Select an optimizer"*: `RMSprop - RMSProp optimizer`
 >    - In *"Fit Parameters"*:
 >        - *"epochs"*: `10`
 >        - *"batch_size"*: `4`
-> 
+>
 >        The training data is small (only 38 patients). Therefore the number of epochs and batch size are also small.
 >
 {: .hands_on}
@@ -207,7 +207,7 @@ The tool gives 3 files as output - a tabular file containing output (accuracy of
 After training, the saved architecture (fitted estimator) and weights are used to predict labels for the test data. For each patient in the test data, a type of cancer is predicted using the trained model learned in the previous step.
 
 > ### {% icon hands_on %} Hands-on: Model Prediction predicts on new data using a preffited model
-> 
+>
 > 1. **Model Prediction predicts on new data using a preffited model** {% icon tool %} with the following parameters:
 >    - *"Choose the dataset containing pipeline/estimator object"*: `Fitted estimator or estimator skeleton` (output of **Deep learning training and evaluation** {% icon tool %})
 >    - *"Choose the dataset containing weights for the estimator above"*: `Weights trained` (output of **Create deep learning model** {% icon tool %})
@@ -216,7 +216,7 @@ After training, the saved architecture (fitted estimator) and weights are used t
 >        - *"Training samples dataset"*: `X_test`
 >        - *"Does the dataset contain header"*: `Yes`
 >        - *"Choose how to select data by column"*: `All columns`
-> 
+>
 >
 {: .hands_on}
 
@@ -226,15 +226,15 @@ The tool returns the predicted labels (0 for ALL and 1 AML) for test data in a t
 Visualising the results is important to ascertain the generalisation ability of the trained model on an unseen dataset. Using a dataset with the actual labels for the test data, the performance of the trained model is estimated by comparing the actual labels against the predicted labels using a confusion matrix plot.
 
 > ### {% icon hands_on %} Hands-on: Machine Learning Visualization Extension includes several types of plotting for machine learning
-> 
+>
 > 1. **Machine Learning Visualization Extension includes several types of plotting for machine learning** {% icon tool %} with the following parameters:
->    - *"Select a plotting type"*: `Confusion matrix for classes` 
+>    - *"Select a plotting type"*: `Confusion matrix for classes`
 >    - *"Select dataset containing true labels"*: `y_test`
 >    - *"Does the dataset contain header"*: `Yes`
 >    - *"Choose how to select data by column"*: `All columns`
 >    - *"Select dataset containing predicted labels"*: `Model prediction` (output of **Model Prediction predicts on new data using a preffited model** {% icon tool %})
 >    - *"Does the dataset contain header"*: `Yes`
-> 
+>
 >
 {: .hands_on}
 

--- a/topics/statistics/tutorials/iwtomics/data-library.yaml
+++ b/topics/statistics/tutorials/iwtomics/data-library.yaml
@@ -17,28 +17,28 @@ items:
       - url: https://zenodo.org/api/files/04cbd251-fe0b-4408-9f90-e2aecd61ef09/Control.bed
         src: url
         ext: bed
-        info: https://zenodo.org/record/1288429
+        info: https://doi.org/10.5281/zenodo.1288429
       - url: https://zenodo.org/api/files/04cbd251-fe0b-4408-9f90-e2aecd61ef09/DESCRIPTION.txt
         src: url
         ext: txt
-        info: https://zenodo.org/record/1288429
+        info: https://doi.org/10.5281/zenodo.1288429
       - url: https://zenodo.org/api/files/04cbd251-fe0b-4408-9f90-e2aecd61ef09/ETn_fixed.bed
         src: url
         ext: bed
-        info: https://zenodo.org/record/1288429
+        info: https://doi.org/10.5281/zenodo.1288429
       - url: https://zenodo.org/api/files/04cbd251-fe0b-4408-9f90-e2aecd61ef09/features_header.tabular
         src: url
         ext: tabular
-        info: https://zenodo.org/record/1288429
+        info: https://doi.org/10.5281/zenodo.1288429
       - url: https://zenodo.org/api/files/04cbd251-fe0b-4408-9f90-e2aecd61ef09/IWTomics_ETn_dataset_example.zip
         src: url
         ext: zip
-        info: https://zenodo.org/record/1288429
+        info: https://doi.org/10.5281/zenodo.1288429
       - url: https://zenodo.org/api/files/04cbd251-fe0b-4408-9f90-e2aecd61ef09/Recombination_hotspots.txt
         src: url
         ext: txt
-        info: https://zenodo.org/record/1288429
+        info: https://doi.org/10.5281/zenodo.1288429
       - url: https://zenodo.org/api/files/04cbd251-fe0b-4408-9f90-e2aecd61ef09/regions_header.tabular
         src: url
         ext: tabular
-        info: https://zenodo.org/record/1288429
+        info: https://doi.org/10.5281/zenodo.1288429

--- a/topics/statistics/tutorials/machinelearning/tutorial.md
+++ b/topics/statistics/tutorials/machinelearning/tutorial.md
@@ -2,7 +2,7 @@
 layout: tutorial_hands_on
 
 title: "Basics of machine learning"
-zenodo_link: https://zenodo.org/record/1468039#.W8zyxBRoSAo
+zenodo_link: "https://zenodo.org/record/1468039"
 questions:
   - "What is machine learning?"
   - "Why is it useful?"

--- a/topics/statistics/tutorials/regression_machinelearning/data-library.yaml
+++ b/topics/statistics/tutorials/regression_machinelearning/data-library.yaml
@@ -6,12 +6,32 @@ destination:
   synopsis: Galaxy Training Network Material. See https://training.galaxyproject.org
 items:
 - name: Statistics and machine learning
-  description: Statistical Analyses for omics data and machine learning using Galaxy tools.
+  description: Statistical Analyses for omics data and machine learning using Galaxy
+    tools.
   items:
   - name: Regression in Machine Learning
     items:
-    - name: 'DOI: 10.5281/zenodo.2545213'
+    - name: 'DOI: 10.5281/zenodo.2545213#.XEWTJ9-YVa0'
       description: latest
+      items:
+      - url: https://zenodo.org/api/files/f1431fd7-a9dc-426d-ac78-3eaaa61a8d29/test_rows.csv
+        src: url
+        ext: csv
+        info: https://zenodo.org/record/2545213#.XEWTJ9-YVa0
+      - url: https://zenodo.org/api/files/f1431fd7-a9dc-426d-ac78-3eaaa61a8d29/test_rows_labels.csv
+        src: url
+        ext: csv
+        info: https://zenodo.org/record/2545213#.XEWTJ9-YVa0
+      - url: https://zenodo.org/api/files/f1431fd7-a9dc-426d-ac78-3eaaa61a8d29/training_data_normal.tsv
+        src: url
+        ext: tsv
+        info: https://zenodo.org/record/2545213#.XEWTJ9-YVa0
+      - url: https://zenodo.org/api/files/f1431fd7-a9dc-426d-ac78-3eaaa61a8d29/train_rows.csv
+        src: url
+        ext: csv
+        info: https://zenodo.org/record/2545213#.XEWTJ9-YVa0
+    - name: 'DOI: 10.5281/zenodo.2545213'
+      description: ''
       items:
       - url: https://zenodo.org/api/files/f1431fd7-a9dc-426d-ac78-3eaaa61a8d29/test_rows.csv
         src: url

--- a/topics/statistics/tutorials/regression_machinelearning/tutorial.md
+++ b/topics/statistics/tutorials/regression_machinelearning/tutorial.md
@@ -2,7 +2,7 @@
 layout: tutorial_hands_on
 
 title: 'Regression in Machine Learning'
-zenodo_link: https://zenodo.org/record/2545213#.XEWTJ9-YVa0
+zenodo_link: 'https://zenodo.org/record/2545213'
 questions:
 - How to use regression techniques to create predictive models from biological datasets?
 objectives:
@@ -63,13 +63,13 @@ In linear regression, our goal is to find the line that best models the path of 
 >
 >![regression](images/cost_function.png "Distance between true value and prediction.")
 We know an error above the actual value and an error below the actual value should be about as bad as each other. The squared error makes this clear because both positive and negative values of the error result in a positive squared error. We will use the Mean Squared Error (MSE) function as our cost function. This function finds the average squared error value for all of our data points. Cost functions are important to us because they measure how accurate our model is against the target values.
-> 
+>
 {: .details}
 
 
 # Analyze DNA methylation dataset
 
-As a benchmark, we will use the [DNA methylation dataset](https://www.sciencedirect.com/science/article/pii/S1872497317301643?via%3Dihub) to predict the chronological age. One important reason to choose this dataset for an age prediction task is that DNA methylation changes with age and this change occurs at specific CpG sites in humans. 
+As a benchmark, we will use the [DNA methylation dataset](https://www.sciencedirect.com/science/article/pii/S1872497317301643?via%3Dihub) to predict the chronological age. One important reason to choose this dataset for an age prediction task is that DNA methylation changes with age and this change occurs at specific CpG sites in humans.
 It has been recognized that DNA methylation analysis, which mostly occurs in a CpG sequence context, can give additional information besides the DNA profile.  It has been shown that DNA methylation changes with age within each individual. This alteration in DNA methylation occurs at specific CpG sites in all individuals, but with individual differences in “speed”, showing more DNA methylation differences in older twins compared to young ones.
 
 Epigenomic and phenotypic changes which are age-dependent are also contained in these cells. This knowledge is used to select useful biomarkers from the DNA methylation dataset. The CpG sites with the highest correlation to age are selected as biomarkers (features). In this study, specific biomarkers are analyzed by machine learning algorithms to create an age prediction model.
@@ -78,7 +78,7 @@ In this tutorial, we will apply a couple of ([scikit-learn](https://scikit-learn
 
 ## Get training and test datasets
 
-Whole blood samples are collected from humans with their ages falling in the range 18-69 and the best age-correlated CpG sites in the genome are chosen as features. The dataset is divided into two parts - training and test sets. The training set is used to train a regressor and the test set is used to evaluate the performance of the trained model. We proceed with the analysis by uploading new datasets and creating a new history. 
+Whole blood samples are collected from humans with their ages falling in the range 18-69 and the best age-correlated CpG sites in the genome are chosen as features. The dataset is divided into two parts - training and test sets. The training set is used to train a regressor and the test set is used to evaluate the performance of the trained model. We proceed with the analysis by uploading new datasets and creating a new history.
 
 > ### {% icon hands_on %} Hands-on: Data upload
 >
@@ -142,7 +142,7 @@ The dataset is divided into two parts - training and test sets. The training set
 > > ### {% icon solution %} Solution
 > >
 > > The linear regressor learns the coefficients of the best fit line to the data.
-> > 
+> >
 > {: .solution}
 >
 {: .question}
@@ -219,7 +219,7 @@ These plots are important to visualize the quality of regression and the true an
 >
 > > ### {% icon solution %} Solution
 > >
-> > Figures 5, 6 and 7 show that the prediction is acceptable and the predicted age lies about close to the true age, but the reults can be improved by using better algorithms such as ensemble-based regressors. 
+> > Figures 5, 6 and 7 show that the prediction is acceptable and the predicted age lies about close to the true age, but the reults can be improved by using better algorithms such as ensemble-based regressors.
 > >
 > {: .solution}
 {: .question}
@@ -270,7 +270,7 @@ Like the random forest method, gradient boosting is an ensemble-based regressor,
 > > **Gradient boosting** regressor learns multiple attributes like **feature_importances_** (weight for each feature/column),
 > > **oob_improvement_** (which stores incremental improvements in learning), **estimators_** (collection of weak learners) and a few more.
 > > These attributes are used to predict the target for a new sample and are stored in the trained model. They can be accessed by using the **Estimator attributes** tool on the `gradient_boosting_model` dataset.
-> > 
+> >
 > {: .solution}
 >
 {: .question}
@@ -312,7 +312,7 @@ In the final step, we will create a pipeline learner with the **Pipeline builder
 >            - *"Choose estimator class"*: `GradientBoostingRegressor`
 >            - *"Type in parameter settings if different from default"*: `random_state=42`
 >        - In *"Output parameters for searchCV?"*: `Yes`
-> 
+>
 >      `random_state` could be set to any arbitrary integer number; its purpose is to ensure a determistic and therefore reproducible result.
 >
 {: .hands_on}
@@ -421,7 +421,7 @@ Now we will verify the performance by creating and analyzing the plots.
 >
 > > ### {% icon solution %} Solution
 > >
-> > The figures show that the prediction is very good because the predicted age lies close to the true age. 
+> > The figures show that the prediction is very good because the predicted age lies close to the true age.
 > {: .solution}
 {: .question}
 
@@ -442,5 +442,5 @@ Figure [13](#figure-13) shows that we achieved an R2 score of `0.94` and root me
 
 
 # Conclusion
-By following these steps, we learned how to perform regression and visualize the predictions using Galaxy's machine learning and plotting tools. The features of the training dataset are mapped to the real-valued targets. This mapping is used to make predictions on an unseen (test) dataset. 
-The quality of predictions is visualized using multiple plots to ascertain the robustness of machine learning tasks. There are many other regressors in the machine learning suite which can be tried out on these datasets to find how they perform. Different datasets can also be analyzed using these regressors. The regressors have many parameters which can be altered while performing the analyses to see if they affect the prediction accuracy. It may be beneficial to perform a hyperparameter search to tune these parameters for different datasets. 
+By following these steps, we learned how to perform regression and visualize the predictions using Galaxy's machine learning and plotting tools. The features of the training dataset are mapped to the real-valued targets. This mapping is used to make predictions on an unseen (test) dataset.
+The quality of predictions is visualized using multiple plots to ascertain the robustness of machine learning tasks. There are many other regressors in the machine learning suite which can be tried out on these datasets to find how they perform. Different datasets can also be analyzed using these regressors. The regressors have many parameters which can be altered while performing the analyses to see if they affect the prediction accuracy. It may be beneficial to perform a hyperparameter search to tune these parameters for different datasets.

--- a/topics/transcriptomics/tutorials/clipseq/data-library.yaml
+++ b/topics/transcriptomics/tutorials/clipseq/data-library.yaml
@@ -37,3 +37,32 @@ items:
         ext: fastqsanger
         src: url
         info: https://zenodo.org/record/2579279
+  - name: CLIP-Seq data analysis from pre-processing to motif detection
+    items:
+    - name: 'DOI: 10.5281/zenodo.1327423'
+      description: latest
+      items:
+      - url: https://zenodo.org/api/files/102d29d5-2180-490b-be7c-bb0e4ca7b109/hg19_chr_sizes.txt
+        src: url
+        ext: txt
+        info: https://zenodo.org/record/1327423
+      - url: https://zenodo.org/api/files/102d29d5-2180-490b-be7c-bb0e4ca7b109/Homo_sapiens.GRCh37.74.gtf
+        src: url
+        ext: gtf
+        info: https://zenodo.org/record/1327423
+      - url: https://zenodo.org/api/files/102d29d5-2180-490b-be7c-bb0e4ca7b109/RBFOX2-204-CLIP_S1_R1_RBFOX2.fastq
+        src: url
+        ext: fastqsanger
+        info: https://zenodo.org/record/1327423
+      - url: https://zenodo.org/api/files/102d29d5-2180-490b-be7c-bb0e4ca7b109/RBFOX2-204-CLIP_S1_R2_RBFOX2.fastq
+        src: url
+        ext: fastqsanger
+        info: https://zenodo.org/record/1327423
+      - url: https://zenodo.org/api/files/102d29d5-2180-490b-be7c-bb0e4ca7b109/RBFOX2-204-INPUT_S2_R1.fastq
+        src: url
+        ext: fastqsanger
+        info: https://zenodo.org/record/1327423
+      - url: https://zenodo.org/api/files/102d29d5-2180-490b-be7c-bb0e4ca7b109/RBFOX2-204-INPUT_S2_R2.fastq
+        src: url
+        ext: fastqsanger
+        info: https://zenodo.org/record/1327423

--- a/topics/transcriptomics/tutorials/de-novo/data-library.yaml
+++ b/topics/transcriptomics/tutorials/de-novo/data-library.yaml
@@ -15,41 +15,41 @@ items:
       items:
       - url: https://zenodo.org/api/files/47580600-dce0-44cf-b4d9-62713ab9fa63/G1E_R1_forward_downsampled_SRR549355.fastqsanger.gz
         src: url
-        ext: fastqsanger.gz
+        ext: gz
         info: https://zenodo.org/record/254485#.WKODmRIrKRu
       - url: https://zenodo.org/api/files/47580600-dce0-44cf-b4d9-62713ab9fa63/G1E_R1_reverse_downsampled_SRR549355.fastqsanger.gz
         src: url
-        ext: fastqsanger.gz
+        ext: gz
         info: https://zenodo.org/record/254485#.WKODmRIrKRu
       - url: https://zenodo.org/api/files/47580600-dce0-44cf-b4d9-62713ab9fa63/G1E_R2_forward_downsampled_SRR549356.fastqsanger.gz
         src: url
-        ext: fastqsanger.gz
+        ext: gz
         info: https://zenodo.org/record/254485#.WKODmRIrKRu
       - url: https://zenodo.org/api/files/47580600-dce0-44cf-b4d9-62713ab9fa63/G1E_R2_reverse_downsampled_SRR549356.fastqsanger.gz
         src: url
-        ext: fastqsanger.gz
+        ext: gz
         info: https://zenodo.org/record/254485#.WKODmRIrKRu
       - url: https://zenodo.org/api/files/47580600-dce0-44cf-b4d9-62713ab9fa63/Megakaryocyte_R1_forward_downsampled_SRR549357.fastqsanger.gz
         src: url
-        ext: fastqsanger.gz
+        ext: gz
         info: https://zenodo.org/record/254485#.WKODmRIrKRu
       - url: https://zenodo.org/api/files/47580600-dce0-44cf-b4d9-62713ab9fa63/Megakaryocyte_R1_reverse_downsampled_SRR549357.fastqsanger.gz
         src: url
-        ext: fastqsanger.gz
+        ext: gz
         info: https://zenodo.org/record/254485#.WKODmRIrKRu
       - url: https://zenodo.org/api/files/47580600-dce0-44cf-b4d9-62713ab9fa63/Megakaryocyte_R2_forward_downsampled_SRR549358.fastqsanger.gz
         src: url
-        ext: fastqsanger.gz
+        ext: gz
         info: https://zenodo.org/record/254485#.WKODmRIrKRu
       - url: https://zenodo.org/api/files/47580600-dce0-44cf-b4d9-62713ab9fa63/Megakaryocyte_R2_reverse_downsampled_SRR549358.fastqsanger.gz
         src: url
-        ext: fastqsanger.gz
+        ext: gz
         info: https://zenodo.org/record/254485#.WKODmRIrKRu
       - url: https://zenodo.org/api/files/47580600-dce0-44cf-b4d9-62713ab9fa63/RefSeq_gene_annotations_mm10.bed.gtf.gz
         src: url
-        ext: gtf
+        ext: gz
         info: https://zenodo.org/record/254485#.WKODmRIrKRu
       - url: https://zenodo.org/api/files/47580600-dce0-44cf-b4d9-62713ab9fa63/RNAseq_regions_of_interest.bed.gz
         src: url
-        ext: bed
+        ext: gz
         info: https://zenodo.org/record/254485#.WKODmRIrKRu

--- a/topics/transcriptomics/tutorials/de-novo/tutorial.md
+++ b/topics/transcriptomics/tutorials/de-novo/tutorial.md
@@ -2,7 +2,7 @@
 layout: tutorial_hands_on
 
 title: "De novo transcriptome reconstruction with RNA-Seq"
-zenodo_link: "https://zenodo.org/record/254485#.WKODmRIrKRu"
+zenodo_link: "https://zenodo.org/record/254485"
 questions:
   - "What genes are differentially expressed between G1E cells and megakaryocytes?"
   - "How can we generate a transcriptome de novo from RNA sequencing data?"

--- a/topics/transcriptomics/tutorials/full-de-novo/data-library.yaml
+++ b/topics/transcriptomics/tutorials/full-de-novo/data-library.yaml
@@ -1,0 +1,64 @@
+---
+destination:
+  type: library
+  name: GTN - Material
+  description: Galaxy Training Network Material
+  synopsis: Galaxy Training Network Material. See https://training.galaxyproject.org
+items:
+- name: Transcriptomics
+  description: Training material for all kinds of transcriptomics analysis.
+  items:
+  - name: De novo transcriptome assembly, annotation, and differential expression
+      analysis
+    items:
+    - name: 'DOI: 10.5281/zenodo.3541678'
+      description: latest
+      items:
+      - url: https://zenodo.org/api/files/25147e2a-1a97-4480-8514-aa8fd9004db1/A1_left.fq.gz
+        src: url
+        ext: gz
+        info: https://zenodo.org/record/3541678
+      - url: https://zenodo.org/api/files/25147e2a-1a97-4480-8514-aa8fd9004db1/A1_right.fq.gz
+        src: url
+        ext: gz
+        info: https://zenodo.org/record/3541678
+      - url: https://zenodo.org/api/files/25147e2a-1a97-4480-8514-aa8fd9004db1/A2_left.fq.gz
+        src: url
+        ext: gz
+        info: https://zenodo.org/record/3541678
+      - url: https://zenodo.org/api/files/25147e2a-1a97-4480-8514-aa8fd9004db1/A2_right.fq.gz
+        src: url
+        ext: gz
+        info: https://zenodo.org/record/3541678
+      - url: https://zenodo.org/api/files/25147e2a-1a97-4480-8514-aa8fd9004db1/A3_left.fq.gz
+        src: url
+        ext: gz
+        info: https://zenodo.org/record/3541678
+      - url: https://zenodo.org/api/files/25147e2a-1a97-4480-8514-aa8fd9004db1/A3_right.fq.gz
+        src: url
+        ext: gz
+        info: https://zenodo.org/record/3541678
+      - url: https://zenodo.org/api/files/25147e2a-1a97-4480-8514-aa8fd9004db1/B1_left.fq.gz
+        src: url
+        ext: gz
+        info: https://zenodo.org/record/3541678
+      - url: https://zenodo.org/api/files/25147e2a-1a97-4480-8514-aa8fd9004db1/B1_right.fq.gz
+        src: url
+        ext: gz
+        info: https://zenodo.org/record/3541678
+      - url: https://zenodo.org/api/files/25147e2a-1a97-4480-8514-aa8fd9004db1/B2_left.fq.gz
+        src: url
+        ext: gz
+        info: https://zenodo.org/record/3541678
+      - url: https://zenodo.org/api/files/25147e2a-1a97-4480-8514-aa8fd9004db1/B2_right.fq.gz
+        src: url
+        ext: gz
+        info: https://zenodo.org/record/3541678
+      - url: https://zenodo.org/api/files/25147e2a-1a97-4480-8514-aa8fd9004db1/B3_left.fq.gz
+        src: url
+        ext: gz
+        info: https://zenodo.org/record/3541678
+      - url: https://zenodo.org/api/files/25147e2a-1a97-4480-8514-aa8fd9004db1/B3_right.fq.gz
+        src: url
+        ext: gz
+        info: https://zenodo.org/record/3541678

--- a/topics/transcriptomics/tutorials/goenrichment/data-library.yaml
+++ b/topics/transcriptomics/tutorials/goenrichment/data-library.yaml
@@ -10,8 +10,51 @@ items:
   items:
   - name: GO Enrichment Analysis
     items:
-    - name: 'DOI: 10.5281/zenodo.2565417'
+    - name: 'DOI: 10.5281/zenodo.2565417#.XGXUXlz7TIU'
       description: latest
+      items:
+      - url: https://zenodo.org/api/files/a4583abd-0a85-457e-a5c0-1fc323535db7/drosophila_gene_association.fb
+        src: url
+        ext: '# Please add a Galaxy datatype or update the shared/datatypes.yaml file'
+        info: https://zenodo.org/record/2565417#.XGXUXlz7TIU
+      - url: https://zenodo.org/api/files/a4583abd-0a85-457e-a5c0-1fc323535db7/go.obo
+        src: url
+        ext: obo
+        info: https://zenodo.org/record/2565417#.XGXUXlz7TIU
+      - url: https://zenodo.org/api/files/a4583abd-0a85-457e-a5c0-1fc323535db7/goslim_generic.obo
+        src: url
+        ext: obo
+        info: https://zenodo.org/record/2565417#.XGXUXlz7TIU
+      - url: https://zenodo.org/api/files/a4583abd-0a85-457e-a5c0-1fc323535db7/mouse_brain_vs_heart.difgenes.txt
+        src: url
+        ext: txt
+        info: https://zenodo.org/record/2565417#.XGXUXlz7TIU
+      - url: https://zenodo.org/api/files/a4583abd-0a85-457e-a5c0-1fc323535db7/mouse_brain_vs_heart.txt
+        src: url
+        ext: txt
+        info: https://zenodo.org/record/2565417#.XGXUXlz7TIU
+      - url: https://zenodo.org/api/files/a4583abd-0a85-457e-a5c0-1fc323535db7/mouseOverexpressed.txt
+        src: url
+        ext: txt
+        info: https://zenodo.org/record/2565417#.XGXUXlz7TIU
+      - url: https://zenodo.org/api/files/a4583abd-0a85-457e-a5c0-1fc323535db7/mouseUnderexpressed.txt
+        src: url
+        ext: txt
+        info: https://zenodo.org/record/2565417#.XGXUXlz7TIU
+      - url: https://zenodo.org/api/files/a4583abd-0a85-457e-a5c0-1fc323535db7/Mus_musculus_annotations_biomart_e92.tab
+        src: url
+        ext: '# Please add a Galaxy datatype or update the shared/datatypes.yaml file'
+        info: https://zenodo.org/record/2565417#.XGXUXlz7TIU
+      - url: https://zenodo.org/api/files/a4583abd-0a85-457e-a5c0-1fc323535db7/trapnellPopulation.tab
+        src: url
+        ext: '# Please add a Galaxy datatype or update the shared/datatypes.yaml file'
+        info: https://zenodo.org/record/2565417#.XGXUXlz7TIU
+      - url: https://zenodo.org/api/files/a4583abd-0a85-457e-a5c0-1fc323535db7/trapnellStudy.txt
+        src: url
+        ext: txt
+        info: https://zenodo.org/record/2565417#.XGXUXlz7TIU
+    - name: 'DOI: 10.5281/zenodo.2565417'
+      description: ''
       items:
       - url: https://zenodo.org/api/files/a4583abd-0a85-457e-a5c0-1fc323535db7/drosophila_gene_association.fb
         src: url

--- a/topics/transcriptomics/tutorials/goenrichment/tutorial.md
+++ b/topics/transcriptomics/tutorials/goenrichment/tutorial.md
@@ -2,7 +2,7 @@
 layout: tutorial_hands_on
 
 title: "GO Enrichment Analysis"
-zenodo_link: "https://zenodo.org/record/2565417#.XGXUXlz7TIU"
+zenodo_link: "https://zenodo.org/record/2565417"
 questions:
   - "How can I functionally interpret a list of genes of interest that I obtained from my experiment?"
 objectives:

--- a/topics/transcriptomics/tutorials/network-analysis-with-heinz/data-library.yaml
+++ b/topics/transcriptomics/tutorials/network-analysis-with-heinz/data-library.yaml
@@ -10,153 +10,162 @@ items:
   items:
   - name: Network analysis with Heinz
     items:
-    - name: 'DOI: 10.5281/zenodo.1344105 CP'
-      description: Caries Postive (Disease)
+    - name: 'DOI: 10.5281/zenodo.1344105'
+      description: latest
       items:
-      - ext: tabular
-        info: https://doi.org/10.5281/zenodo.1344105
+      - url: https://zenodo.org/api/files/0162d3a3-2b6e-4cb4-9146-fe39eab35fcc/2011_CP_DZ_PairTo_2012.txt
         src: url
-        url: https://zenodo.org/record/1344105/files/2241_CP_DZ_PairTo_2242.txt
-      - ext: tabular
+        ext: txt
         info: https://doi.org/10.5281/zenodo.1344105
+      - url: https://zenodo.org/api/files/0162d3a3-2b6e-4cb4-9146-fe39eab35fcc/2012_CP_DZ_PairTo_2011.txt
         src: url
-        url: https://zenodo.org/record/1344105/files/2126_CP_MZ_PairTo_2125.txt
-      - ext: tabular
+        ext: txt
         info: https://doi.org/10.5281/zenodo.1344105
+      - url: https://zenodo.org/api/files/0162d3a3-2b6e-4cb4-9146-fe39eab35fcc/2051_CN_MZ_PairTo_2052.txt
         src: url
-        url: https://zenodo.org/record/1344105/files/2991_CP_DZ_PairTo_2992.txt
-      - ext: tabular
+        ext: txt
         info: https://doi.org/10.5281/zenodo.1344105
+      - url: https://zenodo.org/api/files/0162d3a3-2b6e-4cb4-9146-fe39eab35fcc/2052_CN_MZ_PairTo_2051.txt
         src: url
-        url: https://zenodo.org/record/1344105/files/2931_CP_DZ_PairTo_2930.txt
-      - ext: tabular
+        ext: txt
         info: https://doi.org/10.5281/zenodo.1344105
+      - url: https://zenodo.org/api/files/0162d3a3-2b6e-4cb4-9146-fe39eab35fcc/2061_CP_DZ_PairTo_2062.txt
         src: url
-        url: https://zenodo.org/record/1344105/files/2284_CP_DZ_PairTo_2283.txt
-      - ext: tabular
+        ext: txt
         info: https://doi.org/10.5281/zenodo.1344105
+      - url: https://zenodo.org/api/files/0162d3a3-2b6e-4cb4-9146-fe39eab35fcc/2062_CN_DZ_PairTo_2061.txt
         src: url
-        url: https://zenodo.org/record/1344105/files/2125_CP_MZ_PairTo_2126.txt
-      - ext: tabular
+        ext: txt
         info: https://doi.org/10.5281/zenodo.1344105
+      - url: https://zenodo.org/api/files/0162d3a3-2b6e-4cb4-9146-fe39eab35fcc/2125_CP_MZ_PairTo_2126.txt
         src: url
-        url: https://zenodo.org/record/1344105/files/4131_CP_DZ_PairTo_4132.txt
-      - ext: tabular
+        ext: txt
         info: https://doi.org/10.5281/zenodo.1344105
+      - url: https://zenodo.org/api/files/0162d3a3-2b6e-4cb4-9146-fe39eab35fcc/2126_CP_MZ_PairTo_2125.txt
         src: url
-        url: https://zenodo.org/record/1344105/files/2954_CP_DZ_PairTo_2955.txt
-      - ext: tabular
+        ext: txt
         info: https://doi.org/10.5281/zenodo.1344105
+      - url: https://zenodo.org/api/files/0162d3a3-2b6e-4cb4-9146-fe39eab35fcc/2169_CN_MZ_PairTo_2170.txt
         src: url
-        url: https://zenodo.org/record/1344105/files/2170_CP_MZ_PairTo_2169.txt
-      - ext: tabular
+        ext: txt
         info: https://doi.org/10.5281/zenodo.1344105
+      - url: https://zenodo.org/api/files/0162d3a3-2b6e-4cb4-9146-fe39eab35fcc/2170_CP_MZ_PairTo_2169.txt
         src: url
-        url: https://zenodo.org/record/1344105/files/2955_CP_DZ_PairTo_2954.txt
-      - ext: tabular
+        ext: txt
         info: https://doi.org/10.5281/zenodo.1344105
+      - url: https://zenodo.org/api/files/0162d3a3-2b6e-4cb4-9146-fe39eab35fcc/2191_CN_MZ_PairTo_2192.txt
         src: url
-        url: https://zenodo.org/record/1344105/files/2011_CP_DZ_PairTo_2012.txt
-      - ext: tabular
+        ext: txt
         info: https://doi.org/10.5281/zenodo.1344105
+      - url: https://zenodo.org/api/files/0162d3a3-2b6e-4cb4-9146-fe39eab35fcc/2192_CN_MZ_PairTo_2191.txt
         src: url
-        url: https://zenodo.org/record/1344105/files/2012_CP_DZ_PairTo_2011.txt
-      - ext: tabular
+        ext: txt
         info: https://doi.org/10.5281/zenodo.1344105
+      - url: https://zenodo.org/api/files/0162d3a3-2b6e-4cb4-9146-fe39eab35fcc/2225_CN_MZ_PairTo_2226.txt
         src: url
-        url: https://zenodo.org/record/1344105/files/2269_CP_DZ_PairTo_2270.txt
-      - ext: tabular
+        ext: txt
         info: https://doi.org/10.5281/zenodo.1344105
+      - url: https://zenodo.org/api/files/0162d3a3-2b6e-4cb4-9146-fe39eab35fcc/2233_CN_DZ_PairTo_2234.txt
         src: url
-        url: https://zenodo.org/record/1344105/files/3215_CP_MZ_PairTo_3214.txt
-      - ext: tabular
+        ext: txt
         info: https://doi.org/10.5281/zenodo.1344105
+      - url: https://zenodo.org/api/files/0162d3a3-2b6e-4cb4-9146-fe39eab35fcc/2234_CN_DZ_PairTo_2233.txt
         src: url
-        url: https://zenodo.org/record/1344105/files/2354_CP_DZ_PairTo_2355.txt
-      - ext: tabular
+        ext: txt
         info: https://doi.org/10.5281/zenodo.1344105
+      - url: https://zenodo.org/api/files/0162d3a3-2b6e-4cb4-9146-fe39eab35fcc/2241_CP_DZ_PairTo_2242.txt
         src: url
-        url: https://zenodo.org/record/1344105/files/3306_CP_DZ_PairTo_3307.txt
-      - ext: tabular
+        ext: txt
         info: https://doi.org/10.5281/zenodo.1344105
+      - url: https://zenodo.org/api/files/0162d3a3-2b6e-4cb4-9146-fe39eab35fcc/2242_CP_DZ_PairTo_2241.txt
         src: url
-        url: https://zenodo.org/record/1344105/files/2061_CP_DZ_PairTo_2062.txt
-      - ext: tabular
+        ext: txt
         info: https://doi.org/10.5281/zenodo.1344105
+      - url: https://zenodo.org/api/files/0162d3a3-2b6e-4cb4-9146-fe39eab35fcc/2269_CP_DZ_PairTo_2270.txt
         src: url
-        url: https://zenodo.org/record/1344105/files/2355_CP_DZ_PairTo_2354.txt
-      - ext: tabular
+        ext: txt
         info: https://doi.org/10.5281/zenodo.1344105
+      - url: https://zenodo.org/api/files/0162d3a3-2b6e-4cb4-9146-fe39eab35fcc/2270_CN_DZ_PairTo_2269.txt
         src: url
-        url: https://zenodo.org/record/1344105/files/2242_CP_DZ_PairTo_2241.txt
-    - name: 'DOI: 10.5281/zenodo.1344105 CN'
-      description: Caries Negative (Health)
-      items:
-      - ext: tabular
+        ext: txt
         info: https://doi.org/10.5281/zenodo.1344105
+      - url: https://zenodo.org/api/files/0162d3a3-2b6e-4cb4-9146-fe39eab35fcc/2284_CP_DZ_PairTo_2283.txt
         src: url
-        url: https://zenodo.org/record/1344105/files/2310_CN_DZ_PairTo_2309.txt
-      - ext: tabular
+        ext: txt
         info: https://doi.org/10.5281/zenodo.1344105
+      - url: https://zenodo.org/api/files/0162d3a3-2b6e-4cb4-9146-fe39eab35fcc/2309_CN_DZ_PairTo_2310.txt
         src: url
-        url: https://zenodo.org/record/1344105/files/2062_CN_DZ_PairTo_2061.txt
-      - ext: tabular
+        ext: txt
         info: https://doi.org/10.5281/zenodo.1344105
+      - url: https://zenodo.org/api/files/0162d3a3-2b6e-4cb4-9146-fe39eab35fcc/2310_CN_DZ_PairTo_2309.txt
         src: url
-        url: https://zenodo.org/record/1344105/files/2191_CN_MZ_PairTo_2192.txt
-      - ext: tabular
+        ext: txt
         info: https://doi.org/10.5281/zenodo.1344105
+      - url: https://zenodo.org/api/files/0162d3a3-2b6e-4cb4-9146-fe39eab35fcc/2354_CP_DZ_PairTo_2355.txt
         src: url
-        url: https://zenodo.org/record/1344105/files/2052_CN_MZ_PairTo_2051.txt
-      - ext: tabular
+        ext: txt
         info: https://doi.org/10.5281/zenodo.1344105
+      - url: https://zenodo.org/api/files/0162d3a3-2b6e-4cb4-9146-fe39eab35fcc/2355_CP_DZ_PairTo_2354.txt
         src: url
-        url: https://zenodo.org/record/1344105/files/2051_CN_MZ_PairTo_2052.txt
-      - ext: tabular
+        ext: txt
         info: https://doi.org/10.5281/zenodo.1344105
+      - url: https://zenodo.org/api/files/0162d3a3-2b6e-4cb4-9146-fe39eab35fcc/2930_CN_DZ_PairTo_2931.txt
         src: url
-        url: https://zenodo.org/record/1344105/files/2192_CN_MZ_PairTo_2191.txt
-      - ext: tabular
+        ext: txt
         info: https://doi.org/10.5281/zenodo.1344105
+      - url: https://zenodo.org/api/files/0162d3a3-2b6e-4cb4-9146-fe39eab35fcc/2931_CP_DZ_PairTo_2930.txt
         src: url
-        url: https://zenodo.org/record/1344105/files/2234_CN_DZ_PairTo_2233.txt
-      - ext: tabular
+        ext: txt
         info: https://doi.org/10.5281/zenodo.1344105
+      - url: https://zenodo.org/api/files/0162d3a3-2b6e-4cb4-9146-fe39eab35fcc/2954_CP_DZ_PairTo_2955.txt
         src: url
-        url: https://zenodo.org/record/1344105/files/2233_CN_DZ_PairTo_2234.txt
-      - ext: tabular
+        ext: txt
         info: https://doi.org/10.5281/zenodo.1344105
+      - url: https://zenodo.org/api/files/0162d3a3-2b6e-4cb4-9146-fe39eab35fcc/2955_CP_DZ_PairTo_2954.txt
         src: url
-        url: https://zenodo.org/record/1344105/files/2270_CN_DZ_PairTo_2269.txt
-      - ext: tabular
+        ext: txt
         info: https://doi.org/10.5281/zenodo.1344105
+      - url: https://zenodo.org/api/files/0162d3a3-2b6e-4cb4-9146-fe39eab35fcc/2991_CP_DZ_PairTo_2992.txt
         src: url
-        url: https://zenodo.org/record/1344105/files/2225_CN_MZ_PairTo_2226.txt
-      - ext: tabular
+        ext: txt
         info: https://doi.org/10.5281/zenodo.1344105
+      - url: https://zenodo.org/api/files/0162d3a3-2b6e-4cb4-9146-fe39eab35fcc/2992_CN_DZ_PairTo_2991.txt
         src: url
-        url: https://zenodo.org/record/1344105/files/4132_CN_DZ_PairTo_4131.txt
-      - ext: tabular
+        ext: txt
         info: https://doi.org/10.5281/zenodo.1344105
+      - url: https://zenodo.org/api/files/0162d3a3-2b6e-4cb4-9146-fe39eab35fcc/3214_CN_MZ_PairTo_3215.txt
         src: url
-        url: https://zenodo.org/record/1344105/files/2309_CN_DZ_PairTo_2310.txt
-      - ext: tabular
+        ext: txt
         info: https://doi.org/10.5281/zenodo.1344105
+      - url: https://zenodo.org/api/files/0162d3a3-2b6e-4cb4-9146-fe39eab35fcc/3215_CP_MZ_PairTo_3214.txt
         src: url
-        url: https://zenodo.org/record/1344105/files/2992_CN_DZ_PairTo_2991.txt
-      - ext: tabular
+        ext: txt
         info: https://doi.org/10.5281/zenodo.1344105
+      - url: https://zenodo.org/api/files/0162d3a3-2b6e-4cb4-9146-fe39eab35fcc/3306_CP_DZ_PairTo_3307.txt
         src: url
-        url: https://zenodo.org/record/1344105/files/3214_CN_MZ_PairTo_3215.txt
-      - ext: tabular
+        ext: txt
         info: https://doi.org/10.5281/zenodo.1344105
+      - url: https://zenodo.org/api/files/0162d3a3-2b6e-4cb4-9146-fe39eab35fcc/3307_CN_DZ_PairTo_3306.txt
         src: url
-        url: https://zenodo.org/record/1344105/files/2169_CN_MZ_PairTo_2170.txt
-      - ext: tabular
+        ext: txt
         info: https://doi.org/10.5281/zenodo.1344105
+      - url: https://zenodo.org/api/files/0162d3a3-2b6e-4cb4-9146-fe39eab35fcc/4131_CP_DZ_PairTo_4132.txt
         src: url
-        url: https://zenodo.org/record/1344105/files/2930_CN_DZ_PairTo_2931.txt
-      - ext: tabular
+        ext: txt
         info: https://doi.org/10.5281/zenodo.1344105
+      - url: https://zenodo.org/api/files/0162d3a3-2b6e-4cb4-9146-fe39eab35fcc/4132_CN_DZ_PairTo_4131.txt
         src: url
-        url: https://zenodo.org/record/1344105/files/3307_CN_DZ_PairTo_3306.txt
+        ext: txt
+        info: https://doi.org/10.5281/zenodo.1344105
+      - url: https://zenodo.org/api/files/0162d3a3-2b6e-4cb4-9146-fe39eab35fcc/CN.zip
+        src: url
+        ext: zip
+        info: https://doi.org/10.5281/zenodo.1344105
+      - url: https://zenodo.org/api/files/0162d3a3-2b6e-4cb4-9146-fe39eab35fcc/CP.zip
+        src: url
+        ext: zip
+        info: https://doi.org/10.5281/zenodo.1344105
+      - url: https://zenodo.org/api/files/0162d3a3-2b6e-4cb4-9146-fe39eab35fcc/edge.txt
+        src: url
+        ext: txt
+        info: https://doi.org/10.5281/zenodo.1344105

--- a/topics/transcriptomics/tutorials/rb-rnaseq/tutorial.md
+++ b/topics/transcriptomics/tutorials/rb-rnaseq/tutorial.md
@@ -2,7 +2,6 @@
 layout: tutorial_hands_on
 
 title: "Reference-based RNAseq data analysis (long)"
-zenodo_link: ""
 enable: false
 questions:
   - "How to perform analysis of RNAseq data when reference genome is available?"

--- a/topics/transcriptomics/tutorials/rna-interactome/data-library.yaml
+++ b/topics/transcriptomics/tutorials/rna-interactome/data-library.yaml
@@ -15,21 +15,25 @@ items:
       items:
       - url: https://zenodo.org/api/files/624162d9-d626-4b60-8301-1f4355232912/miRNA_mature.fa.gz
         src: url
-        ext: fasta.gz
+        ext: gz
         info: https://zenodo.org/record/3709188
       - url: https://zenodo.org/api/files/624162d9-d626-4b60-8301-1f4355232912/Mus_musculus.GRCm38.dna.fa.gz
         src: url
-        ext: fasta.gz
+        ext: gz
+        info: https://zenodo.org/record/3709188
+      - url: https://zenodo.org/api/files/624162d9-d626-4b60-8301-1f4355232912/SRR2413302.100k.fastq.gz
+        src: url
+        ext: gz
         info: https://zenodo.org/record/3709188
       - url: https://zenodo.org/api/files/624162d9-d626-4b60-8301-1f4355232912/SRR2413302.fastq.gz
         src: url
-        ext: fastqsanger.gz
+        ext: gz
         info: https://zenodo.org/record/3709188
       - url: https://zenodo.org/api/files/624162d9-d626-4b60-8301-1f4355232912/transcriptome.fa.gz
         src: url
-        ext: fasta.gz
+        ext: gz
         info: https://zenodo.org/record/3709188
       - url: https://zenodo.org/api/files/624162d9-d626-4b60-8301-1f4355232912/whole_transcriptome.gff.gz
         src: url
-        ext: gtf
+        ext: gz
         info: https://zenodo.org/record/3709188

--- a/topics/transcriptomics/tutorials/rna-seq-analysis-with-askomics-it/data-library.yaml
+++ b/topics/transcriptomics/tutorials/rna-seq-analysis-with-askomics-it/data-library.yaml
@@ -1,0 +1,35 @@
+---
+destination:
+  type: library
+  name: GTN - Material
+  description: Galaxy Training Network Material
+  synopsis: Galaxy Training Network Material. See https://training.galaxyproject.org
+items:
+- name: Transcriptomics
+  description: Training material for all kinds of transcriptomics analysis.
+  items:
+  - name: RNA-Seq analysis with AskOmics Interactive Tool
+    items:
+    - name: 'DOI: 10.5281/zenodo.3925863'
+      description: latest
+      items:
+      - url: https://zenodo.org/api/files/b82b1257-e991-4521-aed8-41eb6711ea06/HOM_MouseHumanSequence.rpt
+        src: url
+        ext: '# Please add a Galaxy datatype or update the shared/datatypes.yaml file'
+        info: https://zenodo.org/record/3925863
+      - url: https://zenodo.org/api/files/b82b1257-e991-4521-aed8-41eb6711ea06/MGIBatchReport_Qtl_Subset.txt
+        src: url
+        ext: txt
+        info: https://zenodo.org/record/3925863
+      - url: https://zenodo.org/api/files/b82b1257-e991-4521-aed8-41eb6711ea06/Mus_musculus.GRCm38.98.subset.gff3
+        src: url
+        ext: gff3
+        info: https://zenodo.org/record/3925863
+      - url: https://zenodo.org/api/files/b82b1257-e991-4521-aed8-41eb6711ea06/nextprot_abstraction.ttl
+        src: url
+        ext: '# Please add a Galaxy datatype or update the shared/datatypes.yaml file'
+        info: https://zenodo.org/record/3925863
+      - url: https://zenodo.org/api/files/b82b1257-e991-4521-aed8-41eb6711ea06/Symbol.tsv
+        src: url
+        ext: tsv
+        info: https://zenodo.org/record/3925863

--- a/topics/transcriptomics/tutorials/rna-seq-counts-to-genes/tutorial.md
+++ b/topics/transcriptomics/tutorials/rna-seq-counts-to-genes/tutorial.md
@@ -106,15 +106,15 @@ We will use three files for this analysis:
 >
 >     To import the files, there are two options:
 >     - Option 1: From a shared data library if available (ask your instructor)
->     - Option 2: From [Figshare](https://figshare.com/s/1d788fd384d33e913a2a)
+>     - Option 2: From [Zenodo](https://zenodo.org/record/4249516)
 >
 >     {% include snippets/import_via_link.md %}
 >
 >     - You can paste both links below into the **Paste/Fetch** box:
 >
 >     ```
->     https://ndownloader.figshare.com/files/5057929?private_link=1d788fd384d33e913a2a
->     https://ndownloader.figshare.com/files/5999829?private_link=1d788fd384d33e913a2a
+>     https://zenodo.org/record/4249555/files/SampleInfo.txt
+>     https://zenodo.org/record/4249555/files/GSE60450_Lactation-GenewiseCounts.txt
 >     ```
 >
 >     - Select *"Genome"*: `mm10`
@@ -262,7 +262,7 @@ It turns out that there has been a mix-up with two samples, they have been misla
 
 > ### {% icon hands_on %} Hands-on: Use the Rerun button to redo steps
 >
-> 1. Import the correct sample information file from `https://ndownloader.figshare.com/files/5999832?private_link=1d788fd384d33e913a2a`
+> 1. Import the correct sample information file from `https://zenodo.org/record/4249555/files/SampleInfo_Corrected.txt`
 > 2. Use the Rerun button in the History to redo the **Merge Columns** and **Cut** steps on the correct sample information file.
 > 3. Delete the incorrect sample information datasets to avoid any confusion.
 > 4. Rerun **limma** as before with the correct `sampleinfo` file and adding the following parameters:

--- a/topics/transcriptomics/tutorials/rna-seq-counts-to-genes/tutorial.md
+++ b/topics/transcriptomics/tutorials/rna-seq-counts-to-genes/tutorial.md
@@ -1,7 +1,7 @@
 ---
 layout: tutorial_hands_on
 title: RNA-seq counts to genes
-zenodo_link: "https://figshare.com/s/f5d63d8c265a05618137"
+zenodo_link: "https://zenodo.org/record/4249555"
 tags:
   - limma-voom
   - mouse

--- a/topics/transcriptomics/tutorials/rna-seq-counts-to-viz-in-r/tutorial.md
+++ b/topics/transcriptomics/tutorials/rna-seq-counts-to-viz-in-r/tutorial.md
@@ -2,7 +2,7 @@
 layout: tutorial_hands_on
 
 title: RNA Seq Counts to Viz in R
-zenodo_link: "https://zenodo.org/record/3477564/"
+zenodo_link: "https://zenodo.org/record/3477564"
 requirements:
   -
     type: "internal"

--- a/topics/transcriptomics/tutorials/rna-seq-genes-to-pathways/data-library.yaml
+++ b/topics/transcriptomics/tutorials/rna-seq-genes-to-pathways/data-library.yaml
@@ -14,53 +14,26 @@ items:
       description: latest
       items:
       - url: https://zenodo.org/api/files/20797b4c-f42b-4afd-b83a-11f2ba993f24/factordata
-        ext: tabular
-        info: https://zenodo.org/record/2596382
         src: url
+        ext: '# Please add a Galaxy datatype or update the shared/datatypes.yaml file'
+        info: https://zenodo.org/record/2596382
       - url: https://zenodo.org/api/files/20797b4c-f42b-4afd-b83a-11f2ba993f24/limma-voom_basalpregnant-basallactate
-        ext: tabular
-        info: https://zenodo.org/record/2596382
         src: url
+        ext: '# Please add a Galaxy datatype or update the shared/datatypes.yaml file'
+        info: https://zenodo.org/record/2596382
       - url: https://zenodo.org/api/files/20797b4c-f42b-4afd-b83a-11f2ba993f24/limma-voom_filtered_counts
-        ext: tabular
-        info: https://zenodo.org/record/2596382
         src: url
+        ext: '# Please add a Galaxy datatype or update the shared/datatypes.yaml file'
+        info: https://zenodo.org/record/2596382
       - url: https://zenodo.org/api/files/20797b4c-f42b-4afd-b83a-11f2ba993f24/limma-voom_luminalpregnant-luminallactate
-        ext: tabular
-        info: https://zenodo.org/record/2596382
         src: url
+        ext: '# Please add a Galaxy datatype or update the shared/datatypes.yaml file'
+        info: https://zenodo.org/record/2596382
       - url: https://zenodo.org/api/files/20797b4c-f42b-4afd-b83a-11f2ba993f24/mouse_hallmark_sets
-        ext: rdata
-        info: https://zenodo.org/record/2596382
         src: url
+        ext: '# Please add a Galaxy datatype or update the shared/datatypes.yaml file'
+        info: https://zenodo.org/record/2596382
       - url: https://zenodo.org/api/files/20797b4c-f42b-4afd-b83a-11f2ba993f24/seqdata
-        ext: tabular
+        src: url
+        ext: '# Please add a Galaxy datatype or update the shared/datatypes.yaml file'
         info: https://zenodo.org/record/2596382
-        src: url
-    - name: 'DOI: 10.5281/zenodo.2491305'
-      description: ''
-      items:
-      - url: https://zenodo.org/api/files/fd880772-78f5-48c7-8960-838ae2f7c496/factordata
-        src: url
-        ext: tabular
-        info: https://zenodo.org/record/2491305
-      - url: https://zenodo.org/api/files/fd880772-78f5-48c7-8960-838ae2f7c496/limma-voom_basalpregnant-basallactate
-        src: url
-        ext: tabular
-        info: https://zenodo.org/record/2491305
-      - url: https://zenodo.org/api/files/fd880772-78f5-48c7-8960-838ae2f7c496/limma-voom_filtered_counts
-        src: url
-        ext: tabular
-        info: https://zenodo.org/record/2491305
-      - url: https://zenodo.org/api/files/fd880772-78f5-48c7-8960-838ae2f7c496/limma-voom_luminalpregnant-luminallactate
-        src: url
-        ext: tabular
-        info: https://zenodo.org/record/2491305
-      - url: https://zenodo.org/api/files/fd880772-78f5-48c7-8960-838ae2f7c496/mouse_hallmark_sets
-        src: url
-        ext: rdata
-        info: https://zenodo.org/record/2491305
-      - url: https://zenodo.org/api/files/fd880772-78f5-48c7-8960-838ae2f7c496/seqdata
-        src: url
-        ext: tabular
-        info: https://zenodo.org/record/2491305

--- a/topics/transcriptomics/tutorials/rna-seq-reads-to-counts/tutorial.md
+++ b/topics/transcriptomics/tutorials/rna-seq-reads-to-counts/tutorial.md
@@ -1,7 +1,7 @@
 ---
 layout: tutorial_hands_on
 title: RNA-Seq reads to counts
-zenodo_link: "https://figshare.com/s/f5d63d8c265a05618137"
+zenodo_link: "https://zenodo.org/record/4249555"
 tags:
   - collections
   - mouse
@@ -28,6 +28,12 @@ contributors:
 - mblue9
 - bphipson
 - hdashnow
+requirements:
+  - type: "internal"
+    topic_name: galaxy-interface
+    tutorials:
+      - collections
+      - upload-rules
 
 ---
 
@@ -70,24 +76,24 @@ Read sequences are usually stored in compressed (gzipped) FASTQ files. Before th
 
 If you are sequencing your own data, the sequencing facility will almost always provide compressed FASTQ files which you can upload into Galaxy. If your FASTQs are provided through Galaxy's Shared Data, you can easily import them into a history. For publicly available sequence data, such as from GEO/SRA/ENA, Galaxy's Rule-based Uploader can be used to import the files from URLs, saving on the need to download to your computer and upload into Galaxy.
 
-The raw reads used in this tutorial were obtained from SRA from the link given in GEO for the the mouse mammary gland dataset (Fu et al. 2015) (e.g `ftp://ftp-trace.ncbi.nlm.nih.gov/sra/sra-instant/reads/ByStudy/sra/SRP%2FSRP045%2FSRP045534`). For the purpose of this tutorial we are going to be working with a small part of the FASTQ files. We are only going to be mapping 1000 reads from each sample to enable running through all the steps quickly. If working with your own data you would use the full data and some results for the full mouse dataset will be shown for comparison. The small FASTQ files are available in [Figshare](https://figshare.com/s/f5d63d8c265a05618137) and the links to the FASTQ files are provided below. We are going to import the files into a Collection. Using Galaxy Collections helps keep the datasets organised and tidy in the history. Collections also make it easier to maintain the sample names through tools and workflows. If you are not familiar with collections, see the [Galaxy Collections tutorial]({% link topics/galaxy-interface/tutorials/collections/tutorial.md %}).
+The raw reads used in this tutorial were obtained from SRA from the link given in GEO for the the mouse mammary gland dataset (Fu et al. 2015) (e.g `ftp://ftp-trace.ncbi.nlm.nih.gov/sra/sra-instant/reads/ByStudy/sra/SRP%2FSRP045%2FSRP045534`). For the purpose of this tutorial we are going to be working with a small part of the FASTQ files. We are only going to be mapping 1000 reads from each sample to enable running through all the steps quickly. If working with your own data you would use the full data and some results for the full mouse dataset will be shown for comparison. The small FASTQ files are available in [Zenodo](https://zenodo.org/record/4249555) and the links to the FASTQ files are provided below. We are going to import the files into a Collection. Using Galaxy Collections helps keep the datasets organised and tidy in the history. Collections also make it easier to maintain the sample names through tools and workflows. If you are not familiar with collections, see the [Galaxy Collections tutorial]({% link topics/galaxy-interface/tutorials/collections/tutorial.md %}).
 
 The sample information (sample ID, Group) and link to the FASTQ file (URL) are in the grey box below. To generate a file like this to import data from SRA/ENA see the [Galaxy Rule-based Uploader tutorial]({% link topics/galaxy-interface/tutorials/upload-rules/tutorial.md %}).
 
 ```
 SampleID	Group	URL
-MCL1-DL	basallactate	https://ndownloader.figshare.com/files/5053573?private_link=f5d63d8c265a05618137
-MCL1-DK	basallactate	https://ndownloader.figshare.com/files/5053570?private_link=f5d63d8c265a05618137
-MCL1-DJ	basalpregnant	https://ndownloader.figshare.com/files/5053567?private_link=f5d63d8c265a05618137
-MCL1-DI	basalpregnant	https://ndownloader.figshare.com/files/5053564?private_link=f5d63d8c265a05618137
-MCL1-DH	basalvirgin	https://ndownloader.figshare.com/files/5053561?private_link=f5d63d8c265a05618137
-MCL1-DG	basalvirgin	https://ndownloader.figshare.com/files/5053558?private_link=f5d63d8c265a05618137
-MCL1-LF	luminalvirgin	https://ndownloader.figshare.com/files/5053555?private_link=f5d63d8c265a05618137
-MCL1-LE	luminalvirgin	https://ndownloader.figshare.com/files/5053588?private_link=f5d63d8c265a05618137
-MCL1-LD	luminalpregnant	https://ndownloader.figshare.com/files/5053579?private_link=f5d63d8c265a05618137
-MCL1-LC	luminalpregnant	https://ndownloader.figshare.com/files/5053582?private_link=f5d63d8c265a05618137
-MCL1-LB	luminalvirgin	https://ndownloader.figshare.com/files/5053585?private_link=f5d63d8c265a05618137
-MCL1-LA	luminalvirgin	https://ndownloader.figshare.com/files/5053552?private_link=f5d63d8c265a05618137
+MCL1-DL	basallactate	https://zenodo.org/record/4249555/files/SRR1552455.fastq.gz
+MCL1-DK	basallactate	https://zenodo.org/record/4249555/files/SRR1552454.fastq.gz
+MCL1-DJ	basalpregnant	https://zenodo.org/record/4249555/files/SRR1552453.fastq.gz
+MCL1-DI	basalpregnant	https://zenodo.org/record/4249555/files/SRR1552452.fastq.gz
+MCL1-DH	basalvirgin	https://zenodo.org/record/4249555/files/SRR1552451.fastq.gz
+MCL1-DG	basalvirgin	https://zenodo.org/record/4249555/files/SRR1552450.fastq.gz
+MCL1-LF	luminalvirgin	https://zenodo.org/record/4249555/files/SRR1552449.fastq.gz
+MCL1-LE	luminalvirgin	https://zenodo.org/record/4249555/files/SRR1552448.fastq.gz
+MCL1-LD	luminalpregnant	https://zenodo.org/record/4249555/files/SRR1552447.fastq.gz
+MCL1-LC	luminalpregnant	https://zenodo.org/record/4249555/files/SRR1552446.fastq.gz
+MCL1-LB	luminalvirgin	https://zenodo.org/record/4249555/files/SRR1552445.fastq.gz
+MCL1-LA	luminalvirgin	https://zenodo.org/record/4249555/files/SRR1552444.fastq.gz
 ```
 
 In order to get these files into Galaxy, we will want to do a few things:
@@ -105,7 +111,7 @@ In order to get these files into Galaxy, we will want to do a few things:
 >    {% include snippets/create_new_history.md %}
 >    {% include snippets/rename_history.md %}
 >
-> 2. Import the files from Figshare using Galaxy's Rule-based Uploader.
+> 2. Import the files from Zenodo using Galaxy's Rule-based Uploader.
 >    - Open the Galaxy Upload Manager
 >    - Click the tab **Rule-based**
 >        - *"Upload data as"*: `Collection(s)`

--- a/topics/transcriptomics/tutorials/rna-seq-viz-with-heatmap2/data-library.yaml
+++ b/topics/transcriptomics/tutorials/rna-seq-viz-with-heatmap2/data-library.yaml
@@ -15,13 +15,13 @@ items:
       items:
       - url: https://zenodo.org/api/files/4ff2c107-d04b-4e76-b661-1059a84004ba/heatmap_genes
         src: url
-        ext: tabular
+        ext: '# Please add a Galaxy datatype or update the shared/datatypes.yaml file'
         info: https://zenodo.org/record/2529926
       - url: https://zenodo.org/api/files/4ff2c107-d04b-4e76-b661-1059a84004ba/limma-voom_luminalpregnant-luminallactate
         src: url
-        ext: tabular
+        ext: '# Please add a Galaxy datatype or update the shared/datatypes.yaml file'
         info: https://zenodo.org/record/2529926
       - url: https://zenodo.org/api/files/4ff2c107-d04b-4e76-b661-1059a84004ba/limma-voom_normalised_counts
         src: url
-        ext: tabular
+        ext: '# Please add a Galaxy datatype or update the shared/datatypes.yaml file'
         info: https://zenodo.org/record/2529926

--- a/topics/transcriptomics/tutorials/rna-seq-viz-with-volcanoplot/data-library.yaml
+++ b/topics/transcriptomics/tutorials/rna-seq-viz-with-volcanoplot/data-library.yaml
@@ -15,9 +15,9 @@ items:
       items:
       - url: https://zenodo.org/api/files/98f46936-5237-43f2-943c-448680e1d07a/limma-voom_luminalpregnant-luminallactate
         src: url
-        ext: tabular
+        ext: '# Please add a Galaxy datatype or update the shared/datatypes.yaml file'
         info: https://zenodo.org/record/2529117
       - url: https://zenodo.org/api/files/98f46936-5237-43f2-943c-448680e1d07a/volcano_genes
         src: url
-        ext: tabular
+        ext: '# Please add a Galaxy datatype or update the shared/datatypes.yaml file'
         info: https://zenodo.org/record/2529117

--- a/topics/transcriptomics/tutorials/scrna-plates-batches-barcodes/slides.html
+++ b/topics/transcriptomics/tutorials/scrna-plates-batches-barcodes/slides.html
@@ -2,7 +2,6 @@
 layout: tutorial_slides
 logo: "GTN"
 title: "Plates, Batches, and Barcodes"
-zenodo_link: ""
 tags:
   - single-cell
 questions:

--- a/topics/transcriptomics/tutorials/scrna-preprocessing-tenx/data-library.yaml
+++ b/topics/transcriptomics/tutorials/scrna-preprocessing-tenx/data-library.yaml
@@ -15,7 +15,7 @@ items:
       items:
       - url: https://zenodo.org/api/files/ef2cd156-eff7-43b1-91cd-e86f91d5b315/3M-february-2018.txt.gz
         src: url
-        ext: txt
+        ext: gz
         info: https://zenodo.org/record/3457880
       - url: https://zenodo.org/api/files/ef2cd156-eff7-43b1-91cd-e86f91d5b315/737K-august-2016.txt
         src: url
@@ -31,43 +31,43 @@ items:
         info: https://zenodo.org/record/3457880
       - url: https://zenodo.org/api/files/ef2cd156-eff7-43b1-91cd-e86f91d5b315/pbmc_1k_v3_S1_L001_I1_001.fastq.gz
         src: url
-        ext: fastqsanger.gz
+        ext: gz
         info: https://zenodo.org/record/3457880
       - url: https://zenodo.org/api/files/ef2cd156-eff7-43b1-91cd-e86f91d5b315/pbmc_1k_v3_S1_L001_R1_001.fastq.gz
         src: url
-        ext: fastqsanger.gz
+        ext: gz
         info: https://zenodo.org/record/3457880
       - url: https://zenodo.org/api/files/ef2cd156-eff7-43b1-91cd-e86f91d5b315/pbmc_1k_v3_S1_L001_R2_001.fastq.gz
         src: url
-        ext: fastqsanger.gz
+        ext: gz
         info: https://zenodo.org/record/3457880
       - url: https://zenodo.org/api/files/ef2cd156-eff7-43b1-91cd-e86f91d5b315/pbmc_1k_v3_S1_L002_I1_001.fastq.gz
         src: url
-        ext: fastqsanger.gz
+        ext: gz
         info: https://zenodo.org/record/3457880
       - url: https://zenodo.org/api/files/ef2cd156-eff7-43b1-91cd-e86f91d5b315/pbmc_1k_v3_S1_L002_R1_001.fastq.gz
         src: url
-        ext: fastqsanger.gz
+        ext: gz
         info: https://zenodo.org/record/3457880
       - url: https://zenodo.org/api/files/ef2cd156-eff7-43b1-91cd-e86f91d5b315/pbmc_1k_v3_S1_L002_R2_001.fastq.gz
         src: url
-        ext: fastqsanger.gz
+        ext: gz
         info: https://zenodo.org/record/3457880
       - url: https://zenodo.org/api/files/ef2cd156-eff7-43b1-91cd-e86f91d5b315/subset_pbmc_1k_v3_S1_L001_R1_001.fastq.gz
         src: url
-        ext: fastqsanger.gz
+        ext: gz
         info: https://zenodo.org/record/3457880
       - url: https://zenodo.org/api/files/ef2cd156-eff7-43b1-91cd-e86f91d5b315/subset_pbmc_1k_v3_S1_L001_R2_001.fastq.gz
         src: url
-        ext: fastqsanger.gz
+        ext: gz
         info: https://zenodo.org/record/3457880
       - url: https://zenodo.org/api/files/ef2cd156-eff7-43b1-91cd-e86f91d5b315/subset_pbmc_1k_v3_S1_L002_R1_001.fastq.gz
         src: url
-        ext: fastqsanger.gz
+        ext: gz
         info: https://zenodo.org/record/3457880
       - url: https://zenodo.org/api/files/ef2cd156-eff7-43b1-91cd-e86f91d5b315/subset_pbmc_1k_v3_S1_L002_R2_001.fastq.gz
         src: url
-        ext: fastqsanger.gz
+        ext: gz
         info: https://zenodo.org/record/3457880
       - url: https://zenodo.org/api/files/ef2cd156-eff7-43b1-91cd-e86f91d5b315/subsetting_data.txt
         src: url

--- a/topics/transcriptomics/tutorials/scrna-preprocessing/data-library.yaml
+++ b/topics/transcriptomics/tutorials/scrna-preprocessing/data-library.yaml
@@ -1,0 +1,75 @@
+---
+destination:
+  type: library
+  name: GTN - Material
+  description: Galaxy Training Network Material
+  synopsis: Galaxy Training Network Material. See https://training.galaxyproject.org
+items:
+- name: Transcriptomics
+  description: Training material for all kinds of transcriptomics analysis.
+  items:
+  - name: Pre-processing of Single-Cell RNA Data
+    items:
+    - name: 'DOI: 10.5281/zenodo.3253142'
+      description: latest
+      items:
+      - url: https://zenodo.org/api/files/1f652989-cf1f-4562-a4e1-c9d58b90f294/celseq_barcodes.192.tabular
+        src: url
+        ext: tabular
+        info: https://zenodo.org/record/3253142
+      - url: https://zenodo.org/api/files/1f652989-cf1f-4562-a4e1-c9d58b90f294/Mus_musculus.GRCm38.93.mm10.UCSC.ncbiRefSeq.gtf
+        src: url
+        ext: gtf
+        info: https://zenodo.org/record/3253142
+      - url: https://zenodo.org/api/files/1f652989-cf1f-4562-a4e1-c9d58b90f294/P1_B1.tsv
+        src: url
+        ext: tsv
+        info: https://zenodo.org/record/3253142
+      - url: https://zenodo.org/api/files/1f652989-cf1f-4562-a4e1-c9d58b90f294/P1_B2.tsv
+        src: url
+        ext: tsv
+        info: https://zenodo.org/record/3253142
+      - url: https://zenodo.org/api/files/1f652989-cf1f-4562-a4e1-c9d58b90f294/P1_B3.tsv
+        src: url
+        ext: tsv
+        info: https://zenodo.org/record/3253142
+      - url: https://zenodo.org/api/files/1f652989-cf1f-4562-a4e1-c9d58b90f294/P1_B4.tsv
+        src: url
+        ext: tsv
+        info: https://zenodo.org/record/3253142
+      - url: https://zenodo.org/api/files/1f652989-cf1f-4562-a4e1-c9d58b90f294/P2_B5.tsv
+        src: url
+        ext: tsv
+        info: https://zenodo.org/record/3253142
+      - url: https://zenodo.org/api/files/1f652989-cf1f-4562-a4e1-c9d58b90f294/P2_B6.tsv
+        src: url
+        ext: tsv
+        info: https://zenodo.org/record/3253142
+      - url: https://zenodo.org/api/files/1f652989-cf1f-4562-a4e1-c9d58b90f294/P2_B7.tsv
+        src: url
+        ext: tsv
+        info: https://zenodo.org/record/3253142
+      - url: https://zenodo.org/api/files/1f652989-cf1f-4562-a4e1-c9d58b90f294/P2_B8.tsv
+        src: url
+        ext: tsv
+        info: https://zenodo.org/record/3253142
+      - url: https://zenodo.org/api/files/1f652989-cf1f-4562-a4e1-c9d58b90f294/simulatingcontamination.html
+        src: url
+        ext: html
+        info: https://zenodo.org/record/3253142
+      - url: https://zenodo.org/api/files/1f652989-cf1f-4562-a4e1-c9d58b90f294/SRR5683689_1.fastq.gz
+        src: url
+        ext: gz
+        info: https://zenodo.org/record/3253142
+      - url: https://zenodo.org/api/files/1f652989-cf1f-4562-a4e1-c9d58b90f294/SRR5683689_1.subset.fastq
+        src: url
+        ext: fastqsanger
+        info: https://zenodo.org/record/3253142
+      - url: https://zenodo.org/api/files/1f652989-cf1f-4562-a4e1-c9d58b90f294/SRR5683689_2.fastq.gz
+        src: url
+        ext: gz
+        info: https://zenodo.org/record/3253142
+      - url: https://zenodo.org/api/files/1f652989-cf1f-4562-a4e1-c9d58b90f294/SRR5683689_2.subset.fastq
+        src: url
+        ext: fastqsanger
+        info: https://zenodo.org/record/3253142

--- a/topics/transcriptomics/tutorials/scrna-preprocessing/slides.html
+++ b/topics/transcriptomics/tutorials/scrna-preprocessing/slides.html
@@ -2,7 +2,6 @@
 layout: tutorial_slides
 logo: "GTN"
 title: "Dealing with Cross-Contamination in Fixed Barcode Protocols"
-zenodo_link: ""
 tags:
   - single-cell
 questions:

--- a/topics/transcriptomics/tutorials/scrna-raceid/data-library.yaml
+++ b/topics/transcriptomics/tutorials/scrna-raceid/data-library.yaml
@@ -1,0 +1,19 @@
+---
+destination:
+  type: library
+  name: GTN - Material
+  description: Galaxy Training Network Material
+  synopsis: Galaxy Training Network Material. See https://training.galaxyproject.org
+items:
+- name: Transcriptomics
+  description: Training material for all kinds of transcriptomics analysis.
+  items:
+  - name: Downstream Single-cell RNA analysis with RaceID
+    items:
+    - name: 'DOI: 10.5281/zenodo.1511582'
+      description: latest
+      items:
+      - url: https://zenodo.org/api/files/9d07494b-b15c-4a69-baf5-1e77087586b7/intestinalData.tsv
+        src: url
+        ext: tsv
+        info: https://zenodo.org/record/1511582

--- a/topics/transcriptomics/tutorials/scrna-scanpy-pbmc3k/slides.html
+++ b/topics/transcriptomics/tutorials/scrna-scanpy-pbmc3k/slides.html
@@ -2,7 +2,6 @@
 layout: tutorial_slides
 logo: "GTN"
 title: "Clustering 3K PBMCs with Scanpy"
-zenodo_link: ''
 questions:
   - "What are the main steps of scRNA-seq?"
   - "What kind of variation can confound an analysis?"

--- a/topics/transcriptomics/tutorials/scrna-scater-qc/data-library.yaml
+++ b/topics/transcriptomics/tutorials/scrna-scater-qc/data-library.yaml
@@ -1,0 +1,27 @@
+---
+destination:
+  type: library
+  name: GTN - Material
+  description: Galaxy Training Network Material
+  synopsis: Galaxy Training Network Material. See https://training.galaxyproject.org
+items:
+- name: Transcriptomics
+  description: Training material for all kinds of transcriptomics analysis.
+  items:
+  - name: Single-cell quality control with scater
+    items:
+    - name: 'DOI: 10.5281/zenodo.3386291'
+      description: latest
+      items:
+      - url: https://zenodo.org/api/files/83bb489c-cd94-4d33-b8f4-da1dd7ee8e2b/annotation.txt
+        src: url
+        ext: txt
+        info: https://zenodo.org/record/3386291
+      - url: https://zenodo.org/api/files/83bb489c-cd94-4d33-b8f4-da1dd7ee8e2b/counts.txt
+        src: url
+        ext: txt
+        info: https://zenodo.org/record/3386291
+      - url: https://zenodo.org/api/files/83bb489c-cd94-4d33-b8f4-da1dd7ee8e2b/mt_controls.txt
+        src: url
+        ext: txt
+        info: https://zenodo.org/record/3386291

--- a/topics/transcriptomics/tutorials/scrna-umis/data-library.yaml
+++ b/topics/transcriptomics/tutorials/scrna-umis/data-library.yaml
@@ -1,0 +1,23 @@
+---
+destination:
+  type: library
+  name: GTN - Material
+  description: Galaxy Training Network Material
+  synopsis: Galaxy Training Network Material. See https://training.galaxyproject.org
+items:
+- name: Transcriptomics
+  description: Training material for all kinds of transcriptomics analysis.
+  items:
+  - name: Understanding Barcodes
+    items:
+    - name: 'DOI: 10.5281/zenodo.2573177'
+      description: latest
+      items:
+      - url: https://zenodo.org/api/files/37fdd67a-9f09-4424-8acc-60c38edaca52/test_barcodes_celseq2_R1.fastq.gz
+        src: url
+        ext: gz
+        info: https://zenodo.org/record/2573177
+      - url: https://zenodo.org/api/files/37fdd67a-9f09-4424-8acc-60c38edaca52/test_barcodes_celseq2_R2.fastq.gz
+        src: url
+        ext: gz
+        info: https://zenodo.org/record/2573177

--- a/topics/transcriptomics/tutorials/srna/data-library.yaml
+++ b/topics/transcriptomics/tutorials/srna/data-library.yaml
@@ -15,41 +15,41 @@ items:
       items:
       - url: https://zenodo.org/api/files/91891445-b940-4880-a087-751075b0f8f9/Blank_RNAi_sRNA-seq_rep1_downsampled.fastqsanger.gz
         src: url
-        ext: fastqsanger.gz
+        ext: gz
         info: https://zenodo.org/record/826906
       - url: https://zenodo.org/api/files/91891445-b940-4880-a087-751075b0f8f9/Blank_RNAi_sRNA-seq_rep2_downsampled.fastqsanger.gz
         src: url
-        ext: fastqsanger.gz
+        ext: gz
         info: https://zenodo.org/record/826906
       - url: https://zenodo.org/api/files/91891445-b940-4880-a087-751075b0f8f9/Blank_RNAi_sRNA-seq_rep3_downsampled.fastqsanger.gz
         src: url
-        ext: fastqsanger.gz
+        ext: gz
         info: https://zenodo.org/record/826906
       - url: https://zenodo.org/api/files/91891445-b940-4880-a087-751075b0f8f9/dm3_miRNA_hairpin_sequences.fa.gz
         src: url
-        ext: fasta
+        ext: gz
         info: https://zenodo.org/record/826906
       - url: https://zenodo.org/api/files/91891445-b940-4880-a087-751075b0f8f9/dm3_rRNA_sequences.fa.gz
         src: url
-        ext: fasta
+        ext: gz
         info: https://zenodo.org/record/826906
       - url: https://zenodo.org/api/files/91891445-b940-4880-a087-751075b0f8f9/dm3_transcriptome_sequences_downsampled.fa.gz
         src: url
-        ext: fasta
+        ext: gz
         info: https://zenodo.org/record/826906
       - url: https://zenodo.org/api/files/91891445-b940-4880-a087-751075b0f8f9/dm3_transcriptome_Tx2Gene_downsampled.tab.gz
         src: url
-        ext: tabular
+        ext: gz
         info: https://zenodo.org/record/826906
       - url: https://zenodo.org/api/files/91891445-b940-4880-a087-751075b0f8f9/Symp_RNAi_sRNA-seq_rep1_downsampled.fastqsanger.gz
         src: url
-        ext: fastqsanger.gz
+        ext: gz
         info: https://zenodo.org/record/826906
       - url: https://zenodo.org/api/files/91891445-b940-4880-a087-751075b0f8f9/Symp_RNAi_sRNA-seq_rep2_downsampled.fastqsanger.gz
         src: url
-        ext: fastqsanger.gz
+        ext: gz
         info: https://zenodo.org/record/826906
       - url: https://zenodo.org/api/files/91891445-b940-4880-a087-751075b0f8f9/Symp_RNAi_sRNA-seq_rep3_downsampled.fastqsanger.gz
         src: url
-        ext: fastqsanger.gz
+        ext: gz
         info: https://zenodo.org/record/826906

--- a/topics/variant-analysis/tutorials/dunovo/tutorial.md
+++ b/topics/variant-analysis/tutorials/dunovo/tutorial.md
@@ -2,7 +2,6 @@
 layout: tutorial_hands_on
 
 title: "Calling very rare variants"
-zenodo_link: ""
 enable: false
 questions:
   - "What frequency of variants is so low that it is obscured by sequencing error rate?"

--- a/topics/variant-analysis/tutorials/exome-seq/data-library.yaml
+++ b/topics/variant-analysis/tutorials/exome-seq/data-library.yaml
@@ -14,23 +14,7 @@ items:
     - name: 'DOI: 10.5281/zenodo.3054169'
       description: latest
       items:
-      - url: https://zenodo.org/api/files/dd4bcd95-4412-4ac0-a7d2-23cf1c69e0bc/mapped_reads_father.bam
+      - url: https://zenodo.org/api/files/aab7197b-7444-447d-a4b3-f81b2250daf1/family_trio_variants.gemini.sqlite
         src: url
-        ext: bam
-        info: https://doi.org/10.5281/zenodo.3054169
-      - url: https://zenodo.org/api/files/dd4bcd95-4412-4ac0-a7d2-23cf1c69e0bc/mapped_reads_proband.bam
-        src: url
-        ext: bam
-        info: https://doi.org/10.5281/zenodo.3054169
-      - url: https://zenodo.org/api/files/dd4bcd95-4412-4ac0-a7d2-23cf1c69e0bc/mapped_reads_mother.bam
-        src: url
-        ext: bam
-        info: https://doi.org/10.5281/zenodo.3054169
-      - url: https://zenodo.org/api/files/dd4bcd95-4412-4ac0-a7d2-23cf1c69e0bc/Pedigree.txt
-        src: url
-        ext: tabular
-        info: https://doi.org/10.5281/zenodo.3054169
-      - url: https://zenodo.org/api/files/dd4bcd95-4412-4ac0-a7d2-23cf1c69e0bc/hg19_chr8.fa.gz
-        src: url
-        ext: fasta
+        ext: sqlite
         info: https://doi.org/10.5281/zenodo.3054169

--- a/topics/variant-analysis/tutorials/mapping-by-sequencing/data-library.yaml
+++ b/topics/variant-analysis/tutorials/mapping-by-sequencing/data-library.yaml
@@ -22,8 +22,8 @@ items:
         src: url
         ext: bam
         info: https://doi.org/10.5281/zenodo.1098033
-    - name: 'Arabidopsis TAIR10 genome'
-      description: latest
+    - name: Arabidopsis TAIR10 genome
+      description: ''
       items:
       - url: https://www.arabidopsis.org/download_files/Genes/TAIR10_genome_release/TAIR10_chromosome_files/TAIR10_chr_all.fas
         src: url

--- a/topics/variant-analysis/tutorials/sars-cov-2/data-library.yaml
+++ b/topics/variant-analysis/tutorials/sars-cov-2/data-library.yaml
@@ -1,0 +1,48 @@
+---
+destination:
+  type: library
+  name: GTN - Material
+  description: Galaxy Training Network Material
+  synopsis: Galaxy Training Network Material. See https://training.galaxyproject.org
+items:
+- name: Variant Analysis
+  description: 'Genetic differences (variants) between healthy and diseased tissue,
+
+    between individuals of a population, or between strains of an organism
+
+    can provide mechanistic insight into disease processes and the natural
+
+    function of affected genes.
+
+
+    The tutorials in this section show how to detect evidence for
+
+    genetic variants in next-generation sequencing data, a process termed
+
+    variant calling.
+
+
+    Of equal importance, they also demonstrate how you can interpret, for
+
+    a range of different organisms, the resulting sets of variants by
+
+    predicting their molecular effects on genes and proteins, by
+
+    annotating previously observed variants with published knowledge, and
+
+    by trying to link phenotypes of the sequenced samples to their variant
+
+    genotypes.
+
+    '
+  items:
+  - name: 'From NCBI''s Sequence Read Archive (SRA) to Galaxy: SARS-CoV-2 variant
+      analysis'
+    items:
+    - name: 'DOI: 10.5281/zenodo.3906454'
+      description: latest
+      items:
+      - url: https://zenodo.org/api/files/e3686a78-602a-43a4-926d-3f3d72bd8218/NC_045512.2.fasta
+        src: url
+        ext: fasta
+        info: http://zenodo.org/record/3906454

--- a/topics/variant-analysis/tutorials/sars-cov-2/tutorial.md
+++ b/topics/variant-analysis/tutorials/sars-cov-2/tutorial.md
@@ -2,7 +2,7 @@
 layout: tutorial_hands_on
 
 title: "From NCBI's Sequence Read Archive (SRA) to Galaxy: SARS-CoV-2 variant analysis"
-zenodo_link: 'http://zenodo.org/record/3906454'
+zenodo_link: "https://zenodo.org/record/3906454"
 questions:
 - Learn how to get and use data from the Sequence Read Archive in Galaxy.
 objectives:

--- a/topics/variant-analysis/tutorials/somatic-variants/data-library.yaml
+++ b/topics/variant-analysis/tutorials/somatic-variants/data-library.yaml
@@ -15,27 +15,27 @@ items:
     - name: 'DOI: 10.5281/zenodo.2582555'
       description: latest
       items:
-      - src: url
-        url: https://zenodo.org/api/files/a8dae68d-74a9-4283-9d3a-942668270643/dbsnp.b147.chr5_12_17.vcf.gz
-        ext: vcf
+      - url: https://zenodo.org/api/files/a8dae68d-74a9-4283-9d3a-942668270643/dbsnp.b147.chr5_12_17.vcf.gz
+        src: url
+        ext: gz
         info: https://doi.org/10.5281/zenodo.2582555
-      - src: url
-        url: https://zenodo.org/api/files/a8dae68d-74a9-4283-9d3a-942668270643/hg19.chr5_12_17.fa.gz
-        ext: fasta.gz
+      - url: https://zenodo.org/api/files/a8dae68d-74a9-4283-9d3a-942668270643/hg19.chr5_12_17.fa.gz
+        src: url
+        ext: gz
         info: https://doi.org/10.5281/zenodo.2582555
-      - src: url
-        url: https://zenodo.org/api/files/a8dae68d-74a9-4283-9d3a-942668270643/SLGFSK-N_231335_r1_chr5_12_17.fastq.gz
-        ext: fastqsanger.gz
+      - url: https://zenodo.org/api/files/a8dae68d-74a9-4283-9d3a-942668270643/SLGFSK-N_231335_r1_chr5_12_17.fastq.gz
+        src: url
+        ext: gz
         info: https://doi.org/10.5281/zenodo.2582555
-      - src: url
-        url: https://zenodo.org/api/files/a8dae68d-74a9-4283-9d3a-942668270643/SLGFSK-N_231335_r2_chr5_12_17.fastq.gz
-        ext: fastqsanger.gz
+      - url: https://zenodo.org/api/files/a8dae68d-74a9-4283-9d3a-942668270643/SLGFSK-N_231335_r2_chr5_12_17.fastq.gz
+        src: url
+        ext: gz
         info: https://doi.org/10.5281/zenodo.2582555
-      - src: url
-        url: https://zenodo.org/api/files/a8dae68d-74a9-4283-9d3a-942668270643/SLGFSK-T_231336_r1_chr5_12_17.fastq.gz
-        ext: fastqsanger.gz
+      - url: https://zenodo.org/api/files/a8dae68d-74a9-4283-9d3a-942668270643/SLGFSK-T_231336_r1_chr5_12_17.fastq.gz
+        src: url
+        ext: gz
         info: https://doi.org/10.5281/zenodo.2582555
-      - src: url
-        url: https://zenodo.org/api/files/a8dae68d-74a9-4283-9d3a-942668270643/SLGFSK-T_231336_r2_chr5_12_17.fastq.gz
-        ext: fastqsanger.gz
+      - url: https://zenodo.org/api/files/a8dae68d-74a9-4283-9d3a-942668270643/SLGFSK-T_231336_r2_chr5_12_17.fastq.gz
+        src: url
+        ext: gz
         info: https://doi.org/10.5281/zenodo.2582555

--- a/topics/variant-analysis/tutorials/tb-variant-analysis/data-library.yaml
+++ b/topics/variant-analysis/tutorials/tb-variant-analysis/data-library.yaml
@@ -5,36 +5,61 @@ destination:
   description: Galaxy Training Network Material
   synopsis: Galaxy Training Network Material. See https://training.galaxyproject.org
 items:
-  - name: Variant Analysis
+- name: Variant Analysis
+  items:
+  - name: 'DOI: 10.5281/zenodo.3960260'
+    description: latest
     items:
-      - name: 'DOI: 10.5281/zenodo.3960260'
-        description: latest
-        items:
-          - url: https://zenodo.org/record/3960260/files/004-2_1.fastq.gz
-            src: url
-            ext: fastqsanger.gz
-            info: https://doi.org/10.5281/zenodo.3960260
-          - url: https://zenodo.org/record/3960260/files/004-2_2.fastq.gz
-            src: url
-            ext: fastqsanger.gz
-            info: https://doi.org/10.5281/zenodo.3960260
-          - url: https://zenodo.org/record/https://zenodo.org/record/3960260/files/Mycobacterium_tuberculosis_ancestral_reference.gbk/files/Mycobacterium_tuberculosis_ancestral_reference.gbk
-            src: url
-            ext: genbank
-            info: https://doi.org/10.5281/zenodo.3960260
-          - url: https://zenodo.org/record/3960260/files/MTB_ancestor_reference.fasta
-            src: url
-            ext: fasta
-            info: https://doi.org/10.5281/zenodo.3960260
-          - url: https://zenodo.org/record/3960260/files/Mycobacterium_tuberculosis_h37rv.ASM19595v2.45.chromosome.Chromosome.gff3
-            src: url
-            ext: fasta
-            info: https://doi.org/10.5281/zenodo.3960260
-          - url: https://zenodo.org/record/3960260/files/018-1_1.fastq.gz
-            src: url
-            ext: fastqsanger.gz
-            info: https://doi.org/10.5281/zenodo.3960260
-          - url: https://zenodo.org/record/3960260/files/018-1_2.fastq.gz
-            src: url
-            ext: fastqsanger.gz
-            info: https://doi.org/10.5281/zenodo.3960260
+    - url: https://zenodo.org/record/3960260/files/004-2_1.fastq.gz
+      src: url
+      ext: fastqsanger.gz
+      info: https://doi.org/10.5281/zenodo.3960260
+    - url: https://zenodo.org/record/3960260/files/004-2_2.fastq.gz
+      src: url
+      ext: fastqsanger.gz
+      info: https://doi.org/10.5281/zenodo.3960260
+    - url: https://zenodo.org/record/https://zenodo.org/record/3960260/files/Mycobacterium_tuberculosis_ancestral_reference.gbk/files/Mycobacterium_tuberculosis_ancestral_reference.gbk
+      src: url
+      ext: genbank
+      info: https://doi.org/10.5281/zenodo.3960260
+    - url: https://zenodo.org/record/3960260/files/MTB_ancestor_reference.fasta
+      src: url
+      ext: fasta
+      info: https://doi.org/10.5281/zenodo.3960260
+    - url: https://zenodo.org/record/3960260/files/Mycobacterium_tuberculosis_h37rv.ASM19595v2.45.chromosome.Chromosome.gff3
+      src: url
+      ext: fasta
+      info: https://doi.org/10.5281/zenodo.3960260
+    - url: https://zenodo.org/record/3960260/files/018-1_1.fastq.gz
+      src: url
+      ext: fastqsanger.gz
+      info: https://doi.org/10.5281/zenodo.3960260
+    - url: https://zenodo.org/record/3960260/files/018-1_2.fastq.gz
+      src: url
+      ext: fastqsanger.gz
+      info: https://doi.org/10.5281/zenodo.3960260
+  - name: M. tuberculosis Variant Analysis
+    items:
+    - name: 'DOI: 10.5281/zenodo.3496437'
+      description: latest
+      items:
+      - url: https://zenodo.org/api/files/30498698-b1a7-4a9a-a832-4cc783eabb71/Mycobacterium_tuberculosis_ancestral_reference.gbk
+        src: url
+        ext: gbk
+        info: https://doi.org/10.5281/zenodo.3496437
+      - url: https://zenodo.org/api/files/30498698-b1a7-4a9a-a832-4cc783eabb71/pe_ppe.bed
+        src: url
+        ext: bed
+        info: https://doi.org/10.5281/zenodo.3496437
+      - url: https://zenodo.org/api/files/30498698-b1a7-4a9a-a832-4cc783eabb71/TB_R1.fastq.gz
+        src: url
+        ext: gz
+        info: https://doi.org/10.5281/zenodo.3496437
+      - url: https://zenodo.org/api/files/30498698-b1a7-4a9a-a832-4cc783eabb71/TB_R2.fastq.gz
+        src: url
+        ext: gz
+        info: https://doi.org/10.5281/zenodo.3496437
+      - url: https://zenodo.org/api/files/30498698-b1a7-4a9a-a832-4cc783eabb71/uvp.bed
+        src: url
+        ext: bed
+        info: https://doi.org/10.5281/zenodo.3496437

--- a/topics/visualisation/tutorials/circos/data-library.yaml
+++ b/topics/visualisation/tutorials/circos/data-library.yaml
@@ -15,11 +15,11 @@ items:
       items:
       - url: https://zenodo.org/api/files/0142d9ad-df0a-416c-b8f8-d8f4b8443c80/chrom.tab
         src: url
-        ext: tsv
+        ext: '# Please add a Galaxy datatype or update the shared/datatypes.yaml file'
         info: https://zenodo.org/record/3603221
       - url: https://zenodo.org/api/files/0142d9ad-df0a-416c-b8f8-d8f4b8443c80/debate_axis.tab
         src: url
-        ext: tsv
+        ext: '# Please add a Galaxy datatype or update the shared/datatypes.yaml file'
         info: https://zenodo.org/record/3603221
       - url: https://zenodo.org/api/files/0142d9ad-df0a-416c-b8f8-d8f4b8443c80/debate_karyotype.txt
         src: url
@@ -27,11 +27,11 @@ items:
         info: https://zenodo.org/record/3603221
       - url: https://zenodo.org/api/files/0142d9ad-df0a-416c-b8f8-d8f4b8443c80/debate_links.tab
         src: url
-        ext: tsv
+        ext: '# Please add a Galaxy datatype or update the shared/datatypes.yaml file'
         info: https://zenodo.org/record/3603221
       - url: https://zenodo.org/api/files/0142d9ad-df0a-416c-b8f8-d8f4b8443c80/debate_slices.tab
         src: url
-        ext: tsv
+        ext: '# Please add a Galaxy datatype or update the shared/datatypes.yaml file'
         info: https://zenodo.org/record/3603221
       - url: https://zenodo.org/api/files/0142d9ad-df0a-416c-b8f8-d8f4b8443c80/hg18_karyotype_bands.tsv
         src: url
@@ -43,7 +43,7 @@ items:
         info: https://zenodo.org/record/3603221
       - url: https://zenodo.org/api/files/0142d9ad-df0a-416c-b8f8-d8f4b8443c80/highlights.tab
         src: url
-        ext: tsv
+        ext: '# Please add a Galaxy datatype or update the shared/datatypes.yaml file'
         info: https://zenodo.org/record/3603221
       - url: https://zenodo.org/api/files/0142d9ad-df0a-416c-b8f8-d8f4b8443c80/VCaP_B-allele-Frequency.tsv
         src: url

--- a/topics/visualisation/tutorials/jbrowse/data-library.yaml
+++ b/topics/visualisation/tutorials/jbrowse/data-library.yaml
@@ -19,7 +19,7 @@ items:
         info: https://doi.org/10.5281/zenodo.3591856
       - url: https://zenodo.org/api/files/0f156ca2-fb89-4d6f-8b80-02e51e5f5339/blastp%20vs%20swissprot.xml
         src: url
-        ext: blastxml
+        ext: '# Please add a Galaxy datatype or update the shared/datatypes.yaml file'
         info: https://doi.org/10.5281/zenodo.3591856
       - url: https://zenodo.org/api/files/0f156ca2-fb89-4d6f-8b80-02e51e5f5339/dna%20sequencing.bam
         src: url
@@ -27,7 +27,7 @@ items:
         info: https://doi.org/10.5281/zenodo.3591856
       - url: https://zenodo.org/api/files/0f156ca2-fb89-4d6f-8b80-02e51e5f5339/dna%20sequencing%20coverage.bw
         src: url
-        ext: bigwig
+        ext: '# Please add a Galaxy datatype or update the shared/datatypes.yaml file'
         info: https://doi.org/10.5281/zenodo.3591856
       - url: https://zenodo.org/api/files/0f156ca2-fb89-4d6f-8b80-02e51e5f5339/genes%20%28de%20novo%29.gff3
         src: url
@@ -43,11 +43,11 @@ items:
         info: https://doi.org/10.5281/zenodo.3591856
       - url: https://zenodo.org/api/files/0f156ca2-fb89-4d6f-8b80-02e51e5f5339/RNA-Seq%20coverage%201.bw
         src: url
-        ext: bigwig
+        ext: '# Please add a Galaxy datatype or update the shared/datatypes.yaml file'
         info: https://doi.org/10.5281/zenodo.3591856
       - url: https://zenodo.org/api/files/0f156ca2-fb89-4d6f-8b80-02e51e5f5339/RNA-Seq%20coverage%202.bw
         src: url
-        ext: bigwig
+        ext: '# Please add a Galaxy datatype or update the shared/datatypes.yaml file'
         info: https://doi.org/10.5281/zenodo.3591856
       - url: https://zenodo.org/api/files/0f156ca2-fb89-4d6f-8b80-02e51e5f5339/variants.vcf
         src: url


### PR DESCRIPTION
I'm not sure what to do about this. We stopped generating these for some reason? Which I now forget.

But it means that the shared-data library doesn't have any of these datasets which is really unfortunate. We were doing a tutorial today and I noticed that some of the tutos were missing.

I've added a script here to update every data library, maybe we can run it on cron or so?

Also there are numerous issues :( 

- [ ] planemo can't handle it when there's a `---` in the tutorial, which is perfectly valid markdown. It needs to do proper yaml streams and only process the first.
  - any one willing to volunteer for this? it needs some refactor (split document with `---` and pick first section, rather than the current regex which breaks.)
- [ ] the share/datatypes doesn't seem to work, judging by the number of 'fastq.gz' that became 'gz' instead of 'fastqsanger.gz' per the file.
- [ ] topics/computational-chemistry/tutorials/htmd-analysis/data-library.yaml has a zip file in their zenodo which means it's useless for us. (Their bib file also has some serious issues we should've caught.)
- [ ] many datatypes are missing