### PR TITLE
Rework the help menu

### DIFF
--- a/_includes/default-header.html
+++ b/_includes/default-header.html
@@ -16,12 +16,9 @@
                             {% icon hall-of-fame %} Contributors
                         </a>
                     </li>
-                    <li class="nav-item">
-                        <a class="nav-link" href="{{ site.github_repository }}" title="View on GitHub">
-                            {% icon github %} View on GitHub
-                        </a>
-                    </li>
                     {% include _includes/help.html %}
+
+                    {% include _includes/extras.html %}
 
                     <!-- Search bar-->
                     <li class="nav-item">

--- a/_includes/extras.html
+++ b/_includes/extras.html
@@ -1,0 +1,61 @@
+<li class="nav-item dropdown">
+    <a href="#" class="nav-link dropdown-toggle" data-toggle="dropdown" aria-expanded="false" title="Extras">
+        {% icon help %} Extras
+    </a>
+    <div class="dropdown-menu dropdown-menu-right">
+
+        {% assign thispage = page.url | replace: '.html', '.md' %}
+        <a class="dropdown-item" href="{{ site.github_repository }}{% unless thispage == '/' %}/edit/{{ site.github_repository_branch }}{{ thispage }}{% endunless %}" title="Edit on GitHub">
+          {% icon github %} Edit on GitHub
+        </a>
+
+        <a class="dropdown-item" href="https://plausible.galaxyproject.eu/training.galaxyproject.org?period=12mo&page={{site.baseurl}}{{ page.url }}" title="Show view statistics of this page">
+            {% icon galaxy-barchart %} Page Metrics
+        </a>
+
+        <div class="dropdown-item">
+            <div>
+                {% icon language %} Translate this page
+            </div>
+
+            <div id="lang-selector">
+                {% for lang in site.other_languages %}
+                <a class="btn btn-info" href="https://translate.google.com/translate?hl=jp&sl=en&tl={{lang[0]}}&u=https%3A%2F%2Ftraining.galaxyproject.org{{page.url}}&edit-text=&act=url">
+                {{lang[1]}}
+                </a>
+                {% endfor %}
+                <a class="btn btn-info" href="https://translate.google.com/translate?hl=jp&sl=en&tl=&u=https%3A%2F%2Ftraining.galaxyproject.org%2Ftopics%2F{{ topic.name }}%2Ftutorials%2F{{ page.tutorial_name }}%2Ftutorial.html&edit-text=&act=url" title="{{ inst[0] }}">
+                And more!
+                </a>
+            </div>
+        </div>
+
+        <div class="dropdown-item">
+            <div>
+                Theme
+            </div>
+
+            <div id="theme-selector" data-toggle="buttons">
+                <label data-value="default" class="btn btn-secondary">
+                    <input type="radio" name="options" id="default" autocomplete="off"> Default
+                </label>
+                <label data-value="night" class="btn btn-secondary">
+                    <input type="radio" name="options" id="night" autocomplete="off"> Night
+                </label>
+                <label data-value="midnight" class="btn btn-secondary">
+                    <input type="radio" name="options" id="midnight" autocomplete="off"> Midnight
+                </label>
+                <label data-value="rainbow" class="btn btn-secondary">
+                    <input type="radio" name="options" id="rainbow" autocomplete="off"> Rainbow
+                </label>
+                <label data-value="halloween" class="btn btn-secondary">
+                    <input type="radio" name="options" id="halloween" autocomplete="off"> 🎃
+                </label>
+                <label data-value="straya" class="btn btn-secondary">
+                    <input type="radio" name="options" id="downunder" autocomplete="off"> 🇦🇺
+                </label>
+            </div>
+
+        </div>
+    </div>
+</li>

--- a/_includes/extras.html
+++ b/_includes/extras.html
@@ -1,6 +1,6 @@
 <li class="nav-item dropdown">
     <a href="#" class="nav-link dropdown-toggle" data-toggle="dropdown" aria-expanded="false" title="Extras">
-        {% icon help %} Extras
+        {% icon galaxy-star %} Extras
     </a>
     <div class="dropdown-menu dropdown-menu-right">
 

