### PR TITLE
[FAQ] Added FAQ for sorting inputs for input errors

### DIFF
--- a/faqs/galaxy/tools_sorting.md
+++ b/faqs/galaxy/tools_sorting.md
@@ -1,0 +1,15 @@
+---
+title: Sorting Tools
+area: tools
+box_type: tip
+layout: faq
+contributors: [jennaj, garimavs]
+---
+
+Sometimes input errors are caused because of non-sorted inputs. Try using these: -
+- **Picard SortSam:** Sort SAM/BAM by coordinate or queryname.
+- **Samtools Sort:** Alternate for SAM/BAM, best when used for coordinate sorting only.
+- **SortBED order the intervals:** Best choice for BED/Interval.
+- **Sort data in ascending or descending order:** Alternate choice for Tabular/BED/Interval/GTF.
+- **VCFsort:** Best choice for VFC.
+- **Tool Form Options for Sorting:** Some tools have an option to sort inputs during job execution. Whenever possible, sort inputs before using tools, especially if jobs fail for not having enough memory resources.

--- a/faqs/galaxy/tools_sorting.md
+++ b/faqs/galaxy/tools_sorting.md
@@ -6,7 +6,7 @@ layout: faq
 contributors: [jennaj, garimavs]
 ---
 
-Sometimes input errors are caused because of non-sorted inputs. Try using these: -
+Sometimes input errors are caused because of non-sorted inputs. Try using these:
 - **Picard SortSam:** Sort SAM/BAM by coordinate or queryname.
 - **Samtools Sort:** Alternate for SAM/BAM, best when used for coordinate sorting only.
 - **SortBED order the intervals:** Best choice for BED/Interval.


### PR DESCRIPTION
The following Pull Request is a part of the Issue: Move FAQs to GTN of the [Galaxy_Hub repository](https://github.com/galaxyproject/galaxy-hub).

I have added [Sorting your inputs](https://galaxyproject.org/support/sort-your-inputs/) in the GTN.
Kindly have a look at it and suggest any improvements or amendments.