### PR TITLE
[Metatranscriptomics] update workflows to include missing input

### DIFF
--- a/topics/metagenomics/tutorials/metatranscriptomics-short/workflows/workflow3_functional_information.ga
+++ b/topics/metagenomics/tutorials/metatranscriptomics-short/workflows/workflow3_functional_information.ga
@@ -20,14 +20,14 @@
             "name": "Input dataset",
             "outputs": [],
             "position": {
-                "bottom": 491.1999969482422,
+                "bottom": 232.1999969482422,
                 "height": 82.19999694824219,
-                "left": 245,
-                "right": 445,
-                "top": 409,
+                "left": 57.5,
+                "right": 257.5,
+                "top": 150,
                 "width": 200,
-                "x": 245,
-                "y": 409
+                "x": 57.5,
+                "y": 150
             },
             "tool_id": null,
             "tool_state": "{\"optional\": false}",
@@ -52,14 +52,14 @@
             "name": "Input dataset",
             "outputs": [],
             "position": {
-                "bottom": 788.1999969482422,
+                "bottom": 529.1999969482422,
                 "height": 82.19999694824219,
-                "left": 237,
-                "right": 437,
-                "top": 706,
+                "left": 49.5,
+                "right": 249.5,
+                "top": 447,
                 "width": 200,
-                "x": 237,
-                "y": 706
+                "x": 49.5,
+                "y": 447
             },
             "tool_id": null,
             "tool_state": "{\"optional\": false}",
@@ -70,9 +70,47 @@
         },
         "2": {
             "annotation": "",
-            "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/humann/humann/3.0.0+galaxy1",
+            "content_id": null,
             "errors": null,
             "id": 2,
+            "input_connections": {},
+            "inputs": [
+                {
+                    "description": "",
+                    "name": "Cut predicted taxon relative abundances table"
+                }
+            ],
+            "label": "Cut predicted taxon relative abundances table",
+            "name": "Input dataset",
+            "outputs": [],
+            "position": {
+                "bottom": 685.6000061035156,
+                "height": 102.60000610351562,
+                "left": 297,
+                "right": 497,
+                "top": 583,
+                "width": 200,
+                "x": 297,
+                "y": 583
+            },
+            "tool_id": null,
+            "tool_state": "{\"optional\": false}",
+            "tool_version": null,
+            "type": "data_input",
+            "uuid": "849666f5-87e5-4a1b-9bf5-750356538b5a",
+            "workflow_outputs": [
+                {
+                    "label": null,
+                    "output_name": "output",
+                    "uuid": "62a1021a-2c32-4565-a24d-45d9a59bf838"
+                }
+            ]
+        },
+        "3": {
+            "annotation": "",
+            "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/humann/humann/3.0.0+galaxy1",
+            "errors": null,
+            "id": 3,
             "input_connections": {
                 "in|input": {
                     "id": 0,
@@ -105,14 +143,14 @@
                 }
             ],
             "position": {
-                "bottom": 776.3999938964844,
+                "bottom": 517.3999938964844,
                 "height": 510.3999938964844,
-                "left": 729,
-                "right": 929,
-                "top": 266,
+                "left": 541.5,
+                "right": 741.5,
+                "top": 7,
                 "width": 200,
-                "x": 729,
-                "y": 266
+                "x": 541.5,
+                "y": 7
             },
             "post_job_actions": {},
             "tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/humann/humann/3.0.0+galaxy1",
@@ -129,34 +167,34 @@
             "workflow_outputs": [
                 {
                     "label": null,
-                    "output_name": "gene_families_tsv",
-                    "uuid": "bb71e05b-9aaa-4fd9-a401-f9c9a2f7dfdf"
+                    "output_name": "log",
+                    "uuid": "2c83805a-5dde-457d-bc75-b6cfb8d24223"
                 },
                 {
                     "label": null,
                     "output_name": "pathcoverage_tsv",
-                    "uuid": "864b480f-f142-47c6-b9db-98c5c83729bc"
-                },
-                {
-                    "label": null,
-                    "output_name": "log",
-                    "uuid": "04ea957a-c919-46e4-ad11-8db0ab4a3bc2"
+                    "uuid": "18390584-8c12-4f13-8076-8a522e961219"
                 },
                 {
                     "label": null,
                     "output_name": "pathabundance_tsv",
-                    "uuid": "15452620-55cf-4f46-9131-ed21700e2793"
+                    "uuid": "3335cfdd-110e-4fb7-b172-c3f16dc86f55"
+                },
+                {
+                    "label": null,
+                    "output_name": "gene_families_tsv",
+                    "uuid": "d16c4649-80e9-4a6d-93d0-069e23b360af"
                 }
             ]
         },
