### PR TITLE
spaces missing in the sentence

### DIFF
--- a/faqs/galaxy/analysis_results_may_vary.md
+++ b/faqs/galaxy/analysis_results_may_vary.md
@@ -6,7 +6,5 @@ layout: faq
 ---
 
 
-Your results may be slightly different from the ones presented in this tutorial
-due to differing versions of tools, reference data, external databases, or
-because of stochastic processes in the algorithms.
+Your results may be slightly different from the ones presented in this tutorial due to differing versions of tools, reference data, external databases, or because of stochastic processes in the algorithms.
 


### PR DESCRIPTION
because there were no spaces at the end of each line.

Put everything on one line to avoid this problem.