### PR TITLE
Add client build info to ansible-galaxy and a few other verbiage changes.

### DIFF
--- a/.github/workflows/git-gat.yml
+++ b/.github/workflows/git-gat.yml
@@ -27,6 +27,9 @@ jobs:
       - name: Export commits
         run: |
             bin/knit-automated.sh export;
+            echo "Debugging"
+            env | sort
+
 
       - name: Install SSH key
         uses: shimataro/ssh-key-action@v2

--- a/.github/workflows/git-gat.yml
+++ b/.github/workflows/git-gat.yml
@@ -27,10 +27,6 @@ jobs:
       - name: Export commits
         run: |
             bin/knit-automated.sh export;
-            env | sort
-        env:
-           TEST: "${{ github.event.pull_request.head.repo.full_name }}"
-
 
       - name: Install SSH key
         uses: shimataro/ssh-key-action@v2
@@ -38,7 +34,7 @@ jobs:
           key: ${{ secrets.GIT_GAT_SSH_KEY }}
           known_hosts: "github.com ssh-rsa AAAAB3NzaC1yc2EAAAABIwAAAQEAq2A7hRGmdnm9tUDbO9IDSwBK6TbQa+PXYPCPy6rbTrTtw7PHkccKrpp0yVhp5HdEIcKr6pLlVDBfOLX9QUsyCOV0wzfjIJNlGEYsdlLJizHhbn2mUjvSAHQqZETYP81eFzLQNnPHt4EVVUh7VfDESU84KezmD5QlWpXLmvU31/yMf+Se8xhHTvKSCZIFImWwoG6mbUoWf9nzpIoaSjB+weqqUUmpaaasXVal72J+UX2B+2RPW3RcT0eOzQgqlJL3RKrTJvdsjE3JEAvGq3lGHSZXy28G3skua2SmVi/w4yCE6gbODqnTWlg7+wC604ydGXA8VJiS5ap43JXiUFFAaQ=="
           if_key_exists: ignore # replace / ignore / fail; optional (defaults to fail)
-        if: github.repository_owner == 'galaxyproject'
+        if: github.event.pull_request.head.repo.owner == 'galaxyproject'
 
       - name: Setup the repo
         run: |
@@ -47,8 +43,15 @@ jobs:
             git init
             git config user.email "galaxytrainingnetwork@gmail.com"
             git config user.name "The Galaxy Training Network"
-            git remote add origin git@github.com:hexylena/git-gat
+            if [[ "$UPSTREAM_REPO" == "galaxyproject" ]]; then
+                git remote add origin git@github.com:hexylena/git-gat
+            else
+                git remote add origin https://github.com/hexylena/git-gat
+            fi
             git fetch origin --tags
+        env:
+            UPSTREAM_REPO: "${{ github.event.pull_request.head.repo.owner }}"
+
 
       - name: Add scripts directory
         run: |
@@ -83,4 +86,4 @@ jobs:
             git checkout -b $today
             git push -f --set-upstream origin $today
             git push -f --tags
-        if: github.repository_owner == 'galaxyproject'
+        if: github.event.pull_request.head.repo.owner == "galaxyproject"

--- a/.github/workflows/git-gat.yml
+++ b/.github/workflows/git-gat.yml
@@ -43,19 +43,21 @@ jobs:
             git init
             git config user.email "galaxytrainingnetwork@gmail.com"
             git config user.name "The Galaxy Training Network"
-            if [[ "$UPSTREAM_REPO" == "galaxyproject" ]]; then
-                git remote add origin git@github.com:hexylena/git-gat
-            else
-                git remote add origin https://github.com/hexylena/git-gat
-            fi
-            git fetch origin --tags
-        env:
-            UPSTREAM_REPO: "${{ github.event.pull_request.head.repo.owner }}"
 
+      - name: Setup the origin (fork)
+        run: |
+            git remote add origin https://github.com/hexylena/git-gat
+        if: github.event.pull_request.head.repo.owner != 'galaxyproject'
+
+      - name: Setup the origin (branch)
+        run: |
+            git remote add origin git@github.com:hexylena/git-gat
+        if: github.event.pull_request.head.repo.owner == 'galaxyproject'
 
       - name: Add scripts directory
         run: |
             cd /tmp/git-gat/
+            git fetch origin --tags
             git add .scripts/
             git commit -m "admin/init/0000: Add scripts directory"
             git am 0-commit-0000-root-commit.patch

--- a/.github/workflows/git-gat.yml
+++ b/.github/workflows/git-gat.yml
@@ -46,11 +46,13 @@ jobs:
 
       - name: Setup the origin (fork)
         run: |
