### PR TITLE
Galaxy 101: replace Select first lines tool

### DIFF
--- a/topics/introduction/tutorials/galaxy-intro-101/tutorial.md
+++ b/topics/introduction/tutorials/galaxy-intro-101/tutorial.md
@@ -368,10 +368,11 @@ Let's say we want a list with just the top-5 exons with highest number of SNPs.
 
 > ### {% icon hands_on %} Hands-on: Select first
 >
-> 1. {% tool [Select first](toolshed.g2.bx.psu.edu/repos/bgruening/text_processing/tp_head_tool/1.1.0) %} lines from a dataset:
+> 1. {% tool [Select first](https://usegalaxy.eu/root?tool_id=toolshed.g2.bx.psu.edu/repos/bgruening/text_processing/tp_head_tool/1.1.0) %} lines from a dataset (head):
 >
->    - *"Select first"*: `5`
->    - *"from"*: The output from **Sort** {% icon tool %}
+>    - *"File to select"*: The output from **Sort** {% icon tool %}
+>    - "*Operation*": `Keep first lines`
+>    - *"Number of libes"*: `5`
 >
 > 2. Click **Execute**
 >

--- a/topics/introduction/tutorials/galaxy-intro-101/tutorial.md
+++ b/topics/introduction/tutorials/galaxy-intro-101/tutorial.md
@@ -368,7 +368,7 @@ Let's say we want a list with just the top-5 exons with highest number of SNPs.
 
 > ### {% icon hands_on %} Hands-on: Select first
 >
-> 1. {% tool [Select first](https://usegalaxy.eu/root?tool_id=toolshed.g2.bx.psu.edu/repos/bgruening/text_processing/tp_head_tool/1.1.0) %} lines from a dataset (head):
+> 1. {% tool [Select first](toolshed.g2.bx.psu.edu/repos/bgruening/text_processing/tp_head_tool/1.1.0) %} lines from a dataset (head):
 >
 >    - *"File to select"*: The output from **Sort** {% icon tool %}
 >    - "*Operation*": `Keep first lines`

--- a/topics/introduction/tutorials/galaxy-intro-101/workflows/galaxy-intro-101-workflow.ga
+++ b/topics/introduction/tutorials/galaxy-intro-101/workflows/galaxy-intro-101-workflow.ga
@@ -9,7 +9,7 @@
         }
     ],
     "format-version": "0.1",
-    "name": "Find exons with the highest number of features (imported from uploaded file)",
+    "name": "Find exons with the highest number of features",
     "steps": {
         "0": {
             "annotation": "",

--- a/topics/introduction/tutorials/galaxy-intro-101/workflows/galaxy-intro-101-workflow.ga
+++ b/topics/introduction/tutorials/galaxy-intro-101/workflows/galaxy-intro-101-workflow.ga
@@ -9,7 +9,7 @@
         }
     ],
     "format-version": "0.1",
-    "name": "Find exons with the highest number of features",
+    "name": "Find exons with the highest number of features (imported from uploaded file)",
     "steps": {
         "0": {
             "annotation": "",
@@ -27,14 +27,14 @@
             "name": "Input dataset",
             "outputs": [],
             "position": {
-                "bottom": 467.9000015258789,
-                "height": 60.400001525878906,
-                "left": 244,
-                "right": 444,
-                "top": 407.5,
+                "bottom": 481.28125,
+                "height": 61.78125,
+                "left": 24,
+                "right": 224,
+                "top": 419.5,
                 "width": 200,
-                "x": 244,
-                "y": 407.5
+                "x": 24,
+                "y": 419.5
             },
             "tool_id": null,
             "tool_state": "{\"optional\": false}",
@@ -59,14 +59,14 @@
             "name": "Input dataset",
             "outputs": [],
             "position": {
-                "bottom": 722.9000015258789,
-                "height": 60.400001525878906,
-                "left": 216,
-                "right": 416,
-                "top": 662.5,
+                "bottom": 736.28125,
+                "height": 61.78125,
+                "left": -4,
+                "right": 196,
+                "top": 674.5,
                 "width": 200,
-                "x": 216,
-                "y": 662.5
+                "x": -4,
+                "y": 674.5
             },
             "tool_id": null,
             "tool_state": "{\"optional\": false}",
@@ -100,24 +100,24 @@
                 }
             ],
             "position": {
-                "bottom": 757.6999969482422,
-                "height": 141.1999969482422,
-                "left": 490,
-                "right": 690,
-                "top": 616.5,
+                "bottom": 772.453125,
+                "height": 143.953125,
+                "left": 270,
+                "right": 470,
+                "top": 628.5,
                 "width": 200,
-                "x": 490,
-                "y": 616.5
+                "x": 270,
+                "y": 628.5
             },
             "post_job_actions": {},
             "tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/bedtools/bedtools_intersectbed/2.30.0",
             "tool_shed_repository": {
-                "changeset_revision": "fe5b4cb8356c",
+                "changeset_revision": "07e8b80f278c",
                 "name": "bedtools",
                 "owner": "iuc",
                 "tool_shed": "toolshed.g2.bx.psu.edu"
             },
-            "tool_state": "{\"__input_ext\": \"bed\", \"bed\": \"false\", \"chromInfo\": \"/cvmfs/data.galaxyproject.org/managed/len/ucsc/?.len\", \"count\": \"false\", \"fraction_cond\": {\"fraction_select\": \"default\", \"__current_case__\": 0}, \"header\": \"false\", \"inputA\": {\"__class__\": \"ConnectedValue\"}, \"invert\": \"false\", \"once\": \"false\", \"overlap_mode\": [\"-wb\"], \"reduce_or_iterate\": {\"reduce_or_iterate_selector\": \"iterate\", \"__current_case__\": 0, \"inputB\": {\"__class__\": \"ConnectedValue\"}}, \"sorted\": \"false\", \"split\": \"false\", \"strand\": \"\", \"__page__\": null, \"__rerun_remap_job_id__\": null}",
+            "tool_state": "{\"__input_ext\": \"bed\", \"bed\": \"false\", \"chromInfo\": \"/cvmfs/data.galaxyproject.org/managed/len/ucsc/?.len\", \"count\": \"false\", \"fraction_cond\": {\"fraction_select\": \"default\", \"__current_case__\": 0}, \"genome_file_opts\": {\"genome_file_opts_selector\": \"loc\", \"__current_case__\": 0, \"genome\": null}, \"header\": \"false\", \"inputA\": {\"__class__\": \"ConnectedValue\"}, \"invert\": \"false\", \"once\": \"false\", \"overlap_mode\": [\"-wb\"], \"reduce_or_iterate\": {\"reduce_or_iterate_selector\": \"iterate\", \"__current_case__\": 0, \"inputB\": {\"__class__\": \"ConnectedValue\"}}, \"sorted\": \"false\", \"split\": \"false\", \"strand\": \"\", \"__page__\": null, \"__rerun_remap_job_id__\": null}",
             "tool_version": "2.30.0",
             "type": "tool",
             "uuid": "4fc2b17c-64d8-4c1c-a2d3-743f2ea9bcaf",
@@ -125,7 +125,7 @@
                 {
                     "label": null,
                     "output_name": "output",
-                    "uuid": "df3b392a-5505-44bc-9845-651724a5db56"
+                    "uuid": "3ac7fac2-60ab-4372-b6ac-50d4df536fb2"
                 }
             ]
         },
