### PR TITLE
Stop deleting newlines within pre blocks

### DIFF
--- a/_plugins/snippet.rb
+++ b/_plugins/snippet.rb
@@ -106,7 +106,10 @@ module Jekyll
             #puts "=== RENDERED ===\n#{markdownify(box_start+z+box_end)}\n\n"
           #end
 
-          '<!--SNIPPET-->' + markdownify(box_start+z+box_end).gsub(/\R+/, '').gsub('<h3','<h3 data-toc-skip')
+          '<!--SNIPPET-->' + markdownify(box_start+z+box_end)
+            .gsub(/<(pre)[^>]*>(.*?)<\/\1>/m){|m| m.gsub(/\n/, '<br>') } # Replace newlines inside of a PRE with <br>, so they don't get eaten during next one.
+            .gsub(/\R+/, '') # Strip out spaces or the boxes break
+            .gsub('<h3','<h3 data-toc-skip')
         end
       end
 

--- a/bin/ari-prep-script.rb
+++ b/bin/ari-prep-script.rb
@@ -80,7 +80,7 @@ editly['clips'] = script['blocks'].map.with_index{ |phrases, idx|
     voice = script['voice']
 
     mp3, json, duration = synthesize(subtitle, engine, 'voice': voice['id'], 'lang': voice['lang'], neural: voice['neural'])
-    puts "\tSynthesizing: #{subtitle}"
+    puts "\tSynthesizing: #{mp3} #{subtitle}"
     FileUtils.cp(mp3, File.join(dir, digest + '.mp3'))
     FileUtils.cp(json, File.join(dir, digest + '.json'))
 

--- a/topics/admin/faqs/diffs.md
+++ b/topics/admin/faqs/diffs.md
@@ -40,7 +40,7 @@ We can see that they have some different entries. We've removed 🍒 because the
 
 Diff lets us compare these files
 
-```diff
+```bash
 $ diff old new
 5c5
 < 🍒
@@ -52,7 +52,7 @@ Here we see that 'pears' is only in a, and 'ananas' is only in b. But otherwise 
 
 There are a couple different formats to diffs, one is the 'unified diff'
 
-```diff
+```bash
 $ diff -U2 old new
 --- old	2022-02-16 14:06:19.697132568 +0100
 +++ new	2022-02-16 14:06:36.340962616 +0100
@@ -84,7 +84,7 @@ The other lines (🍊/🍋 and 🥑) above just provide "context", they help you
 
 Removals are very easy to spot, we just have removed lines
 
-```diff
+```bash
 --- old	2022-02-16 14:06:19.697132568 +0100
 +++ new	2022-02-16 14:10:14.370722802 +0100
 @@ -4,3 +4,2 @@
@@ -95,7 +95,7 @@ Removals are very easy to spot, we just have removed lines
 
 And additions likewise are very easy, just add a new line, between the other lines in your file.
 
-```diff
+```bash
 --- old	2022-02-16 14:06:19.697132568 +0100
 +++ new	2022-02-16 14:11:11.422135393 +0100
 @@ -1,3 +1,4 @@
@@ -109,7 +109,7 @@ And additions likewise are very easy, just add a new line, between the other lin
 
 Completely new files look a bit different, there the "old" file is `/dev/null`, the empty file in a Linux machine.
 
-```diff
+```bash
 $ diff -U2 /dev/null old
 --- /dev/null	2022-02-15 11:47:16.100000270 +0100
 +++ old	2022-02-16 14:06:19.697132568 +0100
@@ -124,7 +124,7 @@ $ diff -U2 /dev/null old
 
 And removed files are similar, except with the the new file being /dev/null
 
-```diff
+```bash
 --- old	2022-02-16 14:06:19.697132568 +0100
 +++ /dev/null	2022-02-15 11:47:16.100000270 +0100
 @@ -1,6 +0,0 @@

--- a/topics/admin/faqs/diffs.md
+++ b/topics/admin/faqs/diffs.md
@@ -10,6 +10,7 @@ If you haven't worked with diffs before, this can be something quite new or diff
 
 If we have two files, let's say a grocery list, in two files. We'll call them 'a' and 'b'.
 
+
 > > ### {% icon code-in %} Old
 > > ```
 > > $ cat old
@@ -108,7 +109,7 @@ And additions likewise are very easy, just add a new line, between the other lin
 
 Completely new files look a bit different, there the "old" file is `/dev/null`, the empty file in a Linux machine.
 
-```
+```diff
 $ diff -U2 /dev/null old
 --- /dev/null	2022-02-15 11:47:16.100000270 +0100
 +++ old	2022-02-16 14:06:19.697132568 +0100
@@ -123,7 +124,7 @@ $ diff -U2 /dev/null old
 
 And removed files are similar, except with the the new file being /dev/null
 
-```
+```diff
 --- old	2022-02-16 14:06:19.697132568 +0100
 +++ /dev/null	2022-02-15 11:47:16.100000270 +0100
 @@ -1,6 +0,0 @@

--- a/topics/admin/tutorials/ansible-galaxy/tutorial.md
+++ b/topics/admin/tutorials/ansible-galaxy/tutorial.md
@@ -275,6 +275,8 @@ We have codified all of the dependencies you will need into a YAML file that `an
 >    ```
 >    {: data-commit="Add requirements"}
 >
+>    {% snippet topics/admin/faqs/diffs.md %}
+>
 >    > ### {% icon details %} What do each of these roles do?
 >    > We'll cover it in more detail as we use each of the roles but briefly:
 >    >


### PR DESCRIPTION
By manually replacing them with BRs before the newline deleter can get
to them

This fixes issues that are currently live:

Before | after
--- | ---
![image](https://user-images.githubusercontent.com/458683/157884341-36b8c818-b28d-45c4-912a-442f4fae69ae.png) | ![image](https://user-images.githubusercontent.com/458683/157884370-c9efb72c-1e0b-43e8-9b8c-66e1b2fb64c6.png)
![image](https://user-images.githubusercontent.com/458683/157884447-ab24283e-c70e-4778-bcfa-0b217db5a70d.png) | ![image](https://user-images.githubusercontent.com/458683/157884458-fb1cdd6b-6453-4506-8284-d339182e4c2a.png)
