### PR TITLE
Some updates - Topic: Contributing - Tutorial: Running website

### DIFF
--- a/topics/contributing/tutorials/running-jekyll/tutorial.md
+++ b/topics/contributing/tutorials/running-jekyll/tutorial.md
@@ -53,7 +53,6 @@ This step has to be done once.
 >     1. Install conda (if not already installed): `make install-conda`
 >     2. (You may need to exit the terminal and re-open for conda to be recognised. Navigate back to the same place.)
 >     3. Create the `galaxy_training_material` conda environment: `make create-env`
->     4. Activate the environment: `conda activate galaxy_training_material`
 >
 > 4. Install Jekyll and related modules into the conda environment: `make install`
 {: .hands_on}

--- a/topics/contributing/tutorials/running-jekyll/tutorial.md
+++ b/topics/contributing/tutorials/running-jekyll/tutorial.md
@@ -68,7 +68,7 @@ Once Jekyll and its modules are installed in our conda environment, we can check
 
 > ### {% icon hands_on %} Hands-on: Checking the website generation locally
 >
-> 1. Run a local Jekyll server with `make serve`
+> 1. Run a local Jekyll server with `make serve-quick`
 > 2. Visualize at [http://localhost:4000/training-material/ ](http://localhost:4000/training-material/)
 > 3. Edit one of the tutorials:
 >    - For example, open `topics/introduction/tutorials/galaxy-intro-peaks2genes/tutorial.md` in a text editor of your choice.
@@ -78,26 +78,33 @@ Once Jekyll and its modules are installed in our conda environment, we can check
 >
 {: .hands_on}
 
-With `make serve`, a local Jekyll server will run in background. It will check the changes and regenerate the website accordingly. You may need to reload the page to see the changes (and sometimes to wait 1-2 minutes).
+With `make serve-quick`, a local Jekyll server will run in background. It will check the changes and regenerate the website accordingly. You may need to reload the page to see the changes (and sometimes to wait 1-2 minutes).
 
 
 > ### {% icon tip %} Tips
 >
-> 1. Running on a VM or remote machine?
+> 1. Use `make serve` instead of `make serve-quick` to get all plugins, but also configure the post, host and pass additional flags. This however can be quite slow.
+>
+> 2. Need to speed up the cloning step? You coud fetch only the latest commit of the master branch:
+>
+>    ```
+>    $ git clone {{ site.github_repository }}.git --depth 1 --branch master
+>    ```
+>
+> 3. Running on a VM or remote machine?
+>
 >    If you are not running this on your local machine, but e.g. on a VM, you may need to configure a webserver to serve the website.
 >
 >    Below is an example NGINX configuration (e.g. in `/etc/nginx/sites-enabled/default`)
+>
 >    ```
 >    location /training-material/ {
 >      root /home/ubuntu/training-material/_site/;
 >    }
 >    ```
->    (Change the `root` path above to wherever you cloned the training material folder)
 >
-> 2. Need to speed up the cloning step? You coud fetch only the latest commit of the master branch:
->    ```
->    git clone https://github.com/galaxyproject/training-material.git --depth 1 --branch master
->    ```
+>    Change the `root` path above to wherever you cloned the training material folder
+>
 {: .tip}
 
 


### PR DESCRIPTION
This PR update the "Running website" tutorial to:

- Remove step to activate conda environment
- Use `make serve-quick` instead of `make serve`