### PR TITLE
Video library: add column to topic page, add dates

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -174,6 +174,7 @@ icon-tag:
   workflow: fas fa-share-alt
   workflow-run: fas fa-play
   video: fas fa-video
+  video-slides: far fa-play-circle
   zenodo_link: far fa-copy
 
 # To exclude in _site

--- a/_includes/resource-slides.html
+++ b/_includes/resource-slides.html
@@ -1,7 +1,13 @@
+{% if include.material.type == 'introduction' %}
+  {% assign subfolder = 'slides' %}
+{% else %}
+  {% assign subfolder = 'tutorials' %}
+{% endif %}
+
 {% if include.material.slides %}
-	<a class="visually-hidden" href="{{ site.baseurl }}/topics/{{ include.topic }}/tutorials/{{ include.material.tutorial_name }}/slides-plain.html" aria-label="more accessible, plain text slides">plain text</a>
+	<a class="visually-hidden" href="{{ site.baseurl }}/topics/{{ include.topic }}/{{subfolder}}/{{ include.material.tutorial_name }}/slides-plain.html" aria-label="more accessible, plain text slides">plain text</a>
     <span class="btn-group">
-        <a class="btn btn-default topic-icon" href="{{ site.baseurl }}/topics/{{ include.topic }}/tutorials/{{ include.material.tutorial_name }}/slides.html" title="Slides">
+        <a class="btn btn-default topic-icon" href="{{ site.baseurl }}/topics/{{ include.topic }}/{{subfolder}}/{{ include.material.tutorial_name }}/slides.html" title="Slides">
             {% icon slides aria=false %}
         </a>
         <a href="#" class="btn btn-default dropdown-toggle dropdown-toggle-split" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
@@ -12,7 +18,7 @@
         {% if translations > 0 %}
           <div class="dropdown-item"><strong>Curated translations</strong></div>
            {% for lang in include.material.translations.slides %}
-            <a class="dropdown-item" href="{{ site.baseurl }}/topics/{{ include.topic }}/tutorials/{{ include.material.tutorial_name }}/slides_{{lang | upcase }}.html" title="{{ lang }}">
+            <a class="dropdown-item" href="{{ site.baseurl }}/topics/{{ include.topic }}/{{subfolder}}/{{ include.material.tutorial_name }}/slides_{{lang | upcase }}.html" title="{{ lang }}">
                 {{language[lang]}}
             </a>
            {% endfor %}
@@ -21,15 +27,15 @@
 
         <div class="dropdown-item"><strong>Automatic translations</strong></div>
         {% for lang in language %}{% unless lang[0] == 'en' %}
-            <a class="dropdown-item" href="https://translate.google.com/translate?hl=jp&sl=en&tl={{ lang[0] }}&u=https%3A%2F%2Ftraining.galaxyproject.org%2Ftopics%2F{{ include.topic }}%2Ftutorials%2F{{ include.material.tutorial_name }}%2Fslides.html&edit-text=&act=url" title="{{ inst[0] }}">
+            <a class="dropdown-item" href="https://translate.google.com/translate?hl=jp&sl=en&tl={{ lang[0] }}&u=https%3A%2F%2Ftraining.galaxyproject.org%2Ftopics%2F{{ include.topic }}%2F{{subfolder}}%2F{{ include.material.tutorial_name }}{% unless include.material.type == 'introduction' %}%2Fslides{% endunless %}.html&edit-text=&act=url" title="{{ inst[0] }}">
                 {{ lang[1] }}
             </a>
         {% endunless %}{% endfor %}
-        <a class="dropdown-item" href="https://translate.google.com/translate?hl=jp&sl=en&tl=&u=https%3A%2F%2Ftraining.galaxyproject.org%2Ftopics%2F{{ include.topic }}%2Ftutorials%2F{{ include.material.tutorial_name }}%2Fslides.html&edit-text=&act=url" title="{{ inst[0] }}">
+        <a class="dropdown-item" href="https://translate.google.com/translate?hl=jp&sl=en&tl=&u=https%3A%2F%2Ftraining.galaxyproject.org%2Ftopics%2F{{ include.topic }}%2F{{subfolder}}%2F{{ include.material.tutorial_name }}%2Fslides.html&edit-text=&act=url" title="{{ inst[0] }}">
             More Languages
         </a>
 
