### PR TITLE
Stats page: do not count hidden tutorials towards stats

### DIFF
--- a/stats.md
+++ b/stats.md
@@ -3,12 +3,12 @@ layout: base
 ---
 
 <!-- tutorial stats -->
-{% assign tutorials = site.pages | where:"layout", "tutorial_hands_on" %}
+{% assign tutorials = site.pages | where:"layout", "tutorial_hands_on" | where_exp:"item","item.enable != false" %}
 
 <!-- topic stats -->
-{% assign topics = site.data | where_exp: "item", "item.type" %}
-{% assign topics_science = topics | where: "type","use" | sort: "name" %}
-{% assign topics_technical = topics | where_exp: "item", "item.type != 'use'"%}
+{% assign topics = site.data | where_exp: "item", "item.type" | where_exp:"item","item.enable != false" %}
+{% assign topics_science = topics | where: "type","use" | where_exp:"item","item.enable != false" | sort: "name" %}
+{% assign topics_technical = topics | where_exp: "item", "item.type != 'use'" | where_exp:"item","item.enable != false" %}
 
 <!-- contributors stats -->
 {% assign contributors = site.data['contributors'] | where_exp: "item", "item.halloffame != 'no'" | sort: "joined" %}


### PR DESCRIPTION
disabled tutorials and topics were being counted on the stats page, e.g. the WIP genome editing topic:

![image](https://user-images.githubusercontent.com/2563865/138446479-f1fdd5bd-30cc-48dc-803d-255fb7f396af.png)
