### PR TITLE
Update maker workflow

### DIFF
--- a/topics/genome-annotation/tutorials/annotation-with-maker/workflows/main_workflow.ga
+++ b/topics/genome-annotation/tutorials/annotation-with-maker/workflows/main_workflow.ga
@@ -1,18 +1,30 @@
 {
     "a_galaxy_workflow": "true",
     "annotation": "Genome annotation with Maker",
+    "creator": [
+        {
+            "class": "Person",
+            "identifier": "0000-0003-0914-2470",
+            "name": "Anthony Bretaudeau"
+        },
+        {
+            "class": "Organization",
+            "name": "French National Institute for Agriculture, Food, and Environment (INRAE)"
+        }
+    ],
     "format-version": "0.1",
-    "name": "Genome annotation with Maker",
+    "license": "GPL-3.0-or-later",
+    "name": "Genome annotation with Maker (imported from uploaded file)",
     "steps": {
         "0": {
-            "annotation": "",
+            "annotation": "It contains the sequences used by Maker to construct gene models.",
             "content_id": null,
             "errors": null,
             "id": 0,
             "input_connections": {},
             "inputs": [
                 {
-                    "description": "",
+                    "description": "It contains the sequences used by Maker to construct gene models.",
                     "name": "EST and/or cDNA"
                 }
             ],
@@ -20,37 +32,63 @@
             "name": "Input dataset",
             "outputs": [],
             "position": {
-                "bottom": 139.6999969482422,
-                "height": 82.19999694824219,
-                "left": -365.51666259765625,
-                "right": -165.51666259765625,
-                "top": 57.5,
+                "bottom": -333.625,
+                "height": 81,
+                "left": -231.53125,
+                "right": -31.53125,
+                "top": -414.625,
                 "width": 200,
-                "x": -365.51666259765625,
-                "y": 57.5
+                "x": -231.53125,
+                "y": -414.625
             },
             "tool_id": null,
             "tool_state": "{\"optional\": false}",
             "tool_version": null,
             "type": "data_input",
             "uuid": "6b3edbe9-085d-46ae-9ae3-96e876c003e0",
-            "workflow_outputs": [
-                {
-                    "label": null,
-                    "output_name": "output",
-                    "uuid": "888ad27d-81e1-489b-b2a8-49fd284a5704"
-                }
-            ]
+            "workflow_outputs": []
         },
         "1": {
-            "annotation": "",
+            "annotation": "A set of protein sequences, usually from closely related species or from a curated sequence database like UniProt/SwissProt.",
             "content_id": null,
             "errors": null,
             "id": 1,
             "input_connections": {},
             "inputs": [
                 {
-                    "description": "",
+                    "description": "A set of protein sequences, usually from closely related species or from a curated sequence database like UniProt/SwissProt.",
+                    "name": "Protein sequences"
+                }
+            ],
+            "label": "Protein sequences",
+            "name": "Input dataset",
+            "outputs": [],
+            "position": {
+                "bottom": -345.5,
+                "height": 81,
+                "left": -509.5,
+                "right": -309.5,
+                "top": -426.5,
+                "width": 200,
+                "x": -509.5,
+                "y": -426.5
+            },
+            "tool_id": null,
+            "tool_state": "{\"optional\": false}",
+            "tool_version": null,
+            "type": "data_input",
+            "uuid": "ea808021-e3fa-42a5-b2aa-62c21a4ae355",
+            "workflow_outputs": []
+        },
+        "2": {
+            "annotation": "This file corresponds to the sequence to be annotated.",
+            "content_id": null,
+            "errors": null,
+            "id": 2,
+            "input_connections": {},
+            "inputs": [
+                {
+                    "description": "This file corresponds to the sequence to be annotated.",
                     "name": "Genome sequence"
                 }
             ],
@@ -58,199 +96,33 @@
             "name": "Input dataset",
             "outputs": [],
             "position": {
-                "bottom": 28.616668701171875,
-                "height": 82.19999694824219,
-                "left": -366.5,
-                "right": -166.5,
-                "top": -53.58332824707031,
+                "bottom": 1175.53125,
+                "height": 81,
+                "left": -231.53125,
+                "right": -31.53125,
+                "top": 1094.53125,
                 "width": 200,
-                "x": -366.5,
-                "y": -53.58332824707031
+                "x": -231.53125,
+                "y": 1094.53125
             },
             "tool_id": null,
             "tool_state": "{\"optional\": false}",
             "tool_version": null,
             "type": "data_input",
             "uuid": "a361a75e-5fa4-44ca-a4b7-cc9054a73054",
-            "workflow_outputs": [
-                {
-                    "label": null,
-                    "output_name": "output",
-                    "uuid": "5b61d75f-9865-4f98-baeb-12a7bf3ffa93"
-                }
-            ]
-        },
-        "2": {
-            "annotation": "",
-            "content_id": null,
-            "errors": null,
-            "id": 2,
-            "input_connections": {},
-            "inputs": [
-                {
-                    "description": "",
-                    "name": "Proteins"
-                }
-            ],
-            "label": "Proteins",
-            "name": "Input dataset",
-            "outputs": [],
-            "position": {
-                "bottom": 211.3000030517578,
-                "height": 61.80000305175781,
-                "left": -366.5,
-                "right": -166.5,
-                "top": 149.5,
-                "width": 200,
-                "x": -366.5,
-                "y": 149.5
-            },
-            "tool_id": null,
-            "tool_state": "{\"optional\": false}",
-            "tool_version": null,
-            "type": "data_input",
-            "uuid": "ce4ee756-1713-4e6a-898c-b85a834712bc",
-            "workflow_outputs": [
-                {
-                    "label": null,
-                    "output_name": "output",
-                    "uuid": "58be504e-a183-4e45-a1a1-831b4bbab159"
-                }
-            ]
+            "workflow_outputs": []
         },
         "3": {
             "annotation": "",
-            "content_id": "toolshed.g2.bx.psu.edu/repos/simon-gladman/fasta_stats/fasta-stats/1.0.0",
+            "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/maker/maker/2.31.11",
             "errors": null,
             "id": 3,
-            "input_connections": {
-                "dataset": {
-                    "id": 1,
-                    "output_name": "output"
-                }
-            },
-            "inputs": [],
-            "label": null,
-            "name": "Fasta Statistics",
-            "outputs": [
-                {
-                    "name": "stats",
-                    "type": "tabular"
-                }
-            ],
-            "position": {
-                "bottom": 927.8166809082031,
-                "height": 154.39999389648438,
-                "left": -84.78334045410156,
-                "right": 115.21665954589844,
-                "top": 773.4166870117188,
-                "width": 200,
-                "x": -84.78334045410156,
-                "y": 773.4166870117188
-            },
-            "post_job_actions": {},
-            "tool_id": "toolshed.g2.bx.psu.edu/repos/simon-gladman/fasta_stats/fasta-stats/1.0.0",
-            "tool_shed_repository": {
-                "changeset_revision": "20ca2574216a",
-                "name": "fasta_stats",
-                "owner": "simon-gladman",
-                "tool_shed": "toolshed.g2.bx.psu.edu"
-            },
-            "tool_state": "{\"dataset\": {\"__class__\": \"ConnectedValue\"}, \"__page__\": null, \"__rerun_remap_job_id__\": null}",
-            "tool_version": "1.0.0",
-            "type": "tool",
-            "uuid": "43cab601-f700-4278-bd0a-7f0997cf75cf",
-            "workflow_outputs": [
-                {
-                    "label": null,
-                    "output_name": "stats",
-                    "uuid": "fdaf7634-9c35-4070-90c8-d10193271a0a"
-                }
-            ]
-        },
-        "4": {
-            "annotation": "",
-            "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/busco/busco/3.0.2+galaxy1",
-            "errors": null,
-            "id": 4,
-            "input_connections": {
-                "input": {
-                    "id": 1,
-                    "output_name": "output"
-                }
-            },
-            "inputs": [],
-            "label": null,
-            "name": "Busco",
-            "outputs": [
-                {
-                    "name": "busco_sum",
-                    "type": "txt"
-                },
-                {
-                    "name": "busco_table",
-                    "type": "tabular"
-                },
-                {
-                    "name": "busco_missing",
-                    "type": "tabular"
-                }
-            ],
-            "position": {
-                "bottom": 1250.1666870117188,
-                "height": 276.4000244140625,
-                "left": -97.73333740234375,
-                "right": 102.26666259765625,
-                "top": 973.7666625976562,
-                "width": 200,
-                "x": -97.73333740234375,
-                "y": 973.7666625976562
-            },
-            "post_job_actions": {},
-            "tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/busco/busco/3.0.2+galaxy1",
-            "tool_shed_repository": {
-                "changeset_revision": "602fb8e63aa7",
-                "name": "busco",
-                "owner": "iuc",
-                "tool_shed": "toolshed.g2.bx.psu.edu"
-            },
-            "tool_state": "{\"adv\": {\"evalue\": \"0.01\", \"limit\": \"3\", \"aug_prediction\": {\"augustus_mode\": \"no\", \"__current_case__\": 0}, \"long\": \"false\"}, \"input\": {\"__class__\": \"ConnectedValue\"}, \"lineage_dataset\": \"fungi_odb10\", \"mode\": \"geno\", \"__page__\": null, \"__rerun_remap_job_id__\": null}",
-            "tool_version": "4.1.4",
-            "type": "tool",
-            "uuid": "c5d2c504-fe46-4197-87ed-f8fdf4f5fe8b",
-            "workflow_outputs": [
-                {
-                    "label": null,
-                    "output_name": "busco_sum",
-                    "uuid": "fd2ac15c-15ae-48f6-b76f-15e4a263f796"
-                },
-                {
-                    "label": null,
-                    "output_name": "busco_missing",
-                    "uuid": "854f9162-4031-4010-a558-31f9f1082c41"
-                },
-                {
-                    "label": null,
-                    "output_name": "busco_table",
-                    "uuid": "140329c1-336b-423e-a3e5-7ef55c9036de"
-                }
-            ]
-        },
-        "5": {
-            "annotation": "",
-            "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/maker/maker/2.31.10",
-            "errors": null,
-            "id": 5,
             "input_connections": {
                 "est_evidences|est": {
                     "id": 0,
                     "output_name": "output"
                 },
                 "genome": {
-                    "id": 1,
-                    "output_name": "output"
-                },
-                "protein_evidences|protein": {
                     "id": 2,
                     "output_name": "output"
                 }
@@ -310,14 +182,14 @@
                 }
             ],
             "position": {
-                "bottom": 755.2499694824219,
-                "height": 753.5999755859375,
-                "left": -91.64999389648438,
-                "right": 108.35000610351562,
-                "top": 1.649993896484375,
+                "bottom": 355.5,
+                "height": 782,
+                "left": 46.484375,
+                "right": 246.484375,
+                "top": -426.5,
                 "width": 200,
-                "x": -91.64999389648438,
-                "y": 1.649993896484375
+                "x": 46.484375,
+                "y": -426.5
             },
             "post_job_actions": {
                 "HideDatasetActionoutput_evidences": {
@@ -336,31 +208,325 @@
                     "output_name": "output_gff"
                 }
             },
-            "tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/maker/maker/2.31.10",
+            "tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/maker/maker/2.31.11",
             "tool_shed_repository": {
-                "changeset_revision": "5201ec38c01f",
+                "changeset_revision": "d46d803ca6cc",
                 "name": "maker",
                 "owner": "iuc",
                 "tool_shed": "toolshed.g2.bx.psu.edu"
             },
-            "tool_state": "{\"abinitio_gene_prediction\": {\"snaphmm\": {\"__class__\": \"RuntimeValue\"}, \"aug_prediction\": {\"augustus_mode\": \"no\", \"__current_case__\": 0}, \"unmask\": \"false\"}, \"advanced\": {\"other_gff\": {\"__class__\": \"RuntimeValue\"}, \"alt_peptide\": \"C\", \"max_dna_len\": \"100000\", \"min_contig\": \"1\", \"pred_flank\": \"200\", \"pred_stats\": \"false\", \"AED_threshold\": \"1.0\", \"min_protein\": \"0\", \"alt_splice\": \"false\", \"always_complete\": \"false\", \"map_forward\": \"false\", \"keep_preds\": \"0.0\", \"split_hit\": \"10000\", \"correct_est_fusion\": \"false\", \"single_exon\": {\"single_exon\": \"0\", \"__current_case__\": 0}}, \"est_evidences\": {\"est2genome\": \"true\", \"est\": {\"__class__\": \"ConnectedValue\"}, \"altest\": {\"__class__\": \"RuntimeValue\"}, \"est_gff\": {\"__class__\": \"RuntimeValue\"}, \"altest_gff\": {\"__class__\": \"RuntimeValue\"}}, \"gene_prediction\": {\"pred_gff\": {\"__class__\": \"RuntimeValue\"}, \"model_gff\": {\"__class__\": \"RuntimeValue\"}, \"trna\": \"false\", \"snoscan_rrna\": {\"__class__\": \"RuntimeValue\"}}, \"genome\": {\"__class__\": \"ConnectedValue\"}, \"organism_type\": \"eukaryotic\", \"protein_evidences\": {\"protein2genome\": \"true\", \"protein\": {\"__class__\": \"ConnectedValue\"}, \"protein_gff\": {\"__class__\": \"RuntimeValue\"}}, \"reannotation\": {\"reannotate\": \"no\", \"__current_case__\": 0}, \"repeat_masking\": {\"repeat_source\": {\"source_type\": \"no\", \"__current_case__\": 3}}, \"__page__\": null, \"__rerun_remap_job_id__\": null}",
+            "tool_state": "{\"__job_resource\": {\"__job_resource__select\": \"no\", \"__current_case__\": 0}, \"abinitio_gene_prediction\": {\"snaphmm\": {\"__class__\": \"RuntimeValue\"}, \"aug_prediction\": {\"augustus_mode\": \"no\", \"__current_case__\": 0}, \"unmask\": \"false\"}, \"advanced\": {\"other_gff\": {\"__class__\": \"RuntimeValue\"}, \"alt_peptide\": \"C\", \"max_dna_len\": \"100000\", \"min_contig\": \"1\", \"pred_flank\": \"200\", \"pred_stats\": \"false\", \"AED_threshold\": \"1.0\", \"min_protein\": \"0\", \"alt_splice\": \"false\", \"always_complete\": \"false\", \"map_forward\": \"false\", \"keep_preds\": \"0.0\", \"split_hit\": \"10000\", \"correct_est_fusion\": \"false\", \"single_exon\": {\"single_exon\": \"0\", \"__current_case__\": 0}}, \"est_evidences\": {\"est2genome\": \"true\", \"est\": {\"__class__\": \"ConnectedValue\"}, \"altest\": {\"__class__\": \"RuntimeValue\"}, \"est_gff\": {\"__class__\": \"RuntimeValue\"}, \"altest_gff\": {\"__class__\": \"RuntimeValue\"}}, \"gene_prediction\": {\"pred_gff\": {\"__class__\": \"RuntimeValue\"}, \"model_gff\": {\"__class__\": \"RuntimeValue\"}, \"trna\": \"false\", \"snoscan_rrna\": {\"__class__\": \"RuntimeValue\"}}, \"genome\": {\"__class__\": \"ConnectedValue\"}, \"organism_type\": \"eukaryotic\", \"protein_evidences\": {\"protein2genome\": \"true\", \"protein\": {\"__class__\": \"ConnectedValue\"}, \"protein_gff\": {\"__class__\": \"RuntimeValue\"}}, \"reannotation\": {\"reannotate\": \"no\", \"__current_case__\": 0}, \"repeat_masking\": {\"repeat_source\": {\"source_type\": \"no\", \"__current_case__\": 3}}, \"__page__\": null, \"__rerun_remap_job_id__\": null}",
             "tool_version": "2.31.11",
             "type": "tool",
             "uuid": "1d5a299d-6637-40c6-bc7a-397f58e5d38f",
             "workflow_outputs": []
         },
+        "4": {
+            "annotation": "",
+            "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/fasta_stats/fasta-stats/1.0.1",
+            "errors": null,
+            "id": 4,
+            "input_connections": {
+                "dataset": {
+                    "id": 2,
+                    "output_name": "output"
+                }
+            },
+            "inputs": [],
+            "label": null,
+            "name": "Fasta Statistics",
+            "outputs": [
+                {
+                    "name": "stats",
+                    "type": "tabular"
+                }
+            ],
+            "position": {
+                "bottom": 884.9375,
+                "height": 132,
+                "left": -170.078125,
+                "right": 29.921875,
+                "top": 752.9375,
+                "width": 200,
+                "x": -170.078125,
+                "y": 752.9375
+            },
+            "post_job_actions": {},
+            "tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/fasta_stats/fasta-stats/1.0.1",
+            "tool_shed_repository": {
+                "changeset_revision": "9c620a950d3a",
+                "name": "fasta_stats",
+                "owner": "iuc",
+                "tool_shed": "toolshed.g2.bx.psu.edu"
+            },
+            "tool_state": "{\"dataset\": {\"__class__\": \"ConnectedValue\"}, \"__page__\": null, \"__rerun_remap_job_id__\": null}",
+            "tool_version": "1.0.1",
+            "type": "tool",
+            "uuid": "b4675f66-d234-494e-8e45-7e3942c54ac2",
+            "workflow_outputs": [
+                {
+                    "label": "Fasta Statistics on input dataset(s): Fasta summary stats",
+                    "output_name": "stats",
+                    "uuid": "a1f8912a-7a55-4c14-ab43-1bb54b563a94"
+                }
+            ]
+        },
+        "5": {
+            "annotation": "",
+            "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/busco/busco/4.1.4",
+            "errors": null,
+            "id": 5,
+            "input_connections": {
+                "input": {
+                    "id": 2,
+                    "output_name": "output"
+                }
+            },
+            "inputs": [],
+            "label": null,
+            "name": "Busco",
+            "outputs": [
+                {
+                    "name": "busco_sum",
+                    "type": "txt"
+                },
+                {
+                    "name": "busco_table",
+                    "type": "tabular"
+                },
+                {
+                    "name": "busco_missing",
+                    "type": "tabular"
+                }
+            ],
+            "position": {
+                "bottom": 1367.515625,
+                "height": 212,
+                "left": 46.484375,
+                "right": 246.484375,
+                "top": 1155.515625,
+                "width": 200,
+                "x": 46.484375,
+                "y": 1155.515625
+            },
+            "post_job_actions": {},
+            "tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/busco/busco/4.1.4",
+            "tool_shed_repository": {
+                "changeset_revision": "602fb8e63aa7",
+                "name": "busco",
+                "owner": "iuc",
+                "tool_shed": "toolshed.g2.bx.psu.edu"
+            },
+            "tool_state": "{\"__job_resource\": {\"__job_resource__select\": \"no\", \"__current_case__\": 0}, \"adv\": {\"evalue\": \"0.01\", \"limit\": \"3\", \"aug_prediction\": {\"augustus_mode\": \"no\", \"__current_case__\": 0}, \"long\": \"false\"}, \"input\": {\"__class__\": \"ConnectedValue\"}, \"lineage_dataset\": \"fungi_odb10\", \"mode\": \"geno\", \"__page__\": null, \"__rerun_remap_job_id__\": null}",
+            "tool_version": "4.1.4",
+            "type": "tool",
+            "uuid": "e357b03d-3e3b-4a20-90a8-cf98906a272c",
+            "workflow_outputs": [
+                {
+                    "label": "BUSCO: short summary",
+                    "output_name": "busco_sum",
+                    "uuid": "d2651d2b-15f2-43a0-b405-bdd6662d2834"
+                },
+                {
+                    "label": "BUSCO: list of missing ortholog genes",
+                    "output_name": "busco_missing",
+                    "uuid": "db81bc3d-28af-4689-9e93-ffccab07f204"
+                },
+                {
+                    "label": "BUSCO: full table",
+                    "output_name": "busco_table",
+                    "uuid": "4c8654d2-b093-40c7-a456-40da2e10d3a2"
+                }
+            ]
+        },
         "6": {
             "annotation": "",
-            "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/snap_training/snap_training/2013_11_29+galaxy1",
+            "content_id": "toolshed.g2.bx.psu.edu/repos/bgruening/augustus_training/augustus_training/3.3.3",
             "errors": null,
             "id": 6,
             "input_connections": {
                 "genome": {
-                    "id": 1,
+                    "id": 2,
                     "output_name": "output"
                 },
                 "maker_gff": {
-                    "id": 5,
+                    "id": 3,
+                    "output_name": "output_gff"
+                }
+            },
+            "inputs": [],
+            "label": null,
+            "name": "Train Augustus",
+            "outputs": [
+                {
+                    "name": "output_tar",
+                    "type": "augustus"
+                }
+            ],
+            "position": {
+                "bottom": 295.53125,
+                "height": 202,
+                "left": 354.5,
+                "right": 554.5,
+                "top": 93.53125,
+                "width": 200,
+                "x": 354.5,
+                "y": 93.53125
+            },
+            "post_job_actions": {
+                "HideDatasetActionoutput_tar": {
+                    "action_arguments": {},
+                    "action_type": "HideDatasetAction",
+                    "output_name": "output_tar"
+                }
+            },
+            "tool_id": "toolshed.g2.bx.psu.edu/repos/bgruening/augustus_training/augustus_training/3.3.3",
+            "tool_shed_repository": {
+                "changeset_revision": "6519ebe25019",
+                "name": "augustus_training",
+                "owner": "bgruening",
+                "tool_shed": "toolshed.g2.bx.psu.edu"
+            },
+            "tool_state": "{\"genome\": {\"__class__\": \"ConnectedValue\"}, \"maker_gff\": {\"__class__\": \"ConnectedValue\"}, \"__page__\": null, \"__rerun_remap_job_id__\": null}",
+            "tool_version": "3.3.3",
+            "type": "tool",
+            "uuid": "82c3a67d-d127-444c-9f9d-dfeb0a4637c5",
+            "workflow_outputs": []
+        },
+        "7": {
+            "annotation": "",
+            "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/jcvi_gff_stats/jcvi_gff_stats/0.8.4",
+            "errors": null,
+            "id": 7,
+            "input_connections": {
+                "gff": {
+                    "id": 3,
+                    "output_name": "output_gff"
+                },
+                "ref_genome|genome": {
+                    "id": 2,
+                    "output_name": "output"
+                }
+            },
+            "inputs": [],
+            "label": null,
+            "name": "Genome annotation statistics",
+            "outputs": [
+                {
+                    "name": "summary",
+                    "type": "txt"
+                },
+                {
+                    "name": "graphs",
+                    "type": "pdf"
+                }
+            ],
+            "position": {
+                "bottom": 625.515625,
+                "height": 272,
+                "left": 354.5,
+                "right": 554.5,
+                "top": 353.515625,
+                "width": 200,
+                "x": 354.5,
+                "y": 353.515625
+            },
+            "post_job_actions": {},
+            "tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/jcvi_gff_stats/jcvi_gff_stats/0.8.4",
+            "tool_shed_repository": {
+                "changeset_revision": "8cffbd184762",
+                "name": "jcvi_gff_stats",
+                "owner": "iuc",
+                "tool_shed": "toolshed.g2.bx.psu.edu"
+            },
+            "tool_state": "{\"gff\": {\"__class__\": \"ConnectedValue\"}, \"ref_genome\": {\"genome_type_select\": \"history\", \"__current_case__\": 1, \"genome\": {\"__class__\": \"ConnectedValue\"}}, \"__page__\": null, \"__rerun_remap_job_id__\": null}",
+            "tool_version": "0.8.4",
+            "type": "tool",
+            "uuid": "a8d71bd5-480f-4d5d-8d6e-4cd9c637c3ec",
+            "workflow_outputs": [
+                {
+                    "label": "Genome annotation statistics: summary (first round)",
+                    "output_name": "summary",
+                    "uuid": "ff297f3c-7381-4fd5-b67f-1c91869b222b"
+                },
+                {
+                    "label": "Genome annotation statistics: graphs (first round)",
+                    "output_name": "graphs",
+                    "uuid": "cd31e100-b8fe-457e-be62-c089c5cd7592"
+                }
+            ]
+        },
+        "8": {
+            "annotation": "",
+            "content_id": "toolshed.g2.bx.psu.edu/repos/devteam/gffread/gffread/2.2.1.2",
+            "errors": null,
+            "id": 8,
+            "input_connections": {
+                "input": {
+                    "id": 3,
+                    "output_name": "output_gff"
+                },
+                "reference_genome|genome_fasta": {
+                    "id": 2,
+                    "output_name": "output"
+                }
+            },
+            "inputs": [
+                {
+                    "description": "runtime parameter for tool gffread",
+                    "name": "chr_replace"
+                }
+            ],
+            "label": null,
+            "name": "gffread",
+            "outputs": [
+                {
+                    "name": "output_exons",
+                    "type": "fasta"
+                }
+            ],
+            "position": {
+                "bottom": 896.53125,
+                "height": 232,
+                "left": 354.5,
+                "right": 554.5,
+                "top": 664.53125,
+                "width": 200,
+                "x": 354.5,
+                "y": 664.53125
+            },
+            "post_job_actions": {
+                "HideDatasetActionoutput_exons": {
+                    "action_arguments": {},
+                    "action_type": "HideDatasetAction",
+                    "output_name": "output_exons"
+                }
+            },
+            "tool_id": "toolshed.g2.bx.psu.edu/repos/devteam/gffread/gffread/2.2.1.2",
+            "tool_shed_repository": {
+                "changeset_revision": "69e0806b63a4",
+                "name": "gffread",
+                "owner": "devteam",
+                "tool_shed": "toolshed.g2.bx.psu.edu"
+            },
+            "tool_state": "{\"chr_replace\": {\"__class__\": \"RuntimeValue\"}, \"decode_url\": \"false\", \"expose\": \"false\", \"filtering\": null, \"full_gff_attribute_preservation\": \"false\", \"gffs\": {\"gff_fmt\": \"none\", \"__current_case__\": 0}, \"input\": {\"__class__\": \"ConnectedValue\"}, \"maxintron\": null, \"merging\": {\"merge_sel\": \"none\", \"__current_case__\": 0}, \"reference_genome\": {\"source\": \"history\", \"__current_case__\": 2, \"genome_fasta\": {\"__class__\": \"ConnectedValue\"}, \"ref_filtering\": null, \"fa_outputs\": [\"-w exons.fa\"]}, \"region\": {\"region_filter\": \"none\", \"__current_case__\": 0}, \"__page__\": null, \"__rerun_remap_job_id__\": null}",
+            "tool_version": "2.2.1.2",
+            "type": "tool",
+            "uuid": "73918785-0727-4cb4-a963-35837819616a",
+            "workflow_outputs": []
+        },
+        "9": {
+            "annotation": "",
+            "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/snap_training/snap_training/2013_11_29+galaxy1",
+            "errors": null,
+            "id": 9,
+            "input_connections": {
+                "genome": {
+                    "id": 2,
+                    "output_name": "output"
+                },
+                "maker_gff": {
+                    "id": 3,
                     "output_name": "output_gff"
                 }
             },
@@ -374,14 +540,14 @@
                 }
             ],
             "position": {
-                "bottom": 198.61666870117188,
-                "height": 184.8000030517578,
-                "left": 220.01666259765625,
-                "right": 420.01666259765625,
-                "top": 13.816665649414062,
+                "bottom": 1116.53125,
+                "height": 182,
+                "left": 354.5,
+                "right": 554.5,
+                "top": 934.53125,
                 "width": 200,
-                "x": 220.01666259765625,
-                "y": 13.816665649414062
+                "x": 354.5,
+                "y": 934.53125
             },
             "post_job_actions": {
                 "HideDatasetActionoutput": {
@@ -403,308 +569,11 @@
             "uuid": "6cf74e8a-5896-42a3-91aa-1be2f24bf1c3",
             "workflow_outputs": []
         },
-        "7": {
-            "annotation": "",
-            "content_id": "toolshed.g2.bx.psu.edu/repos/bgruening/augustus_training/augustus_training/3.2.3+galaxy1",
-            "errors": null,
-            "id": 7,
-            "input_connections": {
-                "genome": {
-                    "id": 1,
-                    "output_name": "output"
-                },
-                "maker_gff": {
-                    "id": 5,
-                    "output_name": "output_gff"
-                }
-            },
-            "inputs": [],
-            "label": null,
-            "name": "Train Augustus",
-            "outputs": [
-                {
-                    "name": "output_tar",
-                    "type": "augustus"
-                }
-            ],
-            "position": {
-                "bottom": 472.9499969482422,
-                "height": 205.1999969482422,
-                "left": 221.68333435058594,
-                "right": 421.68333435058594,
-                "top": 267.75,
-                "width": 200,
-                "x": 221.68333435058594,
-                "y": 267.75
-            },
-            "post_job_actions": {
-                "HideDatasetActionoutput_tar": {
-                    "action_arguments": {},
-                    "action_type": "HideDatasetAction",
-                    "output_name": "output_tar"
-                }
-            },
-            "tool_id": "toolshed.g2.bx.psu.edu/repos/bgruening/augustus_training/augustus_training/3.2.3+galaxy1",
-            "tool_shed_repository": {
-                "changeset_revision": "6519ebe25019",
-                "name": "augustus_training",
-                "owner": "bgruening",
-                "tool_shed": "toolshed.g2.bx.psu.edu"
-            },
-            "tool_state": "{\"genome\": {\"__class__\": \"ConnectedValue\"}, \"maker_gff\": {\"__class__\": \"ConnectedValue\"}, \"__page__\": null, \"__rerun_remap_job_id__\": null}",
-            "tool_version": "3.3.3",
-            "type": "tool",
-            "uuid": "82c3a67d-d127-444c-9f9d-dfeb0a4637c5",
-            "workflow_outputs": []
-        },
-        "8": {
-            "annotation": "",
-            "content_id": "toolshed.g2.bx.psu.edu/repos/devteam/gffread/gffread/2.2.1.1",
-            "errors": null,
-            "id": 8,
-            "input_connections": {
-                "input": {
-                    "id": 5,
-                    "output_name": "output_gff"
-                },
-                "reference_genome|genome_fasta": {
-                    "id": 1,
-                    "output_name": "output"
-                }
-            },
-            "inputs": [
-                {
-                    "description": "runtime parameter for tool gffread",
-                    "name": "chr_replace"
-                }
-            ],
-            "label": null,
-            "name": "gffread",
-            "outputs": [
-                {
-                    "name": "output_exons",
-                    "type": "fasta"
-                }
-            ],
-            "position": {
-                "bottom": 802.6999969482422,
-                "height": 215.1999969482422,
-                "left": 220.64999389648438,
-                "right": 420.6499938964844,
-                "top": 587.5,
-                "width": 200,
-                "x": 220.64999389648438,
-                "y": 587.5
-            },
-            "post_job_actions": {
-                "HideDatasetActionoutput_exons": {
-                    "action_arguments": {},
-                    "action_type": "HideDatasetAction",
-                    "output_name": "output_exons"
-                }
-            },
-            "tool_id": "toolshed.g2.bx.psu.edu/repos/devteam/gffread/gffread/2.2.1.1",
-            "tool_shed_repository": {
-                "changeset_revision": "0232f19d300f",
-                "name": "gffread",
-                "owner": "devteam",
-                "tool_shed": "toolshed.g2.bx.psu.edu"
-            },
-            "tool_state": "{\"chr_replace\": {\"__class__\": \"RuntimeValue\"}, \"decode_url\": \"false\", \"expose\": \"false\", \"filtering\": null, \"full_gff_attribute_preservation\": \"false\", \"gffs\": {\"gff_fmt\": \"none\", \"__current_case__\": 0}, \"input\": {\"__class__\": \"ConnectedValue\"}, \"maxintron\": \"\", \"merging\": {\"merge_sel\": \"none\", \"__current_case__\": 0}, \"reference_genome\": {\"source\": \"history\", \"__current_case__\": 2, \"genome_fasta\": {\"__class__\": \"ConnectedValue\"}, \"ref_filtering\": null, \"fa_outputs\": [\"-w exons.fa\"]}, \"region\": {\"region_filter\": \"none\", \"__current_case__\": 0}, \"__page__\": null, \"__rerun_remap_job_id__\": null}",
-            "tool_version": "2.2.1.1",
-            "type": "tool",
-            "uuid": "73918785-0727-4cb4-a963-35837819616a",
-            "workflow_outputs": []
-        },
-        "9": {
-            "annotation": "",
-            "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/jcvi_gff_stats/jcvi_gff_stats/0.8.4",
-            "errors": null,
-            "id": 9,
-            "input_connections": {
-                "gff": {
-                    "id": 5,
-                    "output_name": "output_gff"
-                },
-                "ref_genome|genome": {
-                    "id": 1,
-                    "output_name": "output"
-                }
-            },
-            "inputs": [],
-            "label": null,
-            "name": "Genome annotation statistics",
-            "outputs": [
-                {
-                    "name": "summary",
-                    "type": "txt"
-                },
-                {
-                    "name": "graphs",
-                    "type": "pdf"
-                }
-            ],
-            "position": {
-                "bottom": 1157.36669921875,
-                "height": 276.4000244140625,
-                "left": 225.01666259765625,
-                "right": 425.01666259765625,
-                "top": 880.9666748046875,
-                "width": 200,
-                "x": 225.01666259765625,
-                "y": 880.9666748046875
-            },
-            "post_job_actions": {},
-            "tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/jcvi_gff_stats/jcvi_gff_stats/0.8.4",
-            "tool_shed_repository": {
-                "changeset_revision": "8cffbd184762",
-                "name": "jcvi_gff_stats",
-                "owner": "iuc",
-                "tool_shed": "toolshed.g2.bx.psu.edu"
-            },
-            "tool_state": "{\"gff\": {\"__class__\": \"ConnectedValue\"}, \"ref_genome\": {\"genome_type_select\": \"history\", \"__current_case__\": 1, \"genome\": {\"__class__\": \"ConnectedValue\"}}, \"__page__\": null, \"__rerun_remap_job_id__\": null}",
-            "tool_version": "0.8.4",
-            "type": "tool",
-            "uuid": "673e51c8-a909-481b-ae45-6dc98072a249",
-            "workflow_outputs": [
-                {
-                    "label": null,
-                    "output_name": "summary",
-                    "uuid": "bbddcc12-d9bc-4537-a9fb-717b90ff4eb0"
-                },
-                {
-                    "label": null,
-                    "output_name": "graphs",
-                    "uuid": "c4fcb428-ecc1-4818-b876-1420422bb361"
-                }
-            ]
-        },
         "10": {
             "annotation": "",
-            "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/maker/maker/2.31.10",
+            "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/busco/busco/4.1.4",
             "errors": null,
             "id": 10,
-            "input_connections": {
-                "abinitio_gene_prediction|aug_prediction|augustus_model": {
-                    "id": 7,
-                    "output_name": "output_tar"
-                },
-                "abinitio_gene_prediction|snaphmm": {
-                    "id": 6,
-                    "output_name": "output"
-                },
-                "genome": {
-                    "id": 1,
-                    "output_name": "output"
-                },
-                "reannotation|maker_gff": {
-                    "id": 5,
-                    "output_name": "output_full"
-                }
-            },
-            "inputs": [
-                {
-                    "description": "runtime parameter for tool Maker",
-                    "name": "advanced"
-                },
-                {
-                    "description": "runtime parameter for tool Maker",
-                    "name": "est_evidences"
-                },
-                {
-                    "description": "runtime parameter for tool Maker",
-                    "name": "est_evidences"
-                },
-                {
-                    "description": "runtime parameter for tool Maker",
-                    "name": "est_evidences"
-                },
-                {
-                    "description": "runtime parameter for tool Maker",
-                    "name": "est_evidences"
-                },
-                {
-                    "description": "runtime parameter for tool Maker",
-                    "name": "gene_prediction"
-                },
-                {
-                    "description": "runtime parameter for tool Maker",
-                    "name": "gene_prediction"
-                },
-                {
-                    "description": "runtime parameter for tool Maker",
-                    "name": "gene_prediction"
-                },
-                {
-                    "description": "runtime parameter for tool Maker",
-                    "name": "protein_evidences"
-                },
-                {
-                    "description": "runtime parameter for tool Maker",
-                    "name": "protein_evidences"
-                }
-            ],
-            "label": null,
-            "name": "Maker",
-            "outputs": [
-                {
-                    "name": "output_gff",
-                    "type": "gff3"
-                },
-                {
-                    "name": "output_evidences",
-                    "type": "gff3"
-                },
-                {
-                    "name": "output_full",
-                    "type": "gff3"
-                }
-            ],
-            "position": {
-                "bottom": 826.9500274658203,
-                "height": 814.4000244140625,
-                "left": 524.4833374023438,
-                "right": 724.4833374023438,
-                "top": 12.550003051757812,
-                "width": 200,
-                "x": 524.4833374023438,
-                "y": 12.550003051757812
-            },
-            "post_job_actions": {
-                "HideDatasetActionoutput_evidences": {
-                    "action_arguments": {},
-                    "action_type": "HideDatasetAction",
-                    "output_name": "output_evidences"
-                },
-                "HideDatasetActionoutput_full": {
-                    "action_arguments": {},
-                    "action_type": "HideDatasetAction",
-                    "output_name": "output_full"
-                },
-                "HideDatasetActionoutput_gff": {
-                    "action_arguments": {},
-                    "action_type": "HideDatasetAction",
-                    "output_name": "output_gff"
-                }
-            },
-            "tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/maker/maker/2.31.10",
-            "tool_shed_repository": {
-                "changeset_revision": "5201ec38c01f",
-                "name": "maker",
-                "owner": "iuc",
-                "tool_shed": "toolshed.g2.bx.psu.edu"
-            },
-            "tool_state": "{\"abinitio_gene_prediction\": {\"snaphmm\": {\"__class__\": \"ConnectedValue\"}, \"aug_prediction\": {\"augustus_mode\": \"history\", \"__current_case__\": 1, \"augustus_model\": {\"__class__\": \"ConnectedValue\"}}, \"unmask\": \"false\"}, \"advanced\": {\"other_gff\": {\"__class__\": \"RuntimeValue\"}, \"alt_peptide\": \"C\", \"max_dna_len\": \"100000\", \"min_contig\": \"1\", \"pred_flank\": \"200\", \"pred_stats\": \"false\", \"AED_threshold\": \"1.0\", \"min_protein\": \"0\", \"alt_splice\": \"false\", \"always_complete\": \"false\", \"map_forward\": \"false\", \"keep_preds\": \"0.0\", \"split_hit\": \"10000\", \"correct_est_fusion\": \"false\", \"single_exon\": {\"single_exon\": \"0\", \"__current_case__\": 0}}, \"est_evidences\": {\"est2genome\": \"false\", \"est\": {\"__class__\": \"RuntimeValue\"}, \"altest\": {\"__class__\": \"RuntimeValue\"}, \"est_gff\": {\"__class__\": \"RuntimeValue\"}, \"altest_gff\": {\"__class__\": \"RuntimeValue\"}}, \"gene_prediction\": {\"pred_gff\": {\"__class__\": \"RuntimeValue\"}, \"model_gff\": {\"__class__\": \"RuntimeValue\"}, \"trna\": \"false\", \"snoscan_rrna\": {\"__class__\": \"RuntimeValue\"}}, \"genome\": {\"__class__\": \"ConnectedValue\"}, \"organism_type\": \"eukaryotic\", \"protein_evidences\": {\"protein2genome\": \"false\", \"protein\": {\"__class__\": \"RuntimeValue\"}, \"protein_gff\": {\"__class__\": \"RuntimeValue\"}}, \"reannotation\": {\"reannotate\": \"yes\", \"__current_case__\": 1, \"maker_gff\": {\"__class__\": \"ConnectedValue\"}, \"est_pass\": \"true\", \"altest_pass\": \"true\", \"protein_pass\": \"true\", \"rm_pass\": \"true\", \"model_pass\": \"false\", \"pred_pass\": \"false\", \"other_pass\": \"false\"}, \"repeat_masking\": {\"repeat_source\": {\"source_type\": \"no\", \"__current_case__\": 3}}, \"__page__\": null, \"__rerun_remap_job_id__\": null}",
-            "tool_version": "2.31.11",
-            "type": "tool",
-            "uuid": "0d68cdd8-3438-486f-993a-9ae16ef11dd7",
-            "workflow_outputs": []
-        },
-        "11": {
-            "annotation": "",
-            "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/busco/busco/3.0.2+galaxy1",
-            "errors": null,
-            "id": 11,
             "input_connections": {
                 "input": {
                     "id": 8,
@@ -729,14 +598,14 @@
                 }
             ],
             "position": {
-                "bottom": 1136.8333129882812,
-                "height": 256,
-                "left": 534.4833374023438,
-                "right": 734.4833374023438,
-                "top": 880.8333129882812,
+                "bottom": 1116.53125,
+                "height": 252,
+                "left": 652.5,
+                "right": 852.5,
+                "top": 864.53125,
                 "width": 200,
-                "x": 534.4833374023438,
-                "y": 880.8333129882812
+                "x": 652.5,
+                "y": 864.53125
             },
             "post_job_actions": {
                 "HideDatasetActionbusco_missing": {
@@ -750,14 +619,14 @@
                     "output_name": "busco_table"
                 }
             },
-            "tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/busco/busco/3.0.2+galaxy1",
+            "tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/busco/busco/4.1.4",
             "tool_shed_repository": {
                 "changeset_revision": "602fb8e63aa7",
                 "name": "busco",
                 "owner": "iuc",
                 "tool_shed": "toolshed.g2.bx.psu.edu"
             },
-            "tool_state": "{\"adv\": {\"evalue\": \"0.01\", \"limit\": \"3\", \"aug_prediction\": {\"augustus_mode\": \"no\", \"__current_case__\": 0}, \"long\": \"false\"}, \"input\": {\"__class__\": \"ConnectedValue\"}, \"lineage_dataset\": \"fungi_odb10\", \"mode\": \"tran\", \"__page__\": null, \"__rerun_remap_job_id__\": null}",
+            "tool_state": "{\"__job_resource\": {\"__job_resource__select\": \"no\", \"__current_case__\": 0}, \"adv\": {\"evalue\": \"0.01\", \"limit\": \"3\", \"aug_prediction\": {\"augustus_mode\": \"no\", \"__current_case__\": 0}, \"long\": \"false\"}, \"input\": {\"__class__\": \"ConnectedValue\"}, \"lineage_dataset\": \"fungi_odb10\", \"mode\": \"tran\", \"__page__\": null, \"__rerun_remap_job_id__\": null}",
             "tool_version": "4.1.4",
             "type": "tool",
             "uuid": "66c2b722-7f23-4206-9964-52d057e4b53c",
@@ -765,260 +634,30 @@
                 {
                     "label": "Busco summary first round",
                     "output_name": "busco_sum",
-                    "uuid": "e3191336-ab36-425f-9a53-6eea65c8108c"
+                    "uuid": "29a9f02c-eef5-4574-bb2b-3daf61a594e3"
                 }
             ]
         },
