### PR TITLE
Fix reports path missing and fix gxadmin warning about dupe key

### DIFF
--- a/.github/workflows/git-gat.yml
+++ b/.github/workflows/git-gat.yml
@@ -72,7 +72,7 @@ jobs:
                 # Commit those patches
                 patches=$(ls $i-*.patch 2>/dev/null| wc -c)
                 if (( patches > 0 )); then
-                    git am -3 $i-*.patch;
+                    git am -3 -C2 $i-*.patch;
 
                     # And tag it
                     git tag -f "step-$(( i - 9 ))";

--- a/.github/workflows/git-gat.yml
+++ b/.github/workflows/git-gat.yml
@@ -34,7 +34,7 @@ jobs:
           key: ${{ secrets.GIT_GAT_SSH_KEY }}
           known_hosts: "github.com ssh-rsa AAAAB3NzaC1yc2EAAAABIwAAAQEAq2A7hRGmdnm9tUDbO9IDSwBK6TbQa+PXYPCPy6rbTrTtw7PHkccKrpp0yVhp5HdEIcKr6pLlVDBfOLX9QUsyCOV0wzfjIJNlGEYsdlLJizHhbn2mUjvSAHQqZETYP81eFzLQNnPHt4EVVUh7VfDESU84KezmD5QlWpXLmvU31/yMf+Se8xhHTvKSCZIFImWwoG6mbUoWf9nzpIoaSjB+weqqUUmpaaasXVal72J+UX2B+2RPW3RcT0eOzQgqlJL3RKrTJvdsjE3JEAvGq3lGHSZXy28G3skua2SmVi/w4yCE6gbODqnTWlg7+wC604ydGXA8VJiS5ap43JXiUFFAaQ=="
           if_key_exists: ignore # replace / ignore / fail; optional (defaults to fail)
-        if: github.event.pull_request.head.repo.owner == 'galaxyproject'
+        if: github.event.pull_request.head.repo.full_name == 'galaxyproject/training-material' && github.event.pull_request.base.repo.full_name == 'galaxyproject/training-material'
 
       - name: Setup the repo
         run: |
@@ -48,13 +48,13 @@ jobs:
         run: |
             cd /tmp/git-gat/
             git remote add origin https://github.com/hexylena/git-gat
-        if: github.event.pull_request.head.repo.owner != 'galaxyproject'
+        if: github.event.pull_request.head.repo.full_name != 'galaxyproject/training-material' || github.event.pull_request.base.repo.full_name != 'galaxyproject/training-material'
 
       - name: Setup the origin (branch)
         run: |
             cd /tmp/git-gat/
             git remote add origin git@github.com:hexylena/git-gat
-        if: github.event.pull_request.head.repo.owner == 'galaxyproject'
+        if: github.event.pull_request.head.repo.full_name == 'galaxyproject/training-material' && github.event.pull_request.base.repo.full_name == 'galaxyproject/training-material'
 
       - name: Add scripts directory
         run: |
@@ -90,4 +90,4 @@ jobs:
             git checkout -b $today
             git push -f --set-upstream origin $today
             git push -f --tags
-        if: github.event.pull_request.head.repo.owner == 'galaxyproject'
+        if: github.event.pull_request.head.repo.full_name == 'galaxyproject/training-material' && github.event.pull_request.base.repo.full_name == 'galaxyproject/training-material'

--- a/bin/knit-automated.sh
+++ b/bin/knit-automated.sh
@@ -90,7 +90,7 @@ elif [[ "$op" == "roundtrip" ]]; then
 	bash $0 export
 	cd ${DIR} || exit
 	git init && \
-		git am -3 -- *.patch
+		git am -3 -C2 -- *.patch
 	cd -
 	bash $0 import
 else

--- a/topics/admin/tutorials/gxadmin/tutorial.md
+++ b/topics/admin/tutorials/gxadmin/tutorial.md
@@ -54,7 +54,7 @@ It's simple to install gxadmin. Here's how you do it, if you haven't done it alr
 >     - src: galaxyproject.pulsar
 >       version: 1.0.7
 >    +- src: usegalaxy_eu.gxadmin