-        "3": {
+        "4": {
             "annotation": "",
             "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/humann_renorm_table/humann_renorm_table/3.0.0+galaxy1",
             "errors": null,
-            "id": 3,
+            "id": 4,
             "input_connections": {
                 "input": {
-                    "id": 2,
+                    "id": 3,
                     "output_name": "pathabundance_tsv"
                 }
             },
@@ -170,14 +208,14 @@
                 }
             ],
             "position": {
-                "bottom": 443.1999969482422,
+                "bottom": 184.1999969482422,
                 "height": 93.19999694824219,
-                "left": 1020,
-                "right": 1220,
-                "top": 350,
+                "left": 832.5,
+                "right": 1032.5,
+                "top": 91,
                 "width": 200,
-                "x": 1020,
-                "y": 350
+                "x": 832.5,
+                "y": 91
             },
             "post_job_actions": {
                 "RenameDatasetActionoutput": {
@@ -203,18 +241,18 @@
                 {
                     "label": null,
                     "output_name": "output",
-                    "uuid": "c9adde18-dcef-44d8-afcb-2647008d2910"
+                    "uuid": "d96237c5-9bd7-4d3e-9920-41d5100caad2"
                 }
             ]
         },
-        "4": {
+        "5": {
             "annotation": "",
             "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/humann_renorm_table/humann_renorm_table/3.0.0+galaxy1",
             "errors": null,
-            "id": 4,
+            "id": 5,
             "input_connections": {
                 "input": {
-                    "id": 2,
+                    "id": 3,
                     "output_name": "gene_families_tsv"
                 }
             },
@@ -228,14 +266,14 @@
                 }
             ],
             "position": {
-                "bottom": 828.1999969482422,
+                "bottom": 569.1999969482422,
                 "height": 93.19999694824219,
-                "left": 1008,
-                "right": 1208,
-                "top": 735,
+                "left": 820.5,
+                "right": 1020.5,
+                "top": 476,
                 "width": 200,
-                "x": 1008,
-                "y": 735
+                "x": 820.5,
+                "y": 476
             },
             "post_job_actions": {
                 "RenameDatasetActionoutput": {
@@ -261,18 +299,18 @@
                 {
                     "label": null,
                     "output_name": "output",
-                    "uuid": "090cee03-a347-48d6-a7f6-bb104eb7c0df"
+                    "uuid": "73030f50-cd07-4bc6-b1fa-c8954499600c"
                 }
             ]
         },
-        "5": {
+        "6": {
             "annotation": "",
             "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/humann_regroup_table/humann_regroup_table/3.0.0+galaxy1",
             "errors": null,
-            "id": 5,
+            "id": 6,
             "input_connections": {
                 "input": {
-                    "id": 2,
+                    "id": 3,
                     "output_name": "gene_families_tsv"
                 }
             },
@@ -286,14 +324,14 @@
                 }
             ],
             "position": {
-                "bottom": 1332.1999969482422,
+                "bottom": 1073.1999969482422,
                 "height": 93.19999694824219,
-                "left": 1007,
-                "right": 1207,
-                "top": 1239,
+                "left": 819.5,
+                "right": 1019.5,
+                "top": 980,
                 "width": 200,
-                "x": 1007,
-                "y": 1239
+                "x": 819.5,
+                "y": 980
             },
             "post_job_actions": {},
             "tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/humann_regroup_table/humann_regroup_table/3.0.0+galaxy1",
@@ -311,22 +349,22 @@
                 {
                     "label": null,
                     "output_name": "output",
-                    "uuid": "201239ff-2161-45f0-9783-8a1166437e2c"
+                    "uuid": "ee42a29d-b123-4ffd-a8ed-620c4adf3a61"
                 }
             ]
         },
