### PR TITLE
Fix dataset type in SARS-CoV-2 data library

### DIFF
--- a/topics/variant-analysis/tutorials/sars-cov-2-variant-discovery/data-library.yaml
+++ b/topics/variant-analysis/tutorials/sars-cov-2-variant-discovery/data-library.yaml
@@ -91,7 +91,7 @@ items:
         info: https://zenodo.org/record/5036687
       - url: https://zenodo.org/api/files/e3380e5c-6916-4490-b9df-59b88a2223c9/ERR5949460_2.fastqsanger.gz
         src: url
-        ext: gz
+        ext: fastqsanger.gz
         info: https://zenodo.org/record/5036687
       - url: https://zenodo.org/api/files/e3380e5c-6916-4490-b9df-59b88a2223c9/ERR5949461_1.fastqsanger.gz
         src: url


### PR DESCRIPTION
This typo caused the dataset to be excluded from auto-populated DLs,
which would then break paired collection building for users.