### PR TITLE
Ensure alt-texts ends with punctuations

### DIFF
--- a/_plugins/jekyll-figurify.rb
+++ b/_plugins/jekyll-figurify.rb
@@ -38,6 +38,9 @@ module Jekyll
           num += 1
 
           alt.gsub!(/"/, '&quot;')
+          unless alt.end_with?(".") || alt.end_with?("!") || alt.end_with?("?")
+            alt = "#{alt}. "
+          end
           prefix = figcaption_prefix(page, site)
           "<figure id=\"figure-#{num}\">" +
             "<img src=\"#{url}\" alt=\"#{alt}\" #{style} loading=\"lazy\">" +
@@ -52,6 +55,9 @@ module Jekyll
         style = $4
 
         alt.gsub!(/"/, '&quot;')
+        unless alt.end_with?(".") || alt.end_with?("!") || alt.end_with?("?")
+          alt = "#{alt}. "
+        end
         "<img src=\"#{url}\" alt=\"#{alt}\" #{style} loading=\"lazy\">"
       }
     end


### PR DESCRIPTION
Fixes #2814 

I edited the script to include blocks that will only add full stops to alt-texts if they do not have a full stop, question or exclamation mark.

