### PR TITLE
Add GTN videos to homepage

### DIFF
--- a/_layouts/home.html
+++ b/_layouts/home.html
@@ -187,6 +187,7 @@ layout: base
 
 
             <div class="col-md-6">
+                <h3>GTN Tweets</h3>
                 <a class="twitter-timeline" data-height="500" href="https://twitter.com/gxytraining?ref_src=twsrc%5Etfw">Tweets by gxytraining</a> <script async src="https://platform.twitter.com/widgets.js" charset="utf-8"></script>
             </div>
 

--- a/_layouts/home.html
+++ b/_layouts/home.html
@@ -121,32 +121,25 @@ layout: base
             </div>
         </div>
 
-        <h2>Acknowledgment and Funding</h2>
-        <p>
-            More information about this project can be found in our <a href="https://doi.org/10.1016/j.cels.2018.05.012">publication in Cell Systems</a>.
-            We would like to thank all <a href="{{ site.baseurl }}/hall-of-fame">contributors</a> to our Galaxy
-            training materials, the Galaxy community for their constant support, and our funding sources:
-        </p>
-
-        <p>
-            <a href="https://www.denbi.de/"><img src="https://raw.githubusercontent.com/bgruening/rbc_docs/master/logo/deNBI_Logo_rgb.png" alt="de.NBI" width="15%" style="max-width:100%;"></a>
-            <a href="https://www.nih.gov"><img src="{{ site.baseurl }}/shared/images/nih.png" alt="National Institutes of Health" width="7%" style="max-width:100%;"></a>
-            <a href="https://www.sfb992.uni-freiburg.de/"><img src="https://raw.githubusercontent.com/bgruening/presentations/bce348bb606c312d531c479e63a66efc2bc38d44/shared/resources/img/MEDEP.jpg" alt="Collaborative Research Centre 992" width="15%" style="max-width:100%;"></a>
-            <a href="https://www.ie-freiburg.mpg.de"><img src="https://raw.githubusercontent.com/bgruening/presentations/master/shared/resources/img/14_MPI_IE_logo_mit_180.gif" alt="Max Planck Institute of Immunology and Epigenetics" width="15%" style="max-width:100%;"></a>
-            <a href="https://www.uni-freiburg.de/"><img src="https://raw.githubusercontent.com/bgruening/presentations/a2e38e4b007994af798320db3a0131c4bb891c0e/shared/resources/img/logo_freiburg.jpg" alt="University of Freiburg" width="15%" style="max-width:100%;"></a>
-            <a href="http://www.psu.edu"><img src="{{ site.baseurl }}/shared/images/psu.png" alt="The Pennsylvania State University" width="5%" style="max-width:100%;"></a>
-            <a href="https://wiki.galaxyproject.org/Teach/GTN"><img src="{{ site.baseurl }}/shared/images/GTNLogo1000.png" alt="Galaxy Training Network" width="15%" style="max-width:100%;"></a>
-			<a href="https://www.france-bioinformatique.fr/"><img src="{{ site.baseurl }}/shared/images/ifb.png" alt="Institut Français de Bioinformatique" width="15%" style="max-width:100%;"></a>
-            <a href="https://www.elixir-europe.org/"><img src="{{ site.baseurl }}/shared/images/elixir.png" alt="Elixir" width="10%" style="max-width:100%;"></a>
-            <a href="https://www.elixir-europe.org/excelerate/"><img src="{{ site.baseurl }}/shared/images/Excelerate_whitebackground.png" alt="Elixir Excelerate" width="15%" style="max-width:100%;"></a>
-            <a href="https://www.nsf.gov"><img src="{{ site.baseurl }}/shared/images/nsf.gif" alt="National Science Foundation" width="7%" style="max-width:100%;"></a>
-            <a href="https://www.erasmusmc.nl"><img src="{{ site.baseurl }}/shared/images/logo-erasmusmc.png" alt="Erasmus Mecial Center" width="15%" style="max-width:100%;"></a>
-            <a href="https://cineca-project.eu"><img src="{{ site.baseurl }}/shared/images/CINECA_logo.png" alt="CINECA project" width="15%" style="max-width:100%;"></a>
-            <a href="https://gallantries.github.io/"><img src="{{ site.baseurl }}/shared/images/Gallantries_logo.png" alt="Gallantries Project" width="15%" style="max-width:100%;"></a>
-            <a href="https://ec.europa.eu/programmes/erasmus-plus/node_en"><img src="{{ site.baseurl }}/shared/images/EU-logo-beneficaires-gallantries.jpg" alt="EU Erasmus+ programme" width="15%" style="max-width:100%;"></a>
-        </p>
-
         <div class="row">
+
+            <!-- GTN video -->
+            <div class="col-md-6">
+                 <h3>Welcome to the GTN!</h3>
+                 <p> New to the GTN? This video gives an introduction to what its's all about </p>
+                 <iframe width="100%" height="314" src="https://www.youtube.com/embed/lDqWxzWNk1k" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+                 <p>Video created by Geert Bonamie.</p>
+            </div>
+
+            <!-- Galaxy community video  -->
+            <div class="col-md-6">
+                 <h3>Meet & Join the Galaxy Community! </h3>
+                 <p> Find out how you can become part of the Galaxy community</p>
+                 <iframe width="100%" height="314" src="https://www.youtube.com/embed/-1MPdxmRs8U" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+                 <p> Video created by Beatriz Serrano-Solano</p>
+            </div>
+
+
             <div class="col-md-6">
                 <h2>Contributor Hall of Fame</h2>
                 <p>