--- a/_includes/help.html
+++ b/_includes/help.html
@@ -11,7 +11,6 @@
         </form>
         -->
 
-        <div class="dropdown-divider"></div>
         <a class="dropdown-item" href="{{ site.baseurl }}/faq" title="Check our FAQ">
            {% icon question %} FAQ
         </a>
@@ -21,53 +20,5 @@
         <a class="dropdown-item" href="{{ site.gitter_url }}" title="Discuss on gitter">
            {% icon gitter %} Discuss on Gitter
         </a>
-        <a class="dropdown-item" href="https://plausible.galaxyproject.eu/training.galaxyproject.org?period=12mo&page={{site.baseurl}}{{ page.url }}" title="Show view statistics of this page">
-            {% icon galaxy-barchart %} Page Metrics
-        </a>
-
-        <div class="dropdown-item">
-            <div>
-                {% icon language %} Translate this page
-            </div>
-
-            <div id="lang-selector">
-                {% for lang in site.other_languages %}
-                <a class="btn btn-info" href="https://translate.google.com/translate?hl=jp&sl=en&tl={{lang[0]}}&u=https%3A%2F%2Ftraining.galaxyproject.org{{page.url}}&edit-text=&act=url">
-                {{lang[1]}}
-                </a>
-                {% endfor %}
-                <a class="btn btn-info" href="https://translate.google.com/translate?hl=jp&sl=en&tl=&u=https%3A%2F%2Ftraining.galaxyproject.org%2Ftopics%2F{{ topic.name }}%2Ftutorials%2F{{ page.tutorial_name }}%2Ftutorial.html&edit-text=&act=url" title="{{ inst[0] }}">
-                And more!
-                </a>
-            </div>
-        </div>
-
-        <div class="dropdown-item">
-            <div>
-                Theme
-            </div>
-
-            <div id="theme-selector" data-toggle="buttons">
-                <label data-value="default" class="btn btn-secondary">
-                    <input type="radio" name="options" id="default" autocomplete="off"> Default
-                </label>
-                <label data-value="night" class="btn btn-secondary">
-                    <input type="radio" name="options" id="night" autocomplete="off"> Night
-                </label>
-                <label data-value="midnight" class="btn btn-secondary">
-                    <input type="radio" name="options" id="midnight" autocomplete="off"> Midnight
-                </label>
-                <label data-value="rainbow" class="btn btn-secondary">
-                    <input type="radio" name="options" id="rainbow" autocomplete="off"> Rainbow
-                </label>
-                <label data-value="halloween" class="btn btn-secondary">
-                    <input type="radio" name="options" id="halloween" autocomplete="off"> 🎃
-                </label>
-                <label data-value="straya" class="btn btn-secondary">
-                    <input type="radio" name="options" id="downunder" autocomplete="off"> 🇦🇺
-                </label>
-            </div>
-
-        </div>
     </div>
 </li>

--- a/_includes/help.html
+++ b/_includes/help.html
@@ -18,7 +18,7 @@
         <a class="dropdown-item" href="{{ site.help_url }}" title="Discuss on Galaxy Help">
             {% icon feedback %} Galaxy Help Forum
         </a>
-        <a class="dropdown-item" href="{{ site.gitter_url }}" title="Check our FAQ">
+        <a class="dropdown-item" href="{{ site.gitter_url }}" title="Discuss on gitter">
            {% icon gitter %} Discuss on Gitter
         </a>
         <a class="dropdown-item" href="https://plausible.galaxyproject.eu/training.galaxyproject.org?period=12mo&page={{site.baseurl}}{{ page.url }}" title="Show view statistics of this page">

--- a/_includes/help.html
+++ b/_includes/help.html
@@ -18,6 +18,9 @@
         <a class="dropdown-item" href="{{ site.help_url }}" title="Discuss on Galaxy Help">
             {% icon feedback %} Galaxy Help Forum
         </a>
