### PR TITLE
Fixing IWTomics error while using the ETn example dataset

### DIFF
--- a/topics/statistics/tutorials/iwtomics/data-library.yaml
+++ b/topics/statistics/tutorials/iwtomics/data-library.yaml
@@ -11,34 +11,34 @@ items:
   items:
   - name: Interval-Wise Testing for omics data
     items:
-    - name: 'DOI: 10.5281/zenodo.1288429'
+    - name: 'DOI: 10.5281/zenodo.5589610'
       description: latest
       items:
-      - url: https://zenodo.org/api/files/04cbd251-fe0b-4408-9f90-e2aecd61ef09/Control.bed
+      - url: https://zenodo.org/api/files/1a11420c-337d-462a-b0bc-e2cb767ce2fa/Control.bed
         src: url
         ext: bed
-        info: https://zenodo.org/record/1288429
-      - url: https://zenodo.org/api/files/04cbd251-fe0b-4408-9f90-e2aecd61ef09/DESCRIPTION.txt
+        info: https://zenodo.org/record/5589610
+      - url: https://zenodo.org/api/files/1a11420c-337d-462a-b0bc-e2cb767ce2fa/DESCRIPTION.txt
         src: url
         ext: txt
-        info: https://zenodo.org/record/1288429
-      - url: https://zenodo.org/api/files/04cbd251-fe0b-4408-9f90-e2aecd61ef09/ETn_fixed.bed
+        info: https://zenodo.org/record/5589610
+      - url: https://zenodo.org/api/files/1a11420c-337d-462a-b0bc-e2cb767ce2fa/ETn_fixed.bed
         src: url
         ext: bed
-        info: https://zenodo.org/record/1288429
-      - url: https://zenodo.org/api/files/04cbd251-fe0b-4408-9f90-e2aecd61ef09/features_header.tabular
+        info: https://zenodo.org/record/5589610
+      - url: https://zenodo.org/api/files/1a11420c-337d-462a-b0bc-e2cb767ce2fa/features_header.tabular
         src: url
         ext: tabular
-        info: https://zenodo.org/record/1288429
-      - url: https://zenodo.org/api/files/04cbd251-fe0b-4408-9f90-e2aecd61ef09/IWTomics_ETn_dataset_example.zip
+        info: https://zenodo.org/record/5589610
+      - url: https://zenodo.org/api/files/1a11420c-337d-462a-b0bc-e2cb767ce2fa/IWTomics_ETn_dataset_example.zip
         src: url
         ext: zip
-        info: https://zenodo.org/record/1288429
-      - url: https://zenodo.org/api/files/04cbd251-fe0b-4408-9f90-e2aecd61ef09/Recombination_hotspots.txt
+        info: https://zenodo.org/record/5589610
+      - url: https://zenodo.org/api/files/1a11420c-337d-462a-b0bc-e2cb767ce2fa/Recombination_hotspots.txt
         src: url
         ext: txt
-        info: https://zenodo.org/record/1288429
-      - url: https://zenodo.org/api/files/04cbd251-fe0b-4408-9f90-e2aecd61ef09/regions_header.tabular
+        info: https://zenodo.org/record/5589610
+      - url: https://zenodo.org/api/files/1a11420c-337d-462a-b0bc-e2cb767ce2fa/regions_header.tabular
         src: url
         ext: tabular
-        info: https://zenodo.org/record/1288429
+        info: https://zenodo.org/record/5589610

--- a/topics/statistics/tutorials/iwtomics/tours/tour.yaml
+++ b/topics/statistics/tutorials/iwtomics/tours/tour.yaml
@@ -22,10 +22,10 @@ steps:
       intro: "ETn example: real data from Campos-Sànchez et al. (2016). Upload 'Fixed ETn' and 'Control' regions, as well as 'Recombination Hotspot' content."
       position: "top"
       textinsert: |
