### PR TITLE
Show enable:false in non-production builds

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -70,8 +70,12 @@ serve-quick: api/swagger.json ## run a local server (faster, some plugins disabl
 .PHONY: serve-quick
 
 serve-gitpod: bundle-install api/swagger.json  ## run a server on a gitpod.io environment
-	bundle exec jekyll serve --config _config.yml,_config-dev.yml --incremental
+	bundle exec jekyll serve --config _config.yml --incremental
 .PHONY: serve-gitpod
+
+build-gitpod: bundle-install api/swagger.json  ## run a build on a gitpod.io environment
+	bundle exec jekyll build --config _config.yml
+.PHONY: build-gitpod
 
 build: clean api/swagger.json ## build files but do not run a server (You can specify FLAGS= to pass additional flags to Jekyll)
 	$(ACTIVATE_ENV) && \

--- a/_includes/tutorial_list.html
+++ b/_includes/tutorial_list.html
@@ -29,7 +29,7 @@
     {% endif %}
 
     {% if include.sub == nil or show == true %}
-      {% if material.enable == nil or material.enable == true %}
+      {% if material.enable != false or jekyll.environment != "production" %}
         <tr>
           <td class="tutorial_title">
           {{ material.title}}

--- a/_layouts/feedback.html
+++ b/_layouts/feedback.html
@@ -302,7 +302,7 @@ layout: base
 
                             <div id="collapse-{{ tuto_name }}" class="collapse" aria-labelledby="heading-{{ tuto_name }}" data-parent="#accordion-{{ topic_name }}">
                                 <div class="card-body">
-                                    {% if tuto_metadata.enable == false or tuto_metadata.enable == "false" %}
+                                    {% if tuto_metadata.enable == false %}
                                     <div class="alert alert-warning" role="alert">
                                         <p>This tutorial is not listed in the topic pages.</p>
                                     </div>

--- a/_layouts/home.html
+++ b/_layouts/home.html
@@ -37,7 +37,7 @@ layout: base
                     {% if topic[1].enable != false or jekyll.environment != "production" %}
                     <tr>
                         {% assign tutorial_number = site | topic_filter:topic[1].name | topic_count %}
-                        <td><a href="{{ site.baseurl }}/topics/{{ topic[1].name }}/">{{ topic[1].title }}</a></td>
+                        <td><a href="{{ site.baseurl }}/topics/{{ topic[1].name }}/">{{ topic[1].title }}</a>{% if topic[1].enable == false %} <div class="label label-default tutorial_tag" style="{{ 'work-in-progress' | colour_tag }}">work-in-progress</div>{% endif %}</td>
                         <td>{{ tutorial_number }}</td>
                     </tr>
                     {% endif %}
@@ -60,7 +60,7 @@ layout: base
                     {% if topic[1].enable != false or jekyll.environment != "production" %}
                     <tr>
                         {% assign tutorial_number = site | topic_filter:topic[1].name | topic_count %}
-                        <td><a href="{{ site.baseurl }}/topics/{{ topic[1].name }}/">{{ topic[1].title }}</a></td>
+                        <td><a href="{{ site.baseurl }}/topics/{{ topic[1].name }}/">{{ topic[1].title }}</a>{% if topic[1].enable == false %} <div class="label label-default tutorial_tag" style="{{ 'work-in-progress' | colour_tag }}">work-in-progress</div>{% endif %}</td>
                         <td>{{ tutorial_number }}</td>
                     </tr>
                     {% endif %}
@@ -83,7 +83,7 @@ layout: base
                     {% if topic[1].enable != false or jekyll.environment != "production" %}
                     <tr>
                         {% assign tutorial_number = site | topic_filter:topic[1].name | topic_count %}
-                        <td><a href="{{ site.baseurl }}/topics/{{ topic[1].name }}/">{{ topic[1].title }}</a></td>
+                        <td><a href="{{ site.baseurl }}/topics/{{ topic[1].name }}/">{{ topic[1].title }}</a>{% if topic[1].enable == false %} <div class="label label-default tutorial_tag" style="{{ 'work-in-progress' | colour_tag }}">work-in-progress</div>{% endif %}</td>
                         <td>{{ tutorial_number }}</td>
                     </tr>
                     {% endif %}