-        "6": {
+        "7": {
             "annotation": "",
             "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/humann_unpack_pathways/humann_unpack_pathways/3.0.0+galaxy1",
             "errors": null,
-            "id": 6,
+            "id": 7,
             "input_connections": {
                 "input_genes": {
-                    "id": 4,
+                    "id": 5,
                     "output_name": "output"
                 },
                 "input_pathways": {
-                    "id": 3,
+                    "id": 4,
                     "output_name": "output"
                 }
             },
@@ -340,14 +378,14 @@
                 }
             ],
             "position": {
-                "bottom": 661,
+                "bottom": 402,
                 "height": 266,
-                "left": 1285,
-                "right": 1485,
-                "top": 395,
+                "left": 1097.5,
+                "right": 1297.5,
+                "top": 136,
                 "width": 200,
-                "x": 1285,
-                "y": 395
+                "x": 1097.5,
+                "y": 136
             },
             "post_job_actions": {},
             "tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/humann_unpack_pathways/humann_unpack_pathways/3.0.0+galaxy1",
@@ -365,18 +403,22 @@
                 {
                     "label": null,
                     "output_name": "output",
-                    "uuid": "1584dd68-1810-46e0-8c0f-6939a7d134d1"
+                    "uuid": "7b84db6b-fc18-4ab8-81b3-bab05b29c83f"
                 }
             ]
         },
-        "7": {
+        "8": {
             "annotation": "",
             "content_id": "toolshed.g2.bx.psu.edu/repos/bebatut/combine_metaphlan2_humann2/combine_metaphlan2_humann2/0.1.0",
             "errors": null,
-            "id": 7,
+            "id": 8,
             "input_connections": {
                 "humann2_file": {
-                    "id": 4,
+                    "id": 5,
+                    "output_name": "output"
+                },
+                "metaphlan2_file": {
+                    "id": 2,
                     "output_name": "output"
                 }
             },
@@ -390,14 +432,14 @@
                 }
             ],
             "position": {
-                "bottom": 1006.2000122070312,
+                "bottom": 747.2000122070312,
                 "height": 307.20001220703125,
-                "left": 1285,
-                "right": 1485,
-                "top": 699,
+                "left": 1097.5,
+                "right": 1297.5,
+                "top": 440,
                 "width": 200,
-                "x": 1285,
-                "y": 699
+                "x": 1097.5,
+                "y": 440
             },
             "post_job_actions": {},
             "tool_id": "toolshed.g2.bx.psu.edu/repos/bebatut/combine_metaphlan2_humann2/combine_metaphlan2_humann2/0.1.0",
@@ -415,18 +457,18 @@
                 {
                     "label": null,
                     "output_name": "gene_families_output_file",
-                    "uuid": "340a952c-e508-4aff-80a1-5e4320fe0663"
+                    "uuid": "684a26de-ed96-42d5-b6b4-3387c8ae30a1"
                 }
             ]
         },
-        "8": {
+        "9": {
             "annotation": "",
             "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/humann_rename_table/humann_rename_table/3.0.0+galaxy0",
             "errors": null,
-            "id": 8,
+            "id": 9,
             "input_connections": {
                 "input": {
-                    "id": 5,
+                    "id": 6,
                     "output_name": "output"
                 }
             },
@@ -440,14 +482,14 @@
                 }
             ],
             "position": {
-                "bottom": 1342.6000061035156,
+                "bottom": 1083.6000061035156,
                 "height": 113.60000610351562,
-                "left": 1285,
-                "right": 1485,
-                "top": 1229,
+                "left": 1097.5,
+                "right": 1297.5,
+                "top": 970,
                 "width": 200,
-                "x": 1285,
-                "y": 1229
+                "x": 1097.5,
+                "y": 970
             },
             "post_job_actions": {},
             "tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/humann_rename_table/humann_rename_table/3.0.0+galaxy0",
@@ -465,18 +507,18 @@
                 {
                     "label": null,
                     "output_name": "output",
-                    "uuid": "af98ac14-b59f-4f54-a100-791515e64cec"
+                    "uuid": "263b7db4-3199-47ed-9d1f-c221af47c135"
                 }
             ]
         },
