### PR TITLE
add spelling for proteomics slides

### DIFF
--- a/bin/ari-map.yml
+++ b/bin/ari-map.yml
@@ -36,3 +36,8 @@ scRNA: S C RNA
 RNAmmer: RNA mer
 Rfam: R fam
 Pfam: P fam
+m/z: MZ
+'\>': greater than sign
+b-ions: B ions
+y-ions: Y ions
+MSstats: M S stats

--- a/bin/ari-map.yml
+++ b/bin/ari-map.yml
@@ -37,7 +37,7 @@ RNAmmer: RNA mer
 Rfam: R fam
 Pfam: P fam
 m/z: MZ
-'\>': greater than sign
+'>': greater than sign
 b-ions: B ions
 y-ions: Y ions
 MSstats: M S stats


### PR DESCRIPTION
not sure if the > is correct. In the text it is written: '>'