@@ -191,6 +184,13 @@ layout: base
                 <p>Do you want to help with this project and join our Hall of Fame? Please see our <a href="{{ site.baseurl }}/topics/contributing/">dedicated tutorials</a> or our <a href="{{ site.baseurl }}/faq">Frequently Asked Questions</a> to get you started.</p>
 
             </div>
+
+
+            <div class="col-md-6">
+                <a class="twitter-timeline" data-height="500" href="https://twitter.com/gxytraining?ref_src=twsrc%5Etfw">Tweets by gxytraining</a> <script async src="https://platform.twitter.com/widgets.js" charset="utf-8"></script>
+            </div>
+
+
             <div class="col-md-6">
                 <h2>The Galaxy Training Network<h2>
                 <div class="embed-responsive embed-responsive-4by3">
@@ -198,6 +198,33 @@ layout: base
                 </div>
             </div>
         </div>
+
+         <h2>Acknowledgment and Funding</h2>
+        <p>
+            More information about this project can be found in our <a href="https://doi.org/10.1016/j.cels.2018.05.012">publication in Cell Systems</a>.
+            We would like to thank all <a href="{{ site.baseurl }}/hall-of-fame">contributors</a> to our Galaxy
+            training materials, the Galaxy community for their constant support, and our funding sources:
+        </p>
+
+        <p>
+            <a href="https://www.denbi.de/"><img src="https://raw.githubusercontent.com/bgruening/rbc_docs/master/logo/deNBI_Logo_rgb.png" alt="de.NBI" width="15%" style="max-width:100%;"></a>
+            <a href="https://www.nih.gov"><img src="{{ site.baseurl }}/shared/images/nih.png" alt="National Institutes of Health" width="7%" style="max-width:100%;"></a>
+            <a href="https://www.sfb992.uni-freiburg.de/"><img src="https://raw.githubusercontent.com/bgruening/presentations/bce348bb606c312d531c479e63a66efc2bc38d44/shared/resources/img/MEDEP.jpg" alt="Collaborative Research Centre 992" width="15%" style="max-width:100%;"></a>
+            <a href="https://www.ie-freiburg.mpg.de"><img src="https://raw.githubusercontent.com/bgruening/presentations/master/shared/resources/img/14_MPI_IE_logo_mit_180.gif" alt="Max Planck Institute of Immunology and Epigenetics" width="15%" style="max-width:100%;"></a>
+            <a href="https://www.uni-freiburg.de/"><img src="https://raw.githubusercontent.com/bgruening/presentations/a2e38e4b007994af798320db3a0131c4bb891c0e/shared/resources/img/logo_freiburg.jpg" alt="University of Freiburg" width="15%" style="max-width:100%;"></a>
+            <a href="http://www.psu.edu"><img src="{{ site.baseurl }}/shared/images/psu.png" alt="The Pennsylvania State University" width="5%" style="max-width:100%;"></a>
+            <a href="https://wiki.galaxyproject.org/Teach/GTN"><img src="{{ site.baseurl }}/shared/images/GTNLogo1000.png" alt="Galaxy Training Network" width="15%" style="max-width:100%;"></a>
+			<a href="https://www.france-bioinformatique.fr/"><img src="{{ site.baseurl }}/shared/images/ifb.png" alt="Institut Français de Bioinformatique" width="15%" style="max-width:100%;"></a>
+            <a href="https://www.elixir-europe.org/"><img src="{{ site.baseurl }}/shared/images/elixir.png" alt="Elixir" width="10%" style="max-width:100%;"></a>
+            <a href="https://www.elixir-europe.org/excelerate/"><img src="{{ site.baseurl }}/shared/images/Excelerate_whitebackground.png" alt="Elixir Excelerate" width="15%" style="max-width:100%;"></a>
+            <a href="https://www.nsf.gov"><img src="{{ site.baseurl }}/shared/images/nsf.gif" alt="National Science Foundation" width="7%" style="max-width:100%;"></a>
+            <a href="https://www.erasmusmc.nl"><img src="{{ site.baseurl }}/shared/images/logo-erasmusmc.png" alt="Erasmus Mecial Center" width="15%" style="max-width:100%;"></a>
+            <a href="https://cineca-project.eu"><img src="{{ site.baseurl }}/shared/images/CINECA_logo.png" alt="CINECA project" width="15%" style="max-width:100%;"></a>
+            <a href="https://gallantries.github.io/"><img src="{{ site.baseurl }}/shared/images/Gallantries_logo.png" alt="Gallantries Project" width="15%" style="max-width:100%;"></a>
+            <a href="https://ec.europa.eu/programmes/erasmus-plus/node_en"><img src="{{ site.baseurl }}/shared/images/EU-logo-beneficaires-gallantries.jpg" alt="EU Erasmus+ programme" width="15%" style="max-width:100%;"></a>
+        </p>
+
+
     </section>
 </div>
 

--- a/_layouts/home.html
+++ b/_layouts/home.html
@@ -153,7 +153,7 @@ layout: base
                             {% assign counter = 0 %}
                             {% for contributor in contributors %}
                               {% unless contributor[1].halloffame == "no" %}
-                                {% capture modulo %}{{ counter | modulo:4 }}{% endcapture %}
+                                {% capture modulo %}{{ counter | modulo:10 }}{% endcapture %}
                                   {% if modulo == '0' or counter == 0 %}
                                   {% if counter != 0 %}</div>{% endif %}
 


### PR DESCRIPTION
We have two cool new GTN/community videos, so I wanted to feature those on the GTN home page :tada: 

- The community video created by @beatrizserrano 
- The GTN video created by Geert Bonamie.

![image](https://user-images.githubusercontent.com/2563865/109196633-3bfd6d80-779c-11eb-9544-a1abe9604c1e.png)



Also embeds the GTN twitter timeline.