->    +  version: 0.0.3
+>    +  version: 0.0.8
 >    {% endraw %}
 >    ```
 >    {: data-commit="Add requirement"}

--- a/topics/admin/tutorials/monitoring/tutorial.md
+++ b/topics/admin/tutorials/monitoring/tutorial.md
@@ -79,7 +79,7 @@ The available Ansible roles for InfluxDB unfortunately do not support configurin
 >    @@ -28,3 +28,5 @@
 >       version: 1.0.7
 >     - src: usegalaxy_eu.gxadmin
->       version: 0.0.3
+>       version: 0.0.8
 >    +- src: usegalaxy_eu.influxdb
 >    +  version: v6.0.7
 >    {% endraw %}
@@ -735,7 +735,7 @@ It's simple to install gxadmin. Here's how you do it, if you haven't done it alr
 >
 >    ```yml
 >    - src: usegalaxy_eu.gxadmin
->      version: 0.0.3
+>      version: 0.0.8
 >    ```
 >
 > 2. Install the role with `ansible-galaxy install -p roles -r requirements.yml`

--- a/topics/admin/tutorials/monitoring/tutorial.md
+++ b/topics/admin/tutorials/monitoring/tutorial.md
@@ -200,7 +200,7 @@ There are some nice examples of dashboards available from the public Galaxies, w
 >    --- a/requirements.yml
 >    +++ b/requirements.yml
 >    @@ -30,3 +30,5 @@
->       version: 0.0.3
+>       version: 0.0.8
 >     - src: usegalaxy_eu.influxdb
 >       version: v6.0.7
 >    +- src: cloudalchemy.grafana

--- a/topics/admin/tutorials/reports/tutorial.md
+++ b/topics/admin/tutorials/reports/tutorial.md
@@ -86,12 +86,20 @@ The reports application is included with the Galaxy codebase and this tutorial a
 >    ```diff
 >    --- a/group_vars/galaxyservers.yml
 >    +++ b/group_vars/galaxyservers.yml
->    @@ -125,6 +125,8 @@ galaxy_config_templates:
+>    @@ -46,6 +46,7 @@ galaxy_root: /srv/galaxy
+>     galaxy_user: {name: galaxy, shell: /bin/bash}
+>     galaxy_commit_id: release_20.09
+>     galaxy_force_checkout: true
+>    +galaxy_reports_path: "{{ galaxy_config_dir }}/reports.yml"
+>     miniconda_prefix: "{{ galaxy_tool_dependency_dir }}/_conda"
+>     miniconda_version: 4.7.12
+>     miniconda_manage_dependencies: false
+>    @@ -125,6 +126,8 @@ galaxy_config_templates:
 >         dest: "{{ galaxy_config.galaxy.job_config_file }}"
 >       - src: templates/galaxy/config/container_resolvers_conf.xml.j2
 >         dest: "{{ galaxy_config.galaxy.containers_resolvers_config_file }}"
 >    +  - src: templates/galaxy/config/reports.yml
->    +    dest: "{{ galaxy_config_dir }}/reports.yml"
+>    +    dest: "{{ galaxy_reports_path }}"
 >
 >     galaxy_config_files:
 >     - src: files/galaxy/config/tool_destinations.yml
@@ -106,7 +114,7 @@ The reports application is included with the Galaxy codebase and this tutorial a
 >    ```diff
 >    --- a/group_vars/galaxyservers.yml
 >    +++ b/group_vars/galaxyservers.yml
->    @@ -143,6 +143,7 @@ galaxy_dynamic_job_rules:
+>    @@ -144,6 +144,7 @@ galaxy_dynamic_job_rules:
 >
 >     # systemd
 >     galaxy_manage_systemd: yes

--- a/topics/contributing/tutorials/admin-knitting/tutorial.md
+++ b/topics/contributing/tutorials/admin-knitting/tutorial.md
@@ -464,7 +464,7 @@ Subject: admin/gxadmin/0000: Add requirement
  - src: galaxyproject.pulsar
    version: 1.0.6
 +- src: usegalaxy_eu.gxadmin
-+  version: 0.0.3
++  version: 0.0.8
 --
 2.25.1
 ```


### PR DESCRIPTION
- updates gxadmin to a version which didn't have an ansible metadata issue
- fixes the bad check for fork vs branch in git-gat
- supplies the `-C` flag to check less context in the building of git-gat diffs to make it less picky about context when building from commits. 
- add `galaxy_reports_path` 