### PR TITLE
Revert "Temporarily disable annotations"

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -229,11 +229,10 @@ video: ## Build all videos
 	bash bin/ari-make.sh
 
 annotate: ## annotate the tutorials with usable Galaxy instances and generate badges
-	@echo "Temporarily disabled pending Hub2 updates"
-	#${ACTIVATE_ENV} && \
-	#bash bin/workflow_to_tool_yaml.sh && \
-	#python bin/add_galaxy_instance_annotations.py && \
-	#python bin/add_galaxy_instance_badges.py
+	${ACTIVATE_ENV} && \
+	bash bin/workflow_to_tool_yaml.sh && \
+	python bin/add_galaxy_instance_annotations.py && \
+	python bin/add_galaxy_instance_badges.py
 .PHONY: annotate
 
 rebuild-search-index: ## Rebuild search index


### PR DESCRIPTION
They have re-added the feed to the hub. This reverts commit c5529ad930c038fb0c5bdf9230f08efea9cfa652.