### PR TITLE
Add link in extra to GTN stat page

### DIFF
--- a/_includes/extras.html
+++ b/_includes/extras.html
@@ -10,7 +10,7 @@
         </a>
 
         <a class="dropdown-item" href="{% link stats.md %}" title="Show view statistics about this rrepository">
-            {% icon galaxy-barchart %} Repository statistics
+            {% icon galaxy-barchart %} GTN statistics
         </a>
 
         <a class="dropdown-item" href="https://plausible.galaxyproject.eu/training.galaxyproject.org?period=12mo&page={{site.baseurl}}{{ page.url }}" title="Show view statistics of this page">

--- a/_includes/extras.html
+++ b/_includes/extras.html
@@ -9,6 +9,10 @@
           {% icon github %} Edit on GitHub
         </a>
 
+        <a class="dropdown-item" href="{% link stats.md %}" title="Show view statistics about this rrepository">
+            {% icon galaxy-barchart %} Repository statistics
+        </a>
+
         <a class="dropdown-item" href="https://plausible.galaxyproject.eu/training.galaxyproject.org?period=12mo&page={{site.baseurl}}{{ page.url }}" title="Show view statistics of this page">
             {% icon galaxy-barchart %} Page Metrics
         </a>


### PR DESCRIPTION
I was looking the stat page on GTN website. I saw it was not linked. But maybe it was intended (then feel free to close this PR)