### PR TITLE
Remove the CVMFS tutorial requirement

### DIFF
--- a/topics/admin/tutorials/singularity/tutorial.md
+++ b/topics/admin/tutorials/singularity/tutorial.md
@@ -19,7 +19,6 @@ requirements:
     tutorials:
       - ansible
       - ansible-galaxy
-      - cvmfs
 ---
 
 # Overview


### PR DESCRIPTION
It's not relevant without the "Use Singularity containers from CVMFS" part.