-        https://raw.githubusercontent.com/fabio-cumbo/IWTomics4Galaxy/master/ETn_example/DESCRIPTION.txt
-        https://raw.githubusercontent.com/fabio-cumbo/IWTomics4Galaxy/master/ETn_example/ETn_fixed.bed
-        https://raw.githubusercontent.com/fabio-cumbo/IWTomics4Galaxy/master/ETn_example/Control.bed
-        https://raw.githubusercontent.com/fabio-cumbo/IWTomics4Galaxy/master/ETn_example/Recombination_hotspots.txt
+        https://zenodo.org/api/files/1a11420c-337d-462a-b0bc-e2cb767ce2fa/DESCRIPTION.txt
+        https://zenodo.org/api/files/1a11420c-337d-462a-b0bc-e2cb767ce2fa/ETn_fixed.bed
+        https://zenodo.org/api/files/1a11420c-337d-462a-b0bc-e2cb767ce2fa/Control.bed
+        https://zenodo.org/api/files/1a11420c-337d-462a-b0bc-e2cb767ce2fa/Recombination_hotspots.txt
 
     - title: "Select automatic file type"
       element: ".upload-extension:first"
@@ -52,8 +52,8 @@ steps:
       intro: "ETn example: real data from Campos-Sànchez et al. (2016). Upload header files for regions and features."
       position: "top"
       textinsert: |
-        https://raw.githubusercontent.com/fabio-cumbo/IWTomics4Galaxy/master/ETn_example/regions_header.tabular
-        https://raw.githubusercontent.com/fabio-cumbo/IWTomics4Galaxy/master/ETn_example/features_header.tabular
+        https://zenodo.org/api/files/1a11420c-337d-462a-b0bc-e2cb767ce2fa/regions_header.tabular
+        https://zenodo.org/api/files/1a11420c-337d-462a-b0bc-e2cb767ce2fa/features_header.tabular
 
     - title: "Select header file type"
       element: ".upload-extension:first"

--- a/topics/statistics/tutorials/iwtomics/tutorial.md
+++ b/topics/statistics/tutorials/iwtomics/tutorial.md
@@ -2,7 +2,7 @@
 layout: tutorial_hands_on
 
 title: "Interval-Wise Testing for omics data"
-zenodo_link: "https://doi.org/10.5281/zenodo.1288429"
+zenodo_link: "https://doi.org/10.5281/zenodo.5589610"
 questions:
   - "How to visualize high-resolution omics data in different groups of genomic regions?"
   - "How to evaluate differences in high-resolution omics data between groups of genomic regions?"
@@ -41,7 +41,7 @@ The dataset contains two region datasets "ETn fixed", "Control" and one feature 
 
 Recombination hotspots measurements are associated to each "ETn fixed" and "Control" region. In particular, this feature is measured in 1-kb windows, so that each region is associated to a recombination hotspots curve made of 64 values. The measurement used is the feature content, i.e. the fraction of the 1-kb window that is covered by recombination hotspots
 