-        "12": {
+        "11": {
             "annotation": "",
-            "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/snap_training/snap_training/2013_11_29+galaxy1",
+            "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/maker/maker/2.31.11",
             "errors": null,
-            "id": 12,
-            "input_connections": {
-                "genome": {
-                    "id": 1,
-                    "output_name": "output"
-                },
-                "maker_gff": {
-                    "id": 10,
-                    "output_name": "output_gff"
-                }
-            },
-            "inputs": [],
-            "label": null,
-            "name": "Train SNAP",
-            "outputs": [
-                {
-                    "name": "output",
-                    "type": "snaphmm"
-                }
-            ],
-            "position": {
-                "bottom": 191.89999389648438,
-                "height": 184.79998779296875,
-                "left": 818.3499755859375,
-                "right": 1018.3499755859375,
-                "top": 7.100006103515625,
-                "width": 200,
-                "x": 818.3499755859375,
-                "y": 7.100006103515625
-            },
-            "post_job_actions": {},
-            "tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/snap_training/snap_training/2013_11_29+galaxy1",
-            "tool_shed_repository": {
-                "changeset_revision": "2a598c0aa042",
-                "name": "snap_training",
-                "owner": "iuc",
-                "tool_shed": "toolshed.g2.bx.psu.edu"
-            },
-            "tool_state": "{\"gene_num\": \"1000\", \"genome\": {\"__class__\": \"ConnectedValue\"}, \"maker_gff\": {\"__class__\": \"ConnectedValue\"}, \"__page__\": null, \"__rerun_remap_job_id__\": null}",
-            "tool_version": "2013_11_29+galaxy1",
-            "type": "tool",
-            "uuid": "100ef17b-1337-4727-9ccb-c847e0e290f7",
-            "workflow_outputs": [
-                {
-                    "label": null,
-                    "output_name": "output",
-                    "uuid": "76cf4599-6b1b-45d7-90fd-8f5edaab8e47"
-                }
-            ]
-        },
-        "13": {
-            "annotation": "",
-            "content_id": "toolshed.g2.bx.psu.edu/repos/bgruening/augustus_training/augustus_training/3.2.3+galaxy1",
-            "errors": null,
-            "id": 13,
-            "input_connections": {
-                "genome": {
-                    "id": 1,
-                    "output_name": "output"
-                },
-                "maker_gff": {
-                    "id": 10,
-                    "output_name": "output_gff"
-                }
-            },
-            "inputs": [],
-            "label": null,
-            "name": "Train Augustus",
-            "outputs": [
-                {
-                    "name": "output_tar",
-                    "type": "augustus"
-                }
-            ],
-            "position": {
-                "bottom": 412.98333740234375,
-                "height": 205.1999969482422,
-                "left": 822.7166748046875,
-                "right": 1022.7166748046875,
-                "top": 207.78334045410156,
-                "width": 200,
-                "x": 822.7166748046875,
-                "y": 207.78334045410156
-            },
-            "post_job_actions": {},
-            "tool_id": "toolshed.g2.bx.psu.edu/repos/bgruening/augustus_training/augustus_training/3.2.3+galaxy1",
-            "tool_shed_repository": {
-                "changeset_revision": "6519ebe25019",
-                "name": "augustus_training",
-                "owner": "bgruening",
-                "tool_shed": "toolshed.g2.bx.psu.edu"
-            },
-            "tool_state": "{\"genome\": {\"__class__\": \"ConnectedValue\"}, \"maker_gff\": {\"__class__\": \"ConnectedValue\"}, \"__page__\": null, \"__rerun_remap_job_id__\": null}",
-            "tool_version": "3.3.3",
-            "type": "tool",
-            "uuid": "cbc135cc-d9e5-45bc-b372-a6e8de661181",
-            "workflow_outputs": [
-                {
-                    "label": null,
-                    "output_name": "output_tar",
-                    "uuid": "889814d6-f08a-4bd8-a14a-6f5836735576"
-                }
-            ]
-        },
-        "14": {
-            "annotation": "",
-            "content_id": "toolshed.g2.bx.psu.edu/repos/devteam/gffread/gffread/2.2.1.1",
-            "errors": null,
-            "id": 14,
-            "input_connections": {
-                "input": {
-                    "id": 10,
-                    "output_name": "output_gff"
-                },
-                "reference_genome|genome_fasta": {
-                    "id": 1,
-                    "output_name": "output"
-                }
-            },
-            "inputs": [
-                {
-                    "description": "runtime parameter for tool gffread",
-                    "name": "chr_replace"
-                }
-            ],
-            "label": null,
-            "name": "gffread",
-            "outputs": [
-                {
-                    "name": "output_exons",
-                    "type": "fasta"
-                }
-            ],
-            "position": {
-                "bottom": 881.3666839599609,
-                "height": 215.1999969482422,
-                "left": 840.4500122070312,
-                "right": 1040.4500122070312,
-                "top": 666.1666870117188,
-                "width": 200,
-                "x": 840.4500122070312,
-                "y": 666.1666870117188
-            },
-            "post_job_actions": {
-                "HideDatasetActionoutput_exons": {
-                    "action_arguments": {},
-                    "action_type": "HideDatasetAction",
-                    "output_name": "output_exons"
-                }
-            },
-            "tool_id": "toolshed.g2.bx.psu.edu/repos/devteam/gffread/gffread/2.2.1.1",
-            "tool_shed_repository": {
-                "changeset_revision": "0232f19d300f",
-                "name": "gffread",
-                "owner": "devteam",
-                "tool_shed": "toolshed.g2.bx.psu.edu"
-            },
-            "tool_state": "{\"chr_replace\": {\"__class__\": \"RuntimeValue\"}, \"decode_url\": \"false\", \"expose\": \"false\", \"filtering\": null, \"full_gff_attribute_preservation\": \"false\", \"gffs\": {\"gff_fmt\": \"none\", \"__current_case__\": 0}, \"input\": {\"__class__\": \"ConnectedValue\"}, \"maxintron\": \"\", \"merging\": {\"merge_sel\": \"none\", \"__current_case__\": 0}, \"reference_genome\": {\"source\": \"history\", \"__current_case__\": 2, \"genome_fasta\": {\"__class__\": \"ConnectedValue\"}, \"ref_filtering\": null, \"fa_outputs\": [\"-w exons.fa\"]}, \"region\": {\"region_filter\": \"none\", \"__current_case__\": 0}, \"__page__\": null, \"__rerun_remap_job_id__\": null}",
-            "tool_version": "2.2.1.1",
-            "type": "tool",
-            "uuid": "3a501dca-fa6a-4604-afd4-ee046bbb62cd",
-            "workflow_outputs": []
-        },
-        "15": {
-            "annotation": "",
-            "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/jcvi_gff_stats/jcvi_gff_stats/0.8.4",
-            "errors": null,
-            "id": 15,
-            "input_connections": {
-                "gff": {
-                    "id": 10,
-                    "output_name": "output_gff"
-                },
-                "ref_genome|genome": {
-                    "id": 1,
-                    "output_name": "output"
-                }
-            },
-            "inputs": [],
-            "label": null,
-            "name": "Genome annotation statistics",
-            "outputs": [
-                {
-                    "name": "summary",
-                    "type": "txt"
-                },
-                {
-                    "name": "graphs",
-                    "type": "pdf"
-                }
-            ],
-            "position": {
-                "bottom": 1199.1333312988281,
-                "height": 276.3999938964844,
-                "left": 838.7833251953125,
-                "right": 1038.7833251953125,
-                "top": 922.7333374023438,
-                "width": 200,
-                "x": 838.7833251953125,
-                "y": 922.7333374023438
-            },
-            "post_job_actions": {},
-            "tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/jcvi_gff_stats/jcvi_gff_stats/0.8.4",
-            "tool_shed_repository": {
-                "changeset_revision": "8cffbd184762",
-                "name": "jcvi_gff_stats",
-                "owner": "iuc",
-                "tool_shed": "toolshed.g2.bx.psu.edu"
-            },
-            "tool_state": "{\"gff\": {\"__class__\": \"ConnectedValue\"}, \"ref_genome\": {\"genome_type_select\": \"history\", \"__current_case__\": 1, \"genome\": {\"__class__\": \"ConnectedValue\"}}, \"__page__\": null, \"__rerun_remap_job_id__\": null}",
-            "tool_version": "0.8.4",
-            "type": "tool",
-            "uuid": "d0ec8ae3-a384-4b5f-aac8-31fa9f4d6490",
-            "workflow_outputs": [
-                {
-                    "label": null,
-                    "output_name": "graphs",
-                    "uuid": "9b0d873d-87dd-4c17-893a-e31c08159862"
-                },
-                {
-                    "label": null,
-                    "output_name": "summary",
-                    "uuid": "af3ed4d8-468a-4ef7-95a8-a676e38352f9"
-                }
-            ]
-        },
-        "16": {
-            "annotation": "",
-            "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/maker/maker/2.31.10",
-            "errors": null,
-            "id": 16,
+            "id": 11,
             "input_connections": {
                 "abinitio_gene_prediction|aug_prediction|augustus_model": {
-                    "id": 13,
+                    "id": 6,
                     "output_name": "output_tar"
                 },
                 "abinitio_gene_prediction|snaphmm": {
-                    "id": 12,
+                    "id": 9,
                     "output_name": "output"
                 },
                 "genome": {
-                    "id": 1,
+                    "id": 2,
                     "output_name": "output"
                 },
                 "reannotation|maker_gff": {
-                    "id": 10,
+                    "id": 3,
                     "output_name": "output_full"
                 }
             },
@@ -1081,14 +720,14 @@
                 }
             ],
             "position": {
-                "bottom": 812.9666900634766,
-                "height": 814.4000244140625,
-                "left": 1073.3499755859375,
-                "right": 1273.3499755859375,
-                "top": -1.4333343505859375,
+                "bottom": 825.546875,
+                "height": 862,
+                "left": 652.5,
+                "right": 852.5,
+                "top": -36.453125,
                 "width": 200,
-                "x": 1073.3499755859375,
-                "y": -1.4333343505859375
+                "x": 652.5,
+                "y": -36.453125
             },
             "post_job_actions": {
                 "HideDatasetActionoutput_evidences": {
@@ -1107,27 +746,257 @@
                     "output_name": "output_gff"
                 }
             },
