### PR TITLE
Skip cron and video CI jobs on forks

### DIFF
--- a/.github/workflows/cron.yml
+++ b/.github/workflows/cron.yml
@@ -7,6 +7,7 @@ on:
 
 jobs:
   setup:
+    if: github.repository_owner == 'galaxyproject'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/video.yml
+++ b/.github/workflows/video.yml
@@ -9,6 +9,7 @@ on:
 
 jobs:
   runner-job:
+    if: github.repository_owner == 'galaxyproject'
     runs-on: ubuntu-latest
     services:
       # Label used to access the service container


### PR DESCRIPTION
I keep getting emails like "[nsoranzo/training-material] Run failed: Autogenerated and Deploy Videos - master (d86a8bf)"