### PR TITLE
[FAQ]  Added FAQ for walltime errors in job failure

### DIFF
--- a/faqs/galaxy/analysis_job_failure_walltime.md
+++ b/faqs/galaxy/analysis_job_failure_walltime.md
@@ -1,5 +1,5 @@
 ---
-title: Understanding walltime in job error
+title: Understanding walltime error messages
 area: analysis
 box_type: tip
 layout: faq
@@ -7,15 +7,19 @@ contributors: [jennaj, garimavs]
 ---
 
 The full error message will be reported as below, and can be found by clicking on the bug icon for a failed job run (red dataset):
-`job info:`
-`This job was terminated because it ran longer than the maximum allowed job run time.`
-`Please click the bug icon to report this problem if you need help.`
+<pre>
+job info:
+This job was terminated because it ran longer than the maximum allowed job run time.
+Please click the bug icon to report this problem if you need help.
+</pre>
 Or sometimes,
-`job stderr:`
-`slurmstepd: error: *** JOB XXXX ON XXXX CANCELLED AT 2019-XX-XXTXX:XX:XX DUE TO TIME LIMIT ***`
+<pre>
+job stderr:
+slurmstepd: error: *** JOB XXXX ON XXXX CANCELLED AT 2019-XX-XXTXX:XX:XX DUE TO TIME LIMIT ***
 
-`job info:`
-`Remote job server indicated a problem running or monitoring this job.`
+job info:
+Remote job server indicated a problem running or monitoring this job.
+</pre>
 
 - Causes:
     - The job execution time exceeded the "wall-time" on the cluster node that ran the job. 
@@ -24,5 +28,5 @@ Or sometimes,
 - Solutions: 
     - Try at least one rerun.
     - Check the server homepage for banners or notices. Selected servers also post status [here](https://status.galaxyproject.org/).
-    - Review the Solution section for the Input problems above.
-    - Your data may actually be too large to process at a public Galaxy server. Alternatives include setting up a private Galaxy server.
+    - Review the Solutions section of the Understanding input error messages(link) FAQ.
+    - Your data may actually be too large to process at a public Galaxy server. Alternatives include setting up a private Galaxy server(link).

--- a/faqs/galaxy/analysis_job_failure_walltime.md
+++ b/faqs/galaxy/analysis_job_failure_walltime.md
@@ -1,0 +1,28 @@
+---
+title: Understanding walltime in job failure
+area: analysis
+box_type: tip
+layout: faq
+contributors: [jennaj, garimavs]
+---
+
+The full error message will be reported as below, and can be found by clicking on the bug icon for a failed job run (red dataset):
+`job info:`
+`This job was terminated because it ran longer than the maximum allowed job run time.`
+`Please click the bug icon to report this problem if you need help.`
+Or sometimes,
+`job stderr:`
+`slurmstepd: error: *** JOB XXXX ON XXXX CANCELLED AT 2019-XX-XXTXX:XX:XX DUE TO TIME LIMIT ***`
+
+`job info:`
+`Remote job server indicated a problem running or monitoring this job.`
+
+- Causes:
+    - The job execution time exceeded the "wall-time" on the cluster node that ran the job. 
+    - The server may be undergoing maintenance. 
+    - Very often input problems also cause this same error.
+- Solutions: 
+    - Try at least one rerun.
+    - Check the server homepage for banners or notices. Selected servers also post status [here](https://status.galaxyproject.org/).
+    - Review the Solution section for the Input problems above.
+    - Your data may actually be too large to process at a public Galaxy server. Alternatives include setting up a private Galaxy server.

--- a/faqs/galaxy/analysis_job_failure_walltime.md
+++ b/faqs/galaxy/analysis_job_failure_walltime.md
@@ -29,4 +29,4 @@ Remote job server indicated a problem running or monitoring this job.
     - Try at least one rerun.
     - Check the server homepage for banners or notices. Selected servers also post status [here](https://status.galaxyproject.org/).
     - Review the Solutions section of the Understanding input error messages(link) FAQ.
-    - Your data may actually be too large to process at a public Galaxy server. Alternatives include setting up a private Galaxy server(link).
+    - Your data may actually be too large to process at a public Galaxy server. Alternatives include setting up a [private Galaxy server](https://training.galaxyproject.org/training-material/faqs/gtn/galaxy_usage.html).

--- a/faqs/galaxy/analysis_job_failure_walltime.md
+++ b/faqs/galaxy/analysis_job_failure_walltime.md
@@ -1,5 +1,5 @@
 ---
-title: Understanding walltime in job failure
+title: Understanding walltime in job error
 area: analysis
 box_type: tip
 layout: faq


### PR DESCRIPTION
This PR is a part of the issue: _Move FAQs to the GTN_ ([Determining the job failure type](https://galaxyproject.org/support/tool-error/#determining-the-job-failure-type)) of the [Galaxy Hub Repository](https://github.com/galaxyproject/galaxy-hub)

Though there is a reference to PR #3378. Once the PR gets merged, I'll update the link here.
 
Kindly suggest any improvements or amendments.
Thanks to @jennaj for helping me with the content.