### PR TITLE
Make path option in DL import snippet more useful

### DIFF
--- a/faqs/galaxy/datasets_import_from_data_library.md
+++ b/faqs/galaxy/datasets_import_from_data_library.md
@@ -9,11 +9,9 @@ layout: faq
 As an alternative to uploading the data from a URL or your computer, the files may also have been made available from a *shared data library*:
 
 * Go into **Shared data** (top panel) then **Data libraries**
+* Navigate to
 {% if include.path %}
-* {{ include.path }}
-{% else %}
-* Find the correct folder (ask your instructor)
-{% endif %}
+  *{{ include.path }}* or {% endif %} the correct folder as indicated by your instructor
 * Select the desired files
 * Click on the **To History** button near the top and select **{{ include.astype | default: "as Datasets" }}** from the dropdown menu
 * In the pop-up window, select the history you want to import the files to (or create a new one)


### PR DESCRIPTION
You cannot be sure about paths in the DL on different Galaxy instances,
but you can provide a likely path to try unless the instructor says
otherwise.