### PR TITLE
[WIP] Updating Tours

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,5 @@ vendor
 .jekyll-metadata
 .jekyll-cache
 plantuml.jar
+.idea
+.venv

--- a/bin/copy_tours.sh
+++ b/bin/copy_tours.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+set -eu
+
+# Copy tour files to a local Galaxy installation. Tours will be renamed using
+# the name of parent directory.
+
+if [[ $# != 2 ]] ; then
+  echo "USAGE: $0 /tours/directory /galaxy/tours/directory"
+  exit 1
+fi
+
+for tour in $(find $1 -name tour.yaml) ; do
+  dir=$(dirname $tour)
+  tour_name=$(basename $dir)
+  echo "cp $tour $2/$tour_name.yaml"
+  cp $tour $2/$tour_name.yaml
+done

--- a/bin/fix_spaces.py
+++ b/bin/fix_spaces.py
@@ -1,0 +1,22 @@
+import os
+import sys
+
+'''
+At least one tour (iwtomics) uses incorrect indentation that causes yamllint
+to complain.
+'''
+
+def fix(path):
+    with open(path) as f:
+        for line in f.readlines():
+            if len(line) > 4 and line.startswith('  '):
+                print(line[2:], end='')
+            else:
+                print(line, end='')
+
+
+if __name__ == '__main__':
+    if len(sys.argv) != 2:
+        print('No filename provided.')
+        sys.exit(1)
+    fix(sys.argv[1])

--- a/bin/fix_tours.py
+++ b/bin/fix_tours.py
@@ -9,29 +9,30 @@ A program to update outdated Galaxy Tours to conform to the latest version
 (21.01 as of this writing) of the Galaxy UI.
 
 This program generates a Jinja2 template and externalizes tool IDs to a 
-separate vars.yaml file so tool versions can be updated automatically (see the
-update-tour.py program) without editing the tour file itself.
+separate vars.yaml file so tool versions can be updated automatically without 
+editing the tour file itself. See the update_tour.py program for details on
+updating tours. 
 
 A list of the tools used in the tour are  written to a tools.yaml file so 
 admins can easily see and install the tools needed by a particular tour. The
-tools.yaml file is also updated by the update-tour.py program.
+tools.yaml file is also updated by the update_tour.py program.
 
-Use the render-tour.py program to generate the tour YAML file that will be 
+Use the render_tour.py program to generate the tour YAML file that will be 
 loaded by Galaxy.
 
-NOTE: Since YAML is a PITA to roundtrip cleanly and easily we don't use a YAML
-parser to read the original tour.yaml file, but simple read it line by line and
-do string replacements.  The problem is Block Literals, i.e. multi-line strings
-specified with >- or |-. Once those strings are stored in dictionaries the style
-of input is lost and the YAML processor will pick what it thinks is best when
-it outputs the string.
+NOTE: Since YAML is a PITA to round trip cleanly and easily we don't use a YAML
+parser to read the original tour.yaml file. Instead we simply read it line by 
+line and do string replacements.  The problem is Block Literals, i.e. multi-line 
+strings specified with >- or |-. Once those strings are stored in dictionaries 
+the style of input is lost and the YAML processor will pick what it thinks is 
+best, which is almost always not what we want.
 '''
 
 DEFAULT_TOOLSHED = 'https://toolshed.g2.bx.psu.edu'
 shed = toolshed.ToolShedInstance(DEFAULT_TOOLSHED)
 
 # The strings that we do simple search/replace on.
-# TODO These values should be parameterized.
+# TODO These values should be parameterized, or at least loaded from a config.
 replacements = [
     (' .fa.fa-upload', ''),
     ('#history-options-button', '#history-new-button'),
@@ -86,9 +87,11 @@ def parse_tour(tour_file, directory):
         for line in f.readlines():
             line = do_replacement(line)
             if line.startswith("steps:"):
+                # Add tags immediately before the steps element.  None of the
+                # existing tours have tags so this is safe.
                 lines.append("tags:\n")
-                lines.append(f'  - "{ tag }"\n')
-                lines.append('  - auto\n')
+                # lines.append(f'  - "{ tag }"\n')
+                lines.append('  - Auto\n')
                 lines.append(line)
             elif line.find("/tool_runner?tool_id=") > 0:
                 start = line.index("tool_id=") + 8

--- a/bin/fix_tours.py
+++ b/bin/fix_tours.py
@@ -1,0 +1,142 @@
+import os
+import sys
+import yaml
+from bioblend import toolshed
+from urllib.parse import unquote as decode
+
+'''
+A program to update outdated Galaxy Tours to conform to the latest version 
+(21.01 as of this writing) of the Galaxy UI.
+
+This program generates a Jinja2 template and externalizes tool IDs to a 
+separate vars.yaml file so tool versions can be updated automatically (see the
+update-tour.py program) without editing the tour file itself.
+
+A list of the tools used in the tour are  written to a tools.yaml file so 
+admins can easily see and install the tools needed by a particular tour. The
+tools.yaml file is also updated by the update-tour.py program.
+
+Use the render-tour.py program to generate the tour YAML file that will be 
+loaded by Galaxy.
+
+NOTE: Since YAML is a PITA to roundtrip cleanly and easily we don't use a YAML
+parser to read the original tour.yaml file, but simple read it line by line and
+do string replacements.  The problem is Block Literals, i.e. multi-line strings
+specified with >- or |-. Once those strings are stored in dictionaries the style
+of input is lost and the YAML processor will pick what it thinks is best when
+it outputs the string.
+'''
+
+DEFAULT_TOOLSHED = 'https://toolshed.g2.bx.psu.edu'
+shed = toolshed.ToolShedInstance(DEFAULT_TOOLSHED)
+
+# The strings that we do simple search/replace on.
+# TODO These values should be parameterized.
+replacements = [
+    (' .fa.fa-upload', ''),
+    ('#history-options-button', '#history-new-button'),
+    ('#tool-search-query', '.search-query')
+]
+
+
+def make_tool_entry(tool_id):
+    '''Create a dictionary to generated the YAML for the tools.yaml file.'''
+    id = decode(tool_id)
+    parts = id.split('/')
+    if len(parts) == 1:
+        return {
+            'name': id,
+            'owner': None,
+            'tool_shed_url': DEFAULT_TOOLSHED,
+            'tool_panel_section_label': 'Tours'
+        }
+    return {
+        'name': parts[3],
+        'owner': parts[2],
+        'tool_shed_url': 'https://' + parts[0],
+        'tool_panel_section_label': 'Tours'
+    }
+
+
+def parse_name_and_tag(file_path):
+    '''Extract a name and tag from the file path.'''
+    parts = file_path.split('/')
+    return (parts[1], parts[3])
+
+
+def do_replacement(s):
+    for before, after in replacements:
+        s = s.replace(before, after)
+    return s
+
+
+def get_indentation(line):
+    index = len(line) - len(line.lstrip())
+    return line[:index]
+
+
+def parse_tour(tour_file, directory):
+    print(f'Parsing {tour_file}')
+    vars = {}
+    lines = []
+    tools = []
+    seen = []
+    tag, name = parse_name_and_tag(tour_file)
+    with open(tour_file) as f:
+        for line in f.readlines():
+            line = do_replacement(line)
+            if line.startswith("steps:"):
+                lines.append("tags:\n")
+                lines.append(f'  - "{ tag }"\n')
+                lines.append('  - auto\n')
+                lines.append(line)
+            elif line.find("/tool_runner?tool_id=") > 0:
+                start = line.index("tool_id=") + 8
+                end = line.index('"', start)
+                id = line[start:end]
+                indent = get_indentation(line)
+                # id = decode(click[start:end])
+                tool_info = make_tool_entry(id)
+                var_name = tool_info['name']
+                if '+' in var_name:
+                    var_name = var_name.replace('+','_')
+                new_line = indent + 'a[href$="/tool_runner?tool_id={{ ' + var_name + ' }}"]'
+                if line.endswith('.tool-old-link'):
+                    new_line += ' .tool-old-link'
+                lines.append(new_line + '\n')
+                if tool_info not in tools:
+                    tools.append(tool_info)
+                vars[var_name] = id
+            else:
+                lines.append(line)
+    lines.append('\n')
+    output_path = os.path.join(directory, name)
+    if not os.path.exists(output_path):
+        os.mkdir(output_path)
+    with open(f"{output_path}/tour.yaml.j2", "w") as f:
+        f.writelines(lines)
+    with open(f"{output_path}/vars.yaml", "w") as f:
+        yaml.dump(vars, f)
+    with open(f"{output_path}/tools.yaml", "w") as f:
+        yaml.dump({ 'tools':tools }, f)
+
+
+def fix_tours(directory):
+    for root, dirs, files in os.walk('topics'):
+        for file in files:
+            if file == 'tour.yaml':
+                parse_tour(os.path.join(root, file), directory)
+
+
+if __name__ == "__main__":
+    if len(sys.argv) != 2:
+        print(f"USAGE: {sys.argv[0]} /output/directory")
+        sys.exit(1)
+    directory = sys.argv[1]
+    if not os.path.exists(directory):
+        print(f'Could not find {directory}')
+        sys.exit(1)
+    if not os.path.isdir(directory):
+        print('The specified path must be a directory')
+        sys.exit(1)
+    fix_tours(directory)

--- a/bin/generate_tours.sh
+++ b/bin/generate_tours.sh
@@ -1,13 +1,16 @@
 #!/usr/bin/env bash
+set -e
 
+# A script that performs all steps needed to upgrade tours.
 if [[ $# != 1 ]] ; then
   echo "USAGE: $0 /output/directory"
   exit 1
 fi
+set -u
 
 if [[ ! -e $1 ]] ; then
-  echo "Could not find $1"
-  exit 1
+  echo "$1 does not exist. Creating it."
+  mkdir -p $1
 fi
 
 python bin/fix_tours.py $1

--- a/bin/generate_tours.sh
+++ b/bin/generate_tours.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+
+if [[ $# != 1 ]] ; then
+  echo "USAGE: $0 /output/directory"
+  exit 1
+fi
+
+if [[ ! -e $1 ]] ; then
+  echo "Could not find $1"
+  exit 1
+fi
+
+python bin/fix_tours.py $1
+
+for tour in $(find $1 -name tour.yaml.j2) ; do
+  dir=$(dirname $tour)
+  echo "Generating tour $tour"
+  python bin/update_tour.py $dir
+  python bin/render_tour.py $dir
+done
+
+
+

--- a/bin/render_tour.py
+++ b/bin/render_tour.py
@@ -1,0 +1,43 @@
+import os
+import sys
+import yaml
+from jinja2 import Template
+
+
+def get_tour_id(template_file):
+    dirname = os.path.dirname(template_file)
+    return os.path.basename(dirname)
+
+
+def render(template_file):
+    dir = os.path.dirname(template_file)
+    vars_file = os.path.join(dir, 'vars.yaml')
+    with open(template_file) as f:
+        template = Template(f.read())
+    with open(vars_file) as f:
+        vars = yaml.safe_load(f)
+    # id = get_tour_id(template_file)
+    output = template.render(vars)
+    outfile = os.path.join(dir, f"tour.yaml")
+    with open(outfile, 'w') as f:
+        f.write(output)
+    print(f'Rendered {outfile}')
+
+
+if __name__ == '__main__':
+    if len(sys.argv) == 1 or len(sys.argv) > 3:
+        print(f'USAGE: python {sys.argv[0]} /path/to/tour.yaml.j2')
+        print('\nThe rendered tour will be written to the same directory as the template file.\n')
+        sys.exit(1)
+
+    path = sys.argv[1]
+    if not path.endswith('tour.yaml.j2'):
+        if os.path.isdir(path):
+            path = os.path.join(path, 'tour.yaml.j2')
+        else:
+            print(f'The path "{path}" does not appear to contain Galaxy Tour.')
+            sys.exit(1)
+    if not os.path.exists(path):
+        print(f'The path "{path}" does not appear to contain a Galaxy Tour.')
+        sys.exit(1)
+    render(path)

--- a/bin/update_tour.py
+++ b/bin/update_tour.py
@@ -4,6 +4,11 @@ import yaml
 from bioblend import toolshed
 from urllib.parse import quote_plus as urlencode
 
+'''
+Update the tool versions used in a given tour.  Both the tools.yaml and
+vars.yaml files are updated with the latest version available on the ToolShed.
+'''
+
 DEFAULT_TOOLSHED = 'https://toolshed.g2.bx.psu.edu'
 
 # Common keys into the tools dict. Defined solely so our IDE can do completions
@@ -18,6 +23,11 @@ REVISIONS = 'revisions'
 tool_sheds = {DEFAULT_TOOLSHED: toolshed.ToolShedInstance(DEFAULT_TOOLSHED)}
 
 def get_guid(info):
+    '''
+    Get the GUID for a given tool.
+
+    The tool's GUID is the tool id used by selectors in the tour.
+    '''
     for m in info:
         if 'model_class' in m and m['model_class'] == 'RepositoryMetadata':
             return m['valid_tools'][0]['guid']
@@ -31,16 +41,13 @@ def validate(tool):
         tool[REVISIONS] = []
 
 
-def append(tool, revision):
-    if revision not in tool[REVISIONS]:
-        tool[REVISIONS].append(revision)
-
-
-def replace(tool, revision):
-    tool[REVISIONS] = [revision]
-
-
 def get_tool_shed(tool):
+    '''
+    Get the ToolShed URL for the toolshed the tool was installed from.
+
+    #TODO We shoud probably raise an exception if a tool comes from anywhere
+          but the main tool shed.
+    '''
     url = tool[SHED]
     if url in tool_sheds:
         ts = tool_sheds[url]
@@ -51,6 +58,10 @@ def get_tool_shed(tool):
 
 
 def update_tour(tour_dir):
+    '''
+    Update the tools.yaml and vars.yaml with the latest tool versions used
+    in the tour.
+    '''
     print(f'Updating {os.path.basename(tour_dir)}')
     tools_file = os.path.join(tour_dir, 'tools.yaml')
     if not os.path.exists(tools_file):

--- a/bin/update_tour.py
+++ b/bin/update_tour.py
@@ -1,0 +1,99 @@
+import os
+import sys
+import yaml
+from bioblend import toolshed
+from urllib.parse import quote_plus as urlencode
+
+DEFAULT_TOOLSHED = 'https://toolshed.g2.bx.psu.edu'
+
+# Common keys into the tools dict. Defined solely so our IDE can do completions
+# and I don't consistently misspell revisisions or have to remember if it is
+# toolshed_url or tool_shed_url
+NAME = 'name'
+OWNER = 'owner'
+TOOLS = 'tools'
+SHED = 'tool_shed_url'
+REVISIONS = 'revisions'
+
+tool_sheds = {DEFAULT_TOOLSHED: toolshed.ToolShedInstance(DEFAULT_TOOLSHED)}
+
+def get_guid(info):
+    for m in info:
+        if 'model_class' in m and m['model_class'] == 'RepositoryMetadata':
+            return m['valid_tools'][0]['guid']
+
+
+def validate(tool):
+    """Ensure the tool has the fields we need so we don't need to check later."""
+    if SHED not in tool:
+        tool[SHED] = DEFAULT_TOOLSHED
+    if REVISIONS not in tool:
+        tool[REVISIONS] = []
+
+
+def append(tool, revision):
+    if revision not in tool[REVISIONS]:
+        tool[REVISIONS].append(revision)
+
+
+def replace(tool, revision):
+    tool[REVISIONS] = [revision]
+
+
+def get_tool_shed(tool):
+    url = tool[SHED]
+    if url in tool_sheds:
+        ts = tool_sheds[url]
+    else:
+        ts = toolshed.ToolShedInstance(url)
+        tool_sheds[url] = ts
+    return ts
+
+
+def update_tour(tour_dir):
+    print(f'Updating {os.path.basename(tour_dir)}')
+    tools_file = os.path.join(tour_dir, 'tools.yaml')
+    if not os.path.exists(tools_file):
+        print(f'Could not find the tools.yaml file.')
+        return
+    vars_file = os.path.join(tour_dir, 'vars.yaml')
+    if not os.path.exists(vars_file):
+        print(f'Could not find the vars.yaml file')
+        return
+    with open(vars_file, 'r') as f:
+        variables = yaml.safe_load(f)
+    with open(tools_file, "r") as f:
+        data = yaml.safe_load(f)
+    tool_list = data[TOOLS]
+    print(f'Updating {len(tool_list)} tools.')
+    for tool in tool_list:
+        name = tool[NAME]
+        owner = tool[OWNER]
+        print(f"Getting latest revision for {name}")
+        validate(tool)
+        ts = get_tool_shed(tool)
+        revs = ts.repositories.get_ordered_installable_revisions(name, owner)
+        if revs and len(revs) > 0:
+            tool[REVISIONS] = [ revs[-1] ]
+            info = ts.repositories.get_repository_revision_install_info(name, owner, revs[-1])
+            guid = get_guid(info)
+            variables[name] = urlencode(guid)
+
+    data = {"tools": tool_list}
+    with open(tools_file, "w") as f:
+        yaml.dump(data, f)
+    with open(vars_file, "w") as f:
+        yaml.dump(variables, f)
+    print(f"Tour {tour_dir} updated")
+
+
+if __name__ == '__main__':
+    if len(sys.argv) != 2:
+        print(f'USAGE: python {sys.argv[0]} /path/to/tour_dir/')
+        sys.exit(1)
+
+    path = sys.argv[1]
+    if not os.path.exists(path):
+        print(f'The path "{path}" does not appear to contain a Galaxy Tour.')
+        sys.exit(1)
+    update_tour(path)


### PR DESCRIPTION
This is a first pass at updating the tours to be in sync with the latest Galaxy UI (21.01) and latest tool versions available on the tool shed.  This PR does not modify any existing tours but adds several scripts that address two of the primary issues. See #2472.

1. Element selectors use CSS styles that are no longer used on the elements they are supposed to select.  For example, the upload button no longer uses the *.fa-fa.upload* style for the icon.  However, most elements have an identifier (ie. HTML id attribute) and the CSS style selectors are not required.
2. Updating tours to use the latest versions of tool  requires finding the latest available version and manually editing the tour YAML file.

The first problem can be solved with simple string search/replace operations.  The second problem is slightly more complicated, and this PR proposes generating [Jinja2](https://jinja.palletsprojects.com/en/2.11.x/) templates with parameterized tool versions to address the difficulties maintaining tours in the future.

1. `fix_tours.py`
   Performs the string replacesment for CSS style selectors and generates a [Jinja2](https://jinja.palletsprojects.com/en/2.11.x/) template with tool ids replaced with variables defined in an external `vars.yaml` file.  Tool ids and revisions are also saved to a `tools.yaml`file that can be used to install the tools.  The `fix_tours.py` script traverses the entire `topics` directory structure looking for `tour.yaml` files and the generated files are written to a separate location so they can be easily collected during development and testing.  In production the generated files would likely be written to the same directory as the original  `tour.yaml` file.
2. `update_tour.py`
   Updates the `tools.yaml` and `vars.yaml` files with the latest verions available from the tool shed.
3. `render_tour.py`
   Generates a `tour.yaml` file from the Jinja template and `vars.yaml` file.

# Usage

### fix_tours.py

The `fix_tours.py` script takes one parameters, the name of the output directory:

```
mkdir /tmp/tours
python bin/fix_tours.py /tmp/tours
```

Each tour will be written to its own directory with the tour id as the directory name.  For example:

```
mapping
├── tools.yaml
├── tour.yaml.j2
└── vars.yaml
```

### update_tour.py

The `update_tour.py` script takes one parameter; the path to the directory containing the tour files generated by `fix_tours.py` script and updates the  versions in the `tools.yaml` and `vars.yaml` files with the latest tool shed versions.  The existing files are overwritten.

```
python bin/update_tour.py /tmp/tours/mapping
```

### render_tour.py

The `render_tour.py` script takes one parameter; the path to the directory containing the tour files generated by `fix_tours.py` script and generates the `tour.yaml` file from the Jinja template and `vars.yaml` file.

```
python bin/render_tour.py /tmp/tours/mapping
```

### Utility Scripts

1. `bin/generate_tours.sh` a Bash script that runs all three of the above Python scripts to process all existing tour files.
2. `bin/copy_tours.sh` copies the generated tours to a local Galaxy instance, or any other directory.

# Next Steps

1. Identify remaining issues that can be fixed automatically in the `fix_tours.py` script.
2. Integrate tours as Selenium tests

# Caveats and Known Issues

Only a few of the generated tours have been tested, but several issues have been identified.

1. The process for creating new histories has changed slightly (there seems to be one less thing to click).  The fix can likely be automated and won't be an issue for tours generated after the history panel change.
2. Tool searches are not working. The text is being entered in the search field but the search doesn't take place. This may be another incorrect element selector.
3. The tour dialog frequently covers the UI element it is describing. 
4. It is not known if updating a tool version breaks a tour due to changes in parameters in the tool's XML configuration that may change the UI.

# Possible Future Work

1. It may be desireable to parameterize the element selectors into the `vars.yaml` files as well.
2. Modify the tour file generator browser extensions so they do not include CSS style selectors if an element contains an #id.
3. Have the tour generator generate the Jinja template, and other files directly
4. Modify Galaxy to load the tour from the Jinja template rather than preprocessing them before installing into Galaxy.
