### PR TITLE
Add JupyterLite to GTN, launch python notebooks there

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -62,6 +62,20 @@ jobs:
         env:
           GTN_FORK: ${{ github.repository_owner }}
 
+      - name: Add jupyter notebooks
+        run: |
+          # Remove our existing directory which was a placeholder
+          rm -rf _site/training-material/jupyter/
+
+          # Collect all notebooks into a tmp dir
+          mkdir /tmp/notebook/
+          find _site -name 'data-science-python-*.ipynb' -exec cp '{}' /tmp/notebook/ \;
+
+          # Build the notebook site and add to deployment.
+          pip install jupyterlab==3.3.4 jupyterlite==0.1.0b5
+          jupyter lite build --contents /tmp/notebook
+          mv _output _site/training-material/jupyter/
+
       - name: Deploy 🚀
         uses: peaceiris/actions-gh-pages@v3
         with:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -69,7 +69,7 @@ jobs:
 
           # Collect all notebooks into a tmp dir
           mkdir /tmp/notebook/
-          find _site -name 'data-science-python-*.ipynb' -exec cp '{}' /tmp/notebook/ \;
+          ruby bin/filter-pyolite-safe | xargs -I{} -n1 cp '{}' /tmp/notebook
 
           # Build the notebook site and add to deployment.
           pip install jupyterlab==3.3.4 jupyterlite==0.1.0b5

--- a/_layouts/tutorial_hands_on.html
+++ b/_layouts/tutorial_hands_on.html
@@ -175,6 +175,7 @@ footer: no
             <div class="col-sm-10">
                  {% if page.notebook %}
                      {% capture ipynbpath %}{{ site.url }}{{ site.baseurl }}/{{ page.path | replace: "tutorial.md", "" }}{{ page.topic_name }}-{{ own_material.tutorial_name }}.ipynb{% endcapture %}
+                     {% capture ipynbpathsimple %}{{ page.topic_name }}-{{ own_material.tutorial_name }}.ipynb{% endcapture %}
                     {% if page.notebook.snippet %}
                         {% assign pagesnippet = page.notebook.snippet %}
                         {% snippet pagesnippet %}
