### PR TITLE
correct deseq2 normalization step 7

### DIFF
--- a/topics/transcriptomics/tutorials/ref-based/tutorial.md
+++ b/topics/transcriptomics/tutorials/ref-based/tutorial.md
@@ -1083,11 +1083,12 @@ TPM, RPKM or FPKM do not deal with these differences in library composition in n
 > 7. Compute the normalized counts: divide the original counts by the scaling factors
 >
 >     Gene | Sample 1 | Sample 2 | Sample 3
->     A | 0 | 23 | 9
->     B | 2 | 6 | 12
->     C | 13 | 21 | 78
+>     A | 0 | 11.11 | 1.6
+>     B | 5 | 6.67 | 4.8
+>     C | 83 | 61.11 | 80
 >
-> *This explanation is a transcription and adaptation of the [StatQuest video explaining Library Normalization in DESEq2](https://www.youtube.com/watch?v=UFB993xufUU)*
+> *This explanation is a transcription and adaptation of the [StatQuest video explaining Library Normalization in DESEq2](https://www.youtube.com/watch?v=UFB993xufUU&t=35s)*
+
 {: .details}
 
 DESeq2 runs also the Differential Gene Expression (DGE) analysis, whose two basic tasks are:


### PR DESCRIPTION
Following @mgabere comment

Gene C should be 33/0.4 = 83    55/0.9= 61.11     200/2.5 = 80
Gene B should be 2/0.4 = 5      6/0.9= 6.67   12/2.5 = 4.8 
Gene A should be 0/0.4 = 0   10/0.9 = 11.11   4/2.5 = 1.6

fixes #2224 