### PR TITLE
Improved and corrected some alt texts to improve accessibility

### DIFF
--- a/topics/introduction/tutorials/galaxy-intro-101-everyone/tutorial.md
+++ b/topics/introduction/tutorials/galaxy-intro-101-everyone/tutorial.md
@@ -82,7 +82,7 @@ The Galaxy interface consists of three main parts:
 2. Your analysis history is recorded on the right
 3. The central panel will let you run analyses and view outputs
 
-![Galaxy ecosystem]({% link shared/images/galaxy_interface.png %})
+![Galaxy interface screenshot showing history panel on the right, tools panel on the left, and main panel at the center]({% link shared/images/galaxy_interface.png %})
 
 
 # Create a history
@@ -376,7 +376,7 @@ In our dataset, we have the following features measured for each sample:
 
 > ### {% icon comment %} petal and sepal
 > The image below shows you what the terms sepal and petal mean.
-> ![Sepal and petal](../../images/iris_sepal_petal.png "Sepal and petal of Iris flowers")
+> ![Iris flower image showing Petal and Sepal](../../images/iris_sepal_petal.png "Sepal and petal of Iris flowers")
 {: .comment}
 
 ## Generate summary and descriptive statistics with

--- a/topics/introduction/tutorials/galaxy-intro-101/tutorial.md
+++ b/topics/introduction/tutorials/galaxy-intro-101/tutorial.md
@@ -84,7 +84,7 @@ The Galaxy interface consists of three main parts:
 3. Your analysis **History** is recorded on the right
 
 
-> ![Galaxy interface](../../images/galaxy_interface.svg "Galactic triptych: the three panels of Galaxy interface: <em>Tools</em>, <em>Center Panel</em>, and <em>History</em>")
+> ![Galaxy interface screenshot showing History panel on the right, tools panel on the left, and main panel in the center](../../images/galaxy_interface.svg "Galactic triptych: the three panels of Galaxy interface: <em>Tools</em>, <em>Center Panel</em>, and <em>History</em>")
 {: .comment}
 
 When you start Galaxy for very first time, your history will be empty. Let's add some data to it.
@@ -108,7 +108,7 @@ First we need to get some data into our history. You can upload files from your 
 > ### {% icon hands_on %} Hands-on: Upload SNPs and Exons
 > 1. At the top of the **Tools** panel (on the left), click {% icon galaxy-upload %} **Upload Data**
 >
->    ![upload button](../../images/upload-data.png)
+>    ![upload data button](../../images/upload-data.png)
 >
 >    This brings up a box:
 >
@@ -255,7 +255,7 @@ Our objective is to find which exon contains the most SNPs. Therefore we have to
 >
 >  The interface of the tool should look like this:
 >
->    ![Contents of the `Join` output dataset](../../images/101_bed_intersect_interface.png)
+>    ![Bedtool intersect interval interface](../../images/101_bed_intersect_interface.png)
 >
 >    > ### {% icon tip %} How do I use this tool?
 >    > All Galaxy tools include documentation. If you scroll down on this page, you will find the help of the tool.
@@ -309,13 +309,13 @@ Since each line in our file represents a single overlap between SNP and exon, we
 >    - *"Input tabular dataset"*: select the output dataset from **bedtools intersect intervals** {% icon tool %}
 >    - *"Group by fields"*: `Column: 4` (the column with the exon IDs)
 >
->    ![Contents of the `Group` output dataset](../../images/101_datamash_1.png)
+>    ![Datamash tool interface](../../images/101_datamash_1.png)
 >
 >    - Scroll tool interface down to *"Operation to perform on each group"*
 >      - *"Type"*: `Count Unique values`
 >      - *"On column"*: `Column: 10` (this column contains SNPs ids like `rs2236639`. This we will count occurrences of unique SNP ids for each exon)
 >
->    ![Contents of the `Group` output dataset](../../images/101_datamash_2.png)
+>    ![Operation to perform on each group](../../images/101_datamash_2.png)
 >
 > 2. Click **Execute**. Your new output dataset will look something like this:
 >

--- a/topics/introduction/tutorials/galaxy-intro-peaks2genes/tutorial.md
+++ b/topics/introduction/tutorials/galaxy-intro-peaks2genes/tutorial.md
@@ -72,7 +72,7 @@ The goal of this exercise is to **turn this list of genomic regions into a list 
 
 The Galaxy interface consist of three main parts. The available tools are listed on the left, your analysis history is recorded on the right, and the central panel will show the tools and datasets.
 
-![Galaxy interface](../../images/galaxy_interface.png "The Galaxy interface")
+![Galaxy interface screenshot showing history panel on the right, tools panel on the left, and main panel at the center](../../images/galaxy_interface.png "The Galaxy interface")
 
 Let's start with a fresh history.
 
