### PR TITLE
Singularity role imposter

### DIFF
--- a/topics/admin/tutorials/singularity/tutorial.md
+++ b/topics/admin/tutorials/singularity/tutorial.md
@@ -64,7 +64,7 @@ First, we will install Singularity using Ansible. On most operating systems ther
 >
 >    ```yaml
 >    - src: cyverse-ansible.singularity
->      version: ad4de5e4b0bb3f8a43de0f3565757aa156853485
+>      version: 048c4f178077d05c1e67ae8d9893809aac9ab3b7
 >    - src: gantsign.golang
 >      version: 2.6.3
 >    ```


### PR DESCRIPTION
So through the :sparkles: magic :sparkles: of git/GH, commits from forks are included in the parent repository.

As they haven't merged my PR yet (https://github.com/CyVerse-Ansible/ansible-singularity/pull/1), *and* they pull their role from github rather than publishing on ansible, we can simply point at my PR commit and it behaves just like we want, pulling that PR commit.

The commit is **required** for GAT, it skips a 1-2 minute build on *every* run of the role.