-            "tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/maker/maker/2.31.10",
+            "tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/maker/maker/2.31.11",
             "tool_shed_repository": {
-                "changeset_revision": "5201ec38c01f",
+                "changeset_revision": "d46d803ca6cc",
                 "name": "maker",
                 "owner": "iuc",
                 "tool_shed": "toolshed.g2.bx.psu.edu"
             },
-            "tool_state": "{\"abinitio_gene_prediction\": {\"snaphmm\": {\"__class__\": \"ConnectedValue\"}, \"aug_prediction\": {\"augustus_mode\": \"history\", \"__current_case__\": 1, \"augustus_model\": {\"__class__\": \"ConnectedValue\"}}, \"unmask\": \"false\"}, \"advanced\": {\"other_gff\": {\"__class__\": \"RuntimeValue\"}, \"alt_peptide\": \"C\", \"max_dna_len\": \"100000\", \"min_contig\": \"1\", \"pred_flank\": \"200\", \"pred_stats\": \"false\", \"AED_threshold\": \"1.0\", \"min_protein\": \"0\", \"alt_splice\": \"false\", \"always_complete\": \"false\", \"map_forward\": \"false\", \"keep_preds\": \"0.0\", \"split_hit\": \"10000\", \"correct_est_fusion\": \"false\", \"single_exon\": {\"single_exon\": \"0\", \"__current_case__\": 0}}, \"est_evidences\": {\"est2genome\": \"false\", \"est\": {\"__class__\": \"RuntimeValue\"}, \"altest\": {\"__class__\": \"RuntimeValue\"}, \"est_gff\": {\"__class__\": \"RuntimeValue\"}, \"altest_gff\": {\"__class__\": \"RuntimeValue\"}}, \"gene_prediction\": {\"pred_gff\": {\"__class__\": \"RuntimeValue\"}, \"model_gff\": {\"__class__\": \"RuntimeValue\"}, \"trna\": \"false\", \"snoscan_rrna\": {\"__class__\": \"RuntimeValue\"}}, \"genome\": {\"__class__\": \"ConnectedValue\"}, \"organism_type\": \"eukaryotic\", \"protein_evidences\": {\"protein2genome\": \"false\", \"protein\": {\"__class__\": \"RuntimeValue\"}, \"protein_gff\": {\"__class__\": \"RuntimeValue\"}}, \"reannotation\": {\"reannotate\": \"yes\", \"__current_case__\": 1, \"maker_gff\": {\"__class__\": \"ConnectedValue\"}, \"est_pass\": \"true\", \"altest_pass\": \"true\", \"protein_pass\": \"true\", \"rm_pass\": \"true\", \"model_pass\": \"false\", \"pred_pass\": \"false\", \"other_pass\": \"false\"}, \"repeat_masking\": {\"repeat_source\": {\"source_type\": \"no\", \"__current_case__\": 3}}, \"__page__\": null, \"__rerun_remap_job_id__\": null}",
+            "tool_state": "{\"__job_resource\": {\"__job_resource__select\": \"no\", \"__current_case__\": 0}, \"abinitio_gene_prediction\": {\"snaphmm\": {\"__class__\": \"ConnectedValue\"}, \"aug_prediction\": {\"augustus_mode\": \"history\", \"__current_case__\": 1, \"augustus_model\": {\"__class__\": \"ConnectedValue\"}}, \"unmask\": \"false\"}, \"advanced\": {\"other_gff\": {\"__class__\": \"RuntimeValue\"}, \"alt_peptide\": \"C\", \"max_dna_len\": \"100000\", \"min_contig\": \"1\", \"pred_flank\": \"200\", \"pred_stats\": \"false\", \"AED_threshold\": \"1.0\", \"min_protein\": \"0\", \"alt_splice\": \"false\", \"always_complete\": \"false\", \"map_forward\": \"false\", \"keep_preds\": \"0.0\", \"split_hit\": \"10000\", \"correct_est_fusion\": \"false\", \"single_exon\": {\"single_exon\": \"0\", \"__current_case__\": 0}}, \"est_evidences\": {\"est2genome\": \"false\", \"est\": {\"__class__\": \"RuntimeValue\"}, \"altest\": {\"__class__\": \"RuntimeValue\"}, \"est_gff\": {\"__class__\": \"RuntimeValue\"}, \"altest_gff\": {\"__class__\": \"RuntimeValue\"}}, \"gene_prediction\": {\"pred_gff\": {\"__class__\": \"RuntimeValue\"}, \"model_gff\": {\"__class__\": \"RuntimeValue\"}, \"trna\": \"false\", \"snoscan_rrna\": {\"__class__\": \"RuntimeValue\"}}, \"genome\": {\"__class__\": \"ConnectedValue\"}, \"organism_type\": \"eukaryotic\", \"protein_evidences\": {\"protein2genome\": \"false\", \"protein\": {\"__class__\": \"RuntimeValue\"}, \"protein_gff\": {\"__class__\": \"RuntimeValue\"}}, \"reannotation\": {\"reannotate\": \"yes\", \"__current_case__\": 1, \"maker_gff\": {\"__class__\": \"ConnectedValue\"}, \"est_pass\": \"true\", \"altest_pass\": \"true\", \"protein_pass\": \"true\", \"rm_pass\": \"true\", \"model_pass\": \"false\", \"pred_pass\": \"false\", \"other_pass\": \"false\"}, \"repeat_masking\": {\"repeat_source\": {\"source_type\": \"no\", \"__current_case__\": 3}}, \"__page__\": null, \"__rerun_remap_job_id__\": null}",
             "tool_version": "2.31.11",
             "type": "tool",