-	<a class="btn btn-default topic-icon" href="{{ site.baseurl }}/topics/{{ include.topic }}/tutorials/{{ include.material.tutorial_name }}/slides-plain.html" aria-label="more accessible, plain text slides">
+	<a class="btn btn-default topic-icon" href="{{ site.baseurl }}/topics/{{ include.topic }}/{{subfolder}}/{{ include.material.tutorial_name }}/slides-plain.html" aria-label="more accessible, plain text slides">
 		{% icon text-document aria=false %} Plain text slides
 	</a>
     </ul>
@@ -40,7 +46,7 @@
 {% if include.material.video %}
 <span class="btn-group">
   <!-- add video button -->
-  <a class="btn btn-default topic-icon" href="{{ site.baseurl }}/videos/watch.html?v={{ include.topic }}/tutorials/{{ include.material.tutorial_name }}/slides" title="Video">
+  <a class="btn btn-default topic-icon" href="{{ site.baseurl }}/videos/watch.html?v={{ include.topic }}/{{subfolder}}/{{ include.material.tutorial_name }}{% unless include.material.type == 'introduction' %}/slides{% endunless%}" title="Video">
     {% icon video aria=false %}
   </a>
 
@@ -54,7 +60,7 @@
 
     <div class="dropdown-item"><strong>Video Languages</strong></div>
       {% for lang in include.material.translations.slides %}
-      <a class="dropdown-item" href="{{ site.baseurl }}/videos/watch.html?v={{ include.topic }}/tutorials/{{ include.material.tutorial_name }}/slides_{{lang | upcase}}" title="{{ lang }}">
+      <a class="dropdown-item" href="{{ site.baseurl }}/videos/watch.html?v={{ include.topic }}/{{subfolder}}/{{ include.material.tutorial_name }}/slides_{{lang | upcase}}" title="{{ lang }}">
          {{language[lang]}}
       </a>
       {% endfor %}

--- a/_includes/resource-slides.html
+++ b/_includes/resource-slides.html
@@ -46,8 +46,8 @@
 {% if include.material.video %}
 <span class="btn-group">
   <!-- add video button -->
-  <a class="btn btn-default topic-icon" href="{{ site.baseurl }}/videos/watch.html?v={{ include.topic }}/{{subfolder}}/{{ include.material.tutorial_name }}{% unless include.material.type == 'introduction' %}/slides{% endunless%}" title="Video">
-    {% icon video aria=false %}
+  <a class="btn btn-default topic-icon" href="{{ site.baseurl }}/videos/watch.html?v={{ include.topic }}/{{subfolder}}/{{ include.material.tutorial_name }}{% unless include.material.type == 'introduction' %}/slides{% endunless%}" title="Video Slides">
+    {% icon video-slides aria=false %}
   </a>
 
 

--- a/_includes/resource-slides.html
+++ b/_includes/resource-slides.html
@@ -5,7 +5,7 @@
 {% endif %}
 
 {% if include.material.slides %}
-	<a class="visually-hidden" href="{{ site.baseurl }}/topics/{{ include.topic }}/{{subfolder}}/{{ include.material.tutorial_name }}/slides-plain.html" aria-label="more accessible, plain text slides">plain text</a>
+	<a class="visually-hidden" href="{{ site.baseurl }}/topics/{{ include.topic }}/{{subfolder}}{% unless include.material.type == 'introduction' %}/{{ include.material.tutorial_name }}/{% endunless %}slides-plain.html" aria-label="more accessible, plain text slides">plain text</a>
     <span class="btn-group">
         <a class="btn btn-default topic-icon" href="{{ site.baseurl }}/topics/{{ include.topic }}/{{subfolder}}/{{ include.material.tutorial_name }}{% unless include.material.type == 'introduction' %}/slides{% endunless %}.html" title="Slides">
             {% icon slides aria=false %}

