### PR TITLE
Tiniest of typos

### DIFF
--- a/topics/transcriptomics/tutorials/scrna-scanpy-pbmc3k/tutorial.md
+++ b/topics/transcriptomics/tutorials/scrna-scanpy-pbmc3k/tutorial.md
@@ -315,7 +315,7 @@ Genes that appear in less than a few cells can be considered noise and thus remo
 >    >
 >    > > ### {% icon solution %} Solution
 >    > >
->    > > There are now 13,714 cells. So 19,024 (32,738 - 13,714) genes have been removed.
+>    > > There are now 13,714 genes. So 19,024 (32,738 - 13,714) genes have been removed.
 >    > >
 >    > {: .solution}
 >    >


### PR DESCRIPTION
Said cells rather than genes. This is embarrassing to even propose as a change. I am ashamed. Enjoy this one-word improvement of a mammoth tutorial.