### PR TITLE
Fix capital in FAQ datatype area

### DIFF
--- a/faqs/galaxy/datatypes_tabular.md
+++ b/faqs/galaxy/datatypes_tabular.md
@@ -1,6 +1,6 @@
 ---
 title: Identifying and formatting Tabular Datasets
-area: Datatypes
+area: datatypes
 description: Format help for Tabular/BED/Interval Datasets
 layout: faq
 box_type: tip


### PR DESCRIPTION
There are 2 "Datatypes" areas, I guess that happens because one of them has the tag in capitals, but not sure. Trying to fix it here.