### PR TITLE
Detect "news" and send it to Matrix & Gitter

### DIFF
--- a/.github/workflows/matrix.yml
+++ b/.github/workflows/matrix.yml
@@ -1,0 +1,31 @@
+name: Send news to Matrix
+
+on:
+  schedule:
+    # * is a special character in YAML so you have to quote this string
+    # We'll run this daily at noon.
+    - cron:  '0 12 * * *'
+  workflow_dispatch:
+
+jobs:
+  runner-job:
+    if: github.repository_owner == 'galaxyproject'
+    runs-on: ubuntu-20.04
+
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+
+      # BEGIN Dependencies
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: "2.5"
+      # END Dependencies
+
+      - name: Send announcements to matrix
+        run: |
+            commit=$(git log --since "24 hours ago" --format=%H | tail -n 1)
+            ruby bin/news.rb -p "${commit}~1" --matrix-post
+        env:
+            MATRIX_ACCESS_TOKEN: ${{ github.matrix_access_token }}

--- a/bin/news.rb
+++ b/bin/news.rb
@@ -1,0 +1,119 @@
+#!/usr/bin/env ruby
+require 'json'
+require 'kramdown'
+require 'uri'
+require 'net/http'
+require 'yaml'
+require 'optparse'
+
+options = {}
+OptionParser.new do |opt|
+  opt.on("-p", "--previous-commit PREVIOUS_COMMIT"){|o| options[:previousCommit] = o}
+  opt.on('--matrix-post'){|o| options[:postToMatrix] = o}
+  opt.on('--matrix-use-test-room'){|o| options[:useTestRoom] = o}
+end.parse!
+
+if options[:previousCommit].nil?
+  puts "Missing a previous commit to compare against"
+  exit 1
+end
+
+addedfiles =`git diff --cached --name-only --diff-filter=A #{options[:previousCommit]}`.split("\n")
+modifiedfiles =`git diff --cached --name-only --diff-filter=M #{options[:previousCommit]}`.split("\n")
+
+NOW = Time.now
+CONTRIBUTORS = YAML.load_file('CONTRIBUTORS.yaml')
+
+# new   news
+# new   slidevideos
+# new   contributors   Done
+# new   tutorials      Done
+# new   slides         Done
+
+def filterTutorials(x)
+  return x =~ /topics\/.*\/tutorials\/.*\/tutorial.*\.md/
+end
+
+def filterSlides(x)
+  return x =~ /topics\/.*\/tutorials\/.*\/slides.*\.html/
+end
+
+def onlyEnabled(x)
+  d = YAML.load_file(x)
+  d.fetch('enabled', true)
+end
+
+def printableMaterial(path)
+  d = YAML.load_file(path)
+  return "[#{d['title']}](#{path.gsub(/.md/, ".html")})"
+end
+
+data = {
+  'added': {
+    'slides': addedfiles.select{|x| filterSlides(x)}.select{|x| onlyEnabled(x)}.map{|x| printableMaterial(x)},
+    'tutorials': addedfiles.select{|x| filterTutorials(x)}.select{|x| onlyEnabled(x)}.map{|x| printableMaterial(x)},
+    'news': addedfiles.select{|x| x =~ /news\/_posts\/.*\.md/}.map{|x| printableMaterial(x)}
+  },
+  #'modified': {
+    #'slides': modifiedfiles.select{|x| filterSlides(x)},
+    #'tutorials': modifiedfiles.select{|x| filterTutorials(x)},
+  #},
+  'contributors': `git diff --unified #{options[:previousCommit]} CONTRIBUTORS.yaml`
+    .split("\n").select{|line| line =~ /^+[^ ]+:\s*$/}.map{|x| x.strip()[1..-2]}
+}
+
+output = "# GTN News for #{NOW.strftime("%b %d")}"
+newsworthy = false
+
+if data[:added][:news].length > 0
+  newsworthy = true
+  output += "\n\n## Big News!\n\n"
+  output += data[:added][:news].join("\n").gsub(/^/, "- ")
+end
+
+if data[:added][:tutorials].length > 0
+  newsworthy = true
+  output += "\n\n## #{data[:added][:tutorials].length} new tutorials!\n\n"
+  output += data[:added][:tutorials].join("\n").gsub(/^/, "- ")
+end
+
+if data[:added][:slides].length > 0
+  newsworthy = true
+  output += "\n\n## #{data[:added][:slides].length} new slides!\n\n"
+  output += data[:added][:slides].join("\n").gsub(/^/, "- ")
+end
+
+if data[:contributors].length > 0
+  newsworthy = true
+  output += "\n\n## #{data[:contributors].length} new contributors!\n\n"
+  output += data[:contributors].join("\n").gsub(/^(.*)$/, '- [\1](https://training.galaxyproject.org/hall-of-fame/\1)')
+end
+
+if newsworthy
+  if options[:postToMatrix]
+    if options[:useTestRoom]
+      homeserver = "https://matrix.org/_matrix/client/r0/rooms/!LcoypptdBmTAvbxeJm:matrix.org/send/m.room.message"
+    else
+      homeserver = "https://matrix.org/_matrix/client/r0/rooms/!yShkfqncgjcRcRztBU:gitter.im/send/m.room.message"
+    end
+
+    data = {
+        "msgtype" => "m.notice",
+        "body" => output,
+        "format" => "org.matrix.custom.html",
+        "formatted_body" => Kramdown::Document.new(output).to_html,
+    }
+
+    headers = {
+        "Authorization" => "Bearer #{ENV['MATRIX_ACCESS_TOKEN']}",
+        "Content-type" => "application/json",
+    }
+
+    uri = URI(homeserver)
+    req = Net::HTTP.post(uri, JSON.generate(data), headers)
+    puts req
+    puts req.body
+  else
+    puts output
+  end
+end


### PR DESCRIPTION
This is a script which compares against an old git commit for:

- new news posts
- new slides
- new tutorials
- new contributors


And then will post that to our matrix channel. It will run daily at noon-ish and post to the GTN matrix/gitter channel.

You can test locally by doing something like:

```
$ ruby bin/news.rb -p HEAD~90
# GTN News for Nov 17

## 4 new tutorials!

- [Advanced Python](topics/data-science/tutorials/python-advanced-np-pd/tutorial.html)
- [Introduction to Python](topics/data-science/tutorials/python-basics/tutorial.html)
- [Plotting in Python](topics/data-science/tutorials/python-plotting/tutorial.html)
- [dplyr & tidyverse for data processing](topics/data-science/tutorials/r-dplyr/tutorial.html)

## 3 new slides!
...
```

and seeing the nice markdown output. It takes a commit hash or something that can be resolved with `git log`. In matrix it will look like

![screenshot of above markdown posted to matrix by a gtn bot account](https://user-images.githubusercontent.com/458683/142167465-52d0cf10-58ed-4d17-8818-d6d54215ce7f.png)

Things it doesn't detect:

- updates to existing tutorials (it could!)
- tutorials being converted from disabled to enabled (write a news post I guess?)
- PRs being merged (need GH APIs and it's just annoying, maybe too noisy vs this bot which only posts if something bigger changes.)