@@ -106,7 +106,7 @@ layout: base
                     {% if topic[1].enable != false or jekyll.environment != "production" %}
                     <tr>
                         {% assign tutorial_number = site | topic_filter:topic[1].name | topic_count %}
-                        <td><a href="{{ site.baseurl }}/topics/{{ topic[1].name }}/">{{ topic[1].title }}</a></td>
+                        <td><a href="{{ site.baseurl }}/topics/{{ topic[1].name }}/">{{ topic[1].title }}</a>{% if topic[1].enable == false %} <div class="label label-default tutorial_tag" style="{{ 'work-in-progress' | colour_tag }}">work-in-progress</div>{% endif %}</td>
                         <td>{{ tutorial_number }}</td>
                     </tr>
                     {% endif %}
@@ -137,7 +137,7 @@ layout: base
                     {% if topic[1].enable != false or jekyll.environment != "production" %}
                     <tr>
                         {% assign tutorial_number = site | topic_filter:topic[1].name | topic_count %}
-                        <td><a href="{{ site.baseurl }}/topics/{{ topic[1].name }}/">{{ topic[1].title }}</a></td>
+                        <td><a href="{{ site.baseurl }}/topics/{{ topic[1].name }}/">{{ topic[1].title }}</a>{% if topic[1].enable == false %} <div class="label label-default tutorial_tag" style="{{ 'work-in-progress' | colour_tag }}">work-in-progress</div>{% endif %}</td>
                         <td>{{ tutorial_number }}</td>
                     </tr>
                     {% endif %}

--- a/_layouts/home.html
+++ b/_layouts/home.html
@@ -33,12 +33,14 @@ layout: base
                 </thead>
                 <tbody>
                 {% for topic in sorted_topics %}
-                    {% if topic[1].type == "use" and topic[1].enable != false %}
+                    {% if topic[1].type == "use" %}
+                    {% if topic[1].enable != false or jekyll.environment != "production" %}
                     <tr>
                         {% assign tutorial_number = site | topic_filter:topic[1].name | topic_count %}
                         <td><a href="{{ site.baseurl }}/topics/{{ topic[1].name }}/">{{ topic[1].title }}</a></td>
                         <td>{{ tutorial_number }}</td>
                     </tr>
+                    {% endif %}
                     {% endif %}
                 {% endfor %}
                 </tbody>
@@ -54,12 +56,14 @@ layout: base
                 </thead>
                 <tbody>
                 {% for topic in sorted_topics %}
-                    {% if topic[1].type == "basics" and topic[1].enable != false  %}
+                    {% if topic[1].type == "basics" %}
+                    {% if topic[1].enable != false or jekyll.environment != "production" %}
                     <tr>
                         {% assign tutorial_number = site | topic_filter:topic[1].name | topic_count %}
                         <td><a href="{{ site.baseurl }}/topics/{{ topic[1].name }}/">{{ topic[1].title }}</a></td>
                         <td>{{ tutorial_number }}</td>
                     </tr>
+                    {% endif %}
                     {% endif %}
                 {% endfor %}
                 </tbody>
@@ -75,12 +79,14 @@ layout: base
                 </thead>
                 <tbody>
                 {% for topic in sorted_topics %}
-                    {% if topic[1].type == "data-science" and topic[1].enable != false  %}
+                    {% if topic[1].type == "data-science" %}
+                    {% if topic[1].enable != false or jekyll.environment != "production" %}
                     <tr>
                         {% assign tutorial_number = site | topic_filter:topic[1].name | topic_count %}
                         <td><a href="{{ site.baseurl }}/topics/{{ topic[1].name }}/">{{ topic[1].title }}</a></td>
                         <td>{{ tutorial_number }}</td>
                     </tr>
+                    {% endif %}
                     {% endif %}
                 {% endfor %}
                 </tbody>
@@ -96,12 +102,14 @@ layout: base
                 </thead>
                 <tbody>
                 {% for topic in sorted_topics %}