@@ -104,7 +104,7 @@ Let's start with a fresh history.
 > 1. Download the list of peak regions (the file [`GSE37268_mof3.out.hpeak.txt.gz`](https://www.ncbi.nlm.nih.gov/geo/download/?acc=GSE37268&format=file&file=GSE37268%5Fmof3%2Eout%2Ehpeak%2Etxt%2Egz)) from [GEO](https://www.ncbi.nlm.nih.gov/geo/query/acc.cgi?acc=GSE37268) to your computer
 > 2. Click on the upload button in the upper left ot the interface
 >
->    ![Upload icon](../../../galaxy-interface/images/upload_button.png)
+>    ![Upload data icon](../../../galaxy-interface/images/upload_button.png)
 >
 > 3. Press **Choose local file** and search for your file on your computer
 > 4. Select `interval` as **Type**

--- a/topics/introduction/tutorials/galaxy-intro-short/tutorial.md
+++ b/topics/introduction/tutorials/galaxy-intro-short/tutorial.md
@@ -101,7 +101,7 @@ Your "Tools" are in the panel at the left.
 > ### {% icon hands_on %} Hands-on: Upload a file from URL
 > 1. At the top of the **Tools** panel (on the left), click {% icon galaxy-upload %} **Upload**
 >
->    ![upload button](../../images/upload-data.png)
+>    ![upload data button](../../images/upload-data.png)
 >
 >    This brings up a box:
 >
@@ -133,7 +133,7 @@ What is this file?
 > ### {% icon hands_on %} Hands-on: View the dataset content
 > 1. Click on the {% icon galaxy-eye %} (eye) icon next to the dataset name, to look at the file content
 >
->    ![eye](../../images/eye-icon.png){:width="320px"}
+>    ![eye icon with dropdown titled View Data](../../images/eye-icon.png){:width="320px"}
 {: .hands_on}
 
 The contents of the file will be displayed in the central Galaxy panel.
@@ -223,7 +223,7 @@ We could click on the eye icon to view the contents of this output file, but it 
 >
 >    This expands the information about the file.
 >
->    ![filter1](../../images/filter-fastq1.png)
+>    ![filter1 with 3 arrows click on filename to expand, click filter settings and how many reads were filtered out](../../images/filter-fastq1.png)
 >
 {: .hands_on}
 
@@ -243,7 +243,7 @@ We have now decided that our input reads have to be filtered to an even higher s
 > ### {% icon hands_on %} Hands-on: Re-run the tool
 > 1. Click on the {% icon galaxy-refresh %} icon (**Run this job again**) for the output dataset of **Filter by quality** {% icon tool %}
 >
->    ![rerun](../../images/rerun.png)
+>    ![rerun the job](../../images/rerun.png)
 >
 >    This brings up the tool interface in the central panel with the parameters set to the values used previously to generate this dataset.
 >
@@ -287,7 +287,7 @@ Where is your first history, called "my-analysis"?
 > ### {% icon hands_on %} Hands-on: View histories
 > 1. Click on the **View all histories** ({% icon galaxy-columns %} icon) at the top right of your history
 >
->    ![view-hist](../../images/galaxy_interface_history_switch.png){:width="320px"}
+>    ![view all histories](../../images/galaxy_interface_history_switch.png){:width="320px"}
 >
 >    A new page will appear with all your histories displayed here.
 >

--- a/topics/introduction/tutorials/galaxy-intro-strands/tutorial.md
+++ b/topics/introduction/tutorials/galaxy-intro-strands/tutorial.md
@@ -106,7 +106,7 @@ It turns out that for this particular question (and for many others), most **Gal
 
 The Galaxy interface consists of three main parts. The available tools are listed on the left, your analysis history is recorded on the right, and the central panel will show the home page, tool forms, and dataset content.
 
-![Galaxy interface](../../images/galaxy_interface.png)
+![Galaxy interface showing history panel on the right, tools panel on the left and main panel at the center](../../images/galaxy_interface.png)
 
 > ### {% icon hands_on %} Hands-on: Start with an empty history
 >
@@ -215,7 +215,7 @@ Watch your new history item.  It will go through three statuses before it's done
 | **Grey** | Clock | Item is waiting to start (waiting for data transfer to start) | ![Status: Queued](../../images/status_queued.png) |
 | **Yellow** | Spinner | Item is running (data is actively being transferred). | ![Status: Running](../../images/status_running.png) |
 | **Green** | None | Item has finished successfully (data transfer complete). | ![Status: Successfully finished](../../images/status_finished_success.png) |
-| **Red**  | Cross | The job has failed. There can be [many reasons](https://galaxyproject.org/support/tool-error/). | ![Status: Successfully finished](../../images/status_failed.png) |
+| **Red**  | Cross | The job has failed. There can be [many reasons](https://galaxyproject.org/support/tool-error/). | ![Status: Failed](../../images/status_failed.png) |
 | ---- | ---- | ---- |
 
 You can find more information in the [Undestanding Galaxy history system](https://training.galaxyproject.org/training-material/topics/galaxy-interface/tutorials/history/tutorial.html) training.


### PR DESCRIPTION
Hi, I checked the alt texts of the images in **Introduction to Galaxy Analyses** hands-on tutorial materials and I found out that some alt texts were not descriptive enough. 

This defeats our goal of making the materials accessible to visually impaired users.
Out of the 9 tutorial materials, 5 materials needed the improvement which I have done.
I also corrected an error in status description image alt text of Introduction to Genomics and Galaxy tutorial: It read _'successful'_ instead of _'failed'._

What do you think?