### PR TITLE
Changing broken links within a tutorial page

### DIFF
--- a/topics/contributing/tutorials/github-interface-contribution/tutorial.md
+++ b/topics/contributing/tutorials/github-interface-contribution/tutorial.md
@@ -21,7 +21,7 @@ contributors:
 # Introduction
 {:.no_toc}
 
-All the training material which you find on [{{ site.url }}{{ site.baseurl }}/]({{ site.baseurl }}/) is stored on a [GitHub](https://github.com) repository ([{{ site.github_repository }}]({{ site.github.repository_url }})), a code hosting platform for version control and collaboration. GitHub interface is quite intuitive and simplifies the contributions from anyone.
+All the training material which you find on [{{ site.url }}{{ site.baseurl }}/]({{ site.baseurl }}/) is stored on a [GitHub](https://github.com) repository ([{{ site.github_repository }}]({{ site.github_repository }})), a code hosting platform for version control and collaboration. GitHub interface is quite intuitive and simplifies the contributions from anyone.
 
 > ### Agenda
 >
@@ -34,11 +34,11 @@ All the training material which you find on [{{ site.url }}{{ site.baseurl }}/](
 
 # GitHub
 
-The GitHub repository for the training material is: [{{ site.github_repository }}]({{ site.github.repository_url }}).
+The GitHub repository for the training material is: [{{ site.github_repository }}]({{ site.github_repository }}).
 
 > ### {% icon hands_on %} Hands-on: Familiarization with GitHub
 >
-> 1. Go on the GitHub repository: [{{ site.github_repository }}]({{ site.github.repository_url }})
+> 1. Go on the GitHub repository: [{{ site.github_repository }}]({{ site.github_repository }})
 >
 >    ![GitHub interface](../../images/github_interface.png "Interface of the GitHub repository of the training material")
 >


### PR DESCRIPTION
Changing broken links found within the “[Contributing with GitHub via its interface](https://training.galaxyproject.org/training-material/topics/contributing/tutorials/github-interface-contribution/tutorial.html)” tutorial page. The GTN Repository link within the page does not open the GitHub page instead it loads the same page (tutorial page).

- Changed the link of the GTN Repository found under the “Introduction” section Line 2 in a parentheses
- Changed the link of the GTN Repository found under the “GitHub” section first line (the one that says “The GitHub repository for the training material is:”)
- Changed the link of the GTN repository found under “Hands-on: Familiarization with GitHub” first line (the one that says “Go on the GitHub repository:”)