-        "9": {
+        "10": {
             "annotation": "",
             "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/humann_split_stratified_table/humann_split_stratified_table/3.0.0+galaxy0",
             "errors": null,
-            "id": 9,
+            "id": 10,
             "input_connections": {
                 "input": {
-                    "id": 5,
+                    "id": 6,
                     "output_name": "output"
                 }
             },
@@ -494,14 +536,14 @@
                 }
             ],
             "position": {
-                "bottom": 1606.6000061035156,
+                "bottom": 1347.6000061035156,
                 "height": 225.60000610351562,
-                "left": 1285,
-                "right": 1485,
-                "top": 1381,
+                "left": 1097.5,
+                "right": 1297.5,
+                "top": 1122,
                 "width": 200,
-                "x": 1285,
-                "y": 1381
+                "x": 1097.5,
+                "y": 1122
             },
             "post_job_actions": {},
             "tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/humann_split_stratified_table/humann_split_stratified_table/3.0.0+galaxy0",
@@ -518,24 +560,24 @@
             "workflow_outputs": [
                 {
                     "label": null,
-                    "output_name": "unstratified",
-                    "uuid": "8e69e099-5ca4-4e06-a8b4-6dfd8995c772"
+                    "output_name": "stratified",
+                    "uuid": "5641680e-55ec-4c23-b5a6-15185cacd2fb"
                 },
                 {
                     "label": null,
-                    "output_name": "stratified",
-                    "uuid": "6d0bc876-0649-49ab-b291-53019ab503a1"
+                    "output_name": "unstratified",
+                    "uuid": "5059ccbc-8d62-4e1f-8362-d80a656c0886"
                 }
             ]
         },
-        "10": {
+        "11": {
             "annotation": "",
             "content_id": "Grep1",
             "errors": null,
-            "id": 10,
+            "id": 11,
             "input_connections": {
                 "input": {
-                    "id": 8,
+                    "id": 9,
                     "output_name": "output"
                 }
             },
@@ -549,14 +591,14 @@
                 }
             ],
             "position": {
-                "bottom": 1201.1999969482422,
+                "bottom": 942.1999969482422,
                 "height": 93.19999694824219,
-                "left": 1563,
-                "right": 1763,
-                "top": 1108,
+                "left": 1375.5,
+                "right": 1575.5,
+                "top": 849,
                 "width": 200,
-                "x": 1563,
-                "y": 1108
+                "x": 1375.5,
+                "y": 849
             },
             "post_job_actions": {
                 "RenameDatasetActionout_file1": {
@@ -576,18 +618,18 @@
                 {
                     "label": null,
                     "output_name": "out_file1",
-                    "uuid": "779f9ef4-fa02-46c7-8fe2-efd6f495e287"
+                    "uuid": "03e50b38-284b-4422-acab-83c653b3cf7f"
                 }
             ]
         },
-        "11": {
+        "12": {
             "annotation": "",
             "content_id": "Grep1",
             "errors": null,
-            "id": 11,
+            "id": 12,
             "input_connections": {
                 "input": {
-                    "id": 8,
+                    "id": 9,
                     "output_name": "output"
                 }
             },
@@ -601,14 +643,14 @@
                 }
             ],
             "position": {
-                "bottom": 1331.1999969482422,
+                "bottom": 1072.1999969482422,
                 "height": 93.19999694824219,
-                "left": 1563,
-                "right": 1763,
-                "top": 1238,
+                "left": 1375.5,
+                "right": 1575.5,
+                "top": 979,
                 "width": 200,
-                "x": 1563,
-                "y": 1238
+                "x": 1375.5,
+                "y": 979
             },
             "post_job_actions": {
                 "RenameDatasetActionout_file1": {
@@ -628,18 +670,18 @@
                 {
                     "label": null,
                     "output_name": "out_file1",
-                    "uuid": "6e4f99cf-de0e-40b6-b112-1f34745e2091"
+                    "uuid": "aea139ad-f862-49dc-91d5-174dbc4e2df0"
                 }
             ]
         },
