### PR TITLE
Fix some links in the read mapper overview slide

### DIFF
--- a/topics/sequence-analysis/tutorials/mapping/slides.html
+++ b/topics/sequence-analysis/tutorials/mapping/slides.html
@@ -968,11 +968,11 @@ class: top
 
 **Mapping tool**   |   **Uses**   | **Characteristics**
 --- | --- | ---
-HISAT2 | DNA/RNA | Short reads. Based on [GCSA](https://www.nature.com/articles/s41587-019-0201-4. [Reference](https://www.nature.com/articles/s41587-019-0201-4). [Reference](https://www.nature.com/articles/s41587-019-0201-4).
-RNASTAR | RNA | Short reads. Extremely fast. High sensitive and accuracy. Based on [MMPs](https://pubs.acs.org/doi/10.1021/ci900450m). [Reference](https://pubmed.ncbi.nlm.nih.gov/23104886/).
+HISAT2 | DNA/RNA | Short reads. Based on [GCSA](https://doi.org/10.1109/TCBB.2013.2297101). [Reference](https://www.nature.com/articles/s41587-019-0201-4).
+RNASTAR | RNA | Short reads. Extremely fast. High sensitive and accuracy. Based on Maximal Mappable Prefixes (MMPs). [Reference](https://pubmed.ncbi.nlm.nih.gov/23104886/).
 BWA-MEM2 | DNA | Short reads. Twice as faster as BWA-MEM. Memory efficient. Based on [Burrows-Wheeler](https://academic.oup.com/bioinformatics/article/25/14/1754/225615). [Reference](https://arxiv.org/abs/1907.12931).
-Minimap2 | DNA/RNA | Long reads (PacBio and ONT).  Extremely fast. Based on [DALINGNER](https://link.springer.com/chapter/10.1007/978-3-662-44753-6_5) and [MHAP](https://www.nature.com/articles/nbt.3238). [Reference](https://www.nature.com/articles/nbt.3238).
-Bismark | DNA/RNA | Short reads. Bisulfite treated sequencing. Based on [GCSA](https://www.nature.com/articles/s41587-019-0201-4). [Reference](https://pubmed.ncbi.nlm.nih.gov/21493656/).
+Minimap2 | DNA/RNA | Long reads (PacBio and ONT).  Extremely fast. Based on [DALIGN](https://link.springer.com/chapter/10.1007/978-3-662-44753-6_5) and [MHAP](https://www.nature.com/articles/nbt.3238). [Reference](https://www.nature.com/articles/nbt.3238).
+Bismark | DNA/RNA | Short reads. Bisulfite treated sequencing. Based on [GCSA](https://doi.org/10.1109/TCBB.2013.2297101). [Reference](https://pubmed.ncbi.nlm.nih.gov/21493656/).
 BBMap | DNA/RNA | Short and long reads (PacBio and ONT). Memory demanding. [Reference](https://bib.irb.hr/datoteka/773708.Josip_Maric_diplomski.pdf).
 Whisper 2 | DNA | Short reads. Indel sensitive. Variant-calling oriented. [Reference](https://academic.oup.com/bioinformatics/article/35/12/2043/5165374).
 S-conLSH | DNA | Long reads (ONT). High sensitivity and accuracy. [Reference](https://bmcbioinformatics.biomedcentral.com/articles/10.1186/s12859-020-03918-3).


### PR DESCRIPTION
Fixed:
- The GCSA link was identical to the HISAT2 link.
- The HISAT2 line was broken due to a missing closing parenthesis
- The MMP link was to an unrelated chemistry method with the same acronym, when really there is no separate link to MMP cause it's defined in the RNASTAR paper itself.