### PR TITLE
Unify trainings plant tags

### DIFF
--- a/topics/assembly/tutorials/chloroplast-assembly/tutorial.md
+++ b/topics/assembly/tutorials/chloroplast-assembly/tutorial.md
@@ -4,7 +4,7 @@ layout: tutorial_hands_on
 title: "Chloroplast genome assembly"
 zenodo_link: "http://doi.org/10.5281/zenodo.3567224"
 tags:
-  - plant
+  - plants
   - nanopore
 questions:
   - "How can we assemble a chloroplast genome?"


### PR DESCRIPTION
In order to use a single criterion, this RP proposes to replace the **plant** label with **plants**, thus unifying the labels.