+        <a class="dropdown-item" href="{{ site.gitter_url }}" title="Check our FAQ">
+           {% icon gitter %} Discuss on Gitter
+        </a>
         <a class="dropdown-item" href="https://plausible.galaxyproject.eu/training.galaxyproject.org?period=12mo&page={{site.baseurl}}{{ page.url }}" title="Show view statistics of this page">
             {% icon galaxy-barchart %} Page Metrics
         </a>

--- a/_includes/help.html
+++ b/_includes/help.html
@@ -3,19 +3,41 @@
         {% icon help %} Help
     </a>
     <div class="dropdown-menu dropdown-menu-right">
+        <!-- disable Tess for now
         <form method="get" action="https://tess.elixir-europe.org/materials">
             <input type="text" id="search" name="q" value="" style="margin-left: 0.5em;/*! border-radius: 0px; */">
             <input type="hidden" value="Galaxy Training" name="content_provider">
             <input type="submit" value="Search on TeSS" style="width: 92%;border-radius: 0px;margin: 0.5em;background: #f47d20;border: 0px;padding: 0.25em;" class="">
         </form>
+        -->
 
         <div class="dropdown-divider"></div>
         <a class="dropdown-item" href="{{ site.baseurl }}/faq" title="Check our FAQ">
-            FAQ
+           {% icon question %} FAQ
         </a>
         <a class="dropdown-item" href="{{ site.help_url }}" title="Discuss on Galaxy Help">
-            Discuss on Galaxy Help
+            {% icon feedback %} Galaxy Help Forum
         </a>
+        <a class="dropdown-item" href="https://plausible.galaxyproject.eu/training.galaxyproject.org?period=12mo&page={{site.baseurl}}{{ page.url }}" title="Show view statistics of this page">
+            {% icon galaxy-barchart %} Page Metrics
+        </a>
+
+        <div class="dropdown-item">
+            <div>
+                {% icon language %} Translate this page
+            </div>
+
+            <div id="lang-selector">
+                {% for lang in site.other_languages %}
+                <a class="btn btn-info" href="https://translate.google.com/translate?hl=jp&sl=en&tl={{lang[0]}}&u=https%3A%2F%2Ftraining.galaxyproject.org{{page.url}}&edit-text=&act=url">
+                {{lang[1]}}
+                </a>
+                {% endfor %}
+                <a class="btn btn-info" href="https://translate.google.com/translate?hl=jp&sl=en&tl=&u=https%3A%2F%2Ftraining.galaxyproject.org%2Ftopics%2F{{ topic.name }}%2Ftutorials%2F{{ page.tutorial_name }}%2Ftutorial.html&edit-text=&act=url" title="{{ inst[0] }}">
+                And more!
+                </a>
+            </div>
+        </div>
 
         <div class="dropdown-item">
             <div>

--- a/_layouts/tutorial_hands_on.html
+++ b/_layouts/tutorial_hands_on.html
@@ -59,10 +59,11 @@ layout: base
                 <ul class="navbar-nav">
                     <li class="nav-item">
                         <a class="nav-link" href="{{ site.baseurl }}/topics/{{ topic.name }}" title="Go back to list of tutorials">
-                            {% icon topic %} {{ topic.title }}
+                            {% icon topic %} Back to Topic
                         </a>
                     </li>
 
+                    <!-- language selector moved to help menu
                     <li class="nav-item dropdown">
                         <a href="#" class="nav-link dropdown-toggle" data-toggle="dropdown" aria-expanded="false" title="Language Selector">
                             {% icon language %} Language
@@ -78,6 +79,7 @@ layout: base
                             </a>
                         </div>
                     </li>
+                    -->
 
                     {% include _includes/help.html %}
 
@@ -86,6 +88,20 @@ layout: base
                             {% icon github %} Edit
                         </a>
                     </li>
+
+                     <!-- Search bar-->
+                    <li class="nav-item">
+                      <div id="navbarSupportedContent">
+                        <!-- Search form -->
+                        <form class="form-inline mr-auto" method="GET" action="{{site.baseurl}}/search">
+                          <i class="fas fa-search nav-link" aria-hidden="true"></i>
+                          <div class="md-form mb-2">
+                            <input name="query" class="form-control nicer" type="text" placeholder="Search Tutorials" aria-label="Search">
+                          </div>
+                        </form>
+                      </div>
+                    </li>
+
                 </ul>
             </div>
         </div>

