### PR TITLE
Update ref-based tutorial.md

### DIFF
--- a/topics/transcriptomics/tutorials/ref-based/tutorial.md
+++ b/topics/transcriptomics/tutorials/ref-based/tutorial.md
@@ -724,11 +724,12 @@ We now run **featureCounts** to count the number of reads per annotated gene.
 >    - *"Create gene-length file"*: `Yes`
 >    - In *"Options for paired-end reads"*:
 >       - *"Count fragments instead of reads"*: `Enabled; fragments (or templates) will be counted instead of reads`
+>    - In *"Read filtering options"*:
+>       - *"Minimum mapping quality per read"*: `10`
 >    - In *"Advanced options"*:
 >       - *"GFF feature type filter"*: `exon`
 >       - *"GFF gene identifier"*: `gene_id`
 >       - *"Allow reads to map to multiple features"*: `Disabled; reads that align to multiple features or overlapping features are excluded`
->       - *"Minimum mapping quality per read"*: `10`
 >
 > 2. {% tool [MultiQC](toolshed.g2.bx.psu.edu/repos/iuc/multiqc/multiqc/1.7) %} to aggregate the report:
 >     - In *"Results"*:


### PR DESCRIPTION
Reorganized an option to match the current 2.0.1+galaxy2 Featurecounts tool form

Questions:

1. This creates a mismatch between the tool version in the tutorial (2.0.1) and the current version (2.0.1+galaxy2) at usegalaxy.* servers. 
2. I didn't change the tool version link yet -- should that be done?
3. What else needs to be changed if we do this -- the workflow? anything else

Ok to reject this -- not sure how it is decided what is worth updating versus not