-            "uuid": "2e0571a6-3867-49d5-8fa2-f4ffbe1f5f50",
+            "uuid": "0d68cdd8-3438-486f-993a-9ae16ef11dd7",
             "workflow_outputs": []
         },
-        "17": {
+        "12": {
             "annotation": "",
-            "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/busco/busco/3.0.2+galaxy1",
+            "content_id": "toolshed.g2.bx.psu.edu/repos/devteam/gffread/gffread/2.2.1.2",
             "errors": null,
-            "id": 17,
+            "id": 12,
             "input_connections": {
                 "input": {
-                    "id": 14,
+                    "id": 11,
+                    "output_name": "output_gff"
+                },
+                "reference_genome|genome_fasta": {
+                    "id": 2,
+                    "output_name": "output"
+                }
+            },
+            "inputs": [
+                {
+                    "description": "runtime parameter for tool gffread",
+                    "name": "chr_replace"
+                }
+            ],
+            "label": null,
+            "name": "gffread",
+            "outputs": [
+                {
+                    "name": "output_exons",
+                    "type": "fasta"
+                }
+            ],
+            "position": {
+                "bottom": 417.5,
+                "height": 232,
+                "left": 970.5,
+                "right": 1170.5,
+                "top": 185.5,
+                "width": 200,
+                "x": 970.5,
+                "y": 185.5
+            },
+            "post_job_actions": {
+                "HideDatasetActionoutput_exons": {
+                    "action_arguments": {},
+                    "action_type": "HideDatasetAction",
+                    "output_name": "output_exons"
+                }
+            },
+            "tool_id": "toolshed.g2.bx.psu.edu/repos/devteam/gffread/gffread/2.2.1.2",
+            "tool_shed_repository": {
+                "changeset_revision": "69e0806b63a4",
+                "name": "gffread",
+                "owner": "devteam",
+                "tool_shed": "toolshed.g2.bx.psu.edu"
+            },
+            "tool_state": "{\"chr_replace\": {\"__class__\": \"RuntimeValue\"}, \"decode_url\": \"false\", \"expose\": \"false\", \"filtering\": null, \"full_gff_attribute_preservation\": \"false\", \"gffs\": {\"gff_fmt\": \"none\", \"__current_case__\": 0}, \"input\": {\"__class__\": \"ConnectedValue\"}, \"maxintron\": null, \"merging\": {\"merge_sel\": \"none\", \"__current_case__\": 0}, \"reference_genome\": {\"source\": \"history\", \"__current_case__\": 2, \"genome_fasta\": {\"__class__\": \"ConnectedValue\"}, \"ref_filtering\": null, \"fa_outputs\": [\"-w exons.fa\"]}, \"region\": {\"region_filter\": \"none\", \"__current_case__\": 0}, \"__page__\": null, \"__rerun_remap_job_id__\": null}",
+            "tool_version": "2.2.1.2",
+            "type": "tool",
+            "uuid": "3a501dca-fa6a-4604-afd4-ee046bbb62cd",
+            "workflow_outputs": []
+        },
+        "13": {
+            "annotation": "",
+            "content_id": "toolshed.g2.bx.psu.edu/repos/bgruening/augustus_training/augustus_training/3.3.3",
+            "errors": null,
+            "id": 13,
+            "input_connections": {
+                "genome": {
+                    "id": 2,
+                    "output_name": "output"
+                },
+                "maker_gff": {
+                    "id": 11,
+                    "output_name": "output_gff"
+                }
+            },
+            "inputs": [],
+            "label": null,
+            "name": "Train Augustus",
+            "outputs": [
+                {
+                    "name": "output_tar",
+                    "type": "augustus"
+                }
+            ],
+            "position": {
+                "bottom": 617.53125,
+                "height": 162,
+                "left": 970.5,
+                "right": 1170.5,
+                "top": 455.53125,
+                "width": 200,
+                "x": 970.5,
+                "y": 455.53125
+            },
+            "post_job_actions": {},
+            "tool_id": "toolshed.g2.bx.psu.edu/repos/bgruening/augustus_training/augustus_training/3.3.3",
+            "tool_shed_repository": {
+                "changeset_revision": "6519ebe25019",
+                "name": "augustus_training",
+                "owner": "bgruening",
+                "tool_shed": "toolshed.g2.bx.psu.edu"
+            },
+            "tool_state": "{\"genome\": {\"__class__\": \"ConnectedValue\"}, \"maker_gff\": {\"__class__\": \"ConnectedValue\"}, \"__page__\": null, \"__rerun_remap_job_id__\": null}",
+            "tool_version": "3.3.3",
+            "type": "tool",
+            "uuid": "f434b146-aea9-4b23-86de-0ca014c4187e",
+            "workflow_outputs": [
+                {
+                    "label": "Augus: trained model",
+                    "output_name": "output_tar",
+                    "uuid": "097959a5-26dd-4a27-ab4a-12e8a5deb25e"
+                }
+            ]
+        },
+        "14": {
+            "annotation": "",
+            "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/jcvi_gff_stats/jcvi_gff_stats/0.8.4",
+            "errors": null,
+            "id": 14,
+            "input_connections": {
+                "gff": {
+                    "id": 11,
+                    "output_name": "output_gff"
+                },
+                "ref_genome|genome": {
+                    "id": 2,
+                    "output_name": "output"
+                }
+            },
+            "inputs": [],
+            "label": null,
+            "name": "Genome annotation statistics",
+            "outputs": [
+                {
+                    "name": "summary",
+                    "type": "txt"
+                },
+                {
+                    "name": "graphs",
+                    "type": "pdf"
+                }
+            ],
+            "position": {
+                "bottom": 947.53125,
+                "height": 272,
+                "left": 970.5,
+                "right": 1170.5,
+                "top": 675.53125,
+                "width": 200,
+                "x": 970.5,
+                "y": 675.53125
+            },
+            "post_job_actions": {},
+            "tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/jcvi_gff_stats/jcvi_gff_stats/0.8.4",
+            "tool_shed_repository": {
+                "changeset_revision": "8cffbd184762",
+                "name": "jcvi_gff_stats",
+                "owner": "iuc",
+                "tool_shed": "toolshed.g2.bx.psu.edu"
+            },
+            "tool_state": "{\"gff\": {\"__class__\": \"ConnectedValue\"}, \"ref_genome\": {\"genome_type_select\": \"history\", \"__current_case__\": 1, \"genome\": {\"__class__\": \"ConnectedValue\"}}, \"__page__\": null, \"__rerun_remap_job_id__\": null}",
+            "tool_version": "0.8.4",
+            "type": "tool",
+            "uuid": "ec31dcc1-1520-4ef2-a01d-9d8f1568276c",
+            "workflow_outputs": [
+                {
+                    "label": "Genome annotation statistics: graphs (second round)",
+                    "output_name": "graphs",
+                    "uuid": "ea13d711-fe3a-4da2-99f8-9b4c904f95a2"
+                },
+                {
+                    "label": "Genome annotation statistics: summary (second round)",
+                    "output_name": "summary",
+                    "uuid": "23d0b92d-c3cb-44a0-9749-7ff9f230952f"
+                }
+            ]
+        },
+        "15": {
+            "annotation": "",
+            "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/snap_training/snap_training/2013_11_29+galaxy1",
+            "errors": null,
+            "id": 15,
+            "input_connections": {
+                "genome": {
+                    "id": 2,
+                    "output_name": "output"
+                },
+                "maker_gff": {
+                    "id": 11,
+                    "output_name": "output_gff"
+                }
+            },
+            "inputs": [],
+            "label": null,
+            "name": "Train SNAP",
+            "outputs": [
+                {
+                    "name": "output",
+                    "type": "snaphmm"
+                }
+            ],
+            "position": {
+                "bottom": 1148.53125,
+                "height": 162,
+                "left": 970.5,
+                "right": 1170.5,
+                "top": 986.53125,
+                "width": 200,
+                "x": 970.5,
+                "y": 986.53125
+            },
+            "post_job_actions": {},
+            "tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/snap_training/snap_training/2013_11_29+galaxy1",
+            "tool_shed_repository": {
+                "changeset_revision": "2a598c0aa042",
+                "name": "snap_training",
+                "owner": "iuc",
+                "tool_shed": "toolshed.g2.bx.psu.edu"
+            },
+            "tool_state": "{\"gene_num\": \"1000\", \"genome\": {\"__class__\": \"ConnectedValue\"}, \"maker_gff\": {\"__class__\": \"ConnectedValue\"}, \"__page__\": null, \"__rerun_remap_job_id__\": null}",
+            "tool_version": "2013_11_29+galaxy1",
+            "type": "tool",
+            "uuid": "360320e6-b0e1-4c83-9f26-3346ff913be8",
+            "workflow_outputs": [
+                {
+                    "label": "SNAP: trained model",
+                    "output_name": "output",
+                    "uuid": "d1d78d8d-e24d-46a4-8eec-3254c391bdae"
+                }
+            ]
+        },
+        "16": {
+            "annotation": "",
+            "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/busco/busco/4.1.4",
+            "errors": null,
+            "id": 16,
+            "input_connections": {
+                "input": {
+                    "id": 12,
                     "output_name": "output_exons"
                 }
             },
@@ -1149,14 +1018,14 @@
                 }
             ],
             "position": {
-                "bottom": 1117.8499755859375,
-                "height": 256,
-                "left": 1366.8333740234375,
-                "right": 1566.8333740234375,
-                "top": 861.8499755859375,
+                "bottom": 248.53125,
+                "height": 252,
+                "left": 1268.484375,
+                "right": 1468.484375,
+                "top": -3.46875,
                 "width": 200,
-                "x": 1366.8333740234375,
-                "y": 861.8499755859375
+                "x": 1268.484375,
+                "y": -3.46875
             },
             "post_job_actions": {
                 "HideDatasetActionbusco_missing": {
@@ -1170,14 +1039,14 @@
                     "output_name": "busco_table"
                 }
             },