--- a/_includes/resource-slides.html
+++ b/_includes/resource-slides.html
@@ -5,7 +5,7 @@
 {% endif %}
 
 {% if include.material.slides %}
-	<a class="visually-hidden" href="{{ site.baseurl }}/topics/{{ include.topic }}/{{subfolder}}{% unless include.material.type == 'introduction' %}/{{ include.material.tutorial_name }}/{% endunless %}slides-plain.html" aria-label="more accessible, plain text slides">plain text</a>
+	<a class="visually-hidden" href="{{ site.baseurl }}/topics/{{ include.topic }}/{{subfolder}}{% unless include.material.type == 'introduction' %}/{{ include.material.tutorial_name }}{% endunless %}/slides-plain.html" aria-label="more accessible, plain text slides">plain text</a>
     <span class="btn-group">
         <a class="btn btn-default topic-icon" href="{{ site.baseurl }}/topics/{{ include.topic }}/{{subfolder}}/{{ include.material.tutorial_name }}{% unless include.material.type == 'introduction' %}/slides{% endunless %}.html" title="Slides">
             {% icon slides aria=false %}

--- a/_includes/resource-slides.html
+++ b/_includes/resource-slides.html
@@ -35,7 +35,7 @@
             More Languages
         </a>
 
-	<a class="btn btn-default topic-icon" href="{{ site.baseurl }}/topics/{{ include.topic }}/{{subfolder}}/{{ include.material.tutorial_name }}/slides-plain.html" aria-label="more accessible, plain text slides">
+	<a class="btn btn-default topic-icon" href="{{ site.baseurl }}/topics/{{ include.topic }}/{{subfolder}}/{% unless include.material.type == 'introduction' %}{{ include.material.tutorial_name }}/{% endunless %}slides-plain.html" aria-label="more accessible, plain text slides">
 		{% icon text-document aria=false %} Plain text slides
 	</a>
     </ul>

--- a/_includes/resource-slides.html
+++ b/_includes/resource-slides.html
@@ -7,7 +7,7 @@
 {% if include.material.slides %}
 	<a class="visually-hidden" href="{{ site.baseurl }}/topics/{{ include.topic }}/{{subfolder}}/{{ include.material.tutorial_name }}/slides-plain.html" aria-label="more accessible, plain text slides">plain text</a>
     <span class="btn-group">
-        <a class="btn btn-default topic-icon" href="{{ site.baseurl }}/topics/{{ include.topic }}/{{subfolder}}/{{ include.material.tutorial_name }}/slides.html" title="Slides">
+        <a class="btn btn-default topic-icon" href="{{ site.baseurl }}/topics/{{ include.topic }}/{{subfolder}}/{{ include.material.tutorial_name }}{% unless include.material.type == 'introduction' %}/slides{% endunless %}.html" title="Slides">
             {% icon slides aria=false %}
         </a>
         <a href="#" class="btn btn-default dropdown-toggle dropdown-toggle-split" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">

--- a/_includes/resource-slides.html
+++ b/_includes/resource-slides.html
@@ -5,12 +5,13 @@
 {% endif %}
 
 {% if include.material.slides %}
+    <span class="btn-group">
 	<a class="visually-hidden" href="{{ site.baseurl }}/topics/{{ include.topic }}/{{subfolder}}{% unless include.material.type == 'introduction' %}/{{ include.material.tutorial_name }}{% endunless %}/slides-plain.html" aria-label="more accessible, plain text slides">plain text</a>
     <span class="btn-group">
         <a class="btn btn-default topic-icon" href="{{ site.baseurl }}/topics/{{ include.topic }}/{{subfolder}}/{{ include.material.tutorial_name }}{% unless include.material.type == 'introduction' %}/slides{% endunless %}.html" title="Slides">
             {% icon slides aria=false %}
         </a>
-        <a href="#" class="btn btn-default dropdown-toggle dropdown-toggle-split" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+        <a href="#" class="btn btn-default dropdown-toggle dropdown-toggle-split" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false" title="View slides in different languages">
             <span class="sr-only">Toggle Dropdown</span>
         </a>
         <ul class="dropdown-menu">