-                    {% if topic[1].type == "admin-dev" and topic[1].enable != false  %}
+                    {% if topic[1].type == "admin-dev" %}
+                    {% if topic[1].enable != false or jekyll.environment != "production" %}
                     <tr>
                         {% assign tutorial_number = site | topic_filter:topic[1].name | topic_count %}
                         <td><a href="{{ site.baseurl }}/topics/{{ topic[1].name }}/">{{ topic[1].title }}</a></td>
                         <td>{{ tutorial_number }}</td>
                     </tr>
+                    {% endif %}
                     {% endif %}
                 {% endfor %}
                 </tbody>
@@ -125,12 +133,14 @@ layout: base
                 </thead>
                 <tbody>
                 {% for topic in sorted_topics %}
-                    {% if topic[1].type == "instructors" and topic[1].enable != false %}
+                    {% if topic[1].type == "instructors" %}
+                    {% if topic[1].enable != false or jekyll.environment != "production" %}
                     <tr>
                         {% assign tutorial_number = site | topic_filter:topic[1].name | topic_count %}
                         <td><a href="{{ site.baseurl }}/topics/{{ topic[1].name }}/">{{ topic[1].title }}</a></td>
                         <td>{{ tutorial_number }}</td>
                     </tr>
+                    {% endif %}
                     {% endif %}
                 {% endfor %}
                 </tbody>

--- a/_layouts/tutorial_hands_on.html
+++ b/_layouts/tutorial_hands_on.html
@@ -14,7 +14,7 @@ footer: no
 {% assign associated_slides = false %}
 {% assign own_material = null %}
 {% for material in topic_material %}
-    {% if material.enable != "false" %}
+    {% if material.enable != "false" or jekyll.environment != "production"  %}
         {% if material.tutorial_name == page.tutorial_name %}
             {% assign own_material = material %}
             {% if material.slides  %}
@@ -339,7 +339,7 @@ document.getElementById("citation-text").innerHTML = document.getElementById("ci
                     {% assign topic = site.data[page.topic_name] %}
                     <ol>
                     {% for material in topic_material %}
-                        {% if material.enable != "false" %}
+                        {% if material.enable != "false" or jekyll.environment != "production" %}
                             {% if material.type == "introduction" %}
                     <li><a href="{{ site.baseurl }}/topics/{{ topic.name }}/slides/{{ material.tutorial_name }}.html">{{ material.title }}</a></li>
                             {% elsif material.type == "tutorial" %}

--- a/_plugins/jekyll-topic-filter.rb
+++ b/_plugins/jekyll-topic-filter.rb
@@ -157,9 +157,15 @@ module TopicFilter
       # make it future proof.
       page_obj['type'] = 'tutorial'
 
-      if not page_obj.has_key?("enable") or page_obj['enable'] then
-        resource_pages.push(page_obj)
+      if page_obj.has_key?("enable") and !page_obj['enable'] then
+        if ! page_obj.has_key? 'tags'
+          page_obj['tags'] = Array.new
+        end
+        page_obj['tags'].append('work-in-progress')
       end
+
+      # Push onto our stack.
+      resource_pages.push(page_obj)
     end
 
     # The complete resources we'll return is the introduction slides first

--- a/topics/data-management/metadata.yaml
+++ b/topics/data-management/metadata.yaml
@@ -1,7 +1,7 @@
 ---
 name: data-management
 type: data-science
-#enable: false
+enable: false
 title: RDMBites Data Management
 summary: Your text goes here! Write something useful about RDMbites and RDM
 requirements:

--- a/topics/transcriptomics/tutorials/full-de-novo/workflows/index.md
+++ b/topics/transcriptomics/tutorials/full-de-novo/workflows/index.md
@@ -1,0 +1,3 @@
+---
+layout: workflow-list
+---


### PR DESCRIPTION
Now hidden topics will be shown in dev builds of the training material (dev = anything other than the deployment script where we explicitly set JEKYLL_ENV=production)

![image](https://user-images.githubusercontent.com/458683/143061390-ea458458-d9f3-4d92-a32d-7b13e6a108aa.png)

And within that all of the `enable:false` tutorials will be shown, with the additional tag of 'work-in-progress' applied to those tutorials.

![image](https://user-images.githubusercontent.com/458683/143061470-4c9104aa-dcf5-4f4e-89a4-f888ab70c204.png)

This one should help you @robertmand 