### PR TITLE
Robots.txt fix: use github env variable

### DIFF
--- a/.github/workflows/deploy-s3.yml
+++ b/.github/workflows/deploy-s3.yml
@@ -49,7 +49,7 @@ jobs:
           JEKYLL_ENV=production bundle exec jekyll build --strict_front_matter -d _site/training-material
         env:
           SOURCE_TAG: ${{ steps.branch_name.outputs.SOURCE_TAG }}
-          GTN_FORK: ${{ secrets.GTN_FORK }}
+          GTN_FORK: ${{ github.repository_owner }}
 
       - name: Deploy 🚀
         run: |

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -39,7 +39,7 @@ jobs:
           make annotate ACTIVATE_ENV=pwd
           JEKYLL_ENV=production bundle exec jekyll build --strict_front_matter -d _site/training-material
         env:
-          GTN_FORK: ${{ secrets.GTN_FORK }}
+          GTN_FORK: ${{ github.repository_owner }}
 
       - name: Deploy 🚀
         uses: peaceiris/actions-gh-pages@v3

--- a/robots.html
+++ b/robots.html
@@ -1,5 +1,10 @@
 ---
 permalink: robots.txt
 ---
-{%- unless site.gtn_fork == 'galaxyproject' -%}User-agent: *
-Disallow: / {% endunless %}
+{%- if site.gtn_fork == 'galaxyproject' -%}
+User-agent: *
+Allow: /
+{% else %}
+User-agent: *
+Disallow: /
+{% endif %}


### PR DESCRIPTION
follow up to https://github.com/galaxyproject/training-material/pull/2205, we can use predefined github repo owner variable as suggested by @nsoranzo (thanks!)

