### PR TITLE
Fix regex find example

### DIFF
--- a/topics/galaxy-interface/tutorials/workflow-parameters/tutorial.md
+++ b/topics/galaxy-interface/tutorials/workflow-parameters/tutorial.md
@@ -146,12 +146,12 @@ compose this text parameter using the `Compose text parameter value` tool.
 > 3. Add **Compose text parameter value** {% icon tool %} to the workflow
 >     - Add two more "Components" using the "Insert components" button in the workflow editor tool form on the right of the screen. You will need three "Component" blocks in total.
 >     - In the first component:
->       - *"Enter text that should be part of the computed value"*: `/(`
+>       - *"Enter text that should be part of the computed value"*: `(`
 >     - In the second component:
 >       - *"Enter text that should be part of the computed value"*: Leave empty and click "Add connection to module" {% icon galaxy-wf-connection %}
 >       - Connect the output of the **Input parameter** {% icon tool %} to this new input
 >     - In the third component:
->       - *"Enter text that should be part of the computed value"*: `)/`
+>       - *"Enter text that should be part of the computed value"*: `)`
 >
 > 4. Add the **Regex Find And Replace** {% icon tool %} to the workflow
 >     - Click on `Insert Check`


### PR DESCRIPTION
Not sure how this could go unnoticed until now, but the sed slashes must not be part of the find pattern.