@@ -150,14 +150,14 @@
                 }
             ],
             "position": {
-                "bottom": 787.7000045776367,
-                "height": 111.20000457763672,
-                "left": 785,
-                "right": 985,
-                "top": 676.5,
+                "bottom": 802.0625,
+                "height": 113.5625,
+                "left": 565,
+                "right": 765,
+                "top": 688.5,
                 "width": 200,
-                "x": 785,
-                "y": 676.5
+                "x": 565,
+                "y": 688.5
             },
             "post_job_actions": {},
             "tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/datamash_ops/datamash_ops/1.1.0",
@@ -175,7 +175,7 @@
                 {
                     "label": null,
                     "output_name": "out_file",
-                    "uuid": "3088a2f9-cc46-46ae-871c-56aec2ac912e"
+                    "uuid": "5ac4094b-38a3-4a22-a4d6-a46db5697072"
                 }
             ]
         },
@@ -200,26 +200,26 @@
                 }
             ],
             "position": {
-                "bottom": 455.7000045776367,
-                "height": 91.20000457763672,
-                "left": 779,
-                "right": 979,
-                "top": 364.5,
+                "bottom": 469.671875,
+                "height": 93.171875,
+                "left": 559,
+                "right": 759,
+                "top": 376.5,
                 "width": 200,
-                "x": 779,
-                "y": 364.5
+                "x": 559,
+                "y": 376.5
             },
             "post_job_actions": {},
             "tool_id": "sort1",
             "tool_state": "{\"__input_ext\": \"tabular\", \"chromInfo\": \"/cvmfs/data.galaxyproject.org/managed/len/ucsc/?.len\", \"column\": \"2\", \"column_set\": [], \"header_lines\": \"0\", \"input\": {\"__class__\": \"ConnectedValue\"}, \"order\": \"DESC\", \"style\": \"num\", \"__page__\": null, \"__rerun_remap_job_id__\": null}",
-            "tool_version": "1.1.0",
+            "tool_version": "1.2.0",
             "type": "tool",
             "uuid": "4dd35991-4996-4f7d-8690-bde783f6fa6a",
             "workflow_outputs": [
                 {
                     "label": null,
                     "output_name": "out_file1",
-                    "uuid": "8e3d4d76-a145-48e8-9ced-e3f7505d2393"
+                    "uuid": "af03d482-4ced-47ad-9c5d-6fb9bd23cb88"
                 }
             ]
         },
@@ -234,7 +234,12 @@
                     "output_name": "out_file1"
                 }
             },
