### PR TITLE
Add zenodo download link in molecular systems tutorial

### DIFF
--- a/topics/computational-chemistry/tutorials/setting-up-molecular-systems/tutorial.md
+++ b/topics/computational-chemistry/tutorials/setting-up-molecular-systems/tutorial.md
@@ -102,7 +102,7 @@ The 7CEL [PDB](https://files.rcsb.org/download/7CEL.pdb) does not include a comp
 > 2. Import the files from the Zenodo link provided.
 >
 >    ```
->    https://zenodo.org/record/2600690
+>    https://zenodo.org/record/2600690/files/7cel_modeled.pdb?download=1
 >    ```
 >
 >    {% snippet faqs/galaxy/datasets_import_via_link.md %}


### PR DESCRIPTION
We've had a bug report from someone that pasted the link directly.
The direct link seems better here.

 Note also that this is sniffed as a pqr file. Is that correct (or unavoidable) or do we need to tighten Galaxy's sniffers ?