@@ -46,7 +47,7 @@
 {% if include.material.video %}
 <span class="btn-group">
   <!-- add video button -->
-  <a class="btn btn-default topic-icon" href="{{ site.baseurl }}/videos/watch.html?v={{ include.topic }}/{{subfolder}}/{{ include.material.tutorial_name }}{% unless include.material.type == 'introduction' %}/slides{% endunless%}" title="Video Slides">
+  <a class="btn btn-default topic-icon" href="{{ site.baseurl }}/videos/watch.html?v={{ include.topic }}/{{subfolder}}/{{ include.material.tutorial_name }}{% unless include.material.type == 'introduction' %}/slides{% endunless%}" title="Video Slides (text-to-speech)">
     {% icon video-slides aria=false %}
   </a>
 
@@ -70,4 +71,5 @@
 
 {% endif %}
 
+</span>
 </span>

--- a/_includes/resource-video-library.html
+++ b/_includes/resource-video-library.html
@@ -1,6 +1,7 @@
 {% assign locale = site.data.lang[page.lang] %}
 
-{% assign id-tutorial = page.url | remove: '/topics/' | remove: "/tutorials" | remove: '.html' %}
+{% assign tut = include.material.url | default: page.url %}
+{% assign id-tutorial = tut | remove: '/topics/' | remove: "/tutorials" | remove: '.html' %}
 {% assign id-slides = id-tutorial | replace: '/tutorial', '/slides' %}
 {% assign id-both = id-tutorial | replace: '/tutorial', '' %}
 
@@ -11,8 +12,8 @@
 
   {% if hasvideo-tutorial or hasvideo-slides or hasvideo-both or hassession %}
   <li class="btn btn-default supporting_material">
-    <a href="#" class="btn btn-default dropdown-toggle topic-icon" data-toggle="dropdown" aria-expanded="false" title="Video Library for these Training Materials">
-        {% icon video %} GTN Video Library
+    <a href="#" class="btn btn-default dropdown-toggle topic-icon" data-toggle="dropdown" aria-expanded="false" title="Latest recordings of this tutorial in the GTN Video Library">
+        {% icon video %} {% if include.label %}Recordings{% endif %}
     </a>
     <ul class="dropdown-menu">
         {% if hasvideo-both %}
@@ -21,6 +22,7 @@
         {% assign sortedversions = allversions | sort: 'date' | reverse %}
 
         <li>
+
             <a class="dropdown-item" href="https://gallantries.github.io/video-library/videos/{{id-both}}" title="View GTN Video Library for this Tutorial">
                 {% icon video %} Lecture & Tutorial ({{sortedversions[0].date | date: "%B %Y" }})
             </a>

--- a/_includes/resource-video-library.html
+++ b/_includes/resource-video-library.html
@@ -16,30 +16,49 @@
     </a>
     <ul class="dropdown-menu">
         {% if hasvideo-both %}
+        {% assign allversions = "" | split: ',' %}
+        {% for vid in site.data['video-library'][id-both].versions %}{% assign allversions = allversions | push: vid %}{% endfor %}
+        {% assign sortedversions = allversions | sort: 'date' | reverse %}
+
         <li>
             <a class="dropdown-item" href="https://gallantries.github.io/video-library/videos/{{id-both}}" title="View GTN Video Library for this Tutorial">
-                {% icon video %} Lecture & Tutorial
+                {% icon video %} Lecture & Tutorial ({{sortedversions[0].date | date: "%B %Y" }})
             </a>
         </li>
         {% endif %}
         {% if hasvideo-tutorial %}
+
+        {% assign allversions = "" | split: ',' %}
+        {% for vid in site.data['video-library'][id-tutorial].versions %}{% assign allversions = allversions | push: vid %}{% endfor %}
+        {% assign sortedversions = allversions | sort: 'date' | reverse %}
+
         <li>
             <a class="dropdown-item" href="https://gallantries.github.io/video-library/videos/{{id-tutorial}}" title="View GTN Video Library for this Tutorial">
-                {% icon video %} Tutorial
+                {% icon video %} Tutorial ({{sortedversions[0].date | date: "%B %Y" }})
             </a>
         </li>
         {% endif %}
         {% if hasvideo-slides %}
