### PR TITLE
Rephrase reference to "bits"

### DIFF
--- a/topics/introduction/tutorials/galaxy-intro-ngs-data-managment/tutorial.md
+++ b/topics/introduction/tutorials/galaxy-intro-ngs-data-managment/tutorial.md
@@ -253,7 +253,7 @@ The following table explains the format and content of each field. The `FLAG`, `
 
 ### `FLAG` field
 
-The FLAG field encodes various pieces of information about the individual read, which is particularly important for PE reads. It contains an integer that is generated from a sequence of Boolean bits (0, 1). This way, answers to multiple binary (Yes/No) questions can be compactly stored as a series of bits, where each of the single bits can be addressed and assigned separately.
+The FLAG field encodes various pieces of information about the individual read, which is particularly important for PE reads. It contains an integer that is generated from a sequence of bits (0, 1). This way, answers to multiple binary (Yes/No) questions can be compactly stored as a series of bits, where each of the single bits can be addressed and assigned separately.
 
 The following table gives an overview of the different properties that can be encoded in the FLAG field. The developers of the SAM format and samtools tend to use the hexadecimal encoding as a means to refer to the different bits in their documentation. The value of the FLAG field in a given SAM file, however, will always be the decimal representation of the sum of the underlying binary values (as shown in Table below, row 2).
 


### PR DESCRIPTION
"Boolean bits" may be confusing to the reader: a Boolean is a data type, whereas a bit is a unit of information. So, "Boolean" cannot be used as a qualifier for "bits". If "...bits (0, 1)" is not clear enough, another option is "...bits (0, 1) representing Boolean values (true, false)"; but I would suggest just "bits (0, 1)" - for that's what the text is describing.