### PR TITLE
Testing plausible analytics as replacement for google

### DIFF
--- a/_includes/analytics.html
+++ b/_includes/analytics.html
@@ -6,3 +6,5 @@
     ga('create', '{{ site.google_analytics_id }}' , 'auto');
     ga('send', 'pageview');
 </script>
+
+<script async defer data-domain="training.galaxyproject.org" src="https://plausible.galaxyproject.eu/js/plausible.js"></script>


### PR DESCRIPTION
The stats can be made public here: https://plausible.galaxyproject.eu/training.galaxyproject.org and it can be a nice replacement for google's 