### PR TITLE
Remove two exercise slides to make it more fit for reuse

### DIFF
--- a/topics/assembly/tutorials/debruijn-graph-assembly/slides.html
+++ b/topics/assembly/tutorials/debruijn-graph-assembly/slides.html
@@ -300,14 +300,6 @@ But: You need to choose **k** and **c** wisely!
 
 ---
 .enlarge120[
-# **Assembly Exercise #2**
-
-* We will perform an optimised assembly using the Velvet Optimiser in Galaxy.
-* The optimiser will pick a good value for **k** and **c**, and perform graph simplification for us.
-* We will compare the results with our earlier, simple assemblies.
-]
----
-.enlarge120[
 # **Extensions of the idea**
 ]
 ---
@@ -361,10 +353,3 @@ But: You need to choose **k** and **c** wisely!
 * Written by Ryan Wick of Centre for Systems Genomics - Uni. Melbourne, Australia
 ]
 ![A screenshot of the bandage gui showning drawing options on left and a middle window with a close up of a genome assembly graph.](../../images/bandage.png)
-
----
-.enlarge120[# **Assembly Exercise #3**
-
-* We will perform an assembly with **SPAdes** in **Galaxy**
-* We will again look at the assembly metrics and compare them with our sample and optimised Velvet assemblies.
-]


### PR DESCRIPTION
The exercises are both covered during the tutorial, and these will be easier to reuse for multiple purposes if we remove the galaxy specific 'do an exercise', most people will give the slides before moving into the tutorial anyway.