### PR TITLE
[FAQ] Added FAQ for 'canceled by admin' or a cluster failure in job failure

### DIFF
--- a/faqs/galaxy/analysis_job_failure_cluster_failure.md
+++ b/faqs/galaxy/analysis_job_failure_cluster_failure.md
@@ -24,5 +24,5 @@ Remote job server indicated a problem running or monitoring this job.
 
 - Solutions:
     - Try at least one rerun. Server/cluster errors like this are usually transient. 
-    - Review the Solutions section of the Understanding input error messages(link) FAQ.
+    - Review the Solutions section of the [Understanding input error messages](https://training.galaxyproject.org/training-material/faqs/galaxy/analysis_job_failure_input_problem.html) FAQ.
     - If after any corrections, the job still fails, please report the technical issue [following the extended issue guidelines](https://training.galaxyproject.org/training-material/faqs/galaxy/analysis_reporting_issues.html).

--- a/faqs/galaxy/analysis_job_failure_cluster_failure.md
+++ b/faqs/galaxy/analysis_job_failure_cluster_failure.md
@@ -1,0 +1,23 @@
+---
+title: Understanding 'canceled by admin' or a cluster failure in job failure
+area: analysis
+box_type: tip
+layout: faq
+contributors: [jennaj, garimavs]
+---
+
+The initial error message could be: 
+`This job failed because it was cancelled by an administrator.`
+`Please click the bug icon to report this problem if you need help.`
+Or
+`job info:`
+`Remote job server indicated a problem running or monitoring this job.`
+
+- Causes:
+    - Server or cluster error.
+    - Less frequently, input problems are a factor.
+
+- Solutions:
+    - Try at least one rerun. Server/cluster errors like this are usually transient. 
+    - Review the Solution section for the Input problems above.
+    - If after any corrections, the job still fails, please report the technical issue [following the extended issue guidelines](https://training.galaxyproject.org/training-material/faqs/galaxy/analysis_reporting_issues.html).

--- a/faqs/galaxy/analysis_job_failure_cluster_failure.md
+++ b/faqs/galaxy/analysis_job_failure_cluster_failure.md
@@ -1,5 +1,5 @@
 ---
-title: Understanding 'canceled by admin' or a cluster failure in job failure
+title: Understanding 'canceled by admin' or cluster failure error messages
 area: analysis
 box_type: tip
 layout: faq
@@ -7,11 +7,16 @@ contributors: [jennaj, garimavs]
 ---
 
 The initial error message could be: 
-`This job failed because it was cancelled by an administrator.`
-`Please click the bug icon to report this problem if you need help.`
+<pre>
+This job failed because it was cancelled by an administrator.
+Please click the bug icon to report this problem if you need help.
+</pre>
+
 Or
-`job info:`
-`Remote job server indicated a problem running or monitoring this job.`
+<pre>
+job info:
+Remote job server indicated a problem running or monitoring this job.
+</pre>
 
 - Causes:
     - Server or cluster error.
@@ -19,5 +24,5 @@ Or
 
 - Solutions:
     - Try at least one rerun. Server/cluster errors like this are usually transient. 
-    - Review the Solution section for the Input problems above.
+    - Review the Solutions section of the Understanding input error messages(link) FAQ.
     - If after any corrections, the job still fails, please report the technical issue [following the extended issue guidelines](https://training.galaxyproject.org/training-material/faqs/galaxy/analysis_reporting_issues.html).


### PR DESCRIPTION
This PR is a part of the issue: _Move FAQs to the GTN_ ([Determining the job failure type](https://galaxyproject.org/support/tool-error/#determining-the-job-failure-type)) of the [Galaxy Hub Repository](https://github.com/galaxyproject/galaxy-hub)

Kindly suggest any improvements or amendments.
Thanks to @jennaj for helping me with the content.