--- a/_layouts/tutorial_hands_on.html
+++ b/_layouts/tutorial_hands_on.html
@@ -59,7 +59,7 @@ layout: base
                 <ul class="navbar-nav">
                     <li class="nav-item">
                         <a class="nav-link" href="{{ site.baseurl }}/topics/{{ topic.name }}" title="Go back to list of tutorials">
-                            {% icon topic %} Topic Page
+                            {% icon topic %} {{ topic.title }}
                         </a>
                     </li>
 

--- a/_layouts/tutorial_hands_on.html
+++ b/_layouts/tutorial_hands_on.html
@@ -59,35 +59,20 @@ layout: base
                 <ul class="navbar-nav">
                     <li class="nav-item">
                         <a class="nav-link" href="{{ site.baseurl }}/topics/{{ topic.name }}" title="Go back to list of tutorials">
-                            {% icon topic %} Back to Topic
+                            {% icon topic %} Topic Page
                         </a>
                     </li>
-
-                    <!-- language selector moved to help menu
-                    <li class="nav-item dropdown">
-                        <a href="#" class="nav-link dropdown-toggle" data-toggle="dropdown" aria-expanded="false" title="Language Selector">
-                            {% icon language %} Language
-                        </a>
-                        <div class="dropdown-menu">
-                            {% for lang in site.other_languages %}
-                            <a class="dropdown-item" href="https://translate.google.com/translate?hl=jp&sl=en&tl={{ lang[0] }}&u=https%3A%2F%2Ftraining.galaxyproject.org%2Ftopics%2F{{ topic.name }}%2Ftutorials%2F{{ page.tutorial_name }}%2Ftutorial.html&edit-text=&act=url" title="{{ inst[0] }}">
-                                {{ lang[1] }}
-                            </a>
-                            {% endfor %}
-                            <a class="dropdown-item" href="https://translate.google.com/translate?hl=jp&sl=en&tl=&u=https%3A%2F%2Ftraining.galaxyproject.org%2Ftopics%2F{{ topic.name }}%2Ftutorials%2F{{ page.tutorial_name }}%2Ftutorial.html&edit-text=&act=url" title="{{ inst[0] }}">
-                                And more!
-                            </a>
-                        </div>
-                    </li>
-                    -->
 
                     {% include _includes/help.html %}
 
+                    {% include _includes/extras.html %}
+                    <!--
                     <li class="nav-item">
                         <a class="nav-link" href="{{ site.github_repository }}/edit/{{ site.github_repository_branch }}/topics/{{ topic.name }}/tutorials/{{ page.tutorial_name }}/tutorial.md">
                             {% icon github %} Edit
                         </a>
                     </li>
+                    -->
 
                      <!-- Search bar-->
                     <li class="nav-item">

--- a/assets/css/main.scss
+++ b/assets/css/main.scss
@@ -105,14 +105,14 @@ body {
 
 @import "assets/css/syntax_highlighting-dark.scss";
 
-div#theme-selector {
+div#theme-selector,div#lang-selector {
 	display: flex;
 	flex-direction: row;
 	flex-wrap: wrap;
 	width: 200px;
 	justify-content: flex-start;
 
-	label.btn {
+	label.btn,a.btn {
 		margin: 0.1em;
 	}
 }


### PR DESCRIPTION
I have reworked the help menu a bit, to 
1. Add link to plausible page metrics (number of views etc). Tutorial creators often ask for this info for their reporting etc.
2. Add link to Gitter
2. Disable TeSS search (it doesn't work currently, we can re-enable in the future)
3. Add the language selector here, to save some space on the top menu (we can see that this isn't often used anyway)
4. Add some icons to the help menu
5. Add tutorial search box to all pages
 
![image](https://user-images.githubusercontent.com/2563865/109157437-4a369400-7772-11eb-8c13-959b992407c7.png)