-            "tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/busco/busco/3.0.2+galaxy1",
+            "tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/busco/busco/4.1.4",
             "tool_shed_repository": {
                 "changeset_revision": "602fb8e63aa7",
                 "name": "busco",
                 "owner": "iuc",
                 "tool_shed": "toolshed.g2.bx.psu.edu"
             },
-            "tool_state": "{\"adv\": {\"evalue\": \"0.01\", \"limit\": \"3\", \"aug_prediction\": {\"augustus_mode\": \"no\", \"__current_case__\": 0}, \"long\": \"false\"}, \"input\": {\"__class__\": \"ConnectedValue\"}, \"lineage_dataset\": \"fungi_odb10\", \"mode\": \"tran\", \"__page__\": null, \"__rerun_remap_job_id__\": null}",
+            "tool_state": "{\"__job_resource\": {\"__job_resource__select\": \"no\", \"__current_case__\": 0}, \"adv\": {\"evalue\": \"0.01\", \"limit\": \"3\", \"aug_prediction\": {\"augustus_mode\": \"no\", \"__current_case__\": 0}, \"long\": \"false\"}, \"input\": {\"__class__\": \"ConnectedValue\"}, \"lineage_dataset\": \"fungi_odb10\", \"mode\": \"tran\", \"__page__\": null, \"__rerun_remap_job_id__\": null}",
             "tool_version": "4.1.4",
             "type": "tool",
             "uuid": "5134efa6-0e54-4662-b40a-81e5482f2739",
