### PR TITLE
Fix offset due to wrongly detected end of slide

### DIFF
--- a/topics/contributing/tutorials/create-new-tutorial-slides/slides.html
+++ b/topics/contributing/tutorials/create-new-tutorial-slides/slides.html
@@ -392,15 +392,20 @@ Allows you to:
 
 ### Presenter Notes: Formatting
 
-```
-### My Slide
-
-???
+.left[
+<br/>
+&#35;&#35;&#35; My Slide
+<br/><br/>
+Some text!
+<br/><br/>
+&#63;&#63;&#63;
+<br/><br/>
 Things written below the ??? are only shown in the
 presenter view. Press `p` to bring this up
-
----
-```
+<br/><br/>
+&#45;&#45;&#45;
+<br/><br/>
+]
 
 ???
 


### PR DESCRIPTION
This replaces the contents of one contributing slide with some html character codes which won't be accidentally detected as the slide-splitting/presenter notes.

This caused the video to be recorded with slightly out of sync images/audio at the end.

This seems like an acceptable solution, it's unlikely any other slide deck will need to do this, no one else is going to be using `???` or `---` intentionally on their slide, on it's own line (maybe within a line, but, that's not an issue.)