### PR TITLE
Add GaloGS as contributor

### DIFF
--- a/CONTRIBUTORS.yaml
+++ b/CONTRIBUTORS.yaml
@@ -431,6 +431,11 @@ gallardoalba:
     name: Cristóbal Gallardo
     joined: 2020-11
 
+GaloGS:
+    name: Galo A. Goig
+    email: galo.goig@swisstph.ch
+    joined: 2022-03
+    
 gatwirival:
     name: Valentine Gatwiri
     email: valegjohn@gmail.com


### PR DESCRIPTION
We are running a Galaxy workshop on WGS analysis of M. tuberculosis in a couple of weeks and we have prepared some tutorials following the GTN guidelines. We are now ready to push the first version of the tutorials so we are now following the guidelines on "Contributing with GitHub".