### PR TITLE
[Small Patch] Format tutorial for paper

### DIFF
--- a/bin/format_tutorial_for_article.py
+++ b/bin/format_tutorial_for_article.py
@@ -325,10 +325,13 @@ def copy_images(images, images_dp, tuto_dp):
     :param images_dp:
     '''
     for img in images:
-        m = re.search(r'(?P<path>\.\.\/\.\.\/images[a-z0-9\-\_\/\.]+)', img)
+        #m = re.search(r'(?P<path>\.\.\/\.\.\/images[a-z0-9\-\_\/\.]+)', img)
+        m = re.search(r'(\blink\b)?(?P<path>(\.\.\/\.\.|topics/[a-z0-9\-\_\/]+)/images[a-z0-9\-\_\/\.]+)', img)
         if m is not None:
             img_fp = tuto_dp / Path(m.group('path'))
-            check_exists(img_fp)
+            if not check_exists(img_fp, noerror=True):
+                img_fp = Path(m.group('path'))
+                check_exists(img_fp)
             new_imgfp = images_dp / Path(img_fp.name)
             shutil.copy(str(img_fp), str(new_imgfp))
         else:

--- a/bin/format_tutorial_for_article.py
+++ b/bin/format_tutorial_for_article.py
@@ -7,11 +7,14 @@ import yaml
 from pathlib import Path
 
 
-def check_exists(fp):
+def check_exists(fp, noerror=False):
     '''Check if file in fp exists
     
     :param fp: Path object to file to test
+    :param noerror: Return a boolean instead of raising an error
     '''
+    if noerror:
+        return(fp.exists())
     if not fp.exists():
         raise ValueError("%s does not exist" % fp)
 


### PR DESCRIPTION
Fix to regex for non backwards relative paths

    python bin/format_tutorial_for_article.py -t topics/transcriptomics/tutorials/scrna-raceid

  Before it would error out an image entry such as:

    '![Histograms of raw and filtered data]({{site.baseurl}}{% link topics/transcriptomics/images/raceid_filter_plots.png %} "RaceID Histograms of raw and filtered data")\n'


Also, the `check_exists` function modified to allow boolean return. This can be used to check whether or not the tutorial path needs to  be appended to the image path (depending on whether or not the image path is relative)