+            cd /tmp/git-gat/
             git remote add origin https://github.com/hexylena/git-gat
         if: github.event.pull_request.head.repo.owner != 'galaxyproject'
 
       - name: Setup the origin (branch)
         run: |
+            cd /tmp/git-gat/
             git remote add origin git@github.com:hexylena/git-gat
         if: github.event.pull_request.head.repo.owner == 'galaxyproject'
 

--- a/.github/workflows/git-gat.yml
+++ b/.github/workflows/git-gat.yml
@@ -27,8 +27,9 @@ jobs:
       - name: Export commits
         run: |
             bin/knit-automated.sh export;
-            echo "Debugging"
             env | sort
+        env:
+           TEST: "${{ github.event.pull_request.head.repo.full_name }}"
 
 
       - name: Install SSH key

--- a/.github/workflows/git-gat.yml
+++ b/.github/workflows/git-gat.yml
@@ -86,4 +86,4 @@ jobs:
             git checkout -b $today
             git push -f --set-upstream origin $today
             git push -f --tags
-        if: github.event.pull_request.head.repo.owner == "galaxyproject"
+        if: github.event.pull_request.head.repo.owner == 'galaxyproject'

--- a/topics/admin/tutorials/ansible-galaxy/tutorial.md
+++ b/topics/admin/tutorials/ansible-galaxy/tutorial.md
@@ -2382,12 +2382,14 @@ If you need to run on a cluster with a shared file system, you will need to expo
 - `galaxy_server_dir`
 - `galaxy_venv_dir`
 
-Some of these can be worked around, by running the portions of the roles that deploy these directories on the shared filesystem. Then Galaxy and the shared filesystem can run off of two different copies of them, if that is better for performance:
+But this isn't strictly true, not every one of these directories needs to be exported over the network. Instead, there are a couple of those directories that can be recreated in different locations (e.g. locally to nodes) using playbook tasks or simply by copying them to the relevant locations. Sometimes admins choose to do this for performance reasons when NFS can be slow or simply unnecessary:
 
 - `galaxy_server_dir`
 - `galaxy_venv_dir`
 
-Most of us use NFS, those who are using something more exotic (ceph, gluster, etc) have some reason for that like "my uni provided it" or "we really wanted to try something shiny". But NFS in most cases is decent and well tested and can be used.
+Both of those directories can be re-created by running parts of the `galaxyproject.galaxy` role on different machines. As neither of these directories is written to during system operations, it is fine for them to be copies living on different machines, rather coming from a single source of truth like an NFS server. For the other directories (e.g. job working directory or tools directory) these need to be written to, and read from, simultaneously from different machines, and should be consistent across the network.
+
+Most of us use NFS, those who are using something more exotic (ceph, gluster, etc) have some reason for that like "my uni provided it" or "we really wanted to try something shiny". But NFS in most cases is decent and well tested and can be used. For larger deployments, a single NFS node may be insufficient, but at these scales it is common that your university or organisation provides some managed NFS service, e.g. Isilon which has load balancing built into its NFS service.
 
 ## Other software
 

--- a/topics/admin/tutorials/ansible-galaxy/tutorial.md
+++ b/topics/admin/tutorials/ansible-galaxy/tutorial.md
@@ -174,7 +174,7 @@ The client lives in the Galaxy code under the [client/](https://github.com/galax
 
 ## Handlers
 
-A number of the tasks that are executed will trigger a restart of Galaxy. Currently there is no auto-magic implementation of this, and you will have to do something that fits for your setup. The role provides a way to reference your own [handler](https://docs.ansible.com/ansible/2.9/user_guide/playbooks_intro.html#handlers-running-operations-on-change), which we will do in this exercise. As Galaxy continues to standardise on setup, something will be implemented directly in the role to automatically restart the correct processes.
+A number of the tasks that are executed will trigger a restart of Galaxy. Currently the only auto-magic implementation of this restart [handler](https://docs.ansible.com/ansible/2.9/user_guide/playbooks_intro.html#handlers-running-operations-on-change) is when Galaxy is started and run using systemd. Thankfully, this tutorial uses systemd, but if systemd is not an option wherever you're deploying Galaxy, you will have to do something custom that fits for your setup. If this is the case for you, the role provides a way to reference your own handler by setting `galaxy_restart_handler_name`.
 
 ## Defaults
 


### PR DESCRIPTION
No changes to code.

@hexylena I can't quite make out what's being said here:

> Some of these can be worked around, by running the portions of the roles that deploy these directories on the shared filesystem. Then Galaxy and the shared filesystem can run off of two different copies of them, if that is better for performance