### PR TITLE
colour blind friendly diff colouring

### DIFF
--- a/assets/css/syntax_highlighting.css
+++ b/assets/css/syntax_highlighting.css
@@ -6,12 +6,12 @@
 .highlight .cp { color: #999999; font-weight: bold } /* Comment.Preproc */
 .highlight .c1 { color: #999988; font-style: italic } /* Comment.Single */
 .highlight .cs { color: #999999; font-weight: bold; font-style: italic } /* Comment.Special */
-.highlight .gd { color: #000000; background-color: #ffdddd } /* Generic.Deleted */
+.highlight .gd { color: #000000; background-color: #000; color: white; text-decoration: line-through; } /* Generic.Deleted */
 .highlight .gd .x { color: #000000; background-color: #ffaaaa } /* Generic.Deleted.Specific */
 .highlight .ge { font-style: italic } /* Generic.Emph */
 .highlight .gr { color: #aa0000 } /* Generic.Error */
 .highlight .gh { color: #999999 } /* Generic.Heading */
-.highlight .gi { color: #000000; background-color: #ddffdd } /* Generic.Inserted */
+.highlight .gi { color: #000000; background-color: #a7a7ff } /* Generic.Inserted */
 .highlight .gi .x { color: #000000; background-color: #aaffaa } /* Generic.Inserted.Specific */
 .highlight .go { color: #888888 } /* Generic.Output */
 .highlight .gp { color: #555555 } /* Generic.Prompt */


### PR DESCRIPTION
@natefoo  https://github.com/galaxyproject/training-material/issues/2583#issuecomment-871492929 This is more or less the styling I use in my terminal (as a red-green impaired human) and it works quite well, and should be black-white colourblind friendly

```
[color "diff"]
	meta = bold
	frag = magenta bold
	old = strike reverse
	new = blue dim reverse
```

![screenshot of diff with removed lines having a black background and strikethrough, and added changes highlighted with blue background.](https://user-images.githubusercontent.com/458683/124148308-d2fe6d00-da8f-11eb-8481-6148f4aa4efc.png)
