### PR TITLE
[FAQ] Added FAQ for 'exceeds memory allocation' in job failure

### DIFF
--- a/faqs/galaxy/analysis_job_failure_excess_memory.md
+++ b/faqs/galaxy/analysis_job_failure_excess_memory.md
@@ -1,0 +1,35 @@
+---
+title: Understanding 'exceeds memory allocation' in job failure
+area: analysis
+box_type: tip
+layout: faq
+contributors: [jennaj, garimavs]
+---
+
+The error message to be displayed are as follows:
+`job info:`
+`This job was terminated because it used more memory than it was allocated.`
+`Please click the bug icon to report this problem if you need help.`
+Or
+`stderr:`
+`Fatal error: Exit code 1 ()`
+`slurmstepd: error: Detected 1 oom-kill event(s) in step XXXXXXX.batch cgroup.`
+Sometimes this message may appear at the bottom
+`job stderr:`
+`slurmstepd: error: Detected 1 oom-kill event(s) in step XXXXXXX.batch cgroup.`
+In rare cases when the memory quota is exceeded very quickly, an error message such as the following can appear
+`job stderr:`
+`Fatal error: Exit code 1 ()`
+`Traceback (most recent call last):`
+`(other lines)`
+`Memory Error`
+ 
+**Note:** Job runtime memory is different from the amount of free storage space (quota) in an account.
+
+- Causes:
+    - The job ran out of memory while executing on the cluster node that ran the job.
+    - The most common reasons for this error are input and tool parameters problems that must be adjusted/corrected.
+- Solutions:
+    - Try at least one rerun to execute the job on a different cluster node.
+    - Review the Solution section for the Input problems above.
+    - Your data may actually be too large to process at a public Galaxy server. Alternatives include setting up a private Galaxy server. 

--- a/faqs/galaxy/analysis_job_failure_excess_memory.md
+++ b/faqs/galaxy/analysis_job_failure_excess_memory.md
@@ -1,5 +1,5 @@
 ---
-title: Understanding 'exceeds memory allocation' in job failure
+title: Understanding 'exceeds memory allocation' error messages
 area: analysis
 box_type: tip
 layout: faq
@@ -7,23 +7,34 @@ contributors: [jennaj, garimavs]
 ---
 
 The error message to be displayed are as follows:
-`job info:`
-`This job was terminated because it used more memory than it was allocated.`
-`Please click the bug icon to report this problem if you need help.`
+<pre>
+job info:
+This job was terminated because it used more memory than it was allocated.
+Please click the bug icon to report this problem if you need help.
+</pre>
+
 Or
-`stderr:`
-`Fatal error: Exit code 1 ()`
-`slurmstepd: error: Detected 1 oom-kill event(s) in step XXXXXXX.batch cgroup.`
+<pre>
+stderr:
+Fatal error: Exit code 1 ()
+slurmstepd: error: Detected 1 oom-kill event(s) in step XXXXXXX.batch cgroup.
+</pre>
+
 Sometimes this message may appear at the bottom
-`job stderr:`
-`slurmstepd: error: Detected 1 oom-kill event(s) in step XXXXXXX.batch cgroup.`
+<pre>
+job stderr:
+slurmstepd: error: Detected 1 oom-kill event(s) in step XXXXXXX.batch cgroup.
+</pre>
+
 In rare cases when the memory quota is exceeded very quickly, an error message such as the following can appear
-`job stderr:`
-`Fatal error: Exit code 1 ()`
-`Traceback (most recent call last):`
-`(other lines)`
-`Memory Error`
- 
+<pre>
+job stderr:
+Fatal error: Exit code 1 ()
+Traceback (most recent call last):
+(other lines)
+Memory Error
+</pre>
+
 **Note:** Job runtime memory is different from the amount of free storage space (quota) in an account.
 
 - Causes:
@@ -31,5 +42,5 @@ In rare cases when the memory quota is exceeded very quickly, an error message s
     - The most common reasons for this error are input and tool parameters problems that must be adjusted/corrected.
 - Solutions:
     - Try at least one rerun to execute the job on a different cluster node.
-    - Review the Solution section for the Input problems above.
-    - Your data may actually be too large to process at a public Galaxy server. Alternatives include setting up a private Galaxy server. 
+    - Review the Solutions section of the Understanding input error messages(link) FAQ.
+    - Your data may actually be too large to process at a public Galaxy server. Alternatives include setting up a private Galaxy server(link).

--- a/faqs/galaxy/analysis_job_failure_excess_memory.md
+++ b/faqs/galaxy/analysis_job_failure_excess_memory.md
@@ -43,4 +43,4 @@ Memory Error
 - Solutions:
     - Try at least one rerun to execute the job on a different cluster node.
     - Review the Solutions section of the Understanding input error messages(link) FAQ.
-    - Your data may actually be too large to process at a public Galaxy server. Alternatives include setting up a private Galaxy server(link).
+    - Your data may actually be too large to process at a public Galaxy server. Alternatives include setting up a [private Galaxy server](https://training.galaxyproject.org/training-material/faqs/gtn/galaxy_usage.html).


### PR DESCRIPTION
This PR is a part of the issue: _Move FAQs to the GTN_ ([Determining the job failure type](https://galaxyproject.org/support/tool-error/#determining-the-job-failure-type)) of the [Galaxy Hub Repository](https://github.com/galaxyproject/galaxy-hub)

Though there is a reference to PR #3378. Once the PR gets merged, I'll update the link here.
 
Kindly suggest any improvements or amendments.
Thanks to @jennaj for helping me with the content.