-        "12": {
+        "13": {
             "annotation": "",
             "content_id": "Grep1",
             "errors": null,
-            "id": 12,
+            "id": 13,
             "input_connections": {
                 "input": {
-                    "id": 8,
+                    "id": 9,
                     "output_name": "output"
                 }
             },
@@ -653,14 +695,14 @@
                 }
             ],
             "position": {
-                "bottom": 1463.1999969482422,
+                "bottom": 1204.1999969482422,
                 "height": 93.19999694824219,
-                "left": 1563,
-                "right": 1763,
-                "top": 1370,
+                "left": 1375.5,
+                "right": 1575.5,
+                "top": 1111,
                 "width": 200,
-                "x": 1563,
-                "y": 1370
+                "x": 1375.5,
+                "y": 1111
             },
             "post_job_actions": {
                 "RenameDatasetActionout_file1": {
@@ -680,7 +722,7 @@
                 {
                     "label": null,
                     "output_name": "out_file1",
-                    "uuid": "892c3c34-21ff-4815-85e4-38a76f2907be"
+                    "uuid": "736116e9-30f4-42a9-be68-8d676d2a888a"
                 }
             ]
         }
@@ -688,6 +730,6 @@
     "tags": [
         "metagenomics"
     ],
-    "uuid": "f422facb-29d4-46ee-b8fb-1207dd5f55ee",
-    "version": 3
+    "uuid": "f45176e5-ab69-4ab1-b4f3-62642b103b5d",
+    "version": 1
 }

--- a/topics/metagenomics/tutorials/metatranscriptomics-short/workflows/workflow3_functional_information_quick.ga
+++ b/topics/metagenomics/tutorials/metatranscriptomics-short/workflows/workflow3_functional_information_quick.ga
@@ -20,14 +20,14 @@
             "name": "Input dataset",
             "outputs": [],
             "position": {
-                "bottom": 101.69999694824219,
+                "bottom": -38.30000305175781,
                 "height": 82.19999694824219,
-                "left": 171.5,
-                "right": 371.5,
-                "top": 19.5,
+                "left": 297,
+                "right": 497,
+                "top": -120.5,
                 "width": 200,
-                "x": 171.5,
-                "y": 19.5
+                "x": 297,
+                "y": -120.5
             },
             "tool_id": null,
             "tool_state": "{\"optional\": false}",
@@ -52,14 +52,14 @@
             "name": "Input dataset",
             "outputs": [],
             "position": {
-                "bottom": 439.6999969482422,
+                "bottom": 299.6999969482422,
                 "height": 82.19999694824219,
-                "left": 171.5,
-                "right": 371.5,
-                "top": 357.5,
+                "left": 297,
+                "right": 497,
+                "top": 217.5,
                 "width": 200,
-                "x": 171.5,
-                "y": 357.5
+                "x": 297,
+                "y": 217.5
             },
             "tool_id": null,
             "tool_state": "{\"optional\": false}",
