### PR TITLE
[FAQs] Show general Qs only on tutorial-level FAQS

### DIFF
--- a/_layouts/faq-page.html
+++ b/_layouts/faq-page.html
@@ -45,19 +45,17 @@ layout: faqs
 
 {% endfor %}
 
-{% unless page.url contains 'faqs/galaxy/' or page.url contains 'faqs/gtn/' %}
+{% if page.url contains '/tutorials/' %}
 <br>
 <h3 id="general-faqs"> <a href="#general-faqs"> General Questions </a></h3>
 <hr>
 <!-- Add the "help my tool is missing FAQ to all tutorial faq pages -->
-{% if page.dir contains 'faqs' and page.dir contains 'tutorial' %}
- <h4 class="faq-area"> Can't find one of the tools for this tutorial? <a href="{{site.baseurl}}/faqs/galaxy/tools_missing.html"><i class="fas fa-external-link-alt"></i></a> </h4>
-  {% snippet /faqs/galaxy/tools_missing.md %}
- <h4 class="faq-area"> Running into an error? <a href="{{site.baseurl}}/faqs/galaxy/analysis_troubleshooting.html"><i class="fas fa-external-link-alt"></i></a> </h4>
-  {% snippet /faqs/galaxy/analysis_troubleshooting.md %}
-{% endif %}
+<h4 class="faq-area"> Can't find one of the tools for this tutorial? <a href="{{site.baseurl}}/faqs/galaxy/tools_missing.html"><i class="fas fa-external-link-alt"></i></a> </h4>
+{% snippet /faqs/galaxy/tools_missing.md %}
+<h4 class="faq-area"> Running into an error? <a href="{{site.baseurl}}/faqs/galaxy/analysis_troubleshooting.html"><i class="fas fa-external-link-alt"></i></a> </h4>
+{% snippet /faqs/galaxy/analysis_troubleshooting.md %}
 
-{% endunless %}
+{% endif %}
 
 
 


### PR DESCRIPTION
It was showing the "general question" header (but not the Qs) on the topic-level FAQ pages