### PR TITLE
Add subtopics for transcriptomics

### DIFF
--- a/_includes/tutorial_list.html
+++ b/_includes/tutorial_list.html
@@ -18,6 +18,7 @@
   </thead>
   <tbody class="list">
 
+  {% assign topic_material = topic_material | sort: 'priority'%}
   {% for material in topic_material %}
     {% if include.sub and include.sub.id == material.subtopic %}
       {% assign show = true %}
@@ -31,7 +32,7 @@
       {% if material.enable == nil or material.enable == true %}
         <tr>
           <td class="tutorial_title">
-          {{ material.title }}
+          {{ material.title}}
           <div class="">
           {% if material.level %}
             {% include _includes/difficulty-indicator.html level=material.level %}

--- a/topics/transcriptomics/metadata.yaml
+++ b/topics/transcriptomics/metadata.yaml
@@ -20,6 +20,20 @@ maintainers:
   - bebatut
   - mblue9
 
+subtopics:
+  - id: introduction
+    title: "Introduction"
+    description: "Start here if you are new to RNA-Seq analysis in Galaxy"
+  - id: end-to-end
+    title: "End-to-End Analysis"
+    description: "These tutorials take you from raw data to final results and visualisation"
+  - id: single-cell
+    title: "Single-cell RNA-seq"
+    description: "Tutorials about analysis of single-cell RNA-seq data"
+  - id: visualisation
+    title: "Visualisation"
+    description: "Tutorials covering data visualisation"
+
 
 references:
   -

--- a/topics/transcriptomics/metadata.yaml
+++ b/topics/transcriptomics/metadata.yaml
@@ -26,7 +26,7 @@ subtopics:
     description: "Start here if you are new to RNA-Seq analysis in Galaxy"
   - id: end-to-end
     title: "End-to-End Analysis"
-    description: "These tutorials take you from raw data to final results and visualisation"
+    description: "These tutorials take you from raw sequencing reads to pathway analysis"
   - id: single-cell
     title: "Single-cell RNA-seq"
     description: "Tutorials about analysis of single-cell RNA-seq data"

--- a/topics/transcriptomics/slides/introduction.html
+++ b/topics/transcriptomics/slides/introduction.html
@@ -2,7 +2,10 @@
 layout: introduction_slides
 logo: "GTN"
 class: enlarge120
+
 subtopic: introduction
+priority: 1
+
 title: "Introduction to Transcriptomics"
 type: "introduction"
 contributors:

--- a/topics/transcriptomics/slides/introduction.html
+++ b/topics/transcriptomics/slides/introduction.html
@@ -2,7 +2,7 @@
 layout: introduction_slides
 logo: "GTN"
 class: enlarge120
-
+subtopic: introduction
 title: "Introduction to Transcriptomics"
 type: "introduction"
 contributors:

--- a/topics/transcriptomics/tutorials/de-novo/tutorial.md
+++ b/topics/transcriptomics/tutorials/de-novo/tutorial.md
@@ -2,6 +2,7 @@
 layout: tutorial_hands_on
 
 title: "De novo transcriptome reconstruction with RNA-Seq"
+subtopic: introduction
 zenodo_link: "https://zenodo.org/record/254485#.WKODmRIrKRu"
 questions:
   - "What genes are differentially expressed between G1E cells and megakaryocytes?"

--- a/topics/transcriptomics/tutorials/de-novo/tutorial.md
+++ b/topics/transcriptomics/tutorials/de-novo/tutorial.md
@@ -3,6 +3,8 @@ layout: tutorial_hands_on
 
 title: "De novo transcriptome reconstruction with RNA-Seq"
 subtopic: introduction
+priority: 3
+
 zenodo_link: "https://zenodo.org/record/254485#.WKODmRIrKRu"
 questions:
   - "What genes are differentially expressed between G1E cells and megakaryocytes?"