-            "inputs": [],
+            "inputs": [
+                {
+                    "description": "runtime parameter for tool Select first",
+                    "name": "infile"
+                }
+            ],
             "label": null,
             "name": "Select first",
             "outputs": [
@@ -244,14 +249,14 @@
                 }
             ],
             "position": {
-                "bottom": 662.7000045776367,
-                "height": 91.20000457763672,
-                "left": 1056,
-                "right": 1256,
-                "top": 571.5,
+                "bottom": 362.171875,
+                "height": 93.171875,
+                "left": 857,
+                "right": 1057,
+                "top": 269,
                 "width": 200,
-                "x": 1056,
-                "y": 571.5
+                "x": 857,
+                "y": 269
             },
             "post_job_actions": {},
             "tool_id": "toolshed.g2.bx.psu.edu/repos/bgruening/text_processing/tp_head_tool/1.1.0",
@@ -261,15 +266,15 @@
                 "owner": "bgruening",
                 "tool_shed": "toolshed.g2.bx.psu.edu"
             },
-            "tool_state": "{\"__input_ext\": \"tabular\", \"chromInfo\": \"/cvmfs/data.galaxyproject.org/managed/len/ucsc/?.len\", \"complement\": \"\", \"count\": \"5\", \"infile\": {\"__class__\": \"ConnectedValue\"}, \"__page__\": null, \"__rerun_remap_job_id__\": null}",
+            "tool_state": "{\"complement\": \"\", \"count\": \"5\", \"infile\": {\"__class__\": \"RuntimeValue\"}, \"__page__\": null, \"__rerun_remap_job_id__\": null}",
             "tool_version": "1.1.0",
             "type": "tool",
-            "uuid": "0f5949eb-d8b0-4347-8578-86b6a6f0d789",
+            "uuid": "820fd964-2460-4b50-8491-968d796500fc",
             "workflow_outputs": [
                 {
                     "label": null,
                     "output_name": "outfile",
-                    "uuid": "d5caecbe-0a3e-44cd-a465-45b91f458bcc"
+                    "uuid": "0bbe5146-9bb8-4238-b69e-a2bce85870f9"
                 }
             ]
         },
@@ -288,7 +293,16 @@
                     "output_name": "outfile"
                 }
             },
-            "inputs": [],
+            "inputs": [
+                {
+                    "description": "runtime parameter for tool Compare two Datasets",
+                    "name": "input1"
+                },
+                {
+                    "description": "runtime parameter for tool Compare two Datasets",
+                    "name": "input2"
+                }
+            ],
             "label": null,
             "name": "Compare two Datasets",
             "outputs": [
@@ -298,14 +312,14 @@
                 }
             ],
             "position": {
-                "bottom": 581.6999969482422,
-                "height": 141.1999969482422,
-                "left": 1300,
-                "right": 1500,
-                "top": 440.5,
+                "bottom": 596.453125,
+                "height": 143.953125,
+                "left": 1080,
+                "right": 1280,
+                "top": 452.5,
                 "width": 200,
-                "x": 1300,
-                "y": 440.5
+                "x": 1080,
+                "y": 452.5
             },
             "post_job_actions": {
                 "RenameDatasetActionout_file1": {
@@ -317,7 +331,7 @@
                 }
             },
             "tool_id": "comp1",
-            "tool_state": "{\"field1\": \"4\", \"field2\": \"1\", \"input1\": {\"__class__\": \"ConnectedValue\"}, \"input2\": {\"__class__\": \"ConnectedValue\"}, \"mode\": \"N\", \"__page__\": null, \"__rerun_remap_job_id__\": null}",
+            "tool_state": "{\"field1\": \"4\", \"field2\": \"1\", \"input1\": {\"__class__\": \"RuntimeValue\"}, \"input2\": {\"__class__\": \"RuntimeValue\"}, \"mode\": \"N\", \"__page__\": null, \"__rerun_remap_job_id__\": null}",
             "tool_version": "1.0.2",
             "type": "tool",
             "uuid": "52698c72-b6cc-4ca4-84b0-c84dd018e389",
@@ -325,7 +339,7 @@
                 {
                     "label": null,
                     "output_name": "out_file1",
-                    "uuid": "a43b68d7-6c41-4c54-a644-7fc08fd7c841"
+                    "uuid": "75319965-0531-4687-97d3-1af4dba9b34c"
                 }
             ]
         }
@@ -333,6 +347,6 @@
     "tags": [
         "introduction"
     ],
-    "uuid": "5781ddce-702b-40c6-981c-392ce672f580",
-    "version": 4
+    "uuid": "043045b9-a399-4c64-b18e-d50ba31ef96a",
+    "version": 1
 }


### PR DESCRIPTION
This PR replaces the tool [Replace first lines](https://usegalaxy.eu/root?tool_id=Show beginning1) by [Replace first lines (head)](https://usegalaxy.eu/root?tool_id=toolshed.g2.bx.psu.edu/repos/bgruening/text_processing/tp_head_tool/1.1.0). The reason is that the first tool doesn't work in usegalaxy.eu.