### PR TITLE
Add archive menu to extras

### DIFF
--- a/.github/workflows/monthly-release.yml
+++ b/.github/workflows/monthly-release.yml
@@ -72,9 +72,10 @@ jobs:
           git tag -l
           git checkout ${SOURCE_TAG}
           gem install bundler
+          bundle config path vendor/bundle
           sed -i s"|^baseurl: .*|baseurl: '/archive/${SOURCE_TAG}'|g" _config.yml
           sed -i s"|^github_repository_branch: .*|github_repository_branch: '${SOURCE_TAG}'|g" _config.yml
-          sed -i s"|^title: .*|github_repository_branch: 'GTN Archive ${SOURCE_TAG}'|g" _config.yml
+          sed -i s"|^title: .*|title: 'GTN Archive ${SOURCE_TAG}'|g" _config.yml
           npm install
           make rebuild-search-index ACTIVATE_ENV=pwd
           JEKYLL_ENV=production bundle exec jekyll build --strict_front_matter -d _site/training-material

--- a/_includes/extras.html
+++ b/_includes/extras.html
@@ -70,5 +70,21 @@
             </div>
 
         </div>
+
+        <div class="dropdown-item">
+            <div>
+                {% icon galaxy-rulebuilder-history %} Previous Versions
+            </div>
+
+            {% assign taglist = site.git_tags | sort | reverse | slice: 0, 3 %}
+            <div id="archive-selector">
+            {% for tag in taglist %}
+                <a class="btn btn-warning" href="https://training.galaxyproject.org/archive/{{tag}}{{ page.url }}" title="Version {{tag}}">{{ tag }}</a>
+            {% endfor %}
+                <a class="btn btn-warning" href="https://training.galaxyproject.org/archive/" title="Older Versions">Older Versions</a>
+            </div>
+
+        </div>
+
     </div>
 </li>

--- a/_plugins/jekyll-environment_variables.rb
+++ b/_plugins/jekyll-environment_variables.rb
@@ -14,6 +14,7 @@ module Jekyll
       end
       site.config['git_revision'] = git_head_ref
       site.config['gtn_fork'] = ENV['GTN_FORK']
+      site.config['git_tags'] = `git tag -l`.strip.split
 
       # Add other environment variables to `site.config` here...
     end

--- a/_plugins/jekyll-environment_variables.rb
+++ b/_plugins/jekyll-environment_variables.rb
@@ -14,7 +14,11 @@ module Jekyll
       end
       site.config['git_revision'] = git_head_ref
       site.config['gtn_fork'] = ENV['GTN_FORK']
-      site.config['git_tags'] = `git tag -l`.strip.split
+      begin
+        site.config['git_tags'] = `git tag -l`.strip.split
+      rescue
+        site.config['git_tags'] = []
+      end
 
       # Add other environment variables to `site.config` here...
     end

--- a/assets/css/main.scss
+++ b/assets/css/main.scss
@@ -105,7 +105,7 @@ body {
 
 @import "assets/css/syntax_highlighting-dark.scss";
 
-div#theme-selector,div#lang-selector {
+div#theme-selector,div#lang-selector,div#archive-selector {
 	display: flex;
 	flex-direction: row;
 	flex-wrap: wrap;

--- a/news/_posts/2021-06-01-archive-menu.md
+++ b/news/_posts/2021-06-01-archive-menu.md
@@ -1,0 +1,11 @@
+---
+title: "Oh no, it changed! Quick, to the archive menu."
+tags: [new feature]
+contributors: [hexylena, shiltemann]
+layout: news
+---
+
+Did you ever start teaching a GTN tutorial, only to realise something changed recently? Oh no! A while ago the GTN created an **Archive** to address just this concern.
+On every tag, we'd build a copy of the website which we would place online and never touch again. This way we'd have permanent online copies so that if someone needed to go back to an older version of the GTN, they could.
+
+However it was hard to reach and you had to know about it, so we've placed the links in the **Extras Menu** of every page. There you'll find a list of the three most recent tags (automatically created monthly, and sometimes manually for big events) and a link to browse all tags in the archive. This should work on every page, however beware that it can direct you to pages that didn't use to exist back then (like this news item!) so give it a test on one of the tutorials in the GTN's library instead.


### PR DESCRIPTION
We'll now have a menu item in the Extras dropdown to link to a few recent tags in the archive as well as a button for all older versions.

![image](https://user-images.githubusercontent.com/458683/120325965-7c630f00-c2e8-11eb-85f8-505a4c252fb8.png)

Per suggestion from @shiltemann we limit this to only a couple tags, with the presumption that the primary use will be teachers going "oh, shoot, someone changed something, let me revert to a previous version"