### PR TITLE
Add Spanish team as codeowners to all translated tutorials

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -34,7 +34,10 @@ topics/variant-analysis/           @galaxyproject/training-variant-analysis
 
 
 # Spanish tutorials
-topics/introduction/tutorials/galaxy-intro-short/     @nomadscientist @beatrizserrano @gallardoalba @davelopez
+topics/introduction/tutorials/galaxy-intro-short/                          @galaxyproject/training-spanish
+topics/transcriptomics/tutorials/droplet-quantification-preprocessing/     @galaxyproject/training-spanish
+topics/transcriptomics/tutorials/scrna-intro/                              @galaxyproject/training-spanish
+topics/transcriptomics/tutorials/scrna-seq-basic-pipeline/                 @galaxyproject/training-spanish
 
 # Lines starting with '#' are comments.
 # # Order is important. The last matching pattern has the most precedence.


### PR DESCRIPTION
Now everybody in @galaxyproject/training-spanish will be notified whenever a PR is made touching a translated tutorial, so that they can help make the required changes in the other language.

If you ever want to be removed from this group and stop receiving these notifications, just let us know. If any other Spanish speakers would like to be added to this group and help out with translations please let us know as well!

@nomadscientist any tutorials missing? 