@@ -70,9 +70,47 @@
         },
         "2": {
             "annotation": "",
-            "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/humann_renorm_table/humann_renorm_table/3.0.0+galaxy1",
+            "content_id": null,
             "errors": null,
             "id": 2,
+            "input_connections": {},
+            "inputs": [
+                {
+                    "description": "",
+                    "name": "Cut predicted taxon relative abundances table"
+                }
+            ],
+            "label": "Cut predicted taxon relative abundances table",
+            "name": "Input dataset",
+            "outputs": [],
+            "position": {
+                "bottom": 520.1000061035156,
+                "height": 102.60000610351562,
+                "left": 304,
+                "right": 504,
+                "top": 417.5,
+                "width": 200,
+                "x": 304,
+                "y": 417.5
+            },
+            "tool_id": null,
+            "tool_state": "{\"optional\": false}",
+            "tool_version": null,
+            "type": "data_input",
+            "uuid": "daa95c9f-58c1-4da6-bdb9-1ea3e31b50c8",
+            "workflow_outputs": [
+                {
+                    "label": null,
+                    "output_name": "output",
+                    "uuid": "75e7f9f2-42b1-4d39-b462-ffdf6c634219"
+                }
+            ]
+        },
+        "3": {
+            "annotation": "",
+            "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/humann_renorm_table/humann_renorm_table/3.0.0+galaxy1",
+            "errors": null,
+            "id": 3,
             "input_connections": {
                 "input": {
                     "id": 0,
@@ -89,14 +127,14 @@
                 }
             ],
             "position": {
-                "bottom": 106.69999694824219,
+                "bottom": -33.30000305175781,
                 "height": 93.19999694824219,
-                "left": 449.5,
-                "right": 649.5,
-                "top": 13.5,
+                "left": 575,
+                "right": 775,
+                "top": -126.5,
                 "width": 200,
-                "x": 449.5,
-                "y": 13.5
+                "x": 575,
+                "y": -126.5
             },
             "post_job_actions": {
                 "RenameDatasetActionoutput": {
@@ -122,15 +160,15 @@
                 {
                     "label": null,
                     "output_name": "output",
-                    "uuid": "fc534e2c-c738-4475-936a-290268e278b4"
+                    "uuid": "4c8bf3bc-ec68-40eb-8001-268abbbbc576"
                 }
             ]
         },
-        "3": {
+        "4": {
             "annotation": "",
             "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/humann_renorm_table/humann_renorm_table/3.0.0+galaxy1",
             "errors": null,
-            "id": 3,
+            "id": 4,
             "input_connections": {
                 "input": {
                     "id": 1,
@@ -147,14 +185,14 @@
                 }
             ],
             "position": {
-                "bottom": 444.6999969482422,
+                "bottom": 304.6999969482422,
                 "height": 93.19999694824219,
-                "left": 449.5,
-                "right": 649.5,
-                "top": 351.5,
+                "left": 575,
+                "right": 775,
+                "top": 211.5,
                 "width": 200,
-                "x": 449.5,
-                "y": 351.5
+                "x": 575,
+                "y": 211.5
             },
             "post_job_actions": {
                 "RenameDatasetActionoutput": {
@@ -180,15 +218,15 @@
                 {
                     "label": null,
                     "output_name": "output",
-                    "uuid": "e3cb9831-2ab0-4271-bad2-456988edaf9c"
+                    "uuid": "c047e2a5-a901-4ad6-b6cf-6723046e6269"
                 }
             ]
         },
-        "4": {
+        "5": {
             "annotation": "",
             "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/humann_regroup_table/humann_regroup_table/3.0.0+galaxy1",
             "errors": null,
-            "id": 4,
+            "id": 5,
             "input_connections": {
                 "input": {
                     "id": 1,
@@ -205,14 +243,14 @@
                 }
             ],
             "position": {
-                "bottom": 769.6999969482422,
+                "bottom": 629.6999969482422,
                 "height": 93.19999694824219,
-                "left": 449.5,
-                "right": 649.5,
-                "top": 676.5,
+                "left": 575,
+                "right": 775,
+                "top": 536.5,
                 "width": 200,
-                "x": 449.5,
-                "y": 676.5
+                "x": 575,
+                "y": 536.5
             },
             "post_job_actions": {},
             "tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/humann_regroup_table/humann_regroup_table/3.0.0+galaxy1",
@@ -230,22 +268,22 @@
                 {
                     "label": null,
                     "output_name": "output",
-                    "uuid": "9a8613dc-7f88-4132-921f-c47b4d88a7ce"
+                    "uuid": "5611f12c-e922-403c-8a5f-a15bcbc135ec"
                 }
             ]
         },
-        "5": {
+        "6": {
             "annotation": "",
             "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/humann_unpack_pathways/humann_unpack_pathways/3.0.0+galaxy1",
             "errors": null,
-            "id": 5,
+            "id": 6,
             "input_connections": {
                 "input_genes": {
-                    "id": 3,
+                    "id": 4,
                     "output_name": "output"
                 },
                 "input_pathways": {
-                    "id": 2,
+                    "id": 3,
                     "output_name": "output"
                 }
             },
@@ -259,14 +297,14 @@
                 }
             ],
             "position": {
-                "bottom": 288.5,
+                "bottom": 148.5,
                 "height": 266,
-                "left": 727.5,
-                "right": 927.5,
-                "top": 22.5,
+                "left": 853,
+                "right": 1053,
+                "top": -117.5,
                 "width": 200,
-                "x": 727.5,
-                "y": 22.5
+                "x": 853,
+                "y": -117.5
             },
             "post_job_actions": {},
             "tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/humann_unpack_pathways/humann_unpack_pathways/3.0.0+galaxy1",
@@ -284,18 +322,22 @@
                 {
                     "label": null,
                     "output_name": "output",
-                    "uuid": "c642d05f-7b01-4d75-ad3e-9d6131d05c37"
+                    "uuid": "9cc326d3-c9ee-41d0-8b9a-f1f17e42ff06"
                 }
             ]
         },
-        "6": {
+        "7": {
             "annotation": "",
             "content_id": "toolshed.g2.bx.psu.edu/repos/bebatut/combine_metaphlan2_humann2/combine_metaphlan2_humann2/0.1.0",
             "errors": null,
-            "id": 6,
+            "id": 7,
             "input_connections": {
                 "humann2_file": {
-                    "id": 3,
+                    "id": 4,
+                    "output_name": "output"
+                },
+                "metaphlan2_file": {
+                    "id": 2,
                     "output_name": "output"
                 }
             },
@@ -309,14 +351,14 @@
                 }
             ],
             "position": {
-                "bottom": 633.7000122070312,
+                "bottom": 493.70001220703125,
                 "height": 307.20001220703125,
-                "left": 727.5,
-                "right": 927.5,
-                "top": 326.5,
+                "left": 853,
+                "right": 1053,
+                "top": 186.5,
                 "width": 200,
-                "x": 727.5,
-                "y": 326.5
+                "x": 853,
+                "y": 186.5
             },
             "post_job_actions": {},
             "tool_id": "toolshed.g2.bx.psu.edu/repos/bebatut/combine_metaphlan2_humann2/combine_metaphlan2_humann2/0.1.0",
@@ -334,18 +376,18 @@
                 {
                     "label": null,
                     "output_name": "gene_families_output_file",
-                    "uuid": "732dbfb3-cf1a-48f2-8261-348e65055b66"
+                    "uuid": "9bf1551b-a3de-4a48-bb2c-07c4988fdcd3"
                 }
             ]
         },