--- a/topics/transcriptomics/tutorials/ref-based/tutorial.md
+++ b/topics/transcriptomics/tutorials/ref-based/tutorial.md
@@ -2,6 +2,7 @@
 layout: tutorial_hands_on
 
 title: "Reference-based RNA-Seq data analysis"
+subtopic: introduction
 tags:
     - bulk
     - rna-seq
@@ -167,8 +168,8 @@ Sequence quality control is therefore an essential first step in your analysis. 
 >    >
 >    > > ### {% icon solution %} Solution
 >    > >
->    > > 1. Everything seems good for 3 of the files. The `GSM461177` have 10.3 millions of sequences and `GSM461180` 12.3 millions of sequences. But in `GSM461180_2` (reverse reads of GSM461180) the quality decreases quite a lot at the end of the sequences. 
->    > >    
+>    > > 1. Everything seems good for 3 of the files. The `GSM461177` have 10.3 millions of sequences and `GSM461180` 12.3 millions of sequences. But in `GSM461180_2` (reverse reads of GSM461180) the quality decreases quite a lot at the end of the sequences.
+>    > >
 >    > >    All files except `GSM461180_2` have a high proportion of duplicated reads (expected in RNA-Seq data)
 >    > >
 >    > >    ![Sequence Counts](../../images/ref-based/fastqc_sequence_counts_plot.png "Sequence Counts")

--- a/topics/transcriptomics/tutorials/ref-based/tutorial.md
+++ b/topics/transcriptomics/tutorials/ref-based/tutorial.md
@@ -3,6 +3,8 @@ layout: tutorial_hands_on
 
 title: "Reference-based RNA-Seq data analysis"
 subtopic: introduction
+priority: 2
+
 tags:
     - bulk
     - rna-seq

--- a/topics/transcriptomics/tutorials/rna-seq-counts-to-genes/tutorial.md
+++ b/topics/transcriptomics/tutorials/rna-seq-counts-to-genes/tutorial.md
@@ -1,6 +1,7 @@
 ---
 layout: tutorial_hands_on
-title: RNA-seq counts to genes
+title: "2: RNA-seq counts to genes"
+subtopic: end-to-end
 zenodo_link: "https://zenodo.org/record/4273218"
 tags:
   - limma-voom
@@ -132,14 +133,14 @@ The `factordata` file contains basic information about the samples that we will 
 
 > ### {% icon details %} Formatting the data
 >
