### PR TITLE
[FAQ] Added FAQ related to ValueError in job failure

### DIFF
--- a/faqs/galaxy/analysis_job_failure_value_error.md
+++ b/faqs/galaxy/analysis_job_failure_value_error.md
@@ -6,14 +6,17 @@ layout: faq
 contributors: [jennaj, garimavs]
 ---
 
-The full error is usually a longer message seen only after clicking on the bug icon:
+The full error is usually a longer message seen only after clicking on the bug icon or by reviewing the job details `stderr`. 
+
+How to do both is covered in the Troubleshooting errors [FAQ]({% link faqs/galaxy/analysis_troubleshooting.md %}).
+
 <pre>
 stderr
 ...
 Many lines of text, may include parameters
 ...
 ...
-ValueError: invalid literal for int() with base 10: 'some-read-identifier-name'
+ValueError: invalid literal for int() with base 10: some-sequence-read-name
 </pre>
 
 - Causes: 

--- a/faqs/galaxy/analysis_job_failure_value_error.md
+++ b/faqs/galaxy/analysis_job_failure_value_error.md
@@ -7,12 +7,14 @@ contributors: [jennaj, garimavs]
 ---
 
 The full error is usually a longer message seen only after clicking on the bug icon:
-`stderr`
-`...`
-`Many lines of text, may include parameters`
-`...`
-`...`
-`ValueError: invalid literal for int() with base 10: 'some-read-identifier-name'`
+<pre>
+stderr
+...
+Many lines of text, may include parameters
+...
+...
+ValueError: invalid literal for int() with base 10: 'some-read-identifier-name'
+</pre>
 
 - Causes: 
     - MACS2 produces this error the first time it is run. MACS is not the only tool that can produce this issue, but it is the most common.

--- a/faqs/galaxy/analysis_job_failure_value_error.md
+++ b/faqs/galaxy/analysis_job_failure_value_error.md
@@ -1,5 +1,5 @@
 ---
-title: Understanding ValueError in job failure
+title: Understanding ValueError error messages
 area: analysis
 box_type: tip
 layout: faq

--- a/faqs/galaxy/analysis_job_failure_value_error.md
+++ b/faqs/galaxy/analysis_job_failure_value_error.md
@@ -1,0 +1,23 @@
+---
+title: Understanding ValueError in job failure
+area: analysis
+box_type: tip
+layout: faq
+contributors: [jennaj, garimavs]
+---
+
+The full error is usually a longer message seen only after clicking on the bug icon:
+`stderr`
+`...`
+`Many lines of text, may include parameters`
+`...`
+`...`
+`ValueError: invalid literal for int() with base 10: 'some-read-identifier-name'`
+
+- Causes: 
+    - MACS2 produces this error the first time it is run. MACS is not the only tool that can produce this issue, but it is the most common.
+- Solutions: 
+    - Try at least one rerun.
+    - MACS/2 is not capable of interpreting sequence read names with spaces included. Try following these two: 
+        - Remove unmapped reads from the SAM dataset. There are several filtering tools in the groups **SAMTools** and **Picard** that can do this.
+        - Convert the SAM input to BAM format with the tool **SAMtools: SAM-to-BAM**. When compressed input is given to MACS, the spaces are no longer an issue.


### PR DESCRIPTION
This PR is a part of the issue: Move FAQs to the GTN ([Determining the job failure type](https://galaxyproject.org/support/tool-error/#determining-the-job-failure-type)) of the [Galaxy Hub Repository](https://github.com/galaxyproject/galaxy-hub)

Kindly suggest any improvements or amendments.
Thanks to @jennaj for helping me with the content.