### PR TITLE
GTN Video Library: support multi-video tutorials

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -59,6 +59,7 @@ jobs:
           make rebuild-search-index ACTIVATE_ENV=pwd
           cat metadata/swagger.yaml | python bin/yaml2json.py > api/swagger.json
           curl --retry 5 https://gallantries.github.io/video-library/api/videos.json > metadata/video-library.json
+          curl --retry 5 https://gallantries.github.io/video-library/api/sessions.json > metadata/session-library.json
           JEKYLL_ENV=production bundle exec jekyll build --strict_front_matter -d _site/training-material
         env:
           GTN_FORK: ${{ github.repository_owner }}

--- a/_includes/resource-video-library.html
+++ b/_includes/resource-video-library.html
@@ -7,8 +7,9 @@
 {% assign hasvideo-tutorial = site.data['video-library'][id-tutorial] %}
 {% assign hasvideo-slides = site.data['video-library'][id-slides] %}
 {% assign hasvideo-both = site.data['video-library'][id-both]%}
+{% assign hassession = site.data['session-library'][id-tutorial]%}
 
-  {% if hasvideo-tutorial or hasvideo-slides or hasvideo-both %}
+  {% if hasvideo-tutorial or hasvideo-slides or hasvideo-both or hassession %}
   <li class="btn btn-default supporting_material">
     <a href="#" class="btn btn-default dropdown-toggle topic-icon" data-toggle="dropdown" aria-expanded="false" title="Video Library for these Training Materials">
         {% icon video %} GTN Video Library
@@ -16,22 +17,29 @@
     <ul class="dropdown-menu">
         {% if hasvideo-both %}
         <li>
-            <a class="dropdown-item" href="https://gallantries.github.io/video-library/videos/{{id-both}}" title="View Video Library for this Tutorial">
+            <a class="dropdown-item" href="https://gallantries.github.io/video-library/videos/{{id-both}}" title="View GTN Video Library for this Tutorial">
                 {% icon video %} Lecture & Tutorial
             </a>
         </li>
         {% endif %}
         {% if hasvideo-tutorial %}
         <li>
-            <a class="dropdown-item" href="https://gallantries.github.io/video-library/videos/{{id-tutorial}}" title="View Video Library for this Tutorial">
+            <a class="dropdown-item" href="https://gallantries.github.io/video-library/videos/{{id-tutorial}}" title="View GTN Video Library for this Tutorial">
                 {% icon video %} Tutorial
             </a>
         </li>
         {% endif %}
         {% if hasvideo-slides %}
         <li>
-            <a class="dropdown-item" href="https://gallantries.github.io/video-library/videos/{{id-slides}}" title="View Video Library for these Slides">
+            <a class="dropdown-item" href="https://gallantries.github.io/video-library/videos/{{id-slides}}" title="View GTN Video Library for these Slides">
                 {% icon video %} Lecture
+            </a>
+        </li>
+        {% endif %}
+        {% if hassession %}
+        <li>
+            <a class="dropdown-item" href="https://gallantries.github.io/video-library/sessions/{{id-tutorial}}" title="View GTN Video Library session for this tutorial ">
+                {% icon video %} Multi-video Tutorial
             </a>
         </li>
         {% endif %}

--- a/topics/dev/tutorials/tool-from-scratch/tutorial.md
+++ b/topics/dev/tutorials/tool-from-scratch/tutorial.md
@@ -31,8 +31,6 @@ contributors:
 # Introduction
 {:.no_toc}
 
-<div class="embed-responsive embed-responsive-16by9"><iframe src="https://www.youtube-nocookie.com/embed/2wW3yqEclko" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe></div>
-
 Tools wrappers allow any command line runnable code or programs to be run inside a galaxy environment.
 Although Galaxy has thousands of tools readily available, new software and packages will always be useful.
 This tutorial is designed to allow anyone to create, run, and deploy new tools in a Galaxy environment.
@@ -60,8 +58,6 @@ with many command line tools, other times, there may be several. The first part 
 the creation and deployment of these packages, making them available for Galaxy to retrieve.
 
 ## Writing a Bioconda Recipe
-
-<div class="embed-responsive embed-responsive-16by9"><iframe src="https://www.youtube-nocookie.com/embed/UtNErGKw8SI" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe></div>
 
 Bioconda is a repository of conda packages for software and tools relevant to the life sciences. Using conda
 packages ensures better reproducibility, since each conda package is usually immutable, an exception being
@@ -338,8 +334,6 @@ anyone wrapping a tool, a more complete list is available in [the Galaxy tool do
 
 ## Initializing a Tool Wrapper
 
-<div class="embed-responsive embed-responsive-16by9"><iframe src="https://www.youtube-nocookie.com/embed/a6XZgEy6hlg" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe></div>
-
 Initializing a tool wrapper to be run in Galaxy is simple
 
 > ### {% icon hands_on %}  Hands-on: Creating a Tool Wrapper Skeleton
@@ -379,8 +373,6 @@ Initializing a tool wrapper to be run in Galaxy is simple
 {: .hands_on}
 
 ## Galaxy Tool Wrappers
-
-<div class="embed-responsive embed-responsive-16by9"><iframe src="https://www.youtube-nocookie.com/embed/FdtD8vBLK5k" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe></div>
 
 Galaxy tool wrapper xml files are made up of several sections:
 
@@ -925,8 +917,6 @@ With all sections complete, the final wrapper for bellerophon can be found [here
 
 ## Toolshed file
 
-<div class="embed-responsive embed-responsive-16by9"><iframe src="https://www.youtube-nocookie.com/embed/WFSQE8bq5qI" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe></div>
-
 The .shed.yml file is placed in the same directory as the tool's xml file and saves metadata for the tool. It enables
 toolshed organization and search by using tags and descriptions.
 
@@ -965,8 +955,6 @@ In the case where the directory represents a group of tools or a 'suite', there 
 For more information on how to write automatic tool suites, visit the [Galaxy docs](https://galaxy-iuc-standards.readthedocs.io/en/latest/best_practices/shed_yml.html).
 
 # Testing Galaxy tool with `planemo`
-
-<div class="embed-responsive embed-responsive-16by9"><iframe src="https://www.youtube-nocookie.com/embed/19mKUENz_i0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe></div>
 
 `planemo` is a command line utility that helps developing Galaxy tools.
 Among many other tasks it can:
@@ -1139,8 +1127,6 @@ It can be very useful to check how Galaxy renders a tool and if this meets the e
 {: .tip}
 
 # Publishing Galaxy tools
-
-<div class="embed-responsive embed-responsive-16by9"><iframe src="https://www.youtube-nocookie.com/embed/hg0YreA8W1I" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe></div>
 
 Galaxy tools are installed from the [Galaxy toolshed](https://toolshed.g2.bx.psu.edu/). With the help of `planemo` tools can be added to the toolshed ([documentation](https://planemo.readthedocs.io/en/latest/publishing.html)). But usually the sources of the tools are maintained in public source code repositories, for instance:
 


### PR DESCRIPTION
Previously, the multi-video tutorials (e.g. debugging and tool development) were not linked from the GTN tutorials yet, this should fix that

![image](https://user-images.githubusercontent.com/2563865/143249343-153a1188-87f0-42e9-b1f5-8c4fbec918e7.png)


 