### PR TITLE
Fixing FAQ - Mismatched Chromosome identifiers and how to avoid them

### DIFF
--- a/faqs/galaxy/datasets_chromosome_identifiers.md
+++ b/faqs/galaxy/datasets_chromosome_identifiers.md
@@ -11,7 +11,7 @@ contributors: [jennaj, Melkeb]
 
 - **If using a Custom Reference genome**, the methods below also apply, but the first step is to make certain that the Custom Genome is formatted correctly. Improper formating is the most common root cause of CG related errors.
 
-Method 1: [Finding BAM dataset identifiers]({% link faqs/galaxy/datasets_BAM_dataset_identifiers.md %})
+Method 1: [Finding BAM dataset identifiers](https://training.galaxyproject.org/training-material/faqs/galaxy/datasets_BAM_dataset_identifiers.html)
 
 Method 2: [Directly obtaining UCSC sourced *genome* identifiers](https://training.galaxyproject.org/training-material/faqs/galaxy/datasets_UCSC_sourced_genome.html)
 

--- a/faqs/galaxy/datasets_chromosome_identifiers.md
+++ b/faqs/galaxy/datasets_chromosome_identifiers.md
@@ -13,11 +13,11 @@ contributors: [jennaj, Melkeb]
 
 Method 1: [Finding BAM dataset identifiers]({% link faqs/galaxy/datasets_BAM_dataset_identifiers.md %})
 
-Method 2: [Directly obtaining UCSC sourced *genome* identifiers]({% link faqs/galaxy/datasets_UCSC_sourced_genome.md %})
+Method 2: [Directly obtaining UCSC sourced *genome* identifiers](https://training.galaxyproject.org/training-material/faqs/galaxy/datasets_UCSC_sourced_genome.html)
 
-Method 3: [Adjusting identifiers for UCSC sourced data used with other sourced data]({% link faqs/galaxy/datasets_adjust_identifiers_UCSC.md %})
+Method 3: [Adjusting identifiers for UCSC sourced data used with other sourced data](https://galaxyproject.org/support/chrom-identifiers/#adjusting-identifiers-or-input-source)
 
-Method 4: [Adjusting identifiers or input source for any mixed sourced data]({% link faqs/galaxy/datasets_adjusting_identifiers_mixed_data.md %})
+Method 4: [Adjusting identifiers or input source for any mixed sourced data](https://galaxyproject.org/support/chrom-identifiers/#any-mixed-sourced-data)
 
 **A Note on Built-in Reference Genomes**
 


### PR DESCRIPTION
I changed the first two links to the GTN FAQ links (Even though the first one was working changed both to make it consistent). The last two links added lead to the Galaxy Hub FAQ Page since it has no GTN FAQ link (If it shouldn't lead to the Galaxy Hub FAQ page then I can remove the link).