### PR TITLE
Fix typos in architecture slides

### DIFF
--- a/topics/dev/tutorials/architecture/slides.html
+++ b/topics/dev/tutorials/architecture/slides.html
@@ -756,9 +756,9 @@ template: left-aligned
 
 ### ASGI - Application
 
-Spirtual successor to
+Spiritual successor to
 [WSGI](https://www.python.org/dev/peps/pep-0333/). An ASGI application
-is a async callable that takes in a `scope` (`dict` describing the
+is an async callable that takes in a `scope` (`dict` describing the
 connection), `send` (an async callable to respond to events via),
 and `receive` (an async callable to receive messages).
 
@@ -777,8 +777,8 @@ template: left-aligned
 
 ### ASGI & Starlette Low-level Example
 
-We will talk about a lot about Galaxy and FastAPI - but much of its
-plubming is just aliases for starlette ASGI handling.
+We will talk a lot about Galaxy and FastAPI - but much of its
+plumbing is just aliases for starlette ASGI handling.
 
 ```python
 from starlette.responses import PlainTextResponse
@@ -907,7 +907,7 @@ def build_middleware_stack(self) -> ASGIApp:
     return app
 ```
 
-Start with the router and surrond it with each layer of configured middleware.
+Start with the router and surround it with each layer of configured middleware.
 
 ---
 
@@ -1013,7 +1013,7 @@ https://www.starlette.io/routing/
 class: enlarge200
 
 In order to understand how the routing classes are setup within Galaxy,
-lets step back and and look really quickly at how Galaxy's FastAPI
+lets step back and look really quickly at how Galaxy's FastAPI
 application (ASGI endpoint) is constructed.
 
 ---
@@ -1139,7 +1139,7 @@ wsgi_handler = WSGIMiddleware(gx_webapp)
 app.mount('/', wsgi_handler)
 ```
 
-This effectively provies a fallback to our legacy WSGI application.
+This effectively provides a fallback to our legacy WSGI application.
 
 ---
 
@@ -1603,8 +1603,8 @@ class DatasetCollectionManager:
 ```]
 
 - We're no longer depending on `app`.
-- The type signature very clearly delinates what dependencies are required.
-- Unit testing can inject percise dependencies supplying only the behavior needed.
+- The type signature very clearly delineates what dependencies are required.
+- Unit testing can inject precise dependencies supplying only the behavior needed.
 
 ---
 
@@ -1631,7 +1631,7 @@ class: enlarge150
 
 ### What is Type-based Dependency Injection?
 
-A dependency injection **container** keeps tracks of singleons or recipes for how to construct each type. By
+A dependency injection **container** keeps tracks of singletons or recipes for how to construct each type. By
 default when it goes to construct an object, it can just ask the container for each dependency based on the
 type signature of the class being constructed.
 
@@ -1811,7 +1811,7 @@ def set_metadata(hda_manager: HDAManager, ldda_manager: LDDAManager, dataset_id,
 
 ### Tips for Designing New Galaxy Backend Components
 
-- Consume only the related components you need to - avoid `app` when possible.
+- Consume only the related components you need to avoid `app` when possible.
 - Annotate inputs to the component with Python types.
 - Use interface types to shield consumers from implementation details.
 - Rely on Galaxy's dependency injection to construct the component and provide it to consumers.
@@ -1828,7 +1828,7 @@ def set_metadata(hda_manager: HDAManager, ldda_manager: LDDAManager, dataset_id,
 
 ---
 
-The are many of ways to describe and visualize the Galaxy server architecture,
+There are many ways to describe and visualize the Galaxy server architecture,
 one is to imagine the Galaxy database as the ultimate source for Galaxy "stuff"
 and the API controllers as the ultimate sink.
 
@@ -1869,7 +1869,7 @@ in a manager instead of in the model.
 ### Galaxy Models
 
 - Database interactions powered by SQLAlchemy - https://www.sqlalchemy.org/.
-- Galaxy doesn't think in terms "rows" but "objects".
+- Galaxy doesn't think in terms of "rows" but "objects".
 - Classes for Galaxy model objects in `lib/galaxy/model/__init__.py`.
 - Classes mapped to tables in `lib/galaxy/model/mapping.py`
   - Describes table definitions and relationships.
@@ -3115,5 +3115,3 @@ class: enlarge150
 We do build on many of the same standards, concepts, and libraries - the entire stack isn't custom code but there is a non-trivial web framework defined in "Galaxy".
 
 The Galaxy community likes Django and uses it to build newer webapps, Galaxy simply predates it and has evolved its own framework.
-
----


### PR DESCRIPTION
Just fixing a few typos found while looking at the slides
Nice slides!