### PR TITLE
[FAQs] Added FAQ in GTN for finding/working on shared histories

### DIFF
--- a/faqs/galaxy/histories_shared.md
+++ b/faqs/galaxy/histories_shared.md
@@ -1,0 +1,23 @@
+---
+title: Finding and working with "Histories shared with me"
+description: How to find and work on histories shared with you
+area: datasets
+layout: faq
+box_type: tip
+contributors: [jennaj, garimavs]
+---
+
+**To find histories shared with me:**
+1. Log into your account.
+2. Select **User**, in the drop-down menu, select **Histories shared with me**.
+
+**To work with shared histories:**
+- Import the History into your account via copying it to work with it.
+- Unshare Histories that you no longer want shared with you or that you have already made a copy of.
+
+**Note:** Shared Histories (when copied into your account or not) do count in portion toward your total account data quota usage. More details on histories shared concerning account quota usage can be found in [this link](https://galaxyproject.org/support/account-quotas/#find-histories-that-have-been-shared-with-you-and-unshare-those-not-needed).
+
+
+
+
+

--- a/faqs/galaxy/histories_shared.md
+++ b/faqs/galaxy/histories_shared.md
@@ -15,9 +15,4 @@ contributors: [jennaj, garimavs]
 - Import the History into your account via copying it to work with it.
 - Unshare Histories that you no longer want shared with you or that you have already made a copy of.
 
-**Note:** Shared Histories (when copied into your account or not) do count in portion toward your total account data quota usage. More details on histories shared concerning account quota usage can be found in [this link](https://galaxyproject.org/support/account-quotas/#find-histories-that-have-been-shared-with-you-and-unshare-those-not-needed).
-
-
-
-
-
+**Note:** Shared Histories (when copied into your account or not) do count in portion toward your total account data quota usage. More details on histories shared concerning account quota usage can be found in [this link](https://training.galaxyproject.org/training-material/faqs/galaxy/#unsharing-unwanted-histories).


### PR DESCRIPTION
The following Pull Request is a part of the Issue: _Move FAQs to GTN_ of the [Galaxy_Hub repository](https://github.com/galaxyproject/galaxy-hub).

I have added [A history was shared with me, where can I find it?](https://galaxyproject.org/support/missing-history/) in the GTN.
Kindly have a look at it and suggest any improvements or amendments.