### PR TITLE
[FAQs] Added Datasets Icons in GTN

### DIFF
--- a/faqs/galaxy/datasets_icons.md
+++ b/faqs/galaxy/datasets_icons.md
@@ -13,5 +13,5 @@ Dataset icons and their usage:
 - {% icon galaxy-pencil %} **"Pencil icon"**: Edit attributes of the job.
 - {% icon galaxy-cross %} **"'X' icon"**: Delete the job.
 - {% icon galaxy-info %} **"Info icon"**: Job details and run information.
-- {% icon galaxy-refresh %} **"Refresh/Rerun icon"**: Run this (selected) job again or examine original submitted form(filled in).
+- {% icon galaxy-refresh %} **"Refresh/Rerun icon"**: Run this (selected) job again or examine original submitted form (filled in).
 - {% icon galaxy-bug %} **"Green bug icon"**: Review and optionally submit a bug report.

--- a/faqs/galaxy/datasets_icons.md
+++ b/faqs/galaxy/datasets_icons.md
@@ -13,5 +13,5 @@ Dataset icons and their usage:
 - {% icon galaxy-pencil %} **"Pencil icon"**: Edit attributes of the job.
 - {% icon galaxy-cross %} **"'X' icon"**: Delete the job.
 - {% icon galaxy-info %} **"Info icon"**: Job details and run information.
-- {% icon galaxy-refresh %} **"Refresh/Rerun icon"**: Run this(selected) job again or examine original submitted form(filled in).
+- {% icon galaxy-refresh %} **"Refresh/Rerun icon"**: Run this (selected) job again or examine original submitted form(filled in).
 - {% icon galaxy-bug %} **"Green bug icon"**: Review and optionally submit a bug report.

--- a/faqs/galaxy/datasets_icons.md
+++ b/faqs/galaxy/datasets_icons.md
@@ -1,0 +1,17 @@
+---
+title: Different dataset icons and their usage
+description: Icons provide a visual experience for objects, actions, and ideas
+area: datasets
+layout: faq
+box_type: tip
+contributors: [jennaj, garimavs]
+---
+
+Dataset icons and their usage: 
+
+- {% icon galaxy-eye %} **"Eye icon"**: Display data of the job in the browser.
+- {% icon galaxy-pencil %} **"Pencil icon"**: Edit attributes of the job.
+- {% icon galaxy-cross %} **"'X' icon"**: Delete the job.
+- {% icon galaxy-info %} **"Info icon"**: Job details and run information.
+- {% icon galaxy-refresh %} **"Refresh/Rerun icon"**: Run this(selected) job again or examine original submitted form(filled in).
+- {% icon galaxy-bug %} **"Green bug icon"**: Review and optionally submit a bug report.


### PR DESCRIPTION
The following Pull Request is a part of the Issue: _Move FAQs to GTN_ of the [Galaxy_Hub repository](https://github.com/galaxyproject/galaxy-hub).

I have added the dataset icons in the GTN.
Kindly have a look at it and suggest any improvements or amendments.

