### PR TITLE
Ref-based RNA-seq try to fix cyot default

### DIFF
--- a/topics/transcriptomics/tutorials/ref-based/tutorial.md
+++ b/topics/transcriptomics/tutorials/ref-based/tutorial.md
@@ -649,6 +649,15 @@ Therefore we offer a parallel tutorial for the 2 methods which give very similar
 
 In principle, the counting of reads overlapping with genomic features is a fairly simple task. But there are some details that need to be given to **featureCounts** or to the output of **STAR**, e.g. the strandness.
 
+<div class="STAR" markdown="1">
+> ### {% icon comment %} If you are displaying this tutorial within galaxy
+> Please, click on the link below so you will always come back to the **STAR** flavour of the tutorial.
+>
+> [CLICK HERE](?gtn-cyoa=STAR#estimation-of-the-strandness)
+>
+{: .comment}
+</div>
+
 ## Estimation of the strandness
 
 RNAs that are typically targeted in RNA-Seq experiments are single stranded (*e.g.*, mRNAs) and thus have polarity (5' and 3' ends that are functionally distinct). During a typical RNA-Seq experiment the information about strandness is lost after both strands of cDNA are synthesized, size selected, and converted into a sequencing library. However, this information can be quite useful for the read counting step, especially for reads located on the overlap of 2 genes that are on different strands.


### PR DESCRIPTION
Hi,
I noticed a "bug" (at least a non expecting behaviour).

If you 

1. go to galaxy
2. open the Ref-based tutorial
3. go to the Counting the number of reads per annotated gene.
4. Select the "STAR" flavour of the tutorial.
5. Click outside of the box, go to 'view all histories', come back to your current history, open back the tutorial.
6. It is back to the "featureCounts" flavour.

It seems that it stored the position where you were in the tutorial but not the choice.
This is probably what happened to: https://github.com/galaxyproject/training-material/issues/989#issuecomment-1110204833
And this happened to us during the training.

The small fix I propose here is to use the URL but I don't know if there is a way to hide it behind the "STAR" button of the Choose your own tutorial. Also I am not sure it will work, is there a way to test?
@hexylena if you can help...

Thanks,
