### PR TITLE
Cut columns from a table -> Cut columns from a table (cut)

### DIFF
--- a/topics/ecology/tutorials/PAMPA-toolsuite-tutorial/tutorial.md
+++ b/topics/ecology/tutorials/PAMPA-toolsuite-tutorial/tutorial.md
@@ -440,7 +440,7 @@ nomenclature for the "observation.unit" fields, namely:
 >    >
 >    {: .question}
 >
-> 4. {% tool [Cut columns from a table](toolshed.g2.bx.psu.edu/repos/bgruening/text_processing/tp_cut_tool/1.1.0) %}
+> 4. {% tool [Cut columns from a table (cut)](toolshed.g2.bx.psu.edu/repos/bgruening/text_processing/tp_cut_tool/1.1.0) %}
 >    with following parameters :
 >    - {% icon param-files %} *"File to cut"*: `#Concatenate` Column Regex Find And Replace data file
 >    - {% icon param-select %} *"Operation"*: `Keep`


### PR DESCRIPTION
This is something where for sure trainees will make mistake... at least with this tool and the concatenate one.... Maybe only keep one "version" of each tools ? ITM be sure we can make the same operations, it seems to me this is not the case so "we" have to work on it carefully