### PR TITLE
Provide support for working on gitpod.io

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,0 +1,7 @@
+tasks:
+  - init: make bundle-install
+    command: make bundle-install
+
+ports:
+  - port: 4000
+    onOpen: open-browser

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -4,4 +4,5 @@ tasks:
 
 ports:
   - port: 4000
-    onOpen: open-browser
+    onOpen: default
+    visibility: public

--- a/Makefile
+++ b/Makefile
@@ -48,6 +48,10 @@ install: clean create-env ## install dependencies
 		gem install addressable:'2.5.2' jekyll jekyll-feed jekyll-scholar jekyll-redirect-from jekyll-last-modified-at csl-styles awesome_bot html-proofer pkg-config kwalify jekyll-sitemap
 .PHONY: install
 
+bundle-install: clean  ## install gems if Ruby is already present (e.g. on gitpod.io)
+	bundle install
+.PHONE: bundle-install
+
 serve: ## run a local server (You can specify PORT=, HOST=, and FLAGS= to set the port, host or to pass additional flags)
 	@echo "Tip: Want faster builds? Use 'serve-quick' in place of 'serve'."
 	@echo "Tip: to serve in incremental mode (faster rebuilds), use the command: make serve FLAGS=--incremental" && echo "" && \
@@ -64,6 +68,10 @@ serve-quick: ## run a local server (faster, some plugins disabled for speed)
 		mv Gemfile.lock Gemfile.lock.backup || true && \
 		${JEKYLL} serve --strict_front_matter -d _site/training-material --incremental --config _config.yml,_config-dev.yml -P ${PORT} -H ${HOST} ${FLAGS}
 .PHONY: serve-quick
+
+serve-gitpod: bundle-install  ## run a server on a gitpod.io environment
+	bundle exec jekyll serve --config _config.yml,_config-dev.yml --incremental
+.PHONY: serve-gitpod
 
 build: clean ## build files but do not run a server (You can specify FLAGS= to pass additional flags to Jekyll)
 	$(ACTIVATE_ENV) && \


### PR DESCRIPTION
[gitpod.io](https://gitpod.io) has Ruby built in (thanks @shiltemann for pointing that out) and can thus can be setup with a simple `bundle install` (now added as a target `bundle-install` in the Makefile).

This PR adds that Makefile target, a `serve-gitpod` target for serving on a `gitpod.io` machine and a `.gitpod.yml` for configuring initialisation and ports.