@@ -1185,18 +1054,139 @@
                 {
                     "label": "Busco summary second round",
                     "output_name": "busco_sum",
-                    "uuid": "54795d35-6523-4262-9fc9-5f9958e9331d"
+                    "uuid": "942493db-4d3c-48be-ac6e-bee3f462f562"
                 }
             ]
         },
+        "17": {
+            "annotation": "",
+            "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/maker/maker/2.31.11",
+            "errors": null,
+            "id": 17,
+            "input_connections": {
+                "abinitio_gene_prediction|aug_prediction|augustus_model": {
+                    "id": 13,
+                    "output_name": "output_tar"
+                },
+                "abinitio_gene_prediction|snaphmm": {
+                    "id": 15,
+                    "output_name": "output"
+                },
+                "genome": {
+                    "id": 2,
+                    "output_name": "output"
+                },
+                "reannotation|maker_gff": {
+                    "id": 11,
+                    "output_name": "output_full"
+                }
+            },
+            "inputs": [
+                {
+                    "description": "runtime parameter for tool Maker",
+                    "name": "advanced"
+                },
+                {
+                    "description": "runtime parameter for tool Maker",
+                    "name": "est_evidences"
+                },
+                {
+                    "description": "runtime parameter for tool Maker",
+                    "name": "est_evidences"
+                },
+                {
+                    "description": "runtime parameter for tool Maker",
+                    "name": "est_evidences"
+                },
+                {
+                    "description": "runtime parameter for tool Maker",
+                    "name": "est_evidences"
+                },
+                {
+                    "description": "runtime parameter for tool Maker",
+                    "name": "gene_prediction"
+                },
+                {
+                    "description": "runtime parameter for tool Maker",
+                    "name": "gene_prediction"
+                },
+                {
+                    "description": "runtime parameter for tool Maker",
+                    "name": "gene_prediction"
+                },
+                {
+                    "description": "runtime parameter for tool Maker",
+                    "name": "protein_evidences"
+                },
+                {
+                    "description": "runtime parameter for tool Maker",
+                    "name": "protein_evidences"
+                }
+            ],
+            "label": null,
+            "name": "Maker",
+            "outputs": [
+                {
+                    "name": "output_gff",
+                    "type": "gff3"
+                },
+                {
+                    "name": "output_evidences",
+                    "type": "gff3"
+                },
+                {
+                    "name": "output_full",
+                    "type": "gff3"
+                }
+            ],
+            "position": {
+                "bottom": 1148.515625,
+                "height": 862,
+                "left": 1268.484375,
+                "right": 1468.484375,
+                "top": 286.515625,
+                "width": 200,
+                "x": 1268.484375,
+                "y": 286.515625
+            },
+            "post_job_actions": {
+                "HideDatasetActionoutput_evidences": {
+                    "action_arguments": {},
+                    "action_type": "HideDatasetAction",
+                    "output_name": "output_evidences"
+                },
+                "HideDatasetActionoutput_full": {
+                    "action_arguments": {},
+                    "action_type": "HideDatasetAction",
+                    "output_name": "output_full"
+                },
+                "HideDatasetActionoutput_gff": {
+                    "action_arguments": {},
+                    "action_type": "HideDatasetAction",
+                    "output_name": "output_gff"
+                }
+            },
+            "tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/maker/maker/2.31.11",
+            "tool_shed_repository": {
+                "changeset_revision": "d46d803ca6cc",
+                "name": "maker",
+                "owner": "iuc",
+                "tool_shed": "toolshed.g2.bx.psu.edu"
+            },
+            "tool_state": "{\"__job_resource\": {\"__job_resource__select\": \"no\", \"__current_case__\": 0}, \"abinitio_gene_prediction\": {\"snaphmm\": {\"__class__\": \"ConnectedValue\"}, \"aug_prediction\": {\"augustus_mode\": \"history\", \"__current_case__\": 1, \"augustus_model\": {\"__class__\": \"ConnectedValue\"}}, \"unmask\": \"false\"}, \"advanced\": {\"other_gff\": {\"__class__\": \"RuntimeValue\"}, \"alt_peptide\": \"C\", \"max_dna_len\": \"100000\", \"min_contig\": \"1\", \"pred_flank\": \"200\", \"pred_stats\": \"false\", \"AED_threshold\": \"1.0\", \"min_protein\": \"0\", \"alt_splice\": \"false\", \"always_complete\": \"false\", \"map_forward\": \"false\", \"keep_preds\": \"0.0\", \"split_hit\": \"10000\", \"correct_est_fusion\": \"false\", \"single_exon\": {\"single_exon\": \"0\", \"__current_case__\": 0}}, \"est_evidences\": {\"est2genome\": \"false\", \"est\": {\"__class__\": \"RuntimeValue\"}, \"altest\": {\"__class__\": \"RuntimeValue\"}, \"est_gff\": {\"__class__\": \"RuntimeValue\"}, \"altest_gff\": {\"__class__\": \"RuntimeValue\"}}, \"gene_prediction\": {\"pred_gff\": {\"__class__\": \"RuntimeValue\"}, \"model_gff\": {\"__class__\": \"RuntimeValue\"}, \"trna\": \"false\", \"snoscan_rrna\": {\"__class__\": \"RuntimeValue\"}}, \"genome\": {\"__class__\": \"ConnectedValue\"}, \"organism_type\": \"eukaryotic\", \"protein_evidences\": {\"protein2genome\": \"false\", \"protein\": {\"__class__\": \"RuntimeValue\"}, \"protein_gff\": {\"__class__\": \"RuntimeValue\"}}, \"reannotation\": {\"reannotate\": \"yes\", \"__current_case__\": 1, \"maker_gff\": {\"__class__\": \"ConnectedValue\"}, \"est_pass\": \"true\", \"altest_pass\": \"true\", \"protein_pass\": \"true\", \"rm_pass\": \"true\", \"model_pass\": \"false\", \"pred_pass\": \"false\", \"other_pass\": \"false\"}, \"repeat_masking\": {\"repeat_source\": {\"source_type\": \"no\", \"__current_case__\": 3}}, \"__page__\": null, \"__rerun_remap_job_id__\": null}",
+            "tool_version": "2.31.11",
+            "type": "tool",
+            "uuid": "2e0571a6-3867-49d5-8fa2-f4ffbe1f5f50",
+            "workflow_outputs": []
+        },
         "18": {
             "annotation": "",
-            "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/maker_map_ids/maker_map_ids/2.31.10",
+            "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/maker_map_ids/maker_map_ids/2.31.11",
             "errors": null,
             "id": 18,
             "input_connections": {
                 "maker_gff": {
-                    "id": 16,
+                    "id": 17,
                     "output_name": "output_gff"
                 }
             },
@@ -1214,14 +1204,14 @@
                 }
             ],
             "position": {
-                "bottom": 272.1333312988281,
-                "height": 246,
-                "left": 1424.88330078125,
-                "right": 1624.88330078125,
-                "top": 26.133331298828125,
+                "bottom": 1015.53125,
+                "height": 222,
+                "left": 1546.5,
+                "right": 1746.5,
+                "top": 793.53125,
                 "width": 200,
-                "x": 1424.88330078125,
-                "y": 26.133331298828125
+                "x": 1546.5,
+                "y": 793.53125
             },
             "post_job_actions": {
                 "ChangeDatatypeActionrenamed": {
@@ -1237,9 +1227,9 @@
                     "output_name": "id_map"
                 }
             },
