### PR TITLE
install recent ruby verion and fixes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -41,11 +41,14 @@ create-env: ## create conda environment
 .PHONY: create-env
 
 ACTIVATE_ENV = source $(shell dirname $(dir $(CONDA)))/bin/activate $(CONDA_ENV)
+COND_ENV_DIR=$(shell dirname $(dir $(CONDA)))
 
 install: clean create-env ## install dependencies
 	$(ACTIVATE_ENV) && \
 		gem update --no-document --system && \
-		ICONV_LIBS="-L${CONDA_PREFIX}/lib/ -liconv" gem install --no-document addressable:'2.5.2' jekyll jekyll-feed jekyll-redirect-from jekyll-last-modified-at csl-styles awesome_bot html-proofer pkg-config kwalify bibtex-ruby citeproc-ruby
+		ICONV_LIBS="-L${CONDA_PREFIX}/lib/ -liconv" gem install --no-document addressable:'2.5.2' jekyll jekyll-feed jekyll-redirect-from jekyll-last-modified-at csl-styles awesome_bot html-proofer pkg-config kwalify bibtex-ruby citeproc-ruby && \
+		pushd ${COND_ENV_DIR}/envs/${CONDA_ENV}/share/rubygems/bin && \
+		ln -sf ../../../bin/ruby ruby
 .PHONY: install
 
 bundle-install: clean  ## install gems if Ruby is already present (e.g. on gitpod.io)
@@ -58,7 +61,7 @@ serve: api/swagger.json ## run a local server (You can specify PORT=, HOST=, and
 	$(ACTIVATE_ENV) && \
 		mv Gemfile Gemfile.backup || true && \
 		mv Gemfile.lock Gemfile.lock.backup || true && \
-		${JEKYLL} serve --strict_front_matter -d _site/training-material -P ${PORT} -H ${HOST} ${FLAGS}
+		${JEKYLL} serve --trace --strict_front_matter -d _site/training-material -P ${PORT} -H ${HOST} ${FLAGS}
 .PHONY: serve
 
 serve-quick: api/swagger.json ## run a local server (faster, some plugins disabled for speed)

--- a/environment.yml
+++ b/environment.yml
@@ -3,25 +3,27 @@ name: galaxy_training_material
 channels:
   - conda-forge
   - bioconda
-  - defaults
 dependencies:
-  - gmp=6.1.2
-  - jemalloc=5.0.1
-  - libiconv=1.15
-  - nodejs=9.11.1
-  - openssl=1.0.2o
-  - pandas=0.22.0
+  - gcc=9
+  - gxx=9
+  - gmp>=6.1.2
+  - jemalloc>=5.0.1
+  - libiconv>=1.15
+  - nodejs>=9.11.1
+  - openssl>=1.0.2o
+  - pandas>=0.22.0
   - pip
   - pip:
     - pathspec==0.5.6
     - oyaml
   - planemo>=0.55.0
-  - readline=7.0
-  - requests=2.18.4
-  - ruby=2.4.4
-  - yaml=0.1.7
-  - yamllint=1.11.0
-  - zlib=1.2.11
+  - readline
+  - requests>=2.18.4
+  - ruby=2.7
+  - libffi
+  - yaml>=0.1.7
+  - yamllint>=1.11.0
+  - zlib
   - libxml2
   - ephemeris
   - pkg-config


### PR DESCRIPTION
Ruby 2.4 does not support `array.append` as it seems. Ruby >2.5 does. So this will install a newer Ruby version in the standard conda env. This will probably break other things. We should also pin the environment.yml file again.

