### PR TITLE
bump nokogiri again

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -77,7 +77,7 @@ GEM
     mercenary (0.4.0)
     mini_portile2 (2.8.0)
     namae (1.1.1)
-    nokogiri (1.13.2)
+    nokogiri (1.13.3)
       mini_portile2 (~> 2.8.0)
       racc (~> 1.4)
     nokogumbo (2.0.5)


### PR DESCRIPTION
1.13.2 seems to have disappeared since dependabot issued that PR, which broke our build.