### PR TITLE
Make slides 16:9

### DIFF
--- a/_layouts/base_slides.html
+++ b/_layouts/base_slides.html
@@ -145,7 +145,7 @@ This material is licensed under the <a rel="license" href="https://creativecommo
     <script type="text/javascript" src="{{ "/assets/js/theme.js" | prepend: site.baseurl }}"></script>
     <script type="text/javascript" src="{{ "/assets/js/clipboard.min.js" | prepend: site.baseurl }}"></script>
     <script type="text/javascript">
-      var slideshow = remark.create({navigation: {scroll: false,}});
+      var slideshow = remark.create({navigation: {scroll: false}, ratio: '16:9'});
       var hljs = remark.highlighter.engine;
       var snippets = document.querySelectorAll('code.remark-code');
         [].forEach.call(snippets,function(snippet){


### PR DESCRIPTION
Most common slide formats default to 16:9 since a while, this enables the more modern aspect ratio for us as well.

(probably merge after gcc to not surprise anyone?)

Before | After
-- | --
![image](https://user-images.githubusercontent.com/458683/123126265-87254580-d449-11eb-99b2-aee1532e7eb7.png) | ![image](https://user-images.githubusercontent.com/458683/123126284-8c829000-d449-11eb-9eb2-1b8c09c779d0.png)