-            "tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/maker_map_ids/maker_map_ids/2.31.10",
+            "tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/maker_map_ids/maker_map_ids/2.31.11",
             "tool_shed_repository": {
-                "changeset_revision": "f1912d5575df",
+                "changeset_revision": "e408aa831db3",
                 "name": "maker_map_ids",
                 "owner": "iuc",
                 "tool_shed": "toolshed.g2.bx.psu.edu"
@@ -1247,50 +1237,50 @@
             "tool_state": "{\"justify\": \"6\", \"maker_gff\": {\"__class__\": \"ConnectedValue\"}, \"prefix\": \"TEST\", \"__page__\": null, \"__rerun_remap_job_id__\": null}",
             "tool_version": "2.31.11",
             "type": "tool",
-            "uuid": "b1127093-0aae-4bfa-b474-042b838a8299",
+            "uuid": "b4c36185-9075-4a2b-a568-137b0a0b1588",
             "workflow_outputs": [
                 {
-                    "label": null,
+                    "label": "Map annotation ids: renamed GFF",
                     "output_name": "renamed",
-                    "uuid": "76e6fe30-7ab1-494f-a2a6-0bf546f444fc"
+                    "uuid": "246102e8-85d4-454f-92be-7ef9a2cb0b5e"
                 }
             ]
         },
         "19": {
             "annotation": "",
-            "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/jbrowse/jbrowse/1.16.4+galaxy3",
+            "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/jbrowse/jbrowse/1.16.10+galaxy0",
             "errors": null,
             "id": 19,
             "input_connections": {
                 "reference_genome|genome": {
-                    "id": 1,
+                    "id": 2,
                     "output_name": "output"
                 },
                 "track_groups_0|data_tracks_0|data_format|annotation": [
                     {
+                        "id": 11,
+                        "output_name": "output_gff"
+                    },
+                    {
+                        "id": 3,
+                        "output_name": "output_gff"
+                    },
+                    {
                         "id": 18,
                         "output_name": "renamed"
-                    },
-                    {
-                        "id": 5,
-                        "output_name": "output_gff"
-                    },
-                    {
-                        "id": 10,
-                        "output_name": "output_gff"
                     }
                 ],
                 "track_groups_1|data_tracks_0|data_format|annotation": [
                     {
-                        "id": 5,
+                        "id": 17,
                         "output_name": "output_evidences"
                     },
                     {
-                        "id": 10,
+                        "id": 11,
                         "output_name": "output_evidences"
                     },
                     {
-                        "id": 16,
+                        "id": 3,
                         "output_name": "output_evidences"
                     }
                 ]
@@ -1305,19 +1295,19 @@
                 }
             ],
             "position": {
-                "bottom": 83.89999389648438,
-                "height": 276.3999938964844,
-                "left": 1708.5999755859375,
-                "right": 1908.5999755859375,
-                "top": -192.5,
+                "bottom": 153.515625,
+                "height": 292,
+                "left": 1854.5,
+                "right": 2054.5,
+                "top": -138.484375,
                 "width": 200,
-                "x": 1708.5999755859375,
-                "y": -192.5
+                "x": 1854.5,
+                "y": -138.484375
             },
             "post_job_actions": {},
-            "tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/jbrowse/jbrowse/1.16.4+galaxy3",
+            "tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/jbrowse/jbrowse/1.16.10+galaxy0",
             "tool_shed_repository": {
-                "changeset_revision": "8774b28235bb",
+                "changeset_revision": "6cd09d7b5f37",
                 "name": "jbrowse",
                 "owner": "iuc",
                 "tool_shed": "toolshed.g2.bx.psu.edu"
@@ -1325,18 +1315,18 @@
             "tool_state": "{\"action\": {\"action_select\": \"create\", \"__current_case__\": 0}, \"gencode\": \"1\", \"jbgen\": {\"defaultLocation\": \"\", \"trackPadding\": \"20\", \"shareLink\": \"true\", \"aboutDescription\": \"\", \"show_tracklist\": \"true\", \"show_nav\": \"true\", \"show_overview\": \"true\", \"show_menu\": \"true\", \"hideGenomeOptions\": \"false\"}, \"plugins\": {\"BlastView\": \"true\", \"ComboTrackSelector\": \"false\", \"GCContent\": \"false\"}, \"reference_genome\": {\"genome_type_select\": \"history\", \"__current_case__\": 1, \"genome\": {\"__class__\": \"ConnectedValue\"}}, \"standalone\": \"minimal\", \"track_groups\": [{\"__index__\": 0, \"category\": \"Maker annotation\", \"data_tracks\": [{\"__index__\": 0, \"data_format\": {\"data_format_select\": \"gene_calls\", \"__current_case__\": 2, \"annotation\": {\"__class__\": \"ConnectedValue\"}, \"match_part\": {\"match_part_select\": \"false\", \"__current_case__\": 1}, \"index\": \"false\", \"track_config\": {\"track_class\": \"NeatHTMLFeatures/View/Track/NeatFeatures\", \"__current_case__\": 3, \"html_options\": {\"topLevelFeatures\": \"\"}}, \"jbstyle\": {\"style_classname\": \"feature\", \"style_label\": \"product,name,id\", \"style_description\": \"note,description\", \"style_height\": \"10px\", \"max_height\": \"600\"}, \"jbcolor_scale\": {\"color_score\": {\"color_score_select\": \"none\", \"__current_case__\": 0, \"color\": {\"color_select\": \"automatic\", \"__current_case__\": 0}}}, \"jb_custom_config\": {\"option\": []}, \"jbmenu\": {\"track_menu\": []}, \"track_visibility\": \"default_off\", \"override_apollo_plugins\": \"False\", \"override_apollo_drag\": \"False\"}}]}, {\"__index__\": 1, \"category\": \"Maker evidences\", \"data_tracks\": [{\"__index__\": 0, \"data_format\": {\"data_format_select\": \"gene_calls\", \"__current_case__\": 2, \"annotation\": {\"__class__\": \"ConnectedValue\"}, \"match_part\": {\"match_part_select\": \"true\", \"__current_case__\": 0, \"name\": {\"__class__\": \"RuntimeValue\"}}, \"index\": \"false\", \"track_config\": {\"track_class\": \"NeatHTMLFeatures/View/Track/NeatFeatures\", \"__current_case__\": 3, \"html_options\": {\"topLevelFeatures\": \"\"}}, \"jbstyle\": {\"style_classname\": \"feature\", \"style_label\": \"product,name,id\", \"style_description\": \"note,description\", \"style_height\": \"10px\", \"max_height\": \"600\"}, \"jbcolor_scale\": {\"color_score\": {\"color_score_select\": \"none\", \"__current_case__\": 0, \"color\": {\"color_select\": \"automatic\", \"__current_case__\": 0}}}, \"jb_custom_config\": {\"option\": []}, \"jbmenu\": {\"track_menu\": []}, \"track_visibility\": \"default_off\", \"override_apollo_plugins\": \"False\", \"override_apollo_drag\": \"False\"}}]}], \"uglyTestingHack\": \"\", \"__page__\": null, \"__rerun_remap_job_id__\": null}",
             "tool_version": "1.16.10+galaxy0",
             "type": "tool",
-            "uuid": "8a4042b8-010c-4e53-bb2c-710a80b0925e",
+            "uuid": "78092f7e-56d2-4570-8d25-0b9545f495a4",
             "workflow_outputs": [
                 {
-                    "label": null,
+                    "label": "JBrowse: report",
                     "output_name": "output",
-                    "uuid": "ce4b78f9-b9ab-4219-af65-30fceab2f691"
+                    "uuid": "d46cce4f-44af-47c0-b198-3b95be862e66"
                 }
             ]
         },
         "20": {
             "annotation": "",
-            "content_id": "toolshed.g2.bx.psu.edu/repos/devteam/gffread/gffread/2.2.1.1",
+            "content_id": "toolshed.g2.bx.psu.edu/repos/devteam/gffread/gffread/2.2.1.2",
             "errors": null,
             "id": 20,
             "input_connections": {
@@ -1345,7 +1335,7 @@
                     "output_name": "renamed"
                 },
                 "reference_genome|genome_fasta": {
-                    "id": 1,
+                    "id": 2,
                     "output_name": "output"
                 }
             },
