### PR TITLE
Reduce codeowners file

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -3,34 +3,6 @@
 #
 # Anybody is free to add their name here
 
-assets/     @bebatut @shiltemann @hexylena
-bin/        @bebatut @shiltemann @hexylena
+bin/ari*    @hexylena
 metadata/   @bebatut @shiltemann @hexylena
-badges/     @hexylena
 _layouts/   @bebatut @shiltemann @hexylena
-_includes/  @bebatut @shiltemann @hexylena
-_plugins/   @bebatut @hexylena
-
-# Topic maintainers are placed in github teams @galaxyproject/training-<topic-name>
-topics/admin/                      @galaxyproject/training-admin
-topics/assembly/                   @galaxyproject/training-assembly
-topics/chip-seq/                   @galaxyproject/training-chip-seq
-topics/computational-chemistry/    @galaxyproject/training-computational-chemistry
-topics/contributing/               @galaxyproject/training-contributing
-topics/dev/                        @galaxyproject/training-dev @abretaud
-topics/ecology/                    @galaxyproject/training-ecology
-topics/epigenetics/                @galaxyproject/training-epigenetics
-topics/galaxy-interface/           @galaxyproject/training-galaxy-ui @galaxyproject/training-galaxy-data-manipulation
-topics/genome-annotation/          @galaxyproject/training-genome-annotation
-topics/instructors/                @galaxyproject/training-instructors
-topics/introduction/               @galaxyproject/training-introduction
-topics/metabolomics/               @galaxyproject/training-metabolomics
-topics/metagenomics/               @galaxyproject/training-metagenomics
-topics/proteomics/                 @galaxyproject/training-proteomics
-topics/sequence-analysis/          @galaxyproject/training-sequence-analysis
-topics/statistics/                 @galaxyproject/training-statistics
-topics/transcriptomics/            @galaxyproject/training-transcriptomics
-topics/variant-analysis/           @galaxyproject/training-variant-analysis
-
-# Lines starting with '#' are comments.
-# # Order is important. The last matching pattern has the most precedence.


### PR DESCRIPTION
I've never seen a maintainer pinged by this actually respond, so, let's just get rid of it and not ping 50 people whenever we need to make formatting changes across the whole GTN? left some small stuff, but, mostly reduced to not ping anyone.

E.g. I've got a snippet fixing PR that touches every single topic, don't want to ping everyone for something that doesn't affect them.