### PR TITLE
Correct sed/M. tuberculosis variant report steps for M. tb variant analysis

### DIFF
--- a/topics/variant-analysis/tutorials/tb-variant-analysis/workflows/tb-variant-analysis-test.yml
+++ b/topics/variant-analysis/tutorials/tb-variant-analysis/workflows/tb-variant-analysis-test.yml
@@ -16,11 +16,11 @@
     'Genome annotation (GFF3)':
       location: https://zenodo.org/record/3960260/files/Mycobacterium_tuberculosis_h37rv.ASM19595v2.45.chromosome.Chromosome.gff3
       class: File
-      filetype: fasta
+      filetype: gff3
     'FASTA reference genome':
       location: https://zenodo.org/record/3960260/files/MTB_ancestor_reference.fasta
       class: File
-      filetype: gff3
+      filetype: fasta
   outputs:
     mtbva_kraken_report:
       asserts:


### PR DESCRIPTION
While working through the tutorial I found a couple of problems with the "Text transformation" step and the step where this output is used. This PR corrects them.