@@ -1372,42 +1362,42 @@
                 }
             ],
             "position": {
-                "bottom": 542.2833251953125,
-                "height": 316.79998779296875,
-                "left": 1723.5999755859375,
-                "right": 1923.5999755859375,
-                "top": 225.48333740234375,
+                "bottom": 463.515625,
+                "height": 272,
+                "left": 1854.5,
+                "right": 2054.5,
+                "top": 191.515625,
                 "width": 200,
-                "x": 1723.5999755859375,
-                "y": 225.48333740234375
+                "x": 1854.5,
+                "y": 191.515625
             },
             "post_job_actions": {},
-            "tool_id": "toolshed.g2.bx.psu.edu/repos/devteam/gffread/gffread/2.2.1.1",
+            "tool_id": "toolshed.g2.bx.psu.edu/repos/devteam/gffread/gffread/2.2.1.2",
             "tool_shed_repository": {
-                "changeset_revision": "0232f19d300f",
+                "changeset_revision": "69e0806b63a4",
                 "name": "gffread",
                 "owner": "devteam",
                 "tool_shed": "toolshed.g2.bx.psu.edu"
             },
-            "tool_state": "{\"chr_replace\": {\"__class__\": \"RuntimeValue\"}, \"decode_url\": \"false\", \"expose\": \"false\", \"filtering\": null, \"full_gff_attribute_preservation\": \"false\", \"gffs\": {\"gff_fmt\": \"none\", \"__current_case__\": 0}, \"input\": {\"__class__\": \"ConnectedValue\"}, \"maxintron\": \"\", \"merging\": {\"merge_sel\": \"none\", \"__current_case__\": 0}, \"reference_genome\": {\"source\": \"history\", \"__current_case__\": 2, \"genome_fasta\": {\"__class__\": \"ConnectedValue\"}, \"ref_filtering\": null, \"fa_outputs\": [\"-w exons.fa\", \"-x cds.fa\", \"-y pep.fa\"]}, \"region\": {\"region_filter\": \"none\", \"__current_case__\": 0}, \"__page__\": null, \"__rerun_remap_job_id__\": null}",
-            "tool_version": "2.2.1.1",
+            "tool_state": "{\"chr_replace\": {\"__class__\": \"RuntimeValue\"}, \"decode_url\": \"false\", \"expose\": \"false\", \"filtering\": null, \"full_gff_attribute_preservation\": \"false\", \"gffs\": {\"gff_fmt\": \"none\", \"__current_case__\": 0}, \"input\": {\"__class__\": \"ConnectedValue\"}, \"maxintron\": null, \"merging\": {\"merge_sel\": \"none\", \"__current_case__\": 0}, \"reference_genome\": {\"source\": \"history\", \"__current_case__\": 2, \"genome_fasta\": {\"__class__\": \"ConnectedValue\"}, \"ref_filtering\": null, \"fa_outputs\": [\"-w exons.fa\", \"-x cds.fa\", \"-y pep.fa\"]}, \"region\": {\"region_filter\": \"none\", \"__current_case__\": 0}, \"__page__\": null, \"__rerun_remap_job_id__\": null}",
+            "tool_version": "2.2.1.2",
             "type": "tool",
-            "uuid": "3b5ecaf4-2d08-42f8-a6f0-f05ad9e5fe92",
+            "uuid": "df146b22-8136-4633-bfca-3102d9ae7359",
             "workflow_outputs": [
                 {
-                    "label": null,
+                    "label": "Gffread: cds",
                     "output_name": "output_cds",
-                    "uuid": "b2302c60-9089-483d-b4d0-78dded9abcdb"
+                    "uuid": "61acd121-4955-4cb9-b83e-6b5f029e9c4a"
                 },
                 {
-                    "label": null,
-                    "output_name": "output_exons",
-                    "uuid": "c242b1da-904a-4460-907b-b4ecd0706a20"
-                },
-                {
-                    "label": null,
+                    "label": "Gffread: translation of cds",
                     "output_name": "output_pep",
-                    "uuid": "89e80c4c-da95-4674-9261-0201e30616a4"
+                    "uuid": "5e0b5060-3f2a-48b8-9bcd-5455bbaa8e53"
+                },
+                {
+                    "label": "Gffread: exons",
+                    "output_name": "output_exons",
+                    "uuid": "f32c7d9c-cae0-4eb8-bb28-fe97c57c630d"
                 }
             ]
         },
@@ -1422,7 +1412,7 @@
                     "output_name": "renamed"
                 },
                 "ref_genome|genome": {
-                    "id": 1,
+                    "id": 2,
                     "output_name": "output"
                 }
             },
@@ -1440,14 +1430,14 @@
                 }
             ],
             "position": {
-                "bottom": 928.3500366210938,
-                "height": 276.4000244140625,
-                "left": 1727.4666748046875,
-                "right": 1927.4666748046875,
-                "top": 651.9500122070312,
+                "bottom": 1332.53125,
+                "height": 272,
+                "left": 1854.5,
+                "right": 2054.5,
+                "top": 1060.53125,
                 "width": 200,
-                "x": 1727.4666748046875,
-                "y": 651.9500122070312
+                "x": 1854.5,
+                "y": 1060.53125
             },
             "post_job_actions": {},
             "tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/jcvi_gff_stats/jcvi_gff_stats/0.8.4",
@@ -1460,23 +1450,23 @@
             "tool_state": "{\"gff\": {\"__class__\": \"ConnectedValue\"}, \"ref_genome\": {\"genome_type_select\": \"history\", \"__current_case__\": 1, \"genome\": {\"__class__\": \"ConnectedValue\"}}, \"__page__\": null, \"__rerun_remap_job_id__\": null}",
             "tool_version": "0.8.4",
             "type": "tool",
-            "uuid": "14236032-ec57-4beb-ab0a-e44bf845643c",
+            "uuid": "21f16815-4107-4198-9b3e-2f652687d00c",
             "workflow_outputs": [
                 {
-                    "label": null,
-                    "output_name": "summary",
-                    "uuid": "83490f5c-6969-4de9-8887-44ea33c2861a"
+                    "label": "Genome annotation statistics: graphs (third round)",
+                    "output_name": "graphs",
+                    "uuid": "3555a5eb-92c4-42fa-8975-548452e5a026"
                 },
                 {
-                    "label": null,
-                    "output_name": "graphs",
-                    "uuid": "e0fdde24-f06f-450b-985c-2567dd2f83cd"
+                    "label": "Genome annotation statistics: summary (third round)",
+                    "output_name": "summary",
+                    "uuid": "95d45df5-5764-4a72-aef8-521d98c59598"
                 }
             ]
         },
         "22": {
             "annotation": "",
-            "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/busco/busco/3.0.2+galaxy1",
+            "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/busco/busco/4.1.4",
             "errors": null,
             "id": 22,
             "input_connections": {
@@ -1503,14 +1493,14 @@
                 }
             ],
             "position": {
-                "bottom": 514.5166625976562,
-                "height": 256,
-                "left": 2023.449951171875,
-                "right": 2223.449951171875,
-                "top": 258.51666259765625,
+                "bottom": 534.53125,
+                "height": 252,
+                "left": 2132.5,
+                "right": 2332.5,
+                "top": 282.53125,
                 "width": 200,
-                "x": 2023.449951171875,
-                "y": 258.51666259765625
+                "x": 2132.5,
+                "y": 282.53125
             },
             "post_job_actions": {
                 "HideDatasetActionbusco_missing": {
@@ -1524,14 +1514,14 @@
                     "output_name": "busco_table"
                 }
             },
-            "tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/busco/busco/3.0.2+galaxy1",
+            "tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/busco/busco/4.1.4",
             "tool_shed_repository": {
                 "changeset_revision": "602fb8e63aa7",
                 "name": "busco",
                 "owner": "iuc",
                 "tool_shed": "toolshed.g2.bx.psu.edu"
             },
-            "tool_state": "{\"adv\": {\"evalue\": \"0.01\", \"limit\": \"3\", \"aug_prediction\": {\"augustus_mode\": \"no\", \"__current_case__\": 0}, \"long\": \"false\"}, \"input\": {\"__class__\": \"ConnectedValue\"}, \"lineage_dataset\": \"fungi_odb10\", \"mode\": \"tran\", \"__page__\": null, \"__rerun_remap_job_id__\": null}",
+            "tool_state": "{\"__job_resource\": {\"__job_resource__select\": \"no\", \"__current_case__\": 0}, \"adv\": {\"evalue\": \"0.01\", \"limit\": \"3\", \"aug_prediction\": {\"augustus_mode\": \"no\", \"__current_case__\": 0}, \"long\": \"false\"}, \"input\": {\"__class__\": \"ConnectedValue\"}, \"lineage_dataset\": \"fungi_odb10\", \"mode\": \"tran\", \"__page__\": null, \"__rerun_remap_job_id__\": null}",
             "tool_version": "4.1.4",
             "type": "tool",
             "uuid": "c0bcff23-19bc-4b8a-9f4f-5f9b82e98409",
@@ -1539,7 +1529,7 @@
                 {
                     "label": "Busco summary final round",
                     "output_name": "busco_sum",
-                    "uuid": "71faba5b-7265-44c1-8405-cd36eb0aabbc"
+                    "uuid": "bfc07659-a63e-4899-9a4d-72c63e648caf"
                 }
             ]
         }
@@ -1547,6 +1537,6 @@
     "tags": [
         "genome-annotation"
     ],
-    "uuid": "7ecf48b6-2706-4665-b96a-ec97c9b2df41",
-    "version": 1
+    "uuid": "0e9cdaa9-6de6-4012-a5d2-7d6adf994eff",
+    "version": 2
 }


### PR DESCRIPTION
This PR includes the following modifications:

- Add best practices information
- Update _gffread_ tool version to  2.2.1.2 (previous version, 2.2.1.1. is not available in usergalaxy.org)
- Update _fasta statistics_ tool to 1.0.1 (previous version, 1.0.0, is not available in usegalaxy.org)