-The data we use in this tutorial is available at [Zenodo](https://doi.org/10.5281/zenodo.1184682).
+The data we use in this tutorial is available at [Zenodo](https://doi.org/10.5281/zenodo.5589610).
 
 > ### Agenda
 >
@@ -67,18 +67,20 @@ The first tool (IWTomics Load Smooth and Plot) imports a collection of genomic r
 >    - Recombination Hotspot (`Recombination_hotspots.txt`) content
 >
 >    ```
->    https://zenodo.org/record/1288429/files/ETn_fixed.bed
->    https://zenodo.org/record/1288429/files/Control.bed
->    https://zenodo.org/record/1288429/files/Recombination_hotspots.txt
+>    https://zenodo.org/record/5589610/files/ETn_fixed.bed
+>    https://zenodo.org/record/5589610/files/Control.bed
+>    https://zenodo.org/record/5589610/files/Recombination_hotspots.txt
 >    ```
 > 3. Import header files for regions and features:
 >    - `regions_header.tabular`
 >    - `features_header.tabular`
 >
 >    ```
->    https://zenodo.org/record/1288429/files/regions_header.tabular
->    https://zenodo.org/record/1288429/files/features_header.tabular
+>    https://zenodo.org/record/5589610/files/regions_header.tabular
+>    https://zenodo.org/record/5589610/files/features_header.tabular
 >    ```
+>
+>    Please note that the file names in the first column of the header files must exactly match the dataset names in the Galaxy history.
 {: .hands_on}
 
 > ### {% icon hands_on %} Hands-on: Pre-process data and create pointwise boxplot

--- a/topics/statistics/tutorials/iwtomics/workflows/IWTomics_Workflow.ga
+++ b/topics/statistics/tutorials/iwtomics/workflows/IWTomics_Workflow.ga
@@ -13,10 +13,10 @@
       "inputs": [
         {
           "description": "",
-          "name": "https://zenodo.org/record/1288429/files/ETn_fixed.bed"
+          "name": "ETn_fixed.bed"
         }
       ],
-      "label": "https://zenodo.org/record/1288429/files/ETn_fixed.bed",
+      "label": "ETn_fixed.bed",
       "name": "Input dataset",
       "outputs": [],
       "position": {
@@ -24,7 +24,7 @@
         "top": 200
       },
       "tool_id": null,
-      "tool_state": "{\"name\": \"https://zenodo.org/record/1288429/files/ETn_fixed.bed\"}",
+      "tool_state": "{\"name\": \"ETn_fixed.bed\"}",
       "tool_version": null,
       "type": "data_input",
       "uuid": "7709e0ee-56fc-491d-afad-b10c18758c07",
@@ -39,10 +39,10 @@
       "inputs": [
         {
           "description": "",
-          "name": "https://zenodo.org/record/1288429/files/Control.bed"
+          "name": "Control.bed"
         }
       ],
-      "label": "https://zenodo.org/record/1288429/files/Control.bed",
+      "label": "Control.bed",
       "name": "Input dataset",
       "outputs": [],
       "position": {
@@ -50,7 +50,7 @@
         "top": 320
       },
       "tool_id": null,
-      "tool_state": "{\"name\": \"https://zenodo.org/record/1288429/files/Control.bed\"}",
+      "tool_state": "{\"name\": \"Control.bed\"}",
       "tool_version": null,
       "type": "data_input",
       "uuid": "9c4be2e1-6f14-4ec4-a0e8-3ec4e21a6523",
@@ -65,10 +65,10 @@
       "inputs": [
         {
           "description": "",
-          "name": "https://zenodo.org/record/1288429/files/features_header.tabular"
+          "name": "features_header.tabular"
         }
       ],
-      "label": "https://zenodo.org/record/1288429/files/features_header.tabular",
+      "label": "features_header.tabular",
       "name": "Input dataset",
       "outputs": [],
       "position": {
@@ -76,7 +76,7 @@
         "top": 680
       },
       "tool_id": null,
-      "tool_state": "{\"name\": \"https://zenodo.org/record/1288429/files/features_header.tabular\"}",
+      "tool_state": "{\"name\": \"features_header.tabular\"}",
       "tool_version": null,
       "type": "data_input",
       "uuid": "4a071a64-59d3-481d-8d84-f063c38ddac7",
@@ -91,10 +91,10 @@
       "inputs": [
         {
           "description": "",
-          "name": "https://zenodo.org/record/1288429/files/regions_header.tabular"
+          "name": "regions_header.tabular"
         }
       ],
-      "label": "https://zenodo.org/record/1288429/files/regions_header.tabular",
+      "label": "regions_header.tabular",
       "name": "Input dataset",
       "outputs": [],
       "position": {
@@ -102,7 +102,7 @@
         "top": 560
       },
       "tool_id": null,
-      "tool_state": "{\"name\": \"https://zenodo.org/record/1288429/files/regions_header.tabular\"}",
+      "tool_state": "{\"name\": \"regions_header.tabular\"}",
       "tool_version": null,
       "type": "data_input",
       "uuid": "ac9cf2c6-9bbc-42b4-b4fb-f0fcf92dcee6",
@@ -117,10 +117,10 @@
       "inputs": [
         {
           "description": "",
-          "name": "https://zenodo.org/record/1288429/files/Recombination_hotspots.txt"
+          "name": "Recombination_hotspots.txt"
         }
       ],
-      "label": "https://zenodo.org/record/1288429/files/Recombination_hotspots.txt",
+      "label": "Recombination_hotspots.txt",
       "name": "Input dataset",
       "outputs": [],
       "position": {
@@ -128,7 +128,7 @@
         "top": 440
       },
       "tool_id": null,
-      "tool_state": "{\"name\": \"https://zenodo.org/record/1288429/files/Recombination_hotspots.txt\"}",
+      "tool_state": "{\"name\": \"Recombination_hotspots.txt\"}",
       "tool_version": null,
       "type": "data_input",
       "uuid": "946f863d-0ef4-42b1-bb87-25247e31d4d9",


### PR DESCRIPTION
This PR allows IWTomics to work with the new fixed ETn example dataset in Zenodo: [10.5281/zenodo.5589610](https://www.doi.org/10.5281/zenodo.5589610)

File names in the first column of the header files now match the dataset names in the Galaxy history.