### PR TITLE
Tool management slides: update questions and key points, delete objectives

### DIFF
--- a/topics/admin/tutorials/tool-management/slides.html
+++ b/topics/admin/tutorials/tool-management/slides.html
@@ -7,17 +7,15 @@ redirect_from:
 
 title: "Galaxy Tool Management with Ephemeris"
 questions:
-  - How to install, update, and maintain Galaxy tools?
-  - How to extract a list of tools from a workflow or Galaxy instance?
-  - How are tool dependencies resolved by Galaxy?
-objectives:
-  - Extract a list of tools from a workflow
-  - Install these tools into a given Galaxy
-  - Understand the tool dependency resolution process
+  - How are tools configured on a Galaxy instance?
+  - What is the Galaxy Tool Shed?
+  - How are Galaxy tools installed?
+  - What is ephemeris and how can it be used to manage tools on a Galaxy instance?
 key_points:
-  - Ephemeris and automation help with the tool management on Galaxy
-  - There are tool management best practices you can learn from
-  - Dependency resolvers have different priorites
+  - The Galaxy Tool Shed contains thousands of tools that can be installed on a Galaxy instance
+  - Galaxy administrators can choose which tools are installed and how they are arranged
+  - Ephemeris can be used to manage tools on a Galaxy instance
+  - Tool installation with ephemeris is best practice and allows for the automation of tool management tasks
 contributors:
   - mvdbeek
   - cat-bro


### PR DESCRIPTION
@hexylena this is last-minute.  The questions, objectives and key points now form part of the slide show and I'd like to change them to fit better with the content of the slides.   I got rid of the objectives altogether but I can replace them with revised objectives if need be.