### PR TITLE
Various fixes for ansible-galaxy tutorial

### DIFF
--- a/topics/admin/tutorials/ansible-galaxy/galaxy.yml
+++ b/topics/admin/tutorials/ansible-galaxy/galaxy.yml
@@ -4,7 +4,7 @@
   pre_tasks:
     - name: Install Dependencies
       package:
-        name: ['git', 'make', 'python3-psycopg2', 'virtualenv', 'tar', 'bzip2', 'acl']
+        name: ['acl', 'bzip2', 'git', 'make', 'python3-psycopg2', 'tar', 'virtualenv']
   handlers:
     - name: Restart Galaxy
       systemd:

--- a/topics/admin/tutorials/ansible-galaxy/group_vars/galaxyservers.yml
+++ b/topics/admin/tutorials/ansible-galaxy/group_vars/galaxyservers.yml
@@ -23,7 +23,7 @@ galaxy_config_style: yaml
 galaxy_force_checkout: true
 
 miniconda_prefix: "{{ galaxy_tool_dependency_dir }}/_conda"
-miniconda_version: "4.6.14"
+miniconda_version: "4.7.12"
 miniconda_manage_dependencies: false
 
 galaxy_config:

--- a/topics/admin/tutorials/ansible-galaxy/requirements.yml
+++ b/topics/admin/tutorials/ansible-galaxy/requirements.yml
@@ -7,7 +7,7 @@
 - src: natefoo.postgresql_objects
   version: 1.1
 - src: geerlingguy.pip
-  version: 1.3.0
+  version: 2.0.0
 - src: uchida.miniconda
   version: 0.3.0
 - src: usegalaxy_eu.galaxy_systemd


### PR DESCRIPTION
- Sort package names in pre-task
- Update `geerlingguy.pip` role to 2.0.0
- Add `miniconda_manage_dependencies: false` to tutorial
- Clarify `galaxy_config_templates` origin