### PR TITLE
Fix git-gat test for repos that don't have permissions

### DIFF
--- a/.github/workflows/git-gat.yml
+++ b/.github/workflows/git-gat.yml
@@ -2,8 +2,6 @@ name: Build GIT-GAT
 
 on:
   pull_request:
-    branches:
-      - main
     paths:
       - 'topics/admin/**'
       - 'bin/knit*'
@@ -17,7 +15,43 @@ on:
       - 'bin/video*'
 
 jobs:
+  test:
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 1
+      - uses: actions/setup-python@v2
+        with:
+          python-version: '3.7'
+          architecture: 'x64'
+
+      - name: Build git-gat repo
+        run: |
+            bin/knit-automated.sh export;
+          if_key_exists: ignore # replace / ignore / fail; optional (defaults to fail)
+
+      - name: Merge all of the commits
+        run: |
+            cd /tmp/git-gat/
+            git config --global init.defaultBranch main
+            git config --global user.email "galaxytrainingnetwork@gmail.com"
+            git config --global user.name "The Galaxy Training Network"
+            git init
+            cd /tmp/git-gat/
+            for i in {0..9}; do
+                # Commit those patches
+                patches=$(ls $i-*.patch 2>/dev/null| wc -c)
+                if (( patches > 0 )); then
+                    git am $i-*.patch;
+                fi
+                # And tag it
+                git tag -f "step-$i";
+            done
+
   deploy:
+    if: github.repository_owner == 'galaxyproject'
+    needs: test
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/git-gat.yml
+++ b/.github/workflows/git-gat.yml
@@ -67,6 +67,12 @@ jobs:
             bin/knit-automated.sh export;
           if_key_exists: ignore # replace / ignore / fail; optional (defaults to fail)
 
+      - name: Install SSH key
+        uses: shimataro/ssh-key-action@v2
+        with:
+          key: ${{ secrets.GIT_GAT_SSH_KEY }}
+          known_hosts: "github.com ssh-rsa AAAAB3NzaC1yc2EAAAABIwAAAQEAq2A7hRGmdnm9tUDbO9IDSwBK6TbQa+PXYPCPy6rbTrTtw7PHkccKrpp0yVhp5HdEIcKr6pLlVDBfOLX9QUsyCOV0wzfjIJNlGEYsdlLJizHhbn2mUjvSAHQqZETYP81eFzLQNnPHt4EVVUh7VfDESU84KezmD5QlWpXLmvU31/yMf+Se8xhHTvKSCZIFImWwoG6mbUoWf9nzpIoaSjB+weqqUUmpaaasXVal72J+UX2B+2RPW3RcT0eOzQgqlJL3RKrTJvdsjE3JEAvGq3lGHSZXy28G3skua2SmVi/w4yCE6gbODqnTWlg7+wC604ydGXA8VJiS5ap43JXiUFFAaQ=="
+
       - name: Setup git-gat repo
         run: |
             cd /tmp/git-gat/
@@ -75,7 +81,7 @@ jobs:
             git config --global user.name "The Galaxy Training Network"
             git init
             # Update the origin early
-            git remote add origin https://github.com/hexylena/git-gat
+            git remote add origin git@github.com:hexylena/git-gat
             git fetch origin --tags
 
       - name: Merge the commits into a full git history
@@ -95,16 +101,9 @@ jobs:
             rm -f *.patch
             ls -al
 
-      - name: Install SSH key
-        uses: shimataro/ssh-key-action@v2
-        with:
-          key: ${{ secrets.GIT_GAT_SSH_KEY }}
-          known_hosts: "github.com ssh-rsa AAAAB3NzaC1yc2EAAAABIwAAAQEAq2A7hRGmdnm9tUDbO9IDSwBK6TbQa+PXYPCPy6rbTrTtw7PHkccKrpp0yVhp5HdEIcKr6pLlVDBfOLX9QUsyCOV0wzfjIJNlGEYsdlLJizHhbn2mUjvSAHQqZETYP81eFzLQNnPHt4EVVUh7VfDESU84KezmD5QlWpXLmvU31/yMf+Se8xhHTvKSCZIFImWwoG6mbUoWf9nzpIoaSjB+weqqUUmpaaasXVal72J+UX2B+2RPW3RcT0eOzQgqlJL3RKrTJvdsjE3JEAvGq3lGHSZXy28G3skua2SmVi/w4yCE6gbODqnTWlg7+wC604ydGXA8VJiS5ap43JXiUFFAaQ=="
-
       - name: Push the results
         run: |
             cd /tmp/git-gat/
-            git remote set-url origin git@github.com:hexylena/git-gat
             # Push the results
             git push -f -u origin main
             git push -f --tags

--- a/.github/workflows/git-gat.yml
+++ b/.github/workflows/git-gat.yml
@@ -65,13 +65,13 @@ jobs:
       - name: Build git-gat repo
         run: |
             bin/knit-automated.sh export;
-          if_key_exists: ignore # replace / ignore / fail; optional (defaults to fail)
 
       - name: Install SSH key
         uses: shimataro/ssh-key-action@v2
         with:
           key: ${{ secrets.GIT_GAT_SSH_KEY }}
           known_hosts: "github.com ssh-rsa AAAAB3NzaC1yc2EAAAABIwAAAQEAq2A7hRGmdnm9tUDbO9IDSwBK6TbQa+PXYPCPy6rbTrTtw7PHkccKrpp0yVhp5HdEIcKr6pLlVDBfOLX9QUsyCOV0wzfjIJNlGEYsdlLJizHhbn2mUjvSAHQqZETYP81eFzLQNnPHt4EVVUh7VfDESU84KezmD5QlWpXLmvU31/yMf+Se8xhHTvKSCZIFImWwoG6mbUoWf9nzpIoaSjB+weqqUUmpaaasXVal72J+UX2B+2RPW3RcT0eOzQgqlJL3RKrTJvdsjE3JEAvGq3lGHSZXy28G3skua2SmVi/w4yCE6gbODqnTWlg7+wC604ydGXA8VJiS5ap43JXiUFFAaQ=="