+          {% assign allversions = "" | split: ',' %}
+          {% for vid in site.data['video-library'][id-slides].versions %}{% assign allversions = allversions | push: vid %}{% endfor %}
+          {% assign sortedversions = allversions | sort: 'date' | reverse %}
+
         <li>
             <a class="dropdown-item" href="https://gallantries.github.io/video-library/videos/{{id-slides}}" title="View GTN Video Library for these Slides">
-                {% icon video %} Lecture
+                {% icon video %} Lecture ({{sortedversions[0].date | date: "%B %Y" }})
             </a>
         </li>
         {% endif %}
         {% if hassession %}
+          {% assign allversions = "" | split: ',' %}
+          {% assign sessionvid = site.data['session-library'][id-tutorial].videos[0] %}
+          {% for vid in site.data['video-library'][sessionvid].versions %}{% assign allversions = allversions | push: vid %}{% endfor %}
+          {% assign sortedversions = allversions | sort: 'date' | reverse %}
+
         <li>
             <a class="dropdown-item" href="https://gallantries.github.io/video-library/sessions/{{id-tutorial}}" title="View GTN Video Library session for this tutorial ">
-                {% icon video %} Multi-video Tutorial
+                {% icon video %} Multi-video Tutorial ({{sortedversions[0].date | date: "%B %Y" }})
+
             </a>
         </li>
         {% endif %}

--- a/_includes/resource-zenodo.html
+++ b/_includes/resource-zenodo.html
@@ -1,7 +1,7 @@
 {% assign locale = site.data.lang[page.lang] %}
 
 {% if include.material.zenodo_link != nil and include.material.zenodo_link != "" %}
-<a class="topic-icon" href="{{ include.material.zenodo_link }}">
+<a class="topic-icon" title="Zenodo datasets used in this tutorial" href="{{ include.material.zenodo_link }}">
     {% icon zenodo_link aria=false %}{% if include.label %} {{ locale['datasets'] | default: "Datasets"}}{% endif %}
 </a>
 {% endif %}

--- a/_includes/tutorial_list.html
+++ b/_includes/tutorial_list.html
@@ -49,30 +49,7 @@
           {% if material.type == "introduction" %}
             <td>
             {% if material.slides %}
-              <span class="btn-group">
-                <a class="btn btn-default topic-icon" href="{{ site.baseurl }}/topics/{{ topic.name }}/slides/{{ material.tutorial_name }}.html">
-                    {% icon slides %}
-                </a>
-                <a href="#" class="btn btn-default dropdown-toggle dropdown-toggle-split" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
-                  <span class="sr-only">Toggle Dropdown</span>
-                </a>
-                <ul class="dropdown-menu">
-                  {% for lang in language %}
-                    <a class="dropdown-item" href="https://translate.google.com/translate?hl=jp&sl=en&tl={{ lang[0] }}&u=https%3A%2F%2Ftraining.galaxyproject.org%2Ftopics%2F{{ topic.name }}%2Fslides%2F{{ material.tutorial_name }}.html&edit-text=&act=url" title="{{ inst[0] }}">
-                      {{ lang[1] }}
-                    </a>
-                  {% endfor %}
-                  <a class="dropdown-item" href="https://translate.google.com/translate?hl=jp&sl=en&tl=&u=https%3A%2F%2Ftraining.galaxyproject.org%2Ftopics%2F{{ topic.name }}%2Fslides%2F{{ material.tutorial_name }}.html&edit-text=&act=url" title="{{ inst[0] }}">
-                      And more!
-                  </a>
-                </ul>
-                {% if material.video %}
-                /
-                <a class="topic-icon" href="{{ site.baseurl }}/videos/watch.html?v={{ topic.name }}/slides/{{ material.tutorial_name }}">
-                    {% icon video %}
-                </a>
-                {% endif %}
-              </span>
+              {% include _includes/resource-slides.html material=material topic=topic.name %}
             {% endif %}
             </td>
             <td></td>