-        "7": {
+        "8": {
             "annotation": "",
             "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/humann_split_stratified_table/humann_split_stratified_table/3.0.0+galaxy0",
             "errors": null,
-            "id": 7,
+            "id": 8,
             "input_connections": {
                 "input": {
-                    "id": 4,
+                    "id": 5,
                     "output_name": "output"
                 }
             },
@@ -363,14 +405,14 @@
                 }
             ],
             "position": {
-                "bottom": 897.1000061035156,
+                "bottom": 757.1000061035156,
                 "height": 225.60000610351562,
-                "left": 727.5,
-                "right": 927.5,
-                "top": 671.5,
+                "left": 853,
+                "right": 1053,
+                "top": 531.5,
                 "width": 200,
-                "x": 727.5,
-                "y": 671.5
+                "x": 853,
+                "y": 531.5
             },
             "post_job_actions": {},
             "tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/humann_split_stratified_table/humann_split_stratified_table/3.0.0+galaxy0",
@@ -388,23 +430,23 @@
                 {
                     "label": null,
                     "output_name": "stratified",
-                    "uuid": "fe64b92a-c7f9-4c4b-a27f-529628659b1d"
+                    "uuid": "ee109c79-0ff2-40fe-b5a3-b2ea4439ce4a"
                 },
                 {
                     "label": null,
                     "output_name": "unstratified",
-                    "uuid": "fed30f2b-9988-4841-aa57-7086ce723040"
+                    "uuid": "2a589b74-dbe4-4c15-affa-f29e26f05eeb"
                 }
             ]
         },
-        "8": {
+        "9": {
             "annotation": "",
             "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/humann_rename_table/humann_rename_table/3.0.0+galaxy0",
             "errors": null,
-            "id": 8,
+            "id": 9,
             "input_connections": {
                 "input": {
-                    "id": 4,
+                    "id": 5,
                     "output_name": "output"
                 }
             },
@@ -418,14 +460,14 @@
                 }
             ],
             "position": {
-                "bottom": 1049.1000061035156,
+                "bottom": 909.1000061035156,
                 "height": 113.60000610351562,
-                "left": 727.5,
-                "right": 927.5,
-                "top": 935.5,
+                "left": 853,
+                "right": 1053,
+                "top": 795.5,
                 "width": 200,
-                "x": 727.5,
-                "y": 935.5
+                "x": 853,
+                "y": 795.5
             },
             "post_job_actions": {},
             "tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/humann_rename_table/humann_rename_table/3.0.0+galaxy0",
@@ -443,18 +485,18 @@
                 {
                     "label": null,
                     "output_name": "output",
-                    "uuid": "6061155e-c5f7-4329-b955-7b29b77350a1"
+                    "uuid": "6f6b772b-89b4-4516-ac97-d60938eb5e97"
                 }
             ]
         },
