### PR TITLE
Populate robots.txt file when served from a fork

### DIFF
--- a/.github/workflows/deploy-s3.yml
+++ b/.github/workflows/deploy-s3.yml
@@ -49,6 +49,7 @@ jobs:
           JEKYLL_ENV=production bundle exec jekyll build --strict_front_matter -d _site/training-material
         env:
           SOURCE_TAG: ${{ steps.branch_name.outputs.SOURCE_TAG }}
+          GTN_FORK: ${{ secrets.GTN_FORK }}
 
       - name: Deploy 🚀
         run: |

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -38,6 +38,8 @@ jobs:
           export PATH=/home/runner/.local/bin:$PATH
           make annotate ACTIVATE_ENV=pwd
           JEKYLL_ENV=production bundle exec jekyll build --strict_front_matter -d _site/training-material
+        env:
+          GTN_FORK: ${{ secrets.GTN_FORK }}
 
       - name: Deploy 🚀
         uses: peaceiris/actions-gh-pages@v3

--- a/_includes/analytics.html
+++ b/_includes/analytics.html
@@ -1,10 +1,1 @@
-<script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
-    ga('create', '{{ site.google_analytics_id }}' , 'auto');
-    ga('send', 'pageview');
-</script>
-
 <script async defer data-domain="training.galaxyproject.org" src="https://plausible.galaxyproject.eu/js/plausible.js"></script>

--- a/_layouts/base.html
+++ b/_layouts/base.html
@@ -7,9 +7,6 @@
         <meta http-equiv="x-ua-compatible" content="ie=edge">
         <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
         <title>{{ page.title | default: site.title }}</title>
-        {% if jekyll.environment == 'production' %}
-            {% include _includes/analytics.html %}
-        {% endif %}
         <link rel="stylesheet" href="{{ "/assets/css/bootstrap.min.css?v=3" | prepend: site.baseurl }}">
         <link rel="stylesheet" href="{{ "/assets/css/bootstrap-toc.min.css" | prepend: site.baseurl }}">
         <link rel="stylesheet" href="{{ "/assets/css/main.css?v=2" | prepend: site.baseurl }}">

--- a/_plugins/jekyll-environment_variables.rb
+++ b/_plugins/jekyll-environment_variables.rb
@@ -14,6 +14,7 @@ module Jekyll
         git_head_ref = 'none'
       end
       site.config['git_revision'] = git_head_ref
+      site.config['gtn_fork'] = ENV['GTN_FORK']
 
       # Add other environment variables to `site.config` here...
     end

--- a/_plugins/jekyll-environment_variables.rb
+++ b/_plugins/jekyll-environment_variables.rb
@@ -5,7 +5,6 @@ module Jekyll
   class EnvironmentVariablesGenerator < Generator
 
     def generate(site)
-      site.config['google_analytics_id'] = ENV['GOOGLE_ANALYTICS_ID']
 
       begin
         git_head = File.open(File.join('.git', 'HEAD')).read.strip.split(' ')[1]

--- a/robots.html
+++ b/robots.html
@@ -1,0 +1,5 @@
+---
+permalink: robots.txt
+---
+{%- unless site.gtn_fork == 'galaxyproject' -%}User-agent: *
+Disallow: / {% endunless %}


### PR DESCRIPTION
To allow users to build the website on their own fork, without search engines indexing it

also removes google analytics since we switched to Plausible

ping @hexylena please check the changes to the github actions workflows