### PR TITLE
Minor updates to tool management tutorial for admin training 2021

### DIFF
--- a/topics/admin/tutorials/tool-management/tutorial.md
+++ b/topics/admin/tutorials/tool-management/tutorial.md
@@ -102,7 +102,7 @@ Ephemeris can take care of this process. Let's practice this on a real worfklow.
 >    >
 >    > > ### {% icon solution %} Solution
 >    > > ```console
->    > > workflow-to-tools -w mapping.ga -o workflow_tools.yml -l "mapping tools"
+>    > > workflow-to-tools -w mapping.ga -o workflow_tools.yml -l Mapping
 >    > > ```
 >    > {: .solution }
 >    {: .question}
@@ -132,7 +132,7 @@ There are two ways to install tools, depending on how you specify the tools to i
 
 > ### {% icon hands_on %} Hands-on: Installing a single tool
 >
-> 1. Use the Ephemeris [`shed-tools`](https://ephemeris.readthedocs.io/en/latest/commands/shed-tools.html) command to install the tool `bwa`, owned by user `devteam` into a section named `Mapping`
+> 1. Use the Ephemeris [`shed-tools`](https://ephemeris.readthedocs.io/en/latest/commands/shed-tools.html) command to install the tool `pilon`, owned by `iuc` into a section named `Assembly`
 >
 >    > ### {% icon question %} Question
 >    > What did your command look like?
@@ -141,7 +141,7 @@ There are two ways to install tools, depending on how you specify the tools to i
 >    > > Use your Galaxy URL and API key in the example command below:
 >    > >
 >    > > ```console
->    > > shed-tools install -g https://your-galaxy -a <api-key> --name bwa --owner devteam --section_label Mapping
+>    > > shed-tools install -g https://your-galaxy -a <api-key> --name pilon --owner iuc --section_label Assembly
 >    > > ```
 >    > {: .solution}
 >    {: .question}
@@ -190,6 +190,16 @@ For that, you can install from a YAML file:
 
 Occasionally the tool installation may fail due to network issues; if it does, just re-run the `shed-tools` installation process until it succeeds. This is a known issue the developers are working on.
 
+> ###  {% icon tip %} Tip: Opening a split screen in byobu
+> `Shift-F2`: Create a horizontal split
+>
+> `Shift-Left/Right/Up/Down`: Move focus among splits
+>
+> `Ctrl-F6`:  Close split in focus
+>
+> There are more byobu commands described in this [gist](https://gist.github.com/devhero/7b9a7281db0ac4ba683f)
+{: .tip}
+
 > ### {% icon tip %} Can I install tools without restarting?
 > Yes. The default tool config (`config/tool_conf.xml.sample`, copy to `config/tool_conf.xml` to modify) has an option, `monitor="true"` set in the root `<toolbox>` tag. This instructs Galaxy to watch the tool files referenced in that config and load or reload them as necessary. It will also add any tools you have added.
 {: .tip}
@@ -205,7 +215,7 @@ Having the tools installed is a good first step, but your users will expect that
 
 > ### {% icon hands_on %} Hands-on: Test the installed tools
 >
-> 1. Use the Ephemeris [`shed-tools`](https://ephemeris.readthedocs.io/en/latest/commands/shed-tools.html) command to test the `bamtools_filter` tool on your Galaxy.
+> 1. Use the Ephemeris [`shed-tools`](https://ephemeris.readthedocs.io/en/latest/commands/shed-tools.html) command to test the `pilon` tool on your Galaxy.
 >
 >    > ### {% icon question %} Question
 >    > What did your command look like?
@@ -214,7 +224,7 @@ Having the tools installed is a good first step, but your users will expect that
 >    > > Use your Galaxy URL and API key in the example command below:
 >    > >
 >    > > ```console
->    > > shed-tools test -g https://your-galaxy -a <api-key> --name bamtools_filter --owner devteam
+>    > > shed-tools test -g https://your-galaxy -a <api-key> --name pilon --owner iuc
 >    > > ```
 >    > {: .solution}
 >    {: .question}


### PR DESCRIPTION
The installed tool for the "Hands-on: Installing a single tool" step has been changed from bwa to pilon.  The tested tool has been changed from bamtools_filter to pilon.  The reason for this change is to avoid the error 'NoneType has no attribute view' which comes from running tests for some tools where pysam is not also installed.  pilon was chosen because it doesn't take up much more conda space than bwa and it installs is about the same amount of time.

There is a new tip for splitting the screen with byobu, because at some point the video tutor will split their byobu screen and instruct the students to do the same.