+          if_key_exists: ignore # replace / ignore / fail; optional (defaults to fail)
 
       - name: Setup git-gat repo
         run: |

--- a/.github/workflows/git-gat.yml
+++ b/.github/workflows/git-gat.yml
@@ -29,7 +29,6 @@ jobs:
       - name: Build git-gat repo
         run: |
             bin/knit-automated.sh export;
-          if_key_exists: ignore # replace / ignore / fail; optional (defaults to fail)
 
       - name: Merge all of the commits
         run: |

--- a/.github/workflows/git-gat.yml
+++ b/.github/workflows/git-gat.yml
@@ -2,6 +2,8 @@ name: Build GIT-GAT
 
 on:
   pull_request:
+    branches:
+      - main
     paths:
       - 'topics/admin/**'
       - 'bin/knit*'
@@ -29,12 +31,6 @@ jobs:
       - name: Build git-gat repo
         run: |
             bin/knit-automated.sh export;
-
-      - name: Install SSH key
-        uses: shimataro/ssh-key-action@v2
-        with:
-          key: ${{ secrets.GIT_GAT_SSH_KEY }}
-          known_hosts: "github.com ssh-rsa AAAAB3NzaC1yc2EAAAABIwAAAQEAq2A7hRGmdnm9tUDbO9IDSwBK6TbQa+PXYPCPy6rbTrTtw7PHkccKrpp0yVhp5HdEIcKr6pLlVDBfOLX9QUsyCOV0wzfjIJNlGEYsdlLJizHhbn2mUjvSAHQqZETYP81eFzLQNnPHt4EVVUh7VfDESU84KezmD5QlWpXLmvU31/yMf+Se8xhHTvKSCZIFImWwoG6mbUoWf9nzpIoaSjB+weqqUUmpaaasXVal72J+UX2B+2RPW3RcT0eOzQgqlJL3RKrTJvdsjE3JEAvGq3lGHSZXy28G3skua2SmVi/w4yCE6gbODqnTWlg7+wC604ydGXA8VJiS5ap43JXiUFFAaQ=="
           if_key_exists: ignore # replace / ignore / fail; optional (defaults to fail)
 
       - name: Setup git-gat repo
@@ -45,16 +41,10 @@ jobs:
             git config --global user.name "The Galaxy Training Network"
             git init
             # Update the origin early
-            git remote add origin git@github.com:hexylena/git-gat.git
+            git remote add origin https://github.com/hexylena/git-gat
             git fetch origin --tags
 
-      #- name: Wipe out existing tags
-        #run: |
-            #cd /tmp/git-gat/
-            ## Wipe out the tags that do exist
-            #git tag -l | xargs --no-run-if-empty git push --delete origin
-
-      - name: Setup git-gat repo
+      - name: Merge the commits into a full git history
         run: |
             cd /tmp/git-gat/
             for i in {0..9}; do
@@ -71,9 +61,16 @@ jobs:
             rm -f *.patch
             ls -al
 
+      - name: Install SSH key
+        uses: shimataro/ssh-key-action@v2
+        with:
+          key: ${{ secrets.GIT_GAT_SSH_KEY }}
+          known_hosts: "github.com ssh-rsa AAAAB3NzaC1yc2EAAAABIwAAAQEAq2A7hRGmdnm9tUDbO9IDSwBK6TbQa+PXYPCPy6rbTrTtw7PHkccKrpp0yVhp5HdEIcKr6pLlVDBfOLX9QUsyCOV0wzfjIJNlGEYsdlLJizHhbn2mUjvSAHQqZETYP81eFzLQNnPHt4EVVUh7VfDESU84KezmD5QlWpXLmvU31/yMf+Se8xhHTvKSCZIFImWwoG6mbUoWf9nzpIoaSjB+weqqUUmpaaasXVal72J+UX2B+2RPW3RcT0eOzQgqlJL3RKrTJvdsjE3JEAvGq3lGHSZXy28G3skua2SmVi/w4yCE6gbODqnTWlg7+wC604ydGXA8VJiS5ap43JXiUFFAaQ=="
+
       - name: Push the results
         run: |
             cd /tmp/git-gat/
+            git remote set-url origin git@github.com:hexylena/git-gat
             # Push the results
             git push -f -u origin main
             git push -f --tags

--- a/topics/admin/tutorials/cvmfs/tutorial.md
+++ b/topics/admin/tutorials/cvmfs/tutorial.md
@@ -654,4 +654,3 @@ If you are working with plants, you can find separate reference data here: [fred
 > hope you enjoyed it and hopefully I'll get to meet some of you in person one
 > day soon at a Galaxy conference. Thank you and goodbye.
 {: .spoken data-visual="gtn" data-target="#feedback"}
-


### PR DESCRIPTION
git-gat/test will be triggered if there are any changes to the admin topic. This'll extract the commits and build them.
git-gat/deploy will only run if the repo owner is galaxyproject (so on main branch + PRs from people opening branches from this repo)