->The files above have been formatted for you. If you are interested to know how they were formatted the information is below. 
+>The files above have been formatted for you. If you are interested to know how they were formatted the information is below.
 >
 > The original files are available at
 >
 >     ```
 >     https://zenodo.org/record/4273218/files/GSE60450_Lactation-GenewiseCounts.txt
 >     https://zenodo.org/record/4273218/files/SampleInfo.txt
->     ``` 
+>     ```
 >
 >![seqdata file](../../images/rna-seq-counts-to-genes/seqdata.png "Count file (before formatting)")
 >
@@ -160,7 +161,7 @@ The `factordata` file contains basic information about the samples that we will 
 >>      - {% icon param-file %} *"File to process"*: output of **Replace Text** {% icon tool %}
 >>      - {% icon param-text %} *"Find pattern"*: `-`
 >>      - {% icon param-text %} *"Replace with"*: `.`
->> 4. Rename file as `countdata` using the {% icon galaxy-pencil %} (pencil) icon. 
+>> 4. Rename file as `countdata` using the {% icon galaxy-pencil %} (pencil) icon.
 >{: .hands_on}
 >
 >To create the file, `factordata`, that contains the groups information that we need for the limma-voom tool. We'll combine the cell type and mouse status to make 6 groups e.g. we'll combine the CellType `basal` with the Status `pregnant` for the group `basalpregnant`. We'll use the **Merge Columns** tool to combine the cell type and mouse status columns in the sample information file, making a column with the 6 group names.
@@ -368,7 +369,7 @@ We can also use box plots to check the distributions of counts in the samples. B
 {: .question}
 
 
-> ### {% icon details %} Normalization factors 
+> ### {% icon details %} Normalization factors
 >
 >The TMM normalization generates normalization factors, where the product of these factors and the library sizes defines the effective library size. TMM normalization (and most scaling normalization methods) scale relative to one sample. The normalization factors multiply to unity across all libraries. A normalization factor below one indicates that the library size will be scaled down, as there is more suppression (i.e., composition bias) in that library relative to the other libraries. This is also equivalent to scaling the counts upwards in that sample. Conversely, a factor above one scales up the library size and is equivalent to downscaling the counts. We can see the normalization factors for these samples in the `Library information` file if we select to output it with *"Output Library information file?"*: `Yes`. Click on the {% icon galaxy-eye %} (eye) icon to view.
 >

--- a/topics/transcriptomics/tutorials/rna-seq-counts-to-viz-in-r/tutorial.md
+++ b/topics/transcriptomics/tutorials/rna-seq-counts-to-viz-in-r/tutorial.md
@@ -2,6 +2,8 @@
 layout: tutorial_hands_on
 
 title: RNA Seq Counts to Viz in R
+subtopic: visualisation
+
 zenodo_link: "https://zenodo.org/record/3477564/"
 requirements:
   -

--- a/topics/transcriptomics/tutorials/rna-seq-genes-to-pathways/tutorial.md
+++ b/topics/transcriptomics/tutorials/rna-seq-genes-to-pathways/tutorial.md
@@ -1,6 +1,7 @@
 ---
 layout: tutorial_hands_on
-title: RNA-seq genes to pathways
+title: "3: RNA-seq genes to pathways"
+subtopic: end-to-end
 zenodo_link: "https://zenodo.org/record/2596382"
 tags:
   - mouse
@@ -225,7 +226,7 @@ An enrichment plot of the each of the top pathways can also be produced, one is 
 ![fgsea Enrichment](../../images/rna-seq-genes-to-pathways/fgsea_enrichplot.png "fgsea Enrichment plot")
 
 > ### {% icon question %} Questions
-> Can you run fgsea on the luminal contrast and generate the fgsea summary table plot? 
+> Can you run fgsea on the luminal contrast and generate the fgsea summary table plot?
 >
 > > ### {% icon solution %} Solution
 > >

--- a/topics/transcriptomics/tutorials/rna-seq-reads-to-counts/tutorial.md
+++ b/topics/transcriptomics/tutorials/rna-seq-reads-to-counts/tutorial.md
@@ -1,6 +1,7 @@
 ---
 layout: tutorial_hands_on
-title: RNA-Seq reads to counts
+title: "1: RNA-Seq reads to counts"
+subtopic: end-to-end
 zenodo_link: "https://zenodo.org/record/4249555"
 tags:
   - collections
@@ -86,7 +87,7 @@ This is a Galaxy tutorial based on material from the [COMBINE R RNAseq workshop]
 
 Read sequences are usually stored in compressed (gzipped) FASTQ files. Before the differential expression analysis can proceed, these reads must be aligned to the reference genome and counted into annotated genes. Mapping reads to the genome is a very important task, and many different aligners are available, such as HISAT2 ({% cite kim2015hisat %}), STAR ({% cite dobin2013star %}) and Subread ({% cite Liao2013 %}). Most mapping tasks require larger computers than an average laptop, so usually read mapping is done on a server in a linux-like environment, requiring some programming knowledge. However, Galaxy enables you to do this mapping without needing to know programming and if you don't have access to a server you can try to use one of the publically available Galaxies e.g. [usegalaxy.org](https://usegalaxy.org), [usegalaxy.eu](https://usegalaxy.eu), [usegalaxy.org.au](https://usegalaxy.org.au/).
 
-The raw reads used in this tutorial were obtained from SRA from the link in GEO for the the mouse mammary gland dataset (e.g `ftp://ftp-trace.ncbi.nlm.nih.gov/sra/sra-instant/reads/ByStudy/sra/SRP%2FSRP045%2FSRP045534`). For the purpose of this tutorial we are going to be working with a small part of the FASTQ files. We are only going to be mapping 1000 reads from each sample to enable running through all the steps quickly. If working with your own data you would use the full data and some results for the full mouse dataset will be shown for comparison. The small FASTQ files are available in [Zenodo](https://zenodo.org/record/4249555) and the links to the FASTQ files are provided below. 
+The raw reads used in this tutorial were obtained from SRA from the link in GEO for the the mouse mammary gland dataset (e.g `ftp://ftp-trace.ncbi.nlm.nih.gov/sra/sra-instant/reads/ByStudy/sra/SRP%2FSRP045%2FSRP045534`). For the purpose of this tutorial we are going to be working with a small part of the FASTQ files. We are only going to be mapping 1000 reads from each sample to enable running through all the steps quickly. If working with your own data you would use the full data and some results for the full mouse dataset will be shown for comparison. The small FASTQ files are available in [Zenodo](https://zenodo.org/record/4249555) and the links to the FASTQ files are provided below.
 
 If you are sequencing your own data, the sequencing facility will almost always provide compressed FASTQ files which you can upload into Galaxy. For sequence data available through URLs, The [Galaxy Rule-based Uploader]({% link topics/galaxy-interface/tutorials/upload-rules/tutorial.md %}) can be used to import the files. It is much quicker than downloading FASTQs to your computer and uploading into Galaxy and also enables importing as a **Collection**. When you have more than a few files, using Galaxy Collections helps keep the datasets organised and tidy in the history. Collections also make it easier to maintain the sample names through tools and workflows. If you are not familiar with collections, you can take a look at the [Galaxy Collections tutorial]({% link topics/galaxy-interface/tutorials/collections/tutorial.md %}) for more details. The screenshots below show a comparison of what the FASTQ datasets for this tutorial would look like in the history if we imported them as datasets versus as a collection with the Rule-based Uploader.
 
@@ -96,13 +97,13 @@ Datasets | Collection
 
 
 > ### {% icon details %} Collections and sample names
-> 
+>
 > Collections can also help to maintain the original sample names on the files throughout the tools used. The screenshots below show what we would see in one of the MultiQC reports that we will generate if we used datasets versus a collection.
-> 
+>
 > Datasets | Collection
 > --- | ---
 > ![Sample names without collection](../../images/rna-seq-reads-to-counts/samplesnames_without_collection.png)| ![Sample names with collection](../../images/rna-seq-reads-to-counts/samplesnames_with_collection.png)
-> 
+>
 {: .details}
 
 
@@ -468,7 +469,7 @@ The counts files are currently in the format of one file per sample. However, it
 >
 {: .hands_on}
 
-Take a look at the output. The tutorial uses a small subset of the data ~ 1000 reads per sample to save on processing time. Most rows in that matrix will contain all zeros, there will be ~600 non-zero rows. The output for the full dataset is shown below. 
+Take a look at the output. The tutorial uses a small subset of the data ~ 1000 reads per sample to save on processing time. Most rows in that matrix will contain all zeros, there will be ~600 non-zero rows. The output for the full dataset is shown below.
 
 ![Count matrix](../../images/rna-seq-reads-to-counts/count_matrix.png "Count matrix")
 
@@ -476,7 +477,7 @@ Now it is easier to see the counts for a gene across all samples. The accompanyi
 
 # Generating a QC summary report
 
-There are several additional QCs we can perform to better understand the data, to see if it's good quality. These can also help determine if changes could be made in the lab to improve the quality of future datasets. 
+There are several additional QCs we can perform to better understand the data, to see if it's good quality. These can also help determine if changes could be made in the lab to improve the quality of future datasets.
 
 We'll use a prepared workflow to run the first few of the QCs below. This will also demonstrate how you can make use of Galaxy workflows to easily run and reuse multiple analysis steps. The workflow will run the first three tools: **Infer Experiment**, **MarkDuplicates** and **IdxStats** and generate a **MultiQC** report. You can then edit the workflow if you'd like to add other steps.
 
@@ -488,11 +489,11 @@ We'll use a prepared workflow to run the first few of the QCs below. This will a
 >
 >    {% include snippets/import_workflow.md %}
 >
-> 2. Import this file as type BED file: 
+> 2. Import this file as type BED file:
 >    ```
 >    https://sourceforge.net/projects/rseqc/files/BED/Mouse_Mus_musculus/mm10_RefSeq.bed.gz/download
 >    ```
->    {% include snippets/import_via_link.md %} 
+>    {% include snippets/import_via_link.md %}
 >
 > 3. Run **Workflow QC Report** {% icon workflow %} using the following parameters:
 >    - *"Send results to a new history"*: `No`
@@ -504,7 +505,7 @@ We'll use a prepared workflow to run the first few of the QCs below. This will a
 {: .hands_on}
 
 
-**You do not need to run the hands-on steps below.** They are just to show how you could run the tools individually and what parameters to set. 
+**You do not need to run the hands-on steps below.** They are just to show how you could run the tools individually and what parameters to set.
 
 ## Strandness
 

--- a/topics/transcriptomics/tutorials/rna-seq-viz-with-cummerbund/tutorial.md
+++ b/topics/transcriptomics/tutorials/rna-seq-viz-with-cummerbund/tutorial.md
@@ -2,6 +2,7 @@
 layout: tutorial_hands_on
 
 title: "Visualization of RNA-Seq results with CummeRbund"
+subtopic: visualisation
 zenodo_link: "https://zenodo.org/record/1001880"
 questions:
   - "How are RNA-Seq results stored?"

--- a/topics/transcriptomics/tutorials/rna-seq-viz-with-heatmap2/tutorial.md
+++ b/topics/transcriptomics/tutorials/rna-seq-viz-with-heatmap2/tutorial.md
@@ -1,6 +1,7 @@
 ---
 layout: tutorial_hands_on
 title: Visualization of RNA-Seq results with heatmap2
+subtopic: visualisation
 zenodo_link: "https://zenodo.org/record/2529926"
 questions:
   - "How to generate heatmaps from RNA-seq data?"

--- a/topics/transcriptomics/tutorials/rna-seq-viz-with-volcanoplot/tutorial.md
+++ b/topics/transcriptomics/tutorials/rna-seq-viz-with-volcanoplot/tutorial.md
@@ -1,6 +1,7 @@
 ---
 layout: tutorial_hands_on
 title: Visualization of RNA-Seq results with Volcano Plot
+subtopic: visualisation
 zenodo_link: "https://zenodo.org/record/2529117"
 questions:
   - "How to generate a volcano plot from RNA-seq data?"

--- a/topics/transcriptomics/tutorials/scrna-plates-batches-barcodes/slides.html
+++ b/topics/transcriptomics/tutorials/scrna-plates-batches-barcodes/slides.html
@@ -2,6 +2,7 @@
 layout: tutorial_slides
 logo: "GTN"
 title: "Plates, Batches, and Barcodes"
+subtopic: single-cell
 zenodo_link: ""
 tags:
   - single-cell

--- a/topics/transcriptomics/tutorials/scrna-plates-batches-barcodes/slides.html
+++ b/topics/transcriptomics/tutorials/scrna-plates-batches-barcodes/slides.html
@@ -2,7 +2,10 @@
 layout: tutorial_slides
 logo: "GTN"
 title: "Plates, Batches, and Barcodes"
+
 subtopic: single-cell
+priority: 3
+
 zenodo_link: ""
 tags:
   - single-cell

--- a/topics/transcriptomics/tutorials/scrna-preprocessing-tenx/tutorial.md
+++ b/topics/transcriptomics/tutorials/scrna-preprocessing-tenx/tutorial.md
@@ -1,6 +1,7 @@
 ---
 layout: tutorial_hands_on
 title: "Pre-processing of 10X Single-Cell RNA Datasets"
+subtopic: single-cell
 zenodo_link: "https://zenodo.org/record/3457880"
 tags:
   - single-cell
@@ -243,8 +244,8 @@ We will now proceed to demultiplex, map, and quantify both sets of reads using t
 
 
 > ### {% icon hands_on %} Hands-on
-> 
-> **Build a Paired Collection** 
+>
+> **Build a Paired Collection**
 > {% include snippets/build_paired_list_collection.md %}
 >
 > **RNA STARsolo** {% icon tool %} with the following parameters:

--- a/topics/transcriptomics/tutorials/scrna-preprocessing-tenx/tutorial.md
+++ b/topics/transcriptomics/tutorials/scrna-preprocessing-tenx/tutorial.md
@@ -2,6 +2,8 @@
 layout: tutorial_hands_on
 title: "Pre-processing of 10X Single-Cell RNA Datasets"
 subtopic: single-cell
+priority: 6
+
 zenodo_link: "https://zenodo.org/record/3457880"
 tags:
   - single-cell

--- a/topics/transcriptomics/tutorials/scrna-preprocessing/tutorial.md
+++ b/topics/transcriptomics/tutorials/scrna-preprocessing/tutorial.md
@@ -4,6 +4,7 @@ redirect_from:
   - /topics/transcriptomics/tutorials/scrna_preprocessing/tutorial
 
 title: "Pre-processing of Single-Cell RNA Data"
+subtopic: single-cell
 zenodo_link: "https://zenodo.org/record/3253142"
 tags:
   - single-cell

--- a/topics/transcriptomics/tutorials/scrna-preprocessing/tutorial.md
+++ b/topics/transcriptomics/tutorials/scrna-preprocessing/tutorial.md
@@ -5,6 +5,8 @@ redirect_from:
 
 title: "Pre-processing of Single-Cell RNA Data"
 subtopic: single-cell
+priority: 1
+
 zenodo_link: "https://zenodo.org/record/3253142"
 tags:
   - single-cell

--- a/topics/transcriptomics/tutorials/scrna-raceid/tutorial.md
+++ b/topics/transcriptomics/tutorials/scrna-raceid/tutorial.md
@@ -1,7 +1,9 @@
 ---
 layout: tutorial_hands_on
-title: Downstream Single-cell RNA analysis with RaceID
+title: "Downstream Single-cell RNA analysis with RaceID"
 subtopic: single-cell
+priority: 5
+
 zenodo_link: 'https://zenodo.org/record/1511582'
 tags:
   - single-cell

--- a/topics/transcriptomics/tutorials/scrna-raceid/tutorial.md
+++ b/topics/transcriptomics/tutorials/scrna-raceid/tutorial.md
@@ -1,6 +1,7 @@
 ---
 layout: tutorial_hands_on
 title: Downstream Single-cell RNA analysis with RaceID
+subtopic: single-cell
 zenodo_link: 'https://zenodo.org/record/1511582'
 tags:
   - single-cell

--- a/topics/transcriptomics/tutorials/scrna-scanpy-pbmc3k/tutorial.md
+++ b/topics/transcriptomics/tutorials/scrna-scanpy-pbmc3k/tutorial.md
@@ -1,8 +1,10 @@
 ---
 layout: tutorial_hands_on
 
-title: Clustering 3K PBMCs with Scanpy
+title: "Clustering 3K PBMCs with Scanpy"
 subtopic: single-cell
+priority: 7
+
 zenodo_link: 'https://zenodo.org/record/3581213'
 questions:
 - What are the steps to prepare single-cell RNA-Seq data for clustering?

--- a/topics/transcriptomics/tutorials/scrna-scanpy-pbmc3k/tutorial.md
+++ b/topics/transcriptomics/tutorials/scrna-scanpy-pbmc3k/tutorial.md
@@ -2,6 +2,7 @@
 layout: tutorial_hands_on
 
 title: Clustering 3K PBMCs with Scanpy
+subtopic: single-cell
 zenodo_link: 'https://zenodo.org/record/3581213'
 questions:
 - What are the steps to prepare single-cell RNA-Seq data for clustering?

--- a/topics/transcriptomics/tutorials/scrna-scater-qc/tutorial.md
+++ b/topics/transcriptomics/tutorials/scrna-scater-qc/tutorial.md
@@ -2,6 +2,7 @@
 layout: tutorial_hands_on
 
 title: Single-cell quality control with scater
+subtopic: single-cell
 zenodo_link: 'https://zenodo.org/record/3386291'
 tags:
   - single-cell

--- a/topics/transcriptomics/tutorials/scrna-scater-qc/tutorial.md
+++ b/topics/transcriptomics/tutorials/scrna-scater-qc/tutorial.md
@@ -1,8 +1,10 @@
 ---
 layout: tutorial_hands_on
 
-title: Single-cell quality control with scater
+title: "Single-cell quality control with scater"
 subtopic: single-cell
+priority: 4
+
 zenodo_link: 'https://zenodo.org/record/3386291'
 tags:
   - single-cell

--- a/topics/transcriptomics/tutorials/scrna-umis/tutorial.md
+++ b/topics/transcriptomics/tutorials/scrna-umis/tutorial.md
@@ -1,6 +1,7 @@
 ---
 layout: tutorial_hands_on
 title: "Understanding Barcodes"
+subtopic: single-cell
 zenodo_link: "https://zenodo.org/record/2573177"
 tags:
   - single-cell

--- a/topics/transcriptomics/tutorials/scrna-umis/tutorial.md
+++ b/topics/transcriptomics/tutorials/scrna-umis/tutorial.md
@@ -2,6 +2,8 @@
 layout: tutorial_hands_on
 title: "Understanding Barcodes"
 subtopic: single-cell
+priority: 2
+
 zenodo_link: "https://zenodo.org/record/2573177"
 tags:
   - single-cell

--- a/topics/transcriptomics/tutorials/small_ncrna_clustering/tutorial.md
+++ b/topics/transcriptomics/tutorials/small_ncrna_clustering/tutorial.md
@@ -2,6 +2,7 @@
 layout: tutorial_hands_on
 
 title: Small Non-coding RNA Clustering using BlockClust
+subtopic: single-cell
 zenodo_link: https://zenodo.org/record/1491876
 questions:
 - What do the read profiles of small non-coding RNAs represent?

--- a/topics/transcriptomics/tutorials/small_ncrna_clustering/tutorial.md
+++ b/topics/transcriptomics/tutorials/small_ncrna_clustering/tutorial.md
@@ -2,7 +2,6 @@
 layout: tutorial_hands_on
 
 title: Small Non-coding RNA Clustering using BlockClust
-subtopic: single-cell
 zenodo_link: https://zenodo.org/record/1491876
 questions:
 - What do the read profiles of small non-coding RNAs represent?


### PR DESCRIPTION
There are a LOT of tutorials in the transcriptomics topic, it would be nice to create some subtopics. I had a first go at it, but am not an expert, so please let me know what would be good groupings, @mblue9, @bebatut, and others?

Currently I made the following subtopics:
- Introduction (with intro slides and ref-based tutorial)
- End-to-End (@mblue9's 3 tutorials that form a unit, please let me know what a better name would be here?)
- Single Cell (@mtekman, @nomadscientist let me know if there is some logical ordering to these that might be nice to enforce?)
- Visualisation
- Anything else ends up in "Other"

Thoughts? Any subtopics we should add/remove/rename? Tutorials that need to move to a different subtopic?
 
![image](https://user-images.githubusercontent.com/2563865/104844206-1cd30c80-58cf-11eb-9b1c-d4d8252f3f54.png)




