### PR TITLE
[CI] use ubuntu 18.04 image for ci

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,7 +5,7 @@ on: [pull_request]
 
 jobs:
   setup:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
     strategy:
       matrix:
         ruby: [2.5]
@@ -30,7 +30,7 @@ jobs:
 
   lint-frontmatter:
     needs: setup
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
     strategy:
       matrix:
         ruby: [2.5]
@@ -55,7 +55,7 @@ jobs:
       - run: make check-frontmatter ACTIVATE_ENV=pwd
 
   lint-workflows:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
     steps:
       - uses: actions/checkout@v2
         with:
@@ -65,7 +65,7 @@ jobs:
           make check-workflows
 
   lint-tool-links:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
     steps:
       - uses: actions/checkout@v2
         with:
@@ -75,7 +75,7 @@ jobs:
           make check-tool-links
 
   lint-data-lib-yaml:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
     steps:
       - uses: actions/checkout@v2
         with:
@@ -86,7 +86,7 @@ jobs:
 
   build-site:
     needs: setup
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
     strategy:
       matrix:
         ruby: [2.5]

--- a/.github/workflows/cron.yml
+++ b/.github/workflows/cron.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   setup:
     if: github.repository_owner == 'galaxyproject'
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
     steps:
       - uses: actions/checkout@v2
         with:

--- a/.github/workflows/deploy-s3.yml
+++ b/.github/workflows/deploy-s3.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   deploy:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
     strategy:
       matrix:
         ruby: [2.5]

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   deploy:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
     strategy:
       matrix:
         ruby: [2.5]

--- a/.github/workflows/docker-build.yaml
+++ b/.github/workflows/docker-build.yaml
@@ -5,7 +5,7 @@ on:
     types: [published]
 jobs:
   admin-docker:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
     steps:
     - uses: actions/checkout@v2
     - name: Build and push to Docker Hub

--- a/.github/workflows/video.yml
+++ b/.github/workflows/video.yml
@@ -10,7 +10,7 @@ on:
 jobs:
   runner-job:
     if: github.repository_owner == 'galaxyproject'
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
     services:
       # Label used to access the service container
       mozillatts:


### PR DESCRIPTION
builds have started to fail since new ubuntu images started being used for actions (e.g. https://github.com/galaxyproject/training-material/pull/2437), use the 18.04 image until this gets fixed upstream so that we can deploy

ping @hexylena 