### PR TITLE
Fixing FAQ format and links

### DIFF
--- a/faqs/galaxy/datasets_moving_datasets_between_galaxy_servers.md
+++ b/faqs/galaxy/datasets_moving_datasets_between_galaxy_servers.md
@@ -11,6 +11,7 @@ On the origin Galaxy server:
 2. Click on the **Copy link icon**{% icon galaxy-link %}.
 
 On the destination Galaxy server:
+
 3. Click on **Upload data > Paste / Fetch Data** and paste the link. Select attributes, such as genome assembly, if required. Hit the **Start** button.
 
 Note: The copy link icon {% icon galaxy-link %} cannot be used to move HTML datasets (but this can be downloaded using the download button {% icon galaxy-save %}) and SQLite datasets.

--- a/faqs/galaxy/datasets_moving_datasets_between_galaxy_servers.md
+++ b/faqs/galaxy/datasets_moving_datasets_between_galaxy_servers.md
@@ -9,6 +9,7 @@ contributors: [jennaj, Melkeb]
 On the origin Galaxy server:
 1. Click on name of the dataset to expand the info.
 2. Click on the **Copy link icon**{% icon galaxy-link %}.
+
 On the destination Galaxy server:
 3. Click on **Upload data > Paste / Fetch Data** and paste the link. Select attributes, such as genome assembly, if required. Hit the **Start** button.
 

--- a/faqs/galaxy/datasets_moving_datasets_between_galaxy_servers.md
+++ b/faqs/galaxy/datasets_moving_datasets_between_galaxy_servers.md
@@ -7,8 +7,8 @@ contributors: [jennaj, Melkeb]
 ---
 
 On the origin Galaxy server:
-1. Click on name of the dataset to expand the info.
-2. Click on the **Copy link icon**{% icon galaxy-link %}.
+1. Click on the name of the dataset to expand the info.
+2. Click on the **Copy link icon** {% icon galaxy-link %}.
 
 On the destination Galaxy server:
 

--- a/faqs/galaxy/datasets_troubleshooting_custom_genome.md
+++ b/faqs/galaxy/datasets_troubleshooting_custom_genome.md
@@ -13,7 +13,7 @@ If a custom genome/transcriptome/exome dataset is producing errors, double check
 
    - **Symptoms include**: Dataset not included in custom genome "From history" pull down menu on tool forms.
    - **Solution**: Check datatype assigned to dataset and assign **fasta** format.
-   - **How**: Click on the dataset's pencil icon {% icon galaxy-pencil %} to reach the "Edit Attributes" form, and in the Datatypes tab >redetect the datatype<(link to FAQ).
+   - **How**: Click on the dataset's pencil icon {% icon galaxy-pencil %} to reach the "Edit Attributes" form, and in the Datatypes tab > [redetect the datatype]({% link faqs/galaxy/datasets_detect_datatype.md %}).
    - If `fasta` is not assigned, there is a format problem to correct.
   
  - Incomplete Custom genome file load

--- a/faqs/galaxy/tools_tool_doesnt_recognize_any_input_datasets.md
+++ b/faqs/galaxy/tools_tool_doesnt_recognize_any_input_datasets.md
@@ -18,7 +18,7 @@ No datasets or collections available? Solutions:
 * To use datasets loaded into a shared Data Library see [this FAQ]({% link faqs/galaxy/datasets_import_from_data_library.md %}).
 2. Resolve a datatype assignment incompatibility between the dataset and the tool. 
 * To redetect a datatype see [this FAQ]({% link faqs/galaxy/datasets_detect_datatype.md %}).
-* To convert a datatype see [this FAQ]({% link faqs/galaxy/datasets_change_datatype.md %}).
+* To convert a datatype see [this FAQ]({% link faqs/galaxy/datasets_convert_datatype.md %}).
 * To change a datatype see [this FAQ]({% link faqs/galaxy/datasets_change_datatype.md %}).
 3. Individual datasets and dataset collections are selected differently on tool forms. 
 * To select a collection input on a tool form see [this FAQ]({% link faqs/galaxy/tools_select_collection.md %}).


### PR DESCRIPTION
1. Fixing moving datasets between Galaxy servers FAQ format as shown in the picture (adding on the destination text on a new line).
![Moving Datasets](https://user-images.githubusercontent.com/92672921/167072030-8a82743c-fc0c-4ece-9342-419643989498.PNG)
2. Replacing the link in Tool doesn't recognize any datasets of the section convert datatype because the link was for change datatype not convert datatype.
3. Adding a link in troubleshooting custom genome fasta FAQ as indicated in the text.