### PR TITLE
Reorganise admin tutorials into new subtopics

### DIFF
--- a/CONTRIBUTORS.yaml
+++ b/CONTRIBUTORS.yaml
@@ -1186,7 +1186,7 @@ erasmusplus:
     github: false
     funder: true
     funding_statement: |
-        This project (`2020-1-NL01-KA203-064717`) is funded with the support of the Erasmus+ programme of the European Union. Their funding has supported a large number of tutorials within the GTN across a wide array of topics.
+        This project ([`2020-1-NL01-KA203-064717`](https://ec.europa.eu/programmes/erasmus-plus/projects/eplus-project-details/#project/2020-1-NL01-KA203-064717)) is funded with the support of the Erasmus+ programme of the European Union. Their funding has supported a large number of tutorials within the GTN across a wide array of topics.
         ![eu flag with the text: with the support of the erasmus programme of the european union](https://gallantries.github.io/assets/images/logosbeneficaireserasmusright_en.jpg)
 
 avans-atgm:

--- a/topics/admin/faqs/diffs.md
+++ b/topics/admin/faqs/diffs.md
@@ -3,6 +3,7 @@ title: How to read a Diff
 area: diffs
 box_type: tip
 layout: faq
+contributors: [hexylena]
 ---
 
 If you haven't worked with diffs before, this can be something quite new or different.

--- a/topics/admin/metadata.yaml
+++ b/topics/admin/metadata.yaml
@@ -9,14 +9,27 @@ subtopics:
   - id: core
     title: "Core"
     description: "These are the core, foundational topics for the majority of administration in Galaxy."
+  - id: jobs
+    title: "Jobs & Scheduling"
+  - id: data
+    title: "Data Management & Reference Data"
   - id: features
     title: "Further Learning"
     description: "These topics will let you further expand your knowledge. They all build upon what you learned in the core topics, and many expect that you have a setup identical to the one started in the core trainings."
+  - id: monitoring
+    title: "Monitoring"
+  - id: maintenance
+    title: "Maintaining a Production Galaxy"
+  - id: cloud
+    title: "Running Galaxy on the Cloud"
+  - id: deprecated
+    title: "Deprecated Tutorials"
 
 maintainers:
+  - hexylena
+  - natefoo
+  - slugger70
   - bgruening
   - martenson
-  - hexylena
-  - slugger70
 
 gitter: galaxyproject/admins

--- a/topics/admin/metadata.yaml
+++ b/topics/admin/metadata.yaml
@@ -11,19 +11,25 @@ subtopics:
     description: "These are the core, foundational topics for the majority of administration in Galaxy."
   - id: jobs
     title: "Jobs & Scheduling"
+    description: "Learn how to use DRMAA and other resources to schedule your jobs on clusters"
   - id: data
     title: "Data Management & Reference Data"
+    description: "Manage data like a pro: tips on scaling to 1PB and more."
   - id: features
     title: "Further Learning"
     description: "These topics will let you further expand your knowledge. They all build upon what you learned in the core topics, and many expect that you have a setup identical to the one started in the core trainings."
   - id: monitoring
     title: "Monitoring"
+    description: "Monitor Galaxy like UseGalaxy.eu, learn the ins and outs of monitoring"
   - id: maintenance
     title: "Maintaining a Production Galaxy"
+    description: "Deployed Galaxy? Now what? All of the knowledge you need to maintain it long term."
   - id: cloud
     title: "Running Galaxy on the Cloud"
+    description: "If acronyms like EKS, EC2, GCP, ECS, K8S mean anything to you, then you've found where your home! Run Galaxy on someone else's computer with Cloud based tutorials"
   - id: deprecated
     title: "Deprecated Tutorials"
+    description: "Please do not run these. They are outdated and for historical, archival purposes only."
 
 maintainers:
   - hexylena

--- a/topics/admin/metadata.yaml
+++ b/topics/admin/metadata.yaml
@@ -18,15 +18,15 @@ subtopics:
   - id: features
     title: "Further Learning"
     description: "These topics will let you further expand your knowledge. They all build upon what you learned in the core topics, and many expect that you have a setup identical to the one started in the core trainings."
-  - id: monitoring
-    title: "Monitoring"
-    description: "Monitor Galaxy like UseGalaxy.eu, learn the ins and outs of monitoring"
-  - id: maintenance
-    title: "Maintaining a Production Galaxy"
-    description: "Deployed Galaxy? Now what? All of the knowledge you need to maintain it long term."
   - id: cloud
     title: "Running Galaxy on the Cloud"
     description: "If acronyms like EKS, EC2, GCP, ECS, K8S mean anything to you, then you've found where your home! Run Galaxy on someone else's computer with Cloud based tutorials"
+  - id: maintenance
+    title: "Maintaining a Production Galaxy"
+    description: "Deployed Galaxy? Now what? All of the knowledge you need to maintain it long term."
+  - id: monitoring
+    title: "Monitoring"
+    description: "Monitor Galaxy like UseGalaxy.eu, learn the ins and outs of monitoring"
   - id: deprecated
     title: "Deprecated Tutorials"
     description: "Please do not run these. They are outdated and for historical, archival purposes only."

--- a/topics/admin/tutorials/ansible-galaxy/tutorial.md
+++ b/topics/admin/tutorials/ansible-galaxy/tutorial.md
@@ -19,7 +19,9 @@ contributors:
   - shiltemann
   - nsoranzo
 tags:
+  - ansible
   - deploying
+  - git-gat
 subtopic: core
 requirements:
   - type: "internal"

--- a/topics/admin/tutorials/ansible/tutorial.md
+++ b/topics/admin/tutorials/ansible/tutorial.md
@@ -20,6 +20,8 @@ contributors:
   - hexylena
   - shiltemann
 subtopic: core
+tags:
+  - ansible
 
 ---
 

--- a/topics/admin/tutorials/cloudbursting/slides.html
+++ b/topics/admin/tutorials/cloudbursting/slides.html
@@ -5,6 +5,7 @@ logo: assets/images/gat.png
 title: "Galaxy on the Cloud"
 contributors:
   - slugger70
+subtopic: cloud
 ---
 
 # All these Clouds

--- a/topics/admin/tutorials/connect-to-compute-cluster/tutorial.md
+++ b/topics/admin/tutorials/connect-to-compute-cluster/tutorial.md
@@ -25,6 +25,8 @@ contributors:
   - hexylena
 tags:
   - jobs
+  - ansible
+  - git-gat
 subtopic: jobs
 requirements:
   - type: "internal"

--- a/topics/admin/tutorials/connect-to-compute-cluster/tutorial.md
+++ b/topics/admin/tutorials/connect-to-compute-cluster/tutorial.md
@@ -25,7 +25,7 @@ contributors:
   - hexylena
 tags:
   - jobs
-subtopic: features
+subtopic: jobs
 requirements:
   - type: "internal"
     topic_name: admin

--- a/topics/admin/tutorials/cvmfs-manual/tutorial.md
+++ b/topics/admin/tutorials/cvmfs-manual/tutorial.md
@@ -13,6 +13,7 @@ key_points:
 contributors:
   - slugger70
   - hexylena
+subtopic: data
 ---
 
 # Overview

--- a/topics/admin/tutorials/cvmfs/tutorial.md
+++ b/topics/admin/tutorials/cvmfs/tutorial.md
@@ -26,6 +26,9 @@ voice:
   lang: en-AU
   neural: true
 subtopic: data
+tags:
+  - ansible
+  - git-gat
 ---
 
 > These words come from a transcript of Simon Gladman teaching this course. He

--- a/topics/admin/tutorials/cvmfs/tutorial.md
+++ b/topics/admin/tutorials/cvmfs/tutorial.md
@@ -25,6 +25,7 @@ voice:
   id: Olivia
   lang: en-AU
   neural: true
+subtopic: data
 ---
 
 > These words come from a transcript of Simon Gladman teaching this course. He

--- a/topics/admin/tutorials/data-library/tutorial.md
+++ b/topics/admin/tutorials/data-library/tutorial.md
@@ -17,7 +17,7 @@ key_points:
 contributors:
   - hexylena
   - shiltemann
-subtopic: features
+subtopic: data
 tags:
   - storage
 requirements:

--- a/topics/admin/tutorials/data-library/tutorial.md
+++ b/topics/admin/tutorials/data-library/tutorial.md
@@ -19,7 +19,9 @@ contributors:
   - shiltemann
 subtopic: data
 tags:
+  - ansible
   - storage
+  - git-gat
 requirements:
  - type: "internal"
    topic_name: admin

--- a/topics/admin/tutorials/ftp/tutorial.md
+++ b/topics/admin/tutorials/ftp/tutorial.md
@@ -25,6 +25,9 @@ requirements:
 abbreviations:
   FTP: File Transfer Protocol
   NAT: Network Address Translation
+tags:
+  - data
+  - git-gat
 ---
 
 # Overview

--- a/topics/admin/tutorials/general-monitoring/slides.html
+++ b/topics/admin/tutorials/general-monitoring/slides.html
@@ -8,6 +8,7 @@ contributors:
   - bgruening
   - slugger70
   - hexylena
+subtopic: monitoring
 ---
 
 ## Manage Jobs

--- a/topics/admin/tutorials/gxadmin/tutorial.md
+++ b/topics/admin/tutorials/gxadmin/tutorial.md
@@ -16,7 +16,7 @@ key_points:
   - new queries are welcome and easy to contribute
 contributors:
   - hexylena
-subtopic: features
+subtopic: monitoring
 tags:
   - monitoring
 ---

--- a/topics/admin/tutorials/gxadmin/tutorial.md
+++ b/topics/admin/tutorials/gxadmin/tutorial.md
@@ -19,6 +19,8 @@ contributors:
 subtopic: monitoring
 tags:
   - monitoring
+  - ansible
+  - git-gat
 ---
 
 # Overview

--- a/topics/admin/tutorials/interactive-tools/tutorial.md
+++ b/topics/admin/tutorials/interactive-tools/tutorial.md
@@ -33,6 +33,7 @@ requirements:
       - ansible-galaxy
       - connect-to-compute-cluster
       - job-destinations
+subtopic: features
 ---
 
 > ### {% icon warning %} Evolving Topic

--- a/topics/admin/tutorials/jenkins/tutorial.md
+++ b/topics/admin/tutorials/jenkins/tutorial.md
@@ -14,7 +14,7 @@ objectives:
 time_estimation: "1h"
 tags:
   - automation
-#subtopic: features
+subtopic: features
 key_points:
   - Automate all the things!
   - Especially regular tasks you might forget to do

--- a/topics/admin/tutorials/jenkins/tutorial.md
+++ b/topics/admin/tutorials/jenkins/tutorial.md
@@ -13,6 +13,7 @@ objectives:
   - Secure Jenkins
 time_estimation: "1h"
 tags:
+  - ansible
   - automation
 subtopic: features
 key_points:

--- a/topics/admin/tutorials/job-destinations/tutorial.md
+++ b/topics/admin/tutorials/job-destinations/tutorial.md
@@ -23,7 +23,7 @@ contributors:
   - hexylena
 tags:
   - jobs
-subtopic: features
+subtopic: jobs
 requirements:
   - type: "internal"
     topic_name: admin

--- a/topics/admin/tutorials/job-destinations/tutorial.md
+++ b/topics/admin/tutorials/job-destinations/tutorial.md
@@ -22,7 +22,9 @@ contributors:
   - bgruening
   - hexylena
 tags:
+  - ansible
   - jobs
+  - git-gat
 subtopic: jobs
 requirements:
   - type: "internal"

--- a/topics/admin/tutorials/k8s-deploying-galaxy/tutorial.md
+++ b/topics/admin/tutorials/k8s-deploying-galaxy/tutorial.md
@@ -21,6 +21,7 @@ contributors:
   - ic4f
 tags:
   - kubernetes
+subtopic: cloud
 follow_up_training:
   - type: "internal"
     topic_name: admin

--- a/topics/admin/tutorials/k8s-deploying-galaxy/tutorial.md
+++ b/topics/admin/tutorials/k8s-deploying-galaxy/tutorial.md
@@ -27,6 +27,7 @@ follow_up_training:
     topic_name: admin
     tutorials:
       - k8s-managing-galaxy
+priority: 2
 ---
 
 # Galaxy Helm Chart

--- a/topics/admin/tutorials/k8s-managing-galaxy/tutorial.md
+++ b/topics/admin/tutorials/k8s-managing-galaxy/tutorial.md
@@ -32,6 +32,7 @@ requirements:
     topic_name: admin
     tutorials:
       - k8s-deploying-galaxy
+priority: 1
 ---
 
 # Managing Galaxy on Kubernetes

--- a/topics/admin/tutorials/k8s-managing-galaxy/tutorial.md
+++ b/topics/admin/tutorials/k8s-managing-galaxy/tutorial.md
@@ -26,6 +26,7 @@ contributors:
   - ic4f
 tags:
   - kubernetes
+subtopic: cloud
 requirements:
   - type: "internal"
     topic_name: admin

--- a/topics/admin/tutorials/maintenance/slides.html
+++ b/topics/admin/tutorials/maintenance/slides.html
@@ -21,6 +21,7 @@ contributors:
   - bgruening
   - slugger70
   - hexylena
+subtopic: maintenance
 ---
 
 # Server Maintenance

--- a/topics/admin/tutorials/monitoring/tutorial.md
+++ b/topics/admin/tutorials/monitoring/tutorial.md
@@ -14,7 +14,9 @@ objectives:
   - Create several charts
 time_estimation: "2h"
 tags:
+  - ansible
   - monitoring
+  - git-gat
 subtopic: monitoring
 key_points:
   - Telegraf provides an easy solution to monitor servers

--- a/topics/admin/tutorials/monitoring/tutorial.md
+++ b/topics/admin/tutorials/monitoring/tutorial.md
@@ -15,7 +15,7 @@ objectives:
 time_estimation: "2h"
 tags:
   - monitoring
-subtopic: features
+subtopic: monitoring
 key_points:
   - Telegraf provides an easy solution to monitor servers
   - Galaxy can send metrics to Telegraf

--- a/topics/admin/tutorials/object-store/slides.html
+++ b/topics/admin/tutorials/object-store/slides.html
@@ -15,6 +15,7 @@ contributors:
   - natefoo
   - martenson
   - hexylena
+subtopic: data
 
 ---
 

--- a/topics/admin/tutorials/object-store/tutorial.md
+++ b/topics/admin/tutorials/object-store/tutorial.md
@@ -17,6 +17,7 @@ contributors:
   - gmauro
 subtopic: data
 tags:
+  - ansible
   - storage
 requirements:
  - type: "internal"

--- a/topics/admin/tutorials/object-store/tutorial.md
+++ b/topics/admin/tutorials/object-store/tutorial.md
@@ -15,7 +15,7 @@ contributors:
   - natefoo
   - hexylena
   - gmauro
-subtopic: features
+subtopic: data
 tags:
   - storage
 requirements:

--- a/topics/admin/tutorials/production/slides.html
+++ b/topics/admin/tutorials/production/slides.html
@@ -9,6 +9,7 @@ contributors:
   - blankenberg
   - abdulrahmanazab
   - martenson
+subtopic: maintenance
 ---
 
 # Production server

--- a/topics/admin/tutorials/pulsar/tutorial.md
+++ b/topics/admin/tutorials/pulsar/tutorial.md
@@ -24,7 +24,9 @@ contributors:
   - gmauro
 subtopic: jobs
 tags:
+  - ansible
   - jobs
+  - git-gat
 requirements:
   - type: "internal"
     topic_name: admin

--- a/topics/admin/tutorials/pulsar/tutorial.md
+++ b/topics/admin/tutorials/pulsar/tutorial.md
@@ -22,7 +22,7 @@ contributors:
   - mvdbeek
   - hexylena
   - gmauro
-subtopic: features
+subtopic: jobs
 tags:
   - jobs
 requirements:

--- a/topics/admin/tutorials/reference-genomes/slides.html
+++ b/topics/admin/tutorials/reference-genomes/slides.html
@@ -6,7 +6,7 @@ title: "Reference Genomes in Galaxy"
 contributors:
   - blankenberg
   - slugger70
-
+subtopic: data
 ---
 
 # Overview

--- a/topics/admin/tutorials/reports/tutorial.md
+++ b/topics/admin/tutorials/reports/tutorial.md
@@ -16,7 +16,7 @@ contributors:
   - bgruening
   - slugger70
   - hexylena
-subtopic: features
+subtopic: monitoring
 tags:
   - monitoring
 requirements:

--- a/topics/admin/tutorials/reports/tutorial.md
+++ b/topics/admin/tutorials/reports/tutorial.md
@@ -18,7 +18,9 @@ contributors:
   - hexylena
 subtopic: monitoring
 tags:
+  - ansible
   - monitoring
+  - git-gat
 requirements:
   - type: "internal"
     topic_name: admin

--- a/topics/admin/tutorials/singularity/tutorial.md
+++ b/topics/admin/tutorials/singularity/tutorial.md
@@ -13,7 +13,7 @@ contributors:
   - mvdbeek
   - bernt-matthias
   - hexylena
-subtopic: features
+subtopic: jobs
 tags:
   - jobs
 requirements:

--- a/topics/admin/tutorials/singularity/tutorial.md
+++ b/topics/admin/tutorials/singularity/tutorial.md
@@ -16,6 +16,8 @@ contributors:
 subtopic: jobs
 tags:
   - jobs
+  - ansible
+  - git-gat
 requirements:
   - type: "internal"
     topic_name: admin

--- a/topics/admin/tutorials/terraform/slides.html
+++ b/topics/admin/tutorials/terraform/slides.html
@@ -14,6 +14,7 @@ objectives:
 key_points:
   - Terraform lets you develop and implement infrastructure-as-code within your organisation
   - It can drastically simplify management of large numbers of VMs
+subtopic: cloud
 contributors:
   - hexylena
 ---

--- a/topics/admin/tutorials/terraform/tutorial.md
+++ b/topics/admin/tutorials/terraform/tutorial.md
@@ -22,6 +22,7 @@ tags:
   - terraform
   - deploying
   - cloud
+priority: 3
 ---
 
 # Overview

--- a/topics/admin/tutorials/terraform/tutorial.md
+++ b/topics/admin/tutorials/terraform/tutorial.md
@@ -17,6 +17,7 @@ key_points:
   - It can drastically simplify management of large numbers of VMs
 contributors:
   - hexylena
+subtopic: cloud
 tags:
   - terraform
   - deploying

--- a/topics/admin/tutorials/tiaas/tutorial.md
+++ b/topics/admin/tutorials/tiaas/tutorial.md
@@ -17,8 +17,10 @@ contributors:
   - shiltemann
 subtopic: features
 tags:
+  - ansible
   - training
   - jobs
+  - git-gat
 requirements:
   - type: "internal"
     topic_name: admin

--- a/topics/admin/tutorials/tool-management/tutorial.md
+++ b/topics/admin/tutorials/tool-management/tutorial.md
@@ -21,6 +21,7 @@ contributors:
 subtopic: features
 tags:
   - tools
+  - git-gat
 ---
 
 # Overview

--- a/topics/admin/tutorials/troubleshooting/slides.html
+++ b/topics/admin/tutorials/troubleshooting/slides.html
@@ -6,6 +6,7 @@ title: "Galaxy Troubleshooting"
 contributors:
   - martenson
   - natefoo
+subtopic: maintenance
 ---
 In system administration...
 # Everything always goes wrong

--- a/topics/admin/tutorials/upgrading/tutorial.md
+++ b/topics/admin/tutorials/upgrading/tutorial.md
@@ -18,7 +18,7 @@ key_points:
   - Re-run the playbook from time to time to keep your Galaxy server up to date with any minor changes and patches
 contributors:
   - slugger70
-subtopic: features
+subtopic: maintenance
 tags:
   - ansible
 requirements:

--- a/topics/admin/tutorials/users-groups-quotas/slides.html
+++ b/topics/admin/tutorials/users-groups-quotas/slides.html
@@ -18,6 +18,7 @@ contributors:
   - natefoo
   - bgruening
   - hexylena
+subtopic: maintenance
 
 ---
 # Users, Groups, and Quotas

--- a/topics/admin/tutorials/uwsgi/slides.html
+++ b/topics/admin/tutorials/uwsgi/slides.html
@@ -6,6 +6,7 @@ title: "uWSGI"
 contributors:
   - natefoo
   - slugger70
+subtopic: deprecated
 
 ---
 


### PR DESCRIPTION
Clean up the admin area into some more useful subtopics. I think it just shows how much we were using tags for what could be subtopics. Also how poorly tagged our tutorials are, and k8s are the only two to use a "level", we should consider what levels are appropriate for the rest.

- ~should we tag everything that uses ansible? I think maybe.~
- ~should we tag the GAT course tutorials as "gat"? I think maybe.~
- ~should we tag git-gat tutorials? could be ok?~

![Screenshot 2022-02-24 at 12-28-01 Galaxy Training Galaxy Server administration](https://user-images.githubusercontent.com/458683/155515785-4b1940ef-df35-4b32-8b20-34dea39658ab.png)