--- a/_includes/tutorial_list.html
+++ b/_includes/tutorial_list.html
@@ -2,17 +2,17 @@
   <thead>
     <tr>
       <th>Lesson</th>
-      <th>Slides</th>
-      <th>Hands-on</th>
-      <th>Recordings</th>
+      <th title="Lecture for this training. May include a video version using automated text-to-speech.">Slides</th>
+      <th title="Practical tutorial guiding you through an analysis step by step.">Hands-on</th>
+      <th title="Recordings of various instructors teaching this tutorial. May use an outdated version of the tutorial.">Recordings</th>
 
       {% if topic.type == "use" %}
-      <th>Input dataset</th>
-      <th>Workflows</th>
+      <th title="Datasets used in this tutorial, available from Zenodo.">Input dataset</th>
+      <th title="Galaxy workflows used in this tutorial.">Workflows</th>
       {% endif %}
 
       {% if instances[topic.name].supported %}
-      <th>Galaxy servers</th>
+      <th title="List of public Galaxies on which this tutorial can be performed. ">Galaxy servers</th>
       {% endif %}
     </tr>
   </thead>

--- a/_includes/tutorial_list.html
+++ b/_includes/tutorial_list.html
@@ -4,11 +4,11 @@
       <th>Lesson</th>
       <th>Slides</th>
       <th>Hands-on</th>
+      <th>Recordings</th>
 
       {% if topic.type == "use" %}
       <th>Input dataset</th>
       <th>Workflows</th>
-      <th>Galaxy tour</th>
       {% endif %}
 
       {% if instances[topic.name].supported %}
@@ -53,8 +53,8 @@
             {% endif %}
             </td>
             <td></td>
+            <td></td>
             {% if topic.type == "use" %}
-              <td></td>
               <td></td>
               <td></td>
             {% endif %}
@@ -64,11 +64,10 @@
           {% elsif material.type == "tutorial" %}
             <td> {% include _includes/resource-slides.html material=material topic=topic.name %} </td>
             <td> {% include _includes/resource-handson.html material=material topic=topic.name %} </td>
-
+            <td> {% include _includes/resource-video-library.html material=material topic=topic.name %}</td>
             {% if topic.type == "use" %}
               <td> {% include _includes/resource-zenodo.html material=material topic=topic.name %} </td>
               <td> {% include _includes/resource-workflows.html material=material topic=topic.name %} </td>
-              <td> {% include _includes/resource-tours.html material=material topic=topic.name %} </td>
             {% endif %}
             {% if instances[topic.name].supported %}
               <td> {% include _includes/instance-dropdown.html instances=instances topic=topic.name tuto=material.tutorial_name %} </td>

--- a/_includes/tutorial_list.html
+++ b/_includes/tutorial_list.html
@@ -12,7 +12,7 @@
       {% endif %}
 
       {% if instances[topic.name].supported %}
-      <th>Galaxy instances</th>
+      <th>Galaxy servers</th>
       {% endif %}
     </tr>
   </thead>

--- a/_layouts/base_slides.html
+++ b/_layouts/base_slides.html
@@ -68,6 +68,7 @@ class: center, middle, inverse
 
 ---
 
+
 {% if page.logo == "GTN" %}
 <img src="{{ site.baseurl }}/{{ site.logo }}" alt="Galaxy Training Network" class="cover-logo"/>
 {% else %}
@@ -86,8 +87,11 @@ class: center, middle, inverse
 </div>
 {% endif %}
 
