### PR TITLE
Update snippet import_via_link to remove rename

### DIFF
--- a/faqs/galaxy/datasets_import_via_link.md
+++ b/faqs/galaxy/datasets_import_via_link.md
@@ -48,6 +48,3 @@ layout: faq
 {% else %}
 * **Close** the window
 {% endif %}
-{% if include.renaming == undefined or include.renaming == true %}
-* By default, Galaxy uses the URL as the name, so rename the files with a more useful name.
-{% endif %}


### PR DESCRIPTION
Galaxy doesn't use the URL as the name anymore so should this bit below be removed from the snippet? (did that in this PR)
```
{% if include.renaming == undefined or include.renaming == true %}
* By default, Galaxy uses the URL as the name, so rename the files with a more useful name.
{% endif %}
```