### PR TITLE
Add Proteomics topic maintainers

### DIFF
--- a/topics/proteomics/metadata.yaml
+++ b/topics/proteomics/metadata.yaml
@@ -17,7 +17,6 @@ maintainers:
   - pratikdjagtap
   - stortebecker
   - bgruening
-  - blankclemens
 
 
 references:

--- a/topics/proteomics/metadata.yaml
+++ b/topics/proteomics/metadata.yaml
@@ -15,7 +15,6 @@ maintainers:
   - foellmelanie
   - subinamehta
   - pratikdjagtap
-  - stortebecker
   - bgruening
 
 

--- a/topics/proteomics/metadata.yaml
+++ b/topics/proteomics/metadata.yaml
@@ -12,6 +12,9 @@ requirements:
     topic_name: introduction
 
 maintainers:
+  - foellmelanie
+  - subinamehta
+  - pratikdjagtap
   - stortebecker
   - bgruening
   - blankclemens


### PR DESCRIPTION
@foellmelanie, @PratikDJagtap and @subinamehta have kindly agreed to be topic maintainers for Proteomics topic, thanks!! :tada: 

@martenson could you add them to the @galaxyproject/training-proteomics team?
