### PR TITLE
Correct stats

### DIFF
--- a/_layouts/base.html
+++ b/_layouts/base.html
@@ -7,6 +7,9 @@
         <meta http-equiv="x-ua-compatible" content="ie=edge">
         <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
         <title>{{ page.title | default: site.title }}</title>
+        {% if jekyll.environment == 'production' %}
+            {% include _includes/analytics.html %}
+        {% endif %}
         <link rel="stylesheet" href="{{ "/assets/css/bootstrap.min.css?v=3" | prepend: site.baseurl }}">
         <link rel="stylesheet" href="{{ "/assets/css/bootstrap-toc.min.css" | prepend: site.baseurl }}">
         <link rel="stylesheet" href="{{ "/assets/css/main.css?v=2" | prepend: site.baseurl }}">


### PR DESCRIPTION
This reverts commit f108a976480273f25a63ac9ddb31d6a8e6637193 which accidentally removed analytics from non-slide pages.