-<div class="footnote" style="bottom: 3em;">{% icon last_modification %} {{locale['last-modification'] | default: "Updated"}}: {{ page.last_modified_at | date: "%b %-d, %Y"}}</div>
-<div class="footnote" style="bottom: 2em;">{% icon text-document %}<a href="slides-plain{% if page.lang %}_{{page.lang | upcase }}{% endif %}.html"> {{locale['plaintext-slides'] | default: "Or view the plain-text slides without JS"}}</a></div>
+<div class="footnote" style="bottom: {% if page.video%}5.5em;{% else %}4 em;{% endif %}">{% icon last_modification %} {{locale['last-modification'] | default: "Updated"}}: {{ page.last_modified_at | date: "%b %-d, %Y"}}</div>
+{% if page.video %}
+<div class="footnote" style="bottom: 4em;"><a href="{{ site.baseurl }}/videos/watch.html?v={{ page.url | remove: '/topics' | remove: '.html' }}">{% icon video-slides %} View video slides for this lecture</a></div>
+{% endif %}
+<div class="footnote" style="bottom: 2.5em;">{% icon text-document %}<a href="slides-plain{% if page.lang %}_{{page.lang | upcase }}{% endif %}.html"> {{locale['plaintext-slides'] | default: "Plain-text slides"}}</a></div>
 <div class="footnote" style="bottom: 1em;"><strong>{{locale['tip'] | default: "Tip"}}: </strong>{{locale['presenter-notes'] | default: "press <kbd>P</kbd> to view the presenter notes"}}</div>
 
 ???

--- a/_layouts/tutorial_hands_on.html
+++ b/_layouts/tutorial_hands_on.html
@@ -146,7 +146,7 @@ footer: no
             {% endif %}
 
             <!-- Check the GTN Video Library for recordings of this tutorial or associated slides -->
-            {% include _includes/resource-video-library.html %}
+            {% include _includes/resource-video-library.html label=true %}
 
 
             {% if tuto_has_docker and topic.name != 'admin' %}

--- a/_plugins/plaintext-slides.rb
+++ b/_plugins/plaintext-slides.rb
@@ -6,7 +6,7 @@ module Jekyll
       # layout: tutorial_slides
       # layout: base_slides
 
-      site.pages.select{|page| page.data['layout'] == 'tutorial_slides' or page.data['layout'] == 'base_slides' or page.data['layout'] == 'rdmbites_slides'}.each do |page|
+      site.pages.select{|page| page.data['layout'] == 'tutorial_slides' or page.data['layout'] == 'base_slides' or page.data['layout'] == 'introduction_slides' or page.data['layout'] == 'rdmbites_slides'}.each do |page|
         dir = File.dirname(File.join('.', page.url))
         page2 = Jekyll::Page.new(site, site.source, dir, page.name)
         page2.data['layout'] = 'slides-plain'

--- a/assets/css/slides.css
+++ b/assets/css/slides.css
@@ -101,7 +101,7 @@ img {
 }
 
 img.cover-logo {
-  max-height: 12em;
+  max-height: 10em;
 }
 
 .image-05 img {

--- a/topics/transcriptomics/slides/introduction.html
+++ b/topics/transcriptomics/slides/introduction.html
@@ -112,7 +112,7 @@ contributors:
 1. Adapter clipping to trim the sequencing adapters
 2. Quality trimming to remove wrongly called and low quality bases
 
-.footnote[See [NGS Quality control](../../NGS-QC/slides/index.html)]
+.footnote[See [NGS Quality control]({{site.baseurl}}/topics/sequence-analysis/tutorials/quality-control/slides.html)]
 
 ---
 
@@ -140,7 +140,7 @@ Simple mapping on a reference genome? More challenging
 
 ![Cartoon of multiple exons collapsed, and paired end reads being shown as easy to align.](../images/transcriptome_alignment.png)
 
-*See [NGS Mapping](../../NGS-mapping/slides/index.html)*
+*See [NGS Mapping]({{site.baseurl}}/topics/sequence-analysis/tutorials/mapping/slides.html)*
 
 - Need reliable gene models
 - No detection of novel genes


### PR DESCRIPTION
added a column for the GTN video library recordings to the topic page. Also added the date of the latest recording to the dropdown.

Removed the tours column since we are not really mainaining those actively.

![image](https://user-images.githubusercontent.com/2563865/146989843-a2a4e25e-75a5-4b51-aee4-26dcb6b79c9f.png)

and also: 
- use different icon for video slides to distinguish from live recordings
- add link to video slides on main slide deck
  
![image](https://user-images.githubusercontent.com/2563865/151374570-70c36da8-ab98-4264-a985-c848dfa1cac9.png)

- re-use the slides include for topic-introduction slides
- generate plaintext slides for introductory slide decks
- rename "Galaxy instances" column to "Galaxy servers"