### PR TITLE
upgrade the timeout for pages to load on GH machines

### DIFF
--- a/.github/workflows/video.yml
+++ b/.github/workflows/video.yml
@@ -82,6 +82,7 @@ jobs:
       # The actual compilation process deposits everything in the ./videos/ folder.
       - name: Build Videos
         run: |
+          sed -i "s|page.waitForNavigation({ waitUntil: 'load', timeout: 20000 });|page.waitForNavigation({ waitUntil: 'load', timeout: 60000 });|" $(which decktape)
           xvfb-run --auto-servernum --server-args="-screen 0 1920x1080x24" bundle exec bash bin/ari-make.sh
         env:
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_POLLY_ACCESS_KEY_ID }}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "dependencies": {
-    "decktape": "^3.2.0",
+    "decktape": "^3.4.0",
     "editly": "^0.11.3",
     "ffmpeg-static": "^4.4.0",
     "http-server": "^13.0.2",


### PR DESCRIPTION
There's no version currently with this as a CLI option (even though there's a fork with it available) so we'll just update the script in place. This is normal. Nothing to see here. :grimacing: 