### PR TITLE
Update core-contributing tutorial

### DIFF
--- a/topics/dev/tutorials/core-contributing/__init__.py_diff.md
+++ b/topics/dev/tutorials/core-contributing/__init__.py_diff.md
@@ -4,20 +4,29 @@
 > Possible changes to file ``lib/galaxy/model/__init__.py``:
 > 
 > ```diff
-> index 2c0b8a4dc4..69a74b0ad2 100644
+> index 35e9ac1ba1..36a3ea9cc5 100644
 > --- a/lib/galaxy/model/__init__.py
 > +++ b/lib/galaxy/model/__init__.py
-> @@ -6617,6 +6617,11 @@ class UserPreference(RepresentById):
+> @@ -512,6 +512,7 @@ class User(Base, Dictifiable, RepresentById):
+>          cascade='all, delete-orphan',
+>          collection_class=ordering_list('order_index'))
+>      _preferences = relationship('UserPreference', collection_class=attribute_mapped_collection('name'))
+> +    favorite_extensions=relationship('UserFavoriteExtension')
+>      values = relationship('FormValues',
+>          primaryjoin=(lambda: User.form_values_id == FormValues.id))  # type: ignore
+>      # Add type hint (will this work w/SA?)
+> @@ -8557,6 +8558,12 @@ class UserPreference(Base, RepresentById):
+>          self.name = name
 >          self.value = value
 >  
+> +class UserFavoriteExtension(Base, RepresentById):
+> +    __tablename__ = 'user_favorite_extension'
+> +
+> +    id = Column(Integer, primary_key=True)
+> +    user_id = Column(Integer, ForeignKey("galaxy_user.id"), index=True)
+> +    value = Column(Text)
 >  
-> +class UserFavoriteExtension(RepresentById):
-> +    def __init__(self, value=None):
-> +        self.value = value
-> +
-> +
->  class UserAction(RepresentById):
->      def __init__(self, id=None, create_time=None, user_id=None, session_id=None, action=None, params=None, context=None):
->          self.id = id
+>  class UserAction(Base, RepresentById):
+>      __tablename__ = 'user_action'
 > ```
 {: .solution }

--- a/topics/dev/tutorials/core-contributing/tutorial.md
+++ b/topics/dev/tutorials/core-contributing/tutorial.md
@@ -208,7 +208,7 @@ Verify this test fails when running stand-alone.
 
 > ### {% icon code-in %} Input: Bash
 > ```bash
-> ./run_tests.sh -api lib/galaxy_test/api/test_users.py::UsersApiTestCase::test_favorite_extensions
+> GALAXY_TEST_USE_UVICORN=TRUE ./run_tests.sh -api lib/galaxy_test/api/test_users.py::UsersApiTestCase::test_favorite_extensions
 > ```
 {: .code-in}
 
@@ -240,7 +240,7 @@ with ``add_favorite_extension`` before finishing with ``delete_favorite_extensio
 
 > ### {% icon code-in %} Input: Bash
 > ```bash
-> ./run_tests.sh -api lib/galaxy_test/api/test_users.py::UsersApiTestCase::test_favorite_extensions
+> GALAXY_TEST_USE_UVICORN=TRUE ./run_tests.sh -api lib/galaxy_test/api/test_users.py::UsersApiTestCase::test_favorite_extensions
 > ```
 {: .code-in}
 

--- a/topics/dev/tutorials/core-contributing/tutorial.md
+++ b/topics/dev/tutorials/core-contributing/tutorial.md
@@ -208,7 +208,7 @@ Verify this test fails when running stand-alone.
 
 > ### {% icon code-in %} Input: Bash
 > ```bash
-> GALAXY_TEST_USE_UVICORN=TRUE ./run_tests.sh -api lib/galaxy_test/api/test_users.py::UsersApiTestCase::test_favorite_extensions
+> ./run_tests.sh -api lib/galaxy_test/api/test_users.py::UsersApiTestCase::test_favorite_extensions
 > ```
 {: .code-in}
 
@@ -240,7 +240,7 @@ with ``add_favorite_extension`` before finishing with ``delete_favorite_extensio
 
 > ### {% icon code-in %} Input: Bash
 > ```bash
-> GALAXY_TEST_USE_UVICORN=TRUE ./run_tests.sh -api lib/galaxy_test/api/test_users.py::UsersApiTestCase::test_favorite_extensions
+> ./run_tests.sh -api lib/galaxy_test/api/test_users.py::UsersApiTestCase::test_favorite_extensions
 > ```
 {: .code-in}
 


### PR DESCRIPTION
Suggested change for the "Contributing a New Feature to Galaxy Core" tutorial. Moving the table definition from `mapping.py` to `__init__.py`. Also, I think it should be noted that python 3.7 is required for FastAPI.  