### PR TITLE
Add workflow tests for DIA_MSstats_Training tutorial

### DIFF
--- a/topics/proteomics/tutorials/DIA_Analysis_MSstats/workflows/Galaxy-Workflow-DIA_MSstats_Training_export_tabular-test.yml
+++ b/topics/proteomics/tutorials/DIA_Analysis_MSstats/workflows/Galaxy-Workflow-DIA_MSstats_Training_export_tabular-test.yml
@@ -1,0 +1,21 @@
+---
+- doc: "Test for DIA_MSstats_Training_export_tabular workflow"
+  job:
+    "PyProphet export tabular":
+      class: File
+      location: https://zenodo.org/record/4307758/files/PyProphet_export.tabular
+      filetype: tabular
+    "Comparison matrix":
+      class: File
+      location: https://zenodo.org/record/4307758/files/Comp_matrix_HEK_Ecoli.txt
+      filetype: tabular
+    "Sample annot MSstats":
+      class: File
+      location: https://zenodo.org/record/4307758/files/Sample_annot_MSstats.txt
+      filetype: tabular
+  outputs:
+    "Histogram_Ecoli":
+      asserts:
+        has_size: 
+          value: 7000
+          delta: 2000

--- a/topics/proteomics/tutorials/DIA_Analysis_MSstats/workflows/Galaxy-Workflow-DIA_MSstats_Training_export_tabular.ga
+++ b/topics/proteomics/tutorials/DIA_Analysis_MSstats/workflows/Galaxy-Workflow-DIA_MSstats_Training_export_tabular.ga
@@ -125,11 +125,11 @@
             "id": 3,
             "input_connections": {
                 "group|comparison_matrix": {
-                    "id": 2,
+                    "id": 1,
                     "output_name": "output"
                 },
                 "input|annotation": {
-                    "id": 1,
+                    "id": 2,
                     "output_name": "output"
                 },
                 "input|evidence": {
@@ -330,7 +330,7 @@
         },
         "6": {
             "annotation": "",
-            "content_id": "toolshed.g2.bx.psu.edu/repos/devteam/dna_filtering/histogram_rpy/1.0.3",
+            "content_id": "toolshed.g2.bx.psu.edu/repos/devteam/histogram/histogram_rpy/1.0.4",
             "errors": null,
             "id": 6,
             "input_connections": {
@@ -364,14 +364,14 @@
                 "y": 258.1202915736607
             },
             "post_job_actions": {},
-            "tool_id": "toolshed.g2.bx.psu.edu/repos/devteam/dna_filtering/histogram_rpy/1.0.3",
+            "tool_id": "toolshed.g2.bx.psu.edu/repos/devteam/histogram/histogram_rpy/1.0.4",
             "tool_shed_repository": {
-                "changeset_revision": "549d2cb4c6f2",
-                "name": "dna_filtering",
+                "changeset_revision": "6f134426c2b0",
+                "name": "histogram",
                 "owner": "devteam",
                 "tool_shed": "toolshed.g2.bx.psu.edu"
             },
-            "tool_state": "{\"breaks\": \"25\", \"density\": \"true\", \"frequency\": \"false\", \"input\": {\"__class__\": \"RuntimeValue\"}, \"numerical_column\": \"c3\", \"title\": \"Distribution of Ecoli Protein log FC values\", \"xlab\": \"log2 Fold Change\", \"__page__\": null, \"__rerun_remap_job_id__\": null}",
+            "tool_state": "{\"breaks\": \"25\", \"density\": \"true\", \"frequency\": \"false\", \"input\": {\"__class__\": \"RuntimeValue\"}, \"numerical_column\": \"3\", \"title\": \"Distribution of Ecoli Protein log FC values\", \"xlab\": \"log2 Fold Change\", \"__page__\": null, \"__rerun_remap_job_id__\": null}",
             "tool_version": "1.0.3",
             "type": "tool",
             "uuid": "dc481c56-b123-48ec-bc5c-81411c3a7a9f",

--- a/topics/proteomics/tutorials/DIA_Analysis_MSstats/workflows/Galaxy-Workflow-DIA_MSstats_Training_msstats_input_tabular-test.yml
+++ b/topics/proteomics/tutorials/DIA_Analysis_MSstats/workflows/Galaxy-Workflow-DIA_MSstats_Training_msstats_input_tabular-test.yml
@@ -1,0 +1,17 @@
+---
+- doc: "Test for DIA_MSstats_Training_msstats_input_tabular workflow"
+  job:
+    "PyProphet MSstats input":
+      class: File
+      location: https://zenodo.org/record/4307758/files/PyProphet_msstats_input.tabular
+      filetype: tabular
+    "Comparison matrix":
+      class: File
+      location: https://zenodo.org/record/4307758/files/Comp_matrix_HEK_Ecoli.txt
+      filetype: tabular
+  outputs:
+    "Histogram_Ecoli":
+      asserts:
+        has_size: 
+          value: 7000
+          delta: 2000

--- a/topics/proteomics/tutorials/DIA_Analysis_MSstats/workflows/Galaxy-Workflow-DIA_MSstats_Training_msstats_input_tabular.ga
+++ b/topics/proteomics/tutorials/DIA_Analysis_MSstats/workflows/Galaxy-Workflow-DIA_MSstats_Training_msstats_input_tabular.ga
@@ -288,7 +288,7 @@
         },
         "5": {
             "annotation": "",
-            "content_id": "toolshed.g2.bx.psu.edu/repos/devteam/dna_filtering/histogram_rpy/1.0.3",
+            "content_id": "toolshed.g2.bx.psu.edu/repos/devteam/histogram/histogram_rpy/1.0.4",
             "errors": null,
             "id": 5,
             "input_connections": {
@@ -322,14 +322,14 @@
                 "y": 443
             },
             "post_job_actions": {},
-            "tool_id": "toolshed.g2.bx.psu.edu/repos/devteam/dna_filtering/histogram_rpy/1.0.3",
+            "tool_id": "toolshed.g2.bx.psu.edu/repos/devteam/histogram/histogram_rpy/1.0.4",
             "tool_shed_repository": {
-                "changeset_revision": "549d2cb4c6f2",
-                "name": "dna_filtering",
+                "changeset_revision": "6f134426c2b0",
+                "name": "histogram",
                 "owner": "devteam",
                 "tool_shed": "toolshed.g2.bx.psu.edu"
             },
-            "tool_state": "{\"breaks\": \"25\", \"density\": \"true\", \"frequency\": \"false\", \"input\": {\"__class__\": \"RuntimeValue\"}, \"numerical_column\": \"c3\", \"title\": \"Distribution of Ecoli Protein log FC values\", \"xlab\": \"log2 Fold Change\", \"__page__\": null, \"__rerun_remap_job_id__\": null}",
+            "tool_state": "{\"breaks\": \"25\", \"density\": \"true\", \"frequency\": \"false\", \"input\": {\"__class__\": \"RuntimeValue\"}, \"numerical_column\": \"3\", \"title\": \"Distribution of Ecoli Protein log FC values\", \"xlab\": \"log2 Fold Change\", \"__page__\": null, \"__rerun_remap_job_id__\": null}",
             "tool_version": "1.0.3",
             "type": "tool",
             "uuid": "65080a30-a49c-4414-a9b7-d72390001eab",


### PR DESCRIPTION
This updates the workflows associated with the tutorial to use histogram/histogram_rpy instead of dna_filtering/histogram_rpy.  This is already up-to-date in the tutorial.md file.