### PR TITLE
Annotate funding entities + Smörgåsbord2 news post

### DIFF
--- a/CONTRIBUTORS.yaml
+++ b/CONTRIBUTORS.yaml
@@ -1114,7 +1114,15 @@ carpentries:
 erasmusplus:
     name: Erasmus+ Programme
     joined: 2020-09
+    github: false
     funder: true
     funding_statement: |
-        This project (`2020-1-NL01-KA203-064717`) is funded with the support of the Erasmus+ programme of the European Union.
+        This project (`2020-1-NL01-KA203-064717`) is funded with the support of the Erasmus+ programme of the European Union. Their funding has supported a large number of tutorials within the GTN across a wide array of topics.
         ![eu flag with the text: with the support of the erasmus programme of the european union](https://gallantries.github.io/assets/images/logosbeneficaireserasmusright_en.jpg)
+
+avans-atgm:
+    name: Avans Hogeschool
+    joined: 2020-11
+    funder: true
+    funding_statement: |
+        A number of our employees contribute directly to the Galaxy Training Network and seek to make our higher education learning materials more accessible to a wider audience through the GTN platform. [avans.nl](https://avans.nl/)

--- a/CONTRIBUTORS.yaml
+++ b/CONTRIBUTORS.yaml
@@ -59,6 +59,10 @@ aisanjiangw:
     name: Aisanjiang Wubuli
     joined: 2017-09
 
+alaaelghamry:
+    name: Alaa Elghamry
+    joined: 2021-11
+
 ales-ibt:
     name: Alejandra Escobar-Zepeda
     joined: 2021-05
@@ -187,10 +191,6 @@ bphipson:
 bfranicevic:
     name: Branka Franicevic
     joined: 2021-10
-
-carpentries:
-    name: The Carpentries
-    joined: 2021-09
 
 cat-bro:
     name: Catherine Bromhead
@@ -1106,6 +1106,15 @@ yvanlebras:
     orcid: 0000-0002-8504-068X
     joined: 2017-09
 
-alaaelghamry:
-    name: Alaa Elghamry
-    joined: 2021-11
+# Funders / External Entities
+carpentries:
+    name: The Carpentries
+    joined: 2021-09
+
+erasmusplus:
+    name: Erasmus+ Programme
+    joined: 2020-09
+    funder: true
+    funding_statement: |
+        This project (`2020-1-NL01-KA203-064717`) is funded with the support of the Erasmus+ programme of the European Union.
+        ![eu flag with the text: with the support of the erasmus programme of the european union](https://gallantries.github.io/assets/images/logosbeneficaireserasmusright_en.jpg)

--- a/_includes/news-card.html
+++ b/_includes/news-card.html
@@ -39,7 +39,7 @@
       {% if n.external %}
         This is an external post, please follow the link to read it.
       {% else %}
-        {{n.excerpt}}
+        {{ n.excerpt | strip_html }}
       {% endif %}
     </p>
     <a href="{% if n.external %}{{ n.link }}{% else %}{{site.baseurl}}{{n.url}}{% endif %}" class="btn btn-primary">Full Story</a>

--- a/_layouts/contributor_index.html
+++ b/_layouts/contributor_index.html
@@ -99,7 +99,11 @@ layout: base
 				<h1>Contributions</h1>
 
 				<p class="text-muted">
+					{% if contributors[page.contributor].funder %}
+						{{ contributors[page.contributor].funding_statement | markdownify }}
+					{% else %}
 					The following list includes only slides and tutorials where the individual has been added to the contributor list. This may not include the sum total of their contributions to the training materials (e.g. GTN css or design, tutorial datasets, workflow development, etc.) unless described by a news post.
+					{% endif %}
 
                 {% unless contributors[page.contributor].github == false %}
                 <br><br>

--- a/bin/schema-contributors.yaml
+++ b/bin/schema-contributors.yaml
@@ -35,3 +35,7 @@ mapping:
             halloffame:
                 type: str
                 pattern: /no/
+            funder:
+                type: bool
+            funding_statement:
+                type: str

--- a/news/_posts/2021-10-12-data-science.md
+++ b/news/_posts/2021-10-12-data-science.md
@@ -1,6 +1,6 @@
 ---
 title: "New Topic: Data Science Survival Kit"
-contributors: [shiltemann, hexylena, bebatut, abretaud, yvanlebras, fpsom, carpentries]
+contributors: [shiltemann, hexylena, bebatut, abretaud, yvanlebras, fpsom, carpentries, erasmusplus]
 tags: [gtn infrastructure, new topic]
 layout: news
 ---

--- a/news/_posts/2021-12-14-funding.md
+++ b/news/_posts/2021-12-14-funding.md
@@ -1,0 +1,23 @@
+---
+title: Support for annotating Funding Agencies
+tags: [new-feature]
+contributors: [hexylena, erasmusplus]
+layout: news
+---
+
+The Galaxy Training Network will now support annotating Funding Agencies on training materials. This is part of our ongoing effort to better annotate how people are contributing to the GTN and recognise all of the sources of contribution.
+
+Funding Agencies and Grants can be recognised in the `CONTRIBUTORS.yaml` file and include a funding statement describing their contributions or the specific award number. In the future, as people add more funding agencies this will become a more controlled field.
+
+```
+erasmusplus:
+    name: Erasmus+ Programme
+    joined: 2020-09
+    github: false
+    funder: true
+    funding_statement: |
+        This project (`2020-1-NL01-KA203-064717`) is funded with the support of the Erasmus+ programme of the European Union. Their funding has supported a large number of tutorials within the GTN across a wide array of topics.
+        ![eu flag with the text: with the support of the erasmus programme of the european union](https://gallantries.github.io/assets/images/logosbeneficaireserasmusright_en.jpg)
+```
+
+They will be recognised in the by-line of tutorials, but in the future we will be separating out the different kinds of contributions to tutorials (authorship, editing, testing, funding, etc.) so watch out for that!

--- a/news/_posts/2021-12-14-smorgasbord.md
+++ b/news/_posts/2021-12-14-smorgasbord.md
@@ -1,0 +1,11 @@
+---
+title: "GTN Smörgåsbord 2: Tapas Edition"
+start: 2022-03-14
+end: 2022-03-18
+tags: [event]
+link: "https://gallantries.github.io/posts/2021/12/14/smorgasbord2-tapas/?utm_source=gtn&utm_medium=news&utm_campaign=smorgasbord2"
+external: true
+cover: "https://gallantries.github.io/assets/images/smorgasbord2/banner-500.png"
+coveralt: "Black text on a yellow background. Title card for Smörgåsbord 2 announcing that it will be 14-18 march in very large text, and the highlights of the course like Single Cell, Proteomics, SARS-CoV-2 and galaxy admin training. A bitly link is included which redirects to this page. There is a watterman butterfly map projection of the earth indicating it is a global event as well as an EU flag and GTN logo of supporters. @gxytraining and @Gallantries_EU's twitter handles are linked"
+---
+

--- a/topics/assembly/tutorials/flye-assembly/tutorial.md
+++ b/topics/assembly/tutorials/flye-assembly/tutorial.md
@@ -23,6 +23,7 @@ contributors:
 - r1corre
 - lleroi
 - stephanierobin
+- erasmusplus
 
 follow_up_training:
  - type: internal

--- a/topics/assembly/tutorials/get-started-genome-assembly/slides.html
+++ b/topics/assembly/tutorials/get-started-genome-assembly/slides.html
@@ -10,8 +10,9 @@ contributors:
   - alexcorm
   - stephanierobin
   - r1corre
-  - lleroi 
-level: Introductory 
+  - lleroi
+  - erasmusplus
+level: Introductory
 ---
 
 # Steps before starting a genome project
@@ -53,10 +54,10 @@ The aim of a genome project is to **sequence the entire target genome** for a wi
 ### Genome information: Genome size
 
 .pull-left[
-**How to collect informations?** 
+**How to collect informations?**
 
 - Flux cytometry
-- Databases: 
+- Databases:
   - Fungi: [http://www.zbi.ee/fungalgenomesize](http://www.zbi.ee/fungalgenomesize)
   - Animals: [http://www.genomesize.com](http://www.genomesize.com)
   - Plants: [http://data.kew.org/cvalues ](http://data.kew.org/cvalues)
@@ -108,9 +109,9 @@ GC and AT rich regions are under-represented.
 
 .pull-left[
 
-**Ploidy (N):** 
+**Ploidy (N):**
 
-Number of sets of chromosomes in a cell 
+Number of sets of chromosomes in a cell
 
 
 | Organism                  | Ploidy    |
@@ -168,8 +169,8 @@ Number of sets of chromosomes in a cell
 **It is impossible to resolve repeats of length L unless you have reads longer than L**
 ]
 
-Most common source of assembly errors: 
- 
+Most common source of assembly errors:
+
 .pull-left[
 .image-65[
   ![Collapsed consensus from repeat copies](../../images/collapsed-consensus.png)
@@ -365,7 +366,7 @@ Intuitively, more reads should increase coverage and depth.
 ### Computational resources and requirements
 
 .left[
-To succeed you need to have **sufficient compute resources (CPUS, RAM, walltime and storage)**. 
+To succeed you need to have **sufficient compute resources (CPUS, RAM, walltime and storage)**.
 - The resource are **different** between:
   - Assembly
   - Annotation

--- a/topics/assembly/tutorials/mrsa-illumina/tutorial.md
+++ b/topics/assembly/tutorials/mrsa-illumina/tutorial.md
@@ -30,6 +30,7 @@ contributors:
 - miaomiaozhou88
 - shiltemann
 - hexylena
+- avans-atgm
 
 follow_up_training:
 - type: "internal"

--- a/topics/assembly/tutorials/mrsa-nanopore/tutorial.md
+++ b/topics/assembly/tutorials/mrsa-nanopore/tutorial.md
@@ -30,6 +30,7 @@ contributors:
 - miaomiaozhou88
 - shiltemann
 - hexylena
+- avans-atgm
 
 follow_up_training:
 - type: "internal"

--- a/topics/data-science/tutorials/cli-advanced/tutorial.md
+++ b/topics/data-science/tutorials/cli-advanced/tutorial.md
@@ -67,6 +67,8 @@ contributors:
   - carpentries
   - hexylena
   - bazante1
+  - erasmusplus
+  - avans-atgm
 tags:
 - jupyter-notebook
 - bash

--- a/topics/data-science/tutorials/cli-bashcrawl/tutorial.md
+++ b/topics/data-science/tutorials/cli-bashcrawl/tutorial.md
@@ -29,6 +29,7 @@ notebook:
 subtopic: bash
 contributors:
 - hexylena
+- erasmusplus
 tags:
 - game
 - jupyter-notebook

--- a/topics/data-science/tutorials/cli-basics/tutorial.md
+++ b/topics/data-science/tutorials/cli-basics/tutorial.md
@@ -67,6 +67,8 @@ contributors:
   - carpentries
   - hexylena
   - bazante1
+  - erasmusplus
+  - avans-atgm
 tags:
 - jupyter-notebook
 - bash

--- a/topics/data-science/tutorials/python-advanced-np-pd/tutorial.md
+++ b/topics/data-science/tutorials/python-advanced-np-pd/tutorial.md
@@ -28,6 +28,7 @@ contributors:
   - mcmaniou
   - fpsom
   - carpentries
+  - erasmusplus
 
 priority: 2
 notebook:

--- a/topics/data-science/tutorials/python-basics/tutorial.md
+++ b/topics/data-science/tutorials/python-basics/tutorial.md
@@ -27,6 +27,7 @@ contributors:
   - mcmaniou
   - fpsom
   - carpentries
+  - erasmusplus
 
 priority: 1
 notebook:

--- a/topics/data-science/tutorials/python-plotting/tutorial.md
+++ b/topics/data-science/tutorials/python-plotting/tutorial.md
@@ -27,6 +27,7 @@ contributors:
   - mcmaniou
   - fpsom
   - carpentries
+  - erasmusplus
 
 priority: 3
 notebook:

--- a/topics/data-science/tutorials/r-advanced/tutorial.md
+++ b/topics/data-science/tutorials/r-advanced/tutorial.md
@@ -45,6 +45,7 @@ contributors:
   - bebatut
   - fpsom
   - tobyhodges
+  - erasmusplus
 tags:
 - R
 ---

--- a/topics/data-science/tutorials/r-basics/tutorial.md
+++ b/topics/data-science/tutorials/r-basics/tutorial.md
@@ -38,6 +38,7 @@ contributors:
   - bebatut
   - fpsom
   - tobyhodges
+  - erasmusplus
 ---
 
 # Introduction

--- a/topics/data-science/tutorials/r-dplyr/tutorial.md
+++ b/topics/data-science/tutorials/r-dplyr/tutorial.md
@@ -25,6 +25,8 @@ key_points:
 - The functions for selecting data are a lot easier to understand than R's built in alternatives.
 contributors:
 - hexylena
+- erasmusplus
+- avans-atgm
 subtopic: sql
 notebook:
     language: r

--- a/topics/data-science/tutorials/snakemake/tutorial.md
+++ b/topics/data-science/tutorials/snakemake/tutorial.md
@@ -33,6 +33,7 @@ contributors:
   - hexylena
   - bazante1
   - dirowa
+  - avans-atgm
 abbreviations:
   SciWMS: Scientific Workflow Management System
   DAG: Directed Acyclic Graph

--- a/topics/data-science/tutorials/sql-advanced/tutorial.md
+++ b/topics/data-science/tutorials/sql-advanced/tutorial.md
@@ -75,6 +75,7 @@ key_points:
 contributors:
 - carpentries
 - hexylena
+- avans-atgm
 
 subtopic: sql
 

--- a/topics/data-science/tutorials/sql-basic/tutorial.md
+++ b/topics/data-science/tutorials/sql-basic/tutorial.md
@@ -56,6 +56,7 @@ contributors:
 - hexylena
 - dirowa
 - bazante1
+- avans-atgm
 
 subtopic: sql
 

--- a/topics/data-science/tutorials/sql-game/tutorial.md
+++ b/topics/data-science/tutorials/sql-game/tutorial.md
@@ -26,6 +26,8 @@ subtopic: sql
 contributors:
 - hexylena
 - NUKnightLab
+- erasmusplus
+- avans-atgm
 tags:
 - game
 - SQL

--- a/topics/data-science/tutorials/sql-python/tutorial.md
+++ b/topics/data-science/tutorials/sql-python/tutorial.md
@@ -28,6 +28,7 @@ key_points:
 contributors:
 - carpentries
 - hexylena
+- avans-atgm
 
 subtopic: sql
 

--- a/topics/data-science/tutorials/sql-r/tutorial.md
+++ b/topics/data-science/tutorials/sql-r/tutorial.md
@@ -33,6 +33,7 @@ key_points:
 contributors:
 - carpentries
 - hexylena
+- avans-atgm
 
 subtopic: sql
 

--- a/topics/galaxy-interface/tutorials/rstudio/tutorial.md
+++ b/topics/galaxy-interface/tutorials/rstudio/tutorial.md
@@ -24,6 +24,7 @@ contributors:
   - bebatut
   - fpsom
   - tobyhodges
+  - erasmusplus
 subtopic: analyse
 ---
 

--- a/topics/genome-annotation/tutorials/apollo/slides.html
+++ b/topics/genome-annotation/tutorials/apollo/slides.html
@@ -29,6 +29,7 @@ contributors:
   - hexylena
   - nathandunn
   - mboudet
+  - erasmusplus
 ---
 
 ### Genome annotation

--- a/topics/genome-annotation/tutorials/apollo/tutorial.md
+++ b/topics/genome-annotation/tutorials/apollo/tutorial.md
@@ -28,6 +28,7 @@ contributors:
   - hexylena
   - nathandunn
   - mboudet
+  - erasmusplus
 
 requirements:
   - type: "internal"

--- a/topics/genome-annotation/tutorials/funannotate/tutorial.md
+++ b/topics/genome-annotation/tutorials/funannotate/tutorial.md
@@ -29,6 +29,7 @@ contributors:
   - lleroi
   - r1corre
   - stephanierobin
+  - erasmusplus
 
 abbreviations:
     NMDS: Non-metric multidimensional scaling

--- a/topics/genome-annotation/tutorials/repeatmasker/tutorial.md
+++ b/topics/genome-annotation/tutorials/repeatmasker/tutorial.md
@@ -21,6 +21,7 @@ contributors:
   - lleroi
   - r1corre
   - stephanierobin
+  - erasmusplus
 
 abbreviations:
     SINEs: Short Interspersed Nuclear Elements

--- a/topics/sequence-analysis/tutorials/mapping/slides.html
+++ b/topics/sequence-analysis/tutorials/mapping/slides.html
@@ -24,7 +24,7 @@ contributors:
   - shiltemann
   - EngyNasr
   - gallardoalba
-
+  - erasmusplus
 ---
 
 # Example NGS pipeline

--- a/topics/sequence-analysis/tutorials/quality-control/slides.html
+++ b/topics/sequence-analysis/tutorials/quality-control/slides.html
@@ -27,6 +27,7 @@ contributors:
   - lleroi
   - r1corre
   - stephanierobin
+  - erasmusplus
 
 ---
 

--- a/topics/sequence-analysis/tutorials/quality-control/tutorial.md
+++ b/topics/sequence-analysis/tutorials/quality-control/tutorial.md
@@ -14,7 +14,7 @@ objectives:
   - Summarise quality metrics MultiQC
   - Process single-end and paired-end data
 follow_up_training:
-  - 
+  -
     type: "internal"
     topic_name: sequence-analysis
     tutorials:
@@ -35,6 +35,7 @@ contributors:
   - lleroi
   - r1corre
   - stephanierobin
+  - erasmusplus
 
 ---
 

--- a/topics/statistics/tutorials/intro-to-ml-with-r/tutorial.md
+++ b/topics/statistics/tutorials/intro-to-ml-with-r/tutorial.md
@@ -43,6 +43,7 @@ key_points:
 - To be added
 contributors:
   - fpsom
+  - erasmusplus
 ---
 
 # Introduction to Machine Learning and Data mining

--- a/topics/transcriptomics/tutorials/rna-seq-counts-to-viz-in-r/tutorial.md
+++ b/topics/transcriptomics/tutorials/rna-seq-counts-to-viz-in-r/tutorial.md
@@ -37,6 +37,7 @@ contributors:
   - bebatut
   - fpsom
   - tobyhodges
+  - erasmusplus
 ---
 
 # Introduction

--- a/topics/visualisation/tutorials/circos/slides.html
+++ b/topics/visualisation/tutorials/circos/slides.html
@@ -15,6 +15,7 @@ key_points:
 contributors:
   - hexylena
   - shiltemann
+  - erasmusplus
 ---
 
 # Circos for Genomics Visualisation

--- a/topics/visualisation/tutorials/jbrowse/tutorial.md
+++ b/topics/visualisation/tutorials/jbrowse/tutorial.md
@@ -17,6 +17,7 @@ key_points:
 contributors:
   - hexylena
   - shiltemann
+  - erasmusplus
 ---
 
 # Introduction


### PR DESCRIPTION
We will now support annotating the funding agencies that have supported work in the GTN, the erasmus+ programme is the first one (as they funded this feature ;) ). This is part of https://github.com/galaxyproject/training-material/issues/2015 where we're doing more work to annotate how the GTN is made and recognising all contributions.

![image](https://user-images.githubusercontent.com/458683/146022901-282e7484-eca5-4a1a-8768-5935c336d860.png)