@@ -216,7 +217,7 @@ download.file("{{ site.url }}{{ site.baseurl }}/{{ page.path | replace: ".md", "
                         <blockquote class="comment">
                             <h3>{% icon comment aria=false %} {{locale['best-in-jupyter'] | default: "Best viewed in a Jupyter Notebook" }}</h3>
                             <p>
-                                This tutorial is best viewed in a Jupyter notebook! You can load this notebook in Jupyter on one of the UseGalaxy.* servers<!--, or you can click to run it in MyBinder-->
+                                This tutorial is best viewed in a Jupyter notebook! You can load this notebook one of the following ways<!--, or you can click to run it in MyBinder-->
                             </p>
                             <!--
                             <p><b>Launching on MyBinder</b>
@@ -224,6 +225,13 @@ download.file("{{ site.url }}{{ site.baseurl }}/{{ page.path | replace: ".md", "
                                 <a href="https://mybinder.org/v2/gh/galaxyproject/training-material/main?filepath={{ site.baseurl | replace: '/','' }}%2F{{ page.path | replace: '/','%2F' }}.ipynb" title="Launch notebook on MyBinder"><img src="https://mybinder.org/badge_logo.svg" alt="My Binder Logo"/></a>
                             </p>
                             -->
+                            {% if page.notebook.pyolite %}
+                            <p><b>Run on the GTN with JupyterLite (in-browser computations)</b>
+                                <ol>
+                                    <li><a href="{{ site.baseurl }}/jupyter/lab/index.html?path={{ ipynbpathsimple }}">Click to Launch JupyterLite</a></li>
+                                </ol>
+                            </p>
+                            {% endif %}
                             <p><b>Launching the notebook in Jupyter in Galaxy</b>
                                 <ol>
                                     <li><a href="{% link faqs/galaxy/interactive_tools_jupyter_launch.md %}">Instructions to Launch JupyterLab</a></li>

--- a/bin/filter-pyolite-safe
+++ b/bin/filter-pyolite-safe
@@ -1,0 +1,16 @@
+#!/usr/bin/env ruby
+require 'yaml'
+require 'find'
+
+
+Find.find("topics/").each{|fn|
+  if File.basename(fn) == 'tutorial.md'
+    data = YAML.load_file(fn)
+    if data.has_key? 'notebook'
+      if data['notebook'].has_key? 'pyolite'
+        parts = fn.split('/')
+        puts "_site/training-material/#{parts[0..-2].join('/')}/#{parts[1]}-#{parts[3]}.ipynb"
+      end
+    end
+  end
+}

--- a/bin/schema-tutorial.yaml
+++ b/bin/schema-tutorial.yaml
@@ -90,6 +90,9 @@ mapping:
             snippet:
                 type: str
                 required: false
+            pyolite:
+                type: bool
+                required: false
             language:
                 type: str
                 required: true

--- a/jupyter/index.md
+++ b/jupyter/index.md
@@ -1,0 +1,6 @@
+---
+layout: base
+title: Jupyter Notebooks
+---
+
+This page is a placeholder will be automatically replaced in production.

--- a/jupyter/lab/index.html
+++ b/jupyter/lab/index.html
@@ -1,0 +1,5 @@
+<html>
+<body>
+	This will be replaced in production
+</body>
+</html>

--- a/topics/contributing/tutorials/create-new-tutorial-content/tutorial.md
+++ b/topics/contributing/tutorials/create-new-tutorial-content/tutorial.md
@@ -1064,6 +1064,25 @@ notebook:
 
 Supported values are python, sql, r, and bash. The notebook will be generated automatically as part of the site build process.
 
+## JupyterLite & Pyodide
+
+The GTN has support for JupyterLite and the Pyodide kernel which runs [Python in the browser via webassembly/javascript](https://pyodide.org/en/stable/). This comes with some restrictions:
+
+- Python only[^pyonly]
+- No filesystem access (so no `wget` prep steps)
+- Little to no cell magic
+
+However, it means we can run a lot of our Python training directly in the GTN! And in the future, hopefully, we will be able to embed individual cells of the notebook directly in the Python training, so the user doesn't even need to switch pages.
+
+To enable this feature, set:
+
+```
+notebook:
+  language: python
+  pyolite: true
+```
+
+[^pyonly]: Not entirely true, other kernels are supported, see their [demo repo](https://github.com/jupyterlite/demo), but e.g. the SQLite kernel comes with severe restrictions like no downloading databases or connecting to ones online.
 
 # Spanish Translation Project
 

--- a/topics/data-science/tutorials/python-advanced-np-pd/tutorial.md
+++ b/topics/data-science/tutorials/python-advanced-np-pd/tutorial.md
@@ -33,6 +33,7 @@ contributors:
 priority: 2
 notebook:
   language: python
+  pyolite: true
 ---
 
 In this lesson, we will be using Python 3 with some of its most popular scientific libraries. This tutorial assumes that the reader is familiar with the fundamentals of the Python programming language, as well as, how to run Python programs using Galaxy. Otherwise, it is advised to follow the "Introduction to Python" tutorial available in the same platform. We will be using JupyterNotebook, a Python interpreter that comes with everything we need for the lesson. Please note:  JupyterNotebook is only currently available on the [usegalaxy.eu](https://usegalaxy.eu/) and [usegalaxy.org](https://usegalaxy.org/) sites.

--- a/topics/data-science/tutorials/python-basics/tutorial.md
+++ b/topics/data-science/tutorials/python-basics/tutorial.md
@@ -32,6 +32,7 @@ contributors:
 priority: 1
 notebook:
   language: python
+  pyolite: true
 ---
 
 In this lesson, we will be using Python 3 with some of its most popular scientific libraries. We will be using JupyterNotebook, a Python interpreter that comes with everything we need for the lesson.

--- a/topics/data-science/tutorials/python-plotting/tutorial.md
+++ b/topics/data-science/tutorials/python-plotting/tutorial.md
@@ -32,6 +32,7 @@ contributors:
 priority: 3
 notebook:
   language: python
+  pyolite: true
 ---
 
 In this lesson, we will be using Python 3 with some of its most popular scientific libraries. This tutorial assumes that the reader is familiar with the fundamentals of data analysis using the Python programming language, as well as, how to run Python programs using Galaxy. Otherwise, it is advised to follow the "Introduction to Python" and "Advanced Python" tutorials available in the same platform. We will be using JupyterNotebook, a Python interpreter that comes with everything we need for the lesson.


### PR DESCRIPTION
The python notebooks *should* all work directly in JupyterLite with the pyodide kernel that runs in-browser. A lot of what we do is very very simple stuff. See their demo for what's possible: https://github.com/jupyterlite/demo 

So! Let's build jupyterlite into the GTN, and then connect specific, known-functional notebooks with that!

![image](https://user-images.githubusercontent.com/458683/164011753-6f507dc6-9d6d-4f3d-a070-95f61a43f11b.png)

And then it's live immediately (ish. It's pretty slow to start but after it's fine.)

![image](https://user-images.githubusercontent.com/458683/164009639-8e81f767-d87e-42f2-ab0d-c873234e70ea.png)
