### PR TITLE
[FAQ] Added unsharing of histories

### DIFF
--- a/faqs/galaxy/histories_unsharing_histories.md
+++ b/faqs/galaxy/histories_unsharing_histories.md
@@ -1,0 +1,19 @@
+---
+title: Unsharing unwanted histories
+area: histories
+box_type: tip
+layout: faq
+contributors: [jennaj, garimavs]
+---
+
+- All account Histories owned by others but shared with you can be reviewed under **User > Histories shared with me**.
+- The other person does not need to unshare a history with you. _Unshare histories yourself_ on this page using the pull-down menu per history.
+- Dataset and History privacy options, including sharing, can be set under **User > Preferences**.
+
+Three key features to work with shared data are: -
+
+- **View** is a review feature. The data cannot be worked with, but many details, including tool and dataset metadata/parameters, are included.
+- **Copy** those you want to work with. This will increase your quota usage. This will also allow you to manipulate the datasets or the history independently from the original owner. All History/Dataset functions are available if the other person granted full access to the datasets to you. 
+- **Unshare** any on the list not needed anymore. After a history is copied, you will still have your version of the history, even if later unshared or the other person who shared it with you changes their version later. Meaning, that _each account's version of a History and the Datasets in it are distinct_ (unless the Datasets were not shared, you will still only be able to "view" but not work with or download them).
+ 
+**Note-** "Histories shared with me" result in only a tiny part of your quota usage. Unsharing will not significantly reduce quota usage unless hundreds (or more!) or many significant histories are shared. If you share a History with someone else, that does not increase or decrease your quota usage.

--- a/faqs/galaxy/histories_unsharing_histories.md
+++ b/faqs/galaxy/histories_unsharing_histories.md
@@ -10,10 +10,10 @@ contributors: [jennaj, garimavs]
 - The other person does not need to unshare a history with you. _Unshare histories yourself_ on this page using the pull-down menu per history.
 - Dataset and History privacy options, including sharing, can be set under **User > Preferences**.
 
-Three key features to work with shared data are: -
+Three key features to work with shared data are:
 
 - **View** is a review feature. The data cannot be worked with, but many details, including tool and dataset metadata/parameters, are included.
 - **Copy** those you want to work with. This will increase your quota usage. This will also allow you to manipulate the datasets or the history independently from the original owner. All History/Dataset functions are available if the other person granted full access to the datasets to you. 
 - **Unshare** any on the list not needed anymore. After a history is copied, you will still have your version of the history, even if later unshared or the other person who shared it with you changes their version later. Meaning, that _each account's version of a History and the Datasets in it are distinct_ (unless the Datasets were not shared, you will still only be able to "view" but not work with or download them).
  
-**Note-** "Histories shared with me" result in only a tiny part of your quota usage. Unsharing will not significantly reduce quota usage unless hundreds (or more!) or many significant histories are shared. If you share a History with someone else, that does not increase or decrease your quota usage.
+**Note:** "Histories shared with me" result in only a tiny part of your quota usage. Unsharing will not significantly reduce quota usage unless hundreds (or more!) or many significant histories are shared. If you share a History with someone else, that does not increase or decrease your quota usage.


### PR DESCRIPTION
The following Pull Request is a part of the Issue: Move FAQs to GTN of the [Galaxy_Hub repository](https://github.com/galaxyproject/galaxy-hub).

I have added [Find Histories that have been shared with you, and unshare those not needed](https://galaxyproject.org/support/account-quotas/#find-histories-that-have-been-shared-with-you-and-unshare-those-not-needed) in the GTN.
Kindly have a look at it and suggest any improvements or amendments.