-        "9": {
+        "10": {
             "annotation": "",
             "content_id": "Grep1",
             "errors": null,
-            "id": 9,
+            "id": 10,
             "input_connections": {
                 "input": {
-                    "id": 8,
+                    "id": 9,
                     "output_name": "output"
                 }
             },
@@ -468,14 +510,14 @@
                 }
             ],
             "position": {
-                "bottom": 926.6999969482422,
+                "bottom": 786.6999969482422,
                 "height": 93.19999694824219,
-                "left": 1005.5,
-                "right": 1205.5,
-                "top": 833.5,
+                "left": 1131,
+                "right": 1331,
+                "top": 693.5,
                 "width": 200,
-                "x": 1005.5,
-                "y": 833.5
+                "x": 1131,
+                "y": 693.5
             },
             "post_job_actions": {
                 "RenameDatasetActionout_file1": {
@@ -495,18 +537,18 @@
                 {
                     "label": null,
                     "output_name": "out_file1",
-                    "uuid": "166af41f-7ad0-44f9-903c-8090d05e4af2"
+                    "uuid": "fe99424d-02f8-4fae-b4d6-28fa01713ce0"
                 }
             ]
         },
-        "10": {
+        "11": {
             "annotation": "",
             "content_id": "Grep1",
             "errors": null,
-            "id": 10,
+            "id": 11,
             "input_connections": {
                 "input": {
-                    "id": 8,
+                    "id": 9,
                     "output_name": "output"
                 }
             },
@@ -520,14 +562,14 @@
                 }
             ],
             "position": {
-                "bottom": 1057.6999969482422,
+                "bottom": 917.6999969482422,
                 "height": 93.19999694824219,
-                "left": 1005.5,
-                "right": 1205.5,
-                "top": 964.5,
+                "left": 1131,
+                "right": 1331,
+                "top": 824.5,
                 "width": 200,
-                "x": 1005.5,
-                "y": 964.5
+                "x": 1131,
+                "y": 824.5
             },
             "post_job_actions": {
                 "RenameDatasetActionout_file1": {
@@ -547,18 +589,18 @@
                 {
                     "label": null,
                     "output_name": "out_file1",
-                    "uuid": "86544dcc-e818-4c06-906b-dcd0b4dbaa58"
+                    "uuid": "463b9730-4273-4388-bd8e-bff12befa625"
                 }
             ]
         },
-        "11": {
+        "12": {
             "annotation": "",
             "content_id": "Grep1",
             "errors": null,
-            "id": 11,
+            "id": 12,
             "input_connections": {
                 "input": {
-                    "id": 8,
+                    "id": 9,
                     "output_name": "output"
                 }
             },
@@ -572,14 +614,14 @@
                 }
             ],
             "position": {
-                "bottom": 1188.6999969482422,
+                "bottom": 1048.6999969482422,
                 "height": 93.19999694824219,
-                "left": 1005.5,
-                "right": 1205.5,
-                "top": 1095.5,
+                "left": 1131,
+                "right": 1331,
+                "top": 955.5,
                 "width": 200,
-                "x": 1005.5,
-                "y": 1095.5
+                "x": 1131,
+                "y": 955.5
             },
             "post_job_actions": {
                 "RenameDatasetActionout_file1": {
@@ -599,7 +641,7 @@
                 {
                     "label": null,
                     "output_name": "out_file1",
-                    "uuid": "0cf5e571-5a3c-4366-98e7-a0f0fea98465"
+                    "uuid": "214ce862-ca99-4c91-8ae1-7275458ce87b"
                 }
             ]
         }
@@ -607,6 +649,6 @@
     "tags": [
         "metagenomics"
     ],
-    "uuid": "697f47fc-dbb6-480d-8fc4-ba3a8bb0f08a",
-    "version": 3
+    "uuid": "3e428a99-c77f-4b94-8397-41380331d6b4",
+    "version": 1
 }


### PR DESCRIPTION
Workflow 3 for the short tutorial was missing one of the input files for `Combine MetaPhlAn2 and HUMAnN2` tool, so I added this (Cut predicted taxon relative abundance table)

![image](https://user-images.githubusercontent.com/2563865/119495249-83c36f00-bd62-11eb-8616-fc48d20233d9.png)

ping @bebatut does this look ok? ping @subinamehta FYI 