### PR TITLE
Moving FAQ "where is the tool help?"

### DIFF
--- a/faqs/gtn/tool-help.md
+++ b/faqs/gtn/tool-help.md
@@ -1,0 +1,27 @@
+---
+title: Support Tool Help
+---
+[Back to Support Hub](/support/)
+
+## Documentation is on the tool form itself
+
+
+* Parameters
+* Expected format for input [dataset(s)](/learn/managing-datasets/)
+* Links to publications and [Tool Shed](/toolshed/) source repositories
+* Tool and wrapper version(s)
+* 3rd party author web sites and documentation
+
+## Many tools include "most common" and "full parameter" run-time options
+
+* Scroll down on the tool form to locate information about expected inputs/outputs, expanded definitions, sample data, example use cases, and graphics.
+
+## Galaxy Resources
+
+* [Galaxy Search](/search/) will locate help across Galaxy's resources.
+* [Galaxy Tutorials](/learn/)
+* [Galaxy Support FAQs](/support/)
+* [Galaxy Help](https://help.galaxyproject.org/) - current Q&A
+* [Galaxy Biostars](https://biostar.usegalaxy.org) - archived Q&A
+
+


### PR DESCRIPTION
FAQ in the community hub moved to the GTN FAQ