### PR TITLE
Add Abbreviation plugin

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -77,6 +77,12 @@ figurify:
   skip_titles:
     - Example of an image with a caption
 
+abbreviate:
+  skip_layouts:
+    - introduction_slides
+    - tutorial_slides
+    - base_slides
+
 # Scholar
 scholar:
   source: topics/

--- a/_layouts/tutorial_hands_on.html
+++ b/_layouts/tutorial_hands_on.html
@@ -231,6 +231,16 @@ layout: base
                     {% bibliography --cited %}
                     {% endif %}
 
+                    {% if page.abbreviations %}
+                    <h1 data-toc-skip>Glossary</h1>
+                    <dl>
+                        {% for abbr in page.abbreviations %}
+                        <dt>{{ abbr[0] }}</dt>
+                        <dd>{{ abbr[1] }}</dd>
+                        {% endfor %}
+                    </dl>
+                    {% endif %}
+
                     <h1>Feedback</h1>
                     <p class="text-muted">Did you use this material as an instructor? Feel free to give us feedback on <a href="https://github.com/galaxyproject/training-material/issues/1452" target="_blank">how it went</a>.</p>
 

--- a/_layouts/tutorial_hands_on.html
+++ b/_layouts/tutorial_hands_on.html
@@ -327,43 +327,43 @@ document.getElementById("citation-code").innerHTML = document.getElementById("ci
 document.getElementById("citation-text").innerHTML = document.getElementById("citation-text").innerHTML.replace("TODAY", d.toDateString());
 </script>
 
+                    <h3>{% icon congratulations %} Congratulations on successfully completing this tutorial!</h3>
+
+                    {% if topic.name == "contributing" %}
+                    <blockquote class="agenda">
+                        <h3>Developing GTN training material</h3>
+                        This tutorial is part of a series to develop GTN training material, feel free to also look at:
+                        {% assign topic = site.data[page.topic_name] %}
+                        <ol>
+                        {% for material in topic_material %}
+                            {% if material.enable != "false" %}
+                                {% if material.type == "introduction" %}
+                        <li><a href="{{ site.baseurl }}/topics/{{ topic.name }}/slides/{{ material.tutorial_name }}.html">{{ material.title }}</a></li>
+                                {% elsif material.type == "tutorial" %}
+                                    {% if material.hands_on %}
+                        <li><a href="{{ site.baseurl }}/topics/{{ topic.name  }}/tutorials/{{ material.tutorial_name }}/tutorial.html">{{ material.title }}</a></li>
+                                    {% elsif material.slides %}
+                        <li><a href="{{ site.baseurl }}/topics/{{ topic.name }}/tutorials/{{ material.tutorial_name }}/slides.html">{{ material.title }}</a></li>
+                                    {% endif %}
+                                {% endif %}
+                            {% endif %}
+                        {% endfor %}
+                        </ol>
+                    </blockquote>
+                    {% endif %}
+
+                    {% if page.follow_up_training %}
+                    <blockquote class="agenda follow-up">
+                        <strong class="follow-up">{% icon curriculum %} Do you want to extend your knowledge? Follow one of our recommended follow-up trainings:</strong>
+                        <ul>
+                            {% include _includes/display_extra_training.md extra_trainings=page.follow_up_training %}
+                        </ul>
+                    </blockquote>
+                    {% endif %}
+
                 </div>
             </div>
         </div>
-
-        <h3>{% icon congratulations %} Congratulations on successfully completing this tutorial!</h3>
-
-        {% if topic.name == "contributing" %}
-        <blockquote class="agenda">
-            <h3>Developing GTN training material</h3>
-            This tutorial is part of a series to develop GTN training material, feel free to also look at:
-            {% assign topic = site.data[page.topic_name] %}
-            <ol>
-            {% for material in topic_material %}
-                {% if material.enable != "false" %}
-                    {% if material.type == "introduction" %}
-            <li><a href="{{ site.baseurl }}/topics/{{ topic.name }}/slides/{{ material.tutorial_name }}.html">{{ material.title }}</a></li>
-                    {% elsif material.type == "tutorial" %}
-                        {% if material.hands_on %}
-            <li><a href="{{ site.baseurl }}/topics/{{ topic.name  }}/tutorials/{{ material.tutorial_name }}/tutorial.html">{{ material.title }}</a></li>
-                        {% elsif material.slides %}
-            <li><a href="{{ site.baseurl }}/topics/{{ topic.name }}/tutorials/{{ material.tutorial_name }}/slides.html">{{ material.title }}</a></li>
-                        {% endif %}
-                    {% endif %}
-                {% endif %}
-            {% endfor %}
-            </ol>
-        </blockquote>
-        {% endif %}
-
-        {% if page.follow_up_training %}
-        <blockquote class="agenda follow-up">
-            <strong class="follow-up">{% icon curriculum %} Do you want to extend your knowledge? Follow one of our recommended follow-up trainings:</strong>
-            <ul>
-                {% include _includes/display_extra_training.md extra_trainings=page.follow_up_training %}
-            </ul>
-        </blockquote>
-        {% endif %}
     </section>
 </div>
 

--- a/_layouts/tutorial_hands_on.html
+++ b/_layouts/tutorial_hands_on.html
@@ -234,7 +234,8 @@ layout: base
                     {% if page.abbreviations %}
                     <h1 data-toc-skip>Glossary</h1>
                     <dl>
-                        {% for abbr in page.abbreviations %}
+                        {% assign sorted_abbrs = page.abbreviations | sort %}
+                        {% for abbr in sorted_abbrs %}
                         <dt>{{ abbr[0] }}</dt>
                         <dd>{{ abbr[1] }}</dd>
                         {% endfor %}

--- a/_layouts/tutorial_hands_on.html
+++ b/_layouts/tutorial_hands_on.html
@@ -299,7 +299,7 @@ layout: base
     year = "{{ page.last_modified_at | date: "%Y"}}",
     month = "{{ page.last_modified_at | date: "%m"}}",
     day = "{{ page.last_modified_at | date: "%d" }}"
-    url = "{% raw %}\url{{% endraw %}{{ site.baseurl }}{{page.url}}{% raw %}}{% endraw %}",
+    url = "{% raw %}\url{{% endraw %}{{ site.url }}{{ site.baseurl }}{{page.url}}{% raw %}}{% endraw %}",
     note = "[Online; accessed TODAY]"
 }
 @article{Batut_2018,

--- a/_plugins/abbr.rb
+++ b/_plugins/abbr.rb
@@ -1,0 +1,54 @@
+require 'jekyll'
+
+module Jekyll
+  class Abbreviate < Jekyll::Generator
+    safe true
+
+    def initialize(config)
+      @config = config['abbreviate'] ||= {}
+    end
+
+    def generate(site)
+      site.pages
+        .select { |page| not skip_layout?(page.data['layout']) }
+        .each { |page| abbreviate page }
+      site.posts.docs
+        .select { |post| not skip_layout?(post.data['layout']) }
+        .each { |post| abbreviate post }
+    end
+
+    private
+
+    def abbreviate(page)
+      if page.data.key?('abbreviations') then
+        seen = Hash.new
+        page.data['abbreviations'].each{|abbr, definition|
+          page.content = page.content.gsub(/\{(#{abbr})\}/) {
+            if seen.key?(abbr) then
+              firstdef = false
+            else
+              firstdef = true
+              seen[abbr] = true
+            end
+
+            if firstdef then
+              "#{page['abbreviations'][abbr]} (#{abbr})"
+            else
+              "<abbr title=\"#{definition}\">#{abbr}</abbr>"
+            end
+          }
+        }
+      end
+    end
+
+    def skip_layout?(layout)
+      to_skip = @config['skip_layouts'] || []
+
+      if to_skip.empty?
+        true
+      end
+
+      to_skip.include?(layout)
+    end
+  end
+end

--- a/assets/css/main.scss
+++ b/assets/css/main.scss
@@ -1108,3 +1108,10 @@ video::cue {
         color: #555;
     }
 }
+
+abbr {
+	// Based on https://developer.mozilla.org/en-US/docs/Web/HTML/Element/abbr#default_styling
+	text-decoration: underline dotted;
+	cursor: help;
+	font-variant: none;
+}

--- a/bin/schema-tutorial.yaml
+++ b/bin/schema-tutorial.yaml
@@ -60,6 +60,11 @@ mapping:
         sequence:
             - type: str
               required: true
+    abbreviations:
+        type: map
+        mapping:
+            "=":
+                type: str
     galaxy_version:
         type: float
         required: false

--- a/bin/validate-frontmatter.rb
+++ b/bin/validate-frontmatter.rb
@@ -98,7 +98,7 @@ def lint_file(fn)
 
   # If it's disabled, exit early
   if data.key?('enable') && (data['enable'] == false || data['enable'].downcase == 'false') then
-    puts "#{fn} skipped (disabled)"
+    #puts "#{fn} skipped (disabled)"
     return
   end
 
@@ -144,7 +144,7 @@ def lint_file(fn)
 
   # If we had no errors, validated successfully
   if errs.length == 0 then
-    puts "\e[38;5;40m#{fn} validated succesfully\e[m"
+    #puts "\e[38;5;40m#{fn} validated succesfully\e[m"
   else
     # Otherwise, print errors and exit non-zero
     puts "\e[48;5;09m#{fn} has errors\e[m"

--- a/news/_posts/2021-05-25-abbreviations-tag.md
+++ b/news/_posts/2021-05-25-abbreviations-tag.md
@@ -1,0 +1,40 @@
+---
+title: "New Feature: Easy Abbreviation"
+tags: [new feature]
+contributors: [hexylena, rikeshi, simonbray]
+tutorial: "topics/dev/tutorials/bioblend-dev/tutorial.html"
+layout: news
+---
+
+Thanks to the great tutorial developed by first time contributor {% include _includes/contributor-badge.html id="rikeshi" %} and edited by {% include _includes/contributor-badge.html id="simonbray" %}, we noticed that they defined a number of abbreviations and re-used those throughout their tutorial.
+
+As the GTN is intended to be easy for contributors and easy for learners, we wanted to make use of the [`<abbr>`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/abbr) tag which allows you to define commonly re-used terms in your HTML. However this is a bit clumsy to write every time, so we've implemented a tag and some metadata which permits easily defining and referencing abbreviations throughout your text.
+
+In your tutorial metadata you can add an abbreviations section like:
+
+```yaml
+---
+title: My awesome tutorial
+...
+abbreviations:
+  API: Application Programming Interface
+  JSON: JavaScript Object Notation
+---
+```
+
+And in your text you can use braces to refer to the term
+
+> > ### {% icon code-in %} Input: Markdown
+> > <code>
+> > The `/jobs` &lbrace;API&rbrace; will return &lbrace;JSON&rbrace;. When we call the &lbrace;API&rbrace; we'll get back this result &lbrace;JSON&rbrace;.
+> > </code>
+> {: .code-in}
+>
+> > ### {% icon code-out %} Output
+> >
+> > The `/jobs` Application Programming Interface (API) will return JavaScript Object Notation (JSON). When we call the <abbr title="Application Programming Interface">API</abbr> we'll get back this result <abbr title="JavaScript Object Notation">JSON</abbr>.
+> >
+> {: .code-out}
+{: .code-2col}
+
+These will even generate an automatic Glossary at the end. Check out the use of this new feature in the BioBlend Dev Tutorial!

--- a/news/_posts/2021-05-25-new-dev-tutorial.md
+++ b/news/_posts/2021-05-25-new-dev-tutorial.md
@@ -1,0 +1,10 @@
+---
+title: "Contributing to BioBlend as a developer"
+tags: [new tutorial]
+contributors: [rikeshi, simonbray]
+tutorial: "topics/dev/tutorials/bioblend-dev/tutorial.html"
+layout: news
+---
+
+The first of the developer tutorials for GCC2021 is live, first time contributor {% include _includes/contributor-badge.html id="rikeshi" %} has produced a fantastic tutorial covering how to develop new functions in BioBlend for new APIs in Galaxy. Many thanks to {% include _includes/contributor-badge.html id="simonbray" %} for editing!
+

--- a/topics/contributing/tutorials/create-new-tutorial-content/tutorial.md
+++ b/topics/contributing/tutorials/create-new-tutorial-content/tutorial.md
@@ -19,6 +19,9 @@ contributors:
   - bgruening
   - shiltemann
   - hexylena
+abbreviations:
+  API: Application Programming Interface
+  JSON: JavaScript Object Notation
 ---
 
 # Introduction
@@ -914,6 +917,38 @@ To use these icons, take the name of the icon, 'details' in this example, and wr
 	</div>
 {% endfor %}
 </div>
+
+## Abbreviations
+
+Oftentimes there are terms you'll use over and over again where there is an acronym or abbreviation you'll use consistently. However for learners new to the material, they might need to scroll up to the first definition every time to remember what it meant. It would be annoying as an author to have to re-define it every time, so we've implemented some very simple syntax to allow you to create a list of definitions and then use those in the text.
+
+In your tutorial metadata you can add an abbreviations section like:
+
+```yaml
+---
+title: My awesome tutorial
+...
+abbreviations:
+  API: Application Programming Interface
+  JSON: JavaScript Object Notation
+---
+```
+
+And in your text you can use braces to refer to the term
+
+> > ### {% icon code-in %} Input: Markdown
+> > <code>
+> > The `/jobs` &lbrace;API&rbrace; will return &lbrace;JSON&rbrace;. When we call the &lbrace;API&rbrace; we'll get back this result &lbrace;JSON&rbrace;.
+> > </code>
+> {: .code-in}
+>
+> > ### {% icon code-out %} Output
+> >
+> > The `/jobs` {API} will return {JSON}. When we call the {API} we'll get back this result {JSON}.
+> >
+> {: .code-out}
+{: .code-2col}
+
 
 # Citations
 If you would like to cite any articles, books or websites in your tutorial, you can do so by adding a file called `tutorial.bib` next to your `tutorial.md` file. In this file you may enter [bibtex](http://www.bibtex.org/Using/) formatted citations. An example is given below:

--- a/topics/dev/tutorials/bioblend-dev/tutorial.md
+++ b/topics/dev/tutorials/bioblend-dev/tutorial.md
@@ -28,15 +28,23 @@ key_points:
 contributors:
     - rikeshi
     - simonbray
+
+abbreviations:
+    LDA: Library Dataset Association
+    HDA: History Dataset Association
+    LDCA: Library Dataset Collection Association
+    HDCA: History Dataset Collection Association
+    API: Application Programming Interface
+    PR: Pull Request
 ---
 
 # Introduction
 
 BioBlend ({% cite Sloggett2013 %}) is a Python library to enable simple interaction with Galaxy ({% cite Afgan2018 %}) via the command line or scripts.
 
-Galaxy is a data analysis platform for accessible, reproducible and transparent computational research. It includes a web interface through which users can design and perform tasks in a visual and interactive manner. The Galaxy server also exposes this functionality through its REST-based Application Programming Interface (API).
+Galaxy is a data analysis platform for accessible, reproducible and transparent computational research. It includes a web interface through which users can design and perform tasks in a visual and interactive manner. The Galaxy server also exposes this functionality through its REST-based {API}.
 
-Computer programs can communicate with the Galaxy server through this API and perform similar tasks as can be achieved manually via the web interface. The program sends a network request to a URL of an API endpoint. The server then computes the result for this request and sends back a response to the program.
+Computer programs can communicate with the Galaxy server through this {API} and perform similar tasks as can be achieved manually via the web interface. The program sends a network request to a URL of an {API} endpoint. The server then computes the result for this request and sends back a response to the program.
 
 BioBlend provides classes and methods that handle the specific details of this communication for Python programs. Similar libraries also exist for interacting with Galaxy via other programming languages:
 
@@ -65,7 +73,7 @@ The GitHub repositories can be found at:
 
 To contribute to BioBlend, a GitHub account is required.
 
-Changes are proposed via a pull request (PR). This allows the project maintainers to review the changes and suggest improvements.
+Changes are proposed via a {PR}. This allows the project maintainers to review the changes and suggest improvements.
 
 The general steps are as follows:
 
@@ -73,11 +81,11 @@ The general steps are as follows:
 2. Make changes in a new branch
 3. Open a pull request for this branch in the upstream BioBlend repository
 
-It is generally a good idea to enable the “Allow edits and access to secrets by maintainers” option for the PR. Enabling this option gives maintainers more freedom to help out.
+It is generally a good idea to enable the “Allow edits and access to secrets by maintainers” option for the {PR}. Enabling this option gives maintainers more freedom to help out.
 
 # Downloading Galaxy and BioBlend
 
-Now we are ready to set up our development environment! Since BioBlend communicates with the Galaxy API, we must also set up a local Galaxy server in order to test BioBlend functionality.
+Now we are ready to set up our development environment! Since BioBlend communicates with the Galaxy {API}, we must also set up a local Galaxy server in order to test BioBlend functionality.
 We use the [git](https://git-scm.com) versioning tool to download the repositories.
 
 For this we require a public SSH key associated with our GitHub account. It makes sense to set this up now, since pushing changes to GitHub without a public key will prompt for credentials every time. See the [GitHub Docs](https://docs.github.com/en/github-ae@latest/github/authenticating-to-github/generating-a-new-ssh-key-and-adding-it-to-the-ssh-agent) for information on setting up an SSH key.
@@ -102,7 +110,7 @@ For this we require a public SSH key associated with our GitHub account. It make
 
 ## Structure of the Galaxy API
 
-The source code for the API endpoints is contained in various files under [lib/galaxy/webapps/galaxy/api/](https://github.com/galaxyproject/galaxy/tree/dev/lib/galaxy/webapps/galaxy/api) in the Galaxy source code. Each of these files contains a controller which exposes functionality for a specific entity. For example, the dataset-related functionality is contained in the `DatasetsController` class in the [datasets.py](https://github.com/galaxyproject/galaxy/blob/v21.01/lib/galaxy/webapps/galaxy/api/datasets.py#L33) file.
+The source code for the {API} endpoints is contained in various files under [lib/galaxy/webapps/galaxy/api/](https://github.com/galaxyproject/galaxy/tree/dev/lib/galaxy/webapps/galaxy/api) in the Galaxy source code. Each of these files contains a controller which exposes functionality for a specific entity. For example, the dataset-related functionality is contained in the `DatasetsController` class in the [datasets.py](https://github.com/galaxyproject/galaxy/blob/v21.01/lib/galaxy/webapps/galaxy/api/datasets.py#L33) file.
 
 Additionally, the [buildapp.py](https://github.com/galaxyproject/galaxy/blob/dev/lib/galaxy/webapps/galaxy/buildapp.py) file contains a complete listing of all the endpoints.
 
@@ -112,9 +120,9 @@ Additionally, the [buildapp.py](https://github.com/galaxyproject/galaxy/blob/dev
 
 
 > ### {% icon tip %} Going deeper into the Galaxy back-end code
-> The various Galaxy API methods that are exposed to the outside are contained in controller classes. These contain the endpoint methods corresponding to the URLs of the Galaxy API. These endpoint methods handle the incoming requests from BioBlend.
+> The various Galaxy {API} methods that are exposed to the outside are contained in controller classes. These contain the endpoint methods corresponding to the URLs of the Galaxy {API}. These endpoint methods handle the incoming requests from BioBlend.
 >
-> A focus for development of the Galaxy API is to make these controllers as “terse” as possible. This basically means that any logic not strictly required by the API endpoint method is moved to a corresponding manager class. This approach separates the API more cleanly from internal functionality. The manager classes should contain as much of the functionality as possible. An example is the [`DatasetManager`](https://github.com/galaxyproject/galaxy/blob/v21.01/lib/galaxy/managers/datasets.py#L26), referenced to regularly by the `DatasetsController` which is exposed directly to the API.
+> A focus for development of the Galaxy {API} is to make these controllers as “terse” as possible. This basically means that any logic not strictly required by the {API} endpoint method is moved to a corresponding manager class. This approach separates the {API} more cleanly from internal functionality. The manager classes should contain as much of the functionality as possible. An example is the [`DatasetManager`](https://github.com/galaxyproject/galaxy/blob/v21.01/lib/galaxy/managers/datasets.py#L26), referenced to regularly by the `DatasetsController` which is exposed directly to the {API}.
 >
 > At the time of writing this transition is ongoing. Therefore, source code of methods for one controller might look and function differently than those of another controller. This might be encountered when debugging a failing request in BioBlend.
 >
@@ -134,10 +142,10 @@ Tool
 : A Galaxy tool packages a particular piece of scientific software, keeping track of its required dependencies. It also contains additional metadata such as the BibTex references to the associated research paper(s). Tools generally take datasets and/or dataset collections as inputs and produce new datasets and/or collections as outputs.
 
 Dataset
-: A dataset represents digital data that can serve as input for a job. It can be associated with (contained in) a history or a library. A dataset can be shared between users. Each time a dataset is copied between histories or libraries, a new History Dataset Association (HDA) or Library Dataset Association (LDA) is created. This naming scheme is used internally by the Galaxy relational database, but the terms might be encountered during BioBlend development as well.
+: A dataset represents digital data that can serve as input for a job. It can be associated with (contained in) a history or a library. A dataset can be shared between users. Each time a dataset is copied between histories or libraries, a new {HDA} or {LDA} is created. {LDA} This naming scheme is used internally by the Galaxy relational database, but the terms might be encountered during BioBlend development as well.
 
 Dataset Collection
-: A dataset collection represents a group of related datasets. Like a dataset, it can be associated with a history or a library. Each time it is copied or shared, a new History Dataset Collection Association (HDCA) or a Library Dataset Collection Association (LDCA) is created.<br><br>There are two kinds of dataset collections, `list` and `paired`. The former is a simple list of elements. The latter has a particular application in bioinformatics; it contains only two elements, corresponding to the `forward` and `reverse` strands of a piece of DNA.<br><br> Collection elements can be other collections; in other words, collections can be nested. These are designated (for example) as `list:list` or `list:paired`.
+: A dataset collection represents a group of related datasets. Like a dataset, it can be associated with a history or a library. Each time it is copied or shared, a new {HDCA} or a {LDCA} is created.<br><br>There are two kinds of dataset collections, `list` and `paired`. The former is a simple list of elements. The latter has a particular application in bioinformatics; it contains only two elements, corresponding to the `forward` and `reverse` strands of a piece of DNA.<br><br> Collection elements can be other collections; in other words, collections can be nested. These are designated (for example) as `list:list` or `list:paired`.
 
 Job
 : Jobs are associated with the execution of a tool on the Galaxy server. Each dataset is created by running a tool and therefore has an associated job. The computation of each step in a workflow has an associated job as well.<br><br>Jobs run as background processes on the Galaxy server. This is relevant because reading results before the appropriate jobs have finished can lead to missing data in the output. BioBlend methods must handle this by waiting for relevant jobs to finish before returning a response to the user.<br><br>Job creation can be different when dealing with dataset collections. If a tool input receives a collection instead of a dataset, it will create a separate job for each element, resulting in an output collection with the same structure as the input. This is referred to as 'mapping over' a collection.


### PR DESCRIPTION
Referencing abbreviations is really kind of annoying to do, and I'm so used to LaTeX's abbreviation abilities which are fantastic and so easy to use. So I've re-implemented something similar here. Note that on first use the term is expanded and include `term (abbr)` and on subsequent uses is just abbreviated with the abbreviation and the abbr tag which provides hover information. 

After reviewing @rikeshi's new tutorial I noticed that terms like HDA/HDCA/LDA are defined and referenced and it made sense to implement a plugin to help make this process easier. I've done this with @rikeshi's tutorial to start with as a demonstrator. cc @simonbray 

## Syntax

The `/jobs` &lbrace;API&rbrace; will return &lbrace;JSON&rbrace;. When we call the &lbrace;API&rbrace; we'll get back this result &lbrace;JSON&rbrace;

## Output

![image](https://user-images.githubusercontent.com/458683/119485700-aac87380-bd57-11eb-8b6c-597a3c05f14a.png)


## Built In Glossary

![image](https://user-images.githubusercontent.com/458683/119485730-b320ae80-bd57-11eb-9fc6-9f625c50fc8d.png)


