### PR TITLE
Video library connecton: support "demo" type videos

### DIFF
--- a/_includes/instance-dropdown.html
+++ b/_includes/instance-dropdown.html
@@ -2,7 +2,7 @@
 {% if include.instances[include.topic].supported or include.docker %}
 {% if include.instances[include.topic]['tutorials'][include.tuto].supported or include.docker %}
     <a href="#" class="btn btn-default dropdown-toggle topic-icon" data-toggle="dropdown" aria-expanded="false" title="Where to run the tutorial">
-        {% icon instances %}{% if include.label %} {{ locale['supporting-galaxies'] | default: "Available on these Galaxies" }} {% endif %}
+        {% icon instances %}{% if include.label %}&nbsp;{{ locale['supporting-galaxies'] | default: "Available on these Galaxies" }} {% endif %}
     </a>
     <ul class="dropdown-menu">
     {% if include.docker %}

--- a/_includes/resource-video-library.html
+++ b/_includes/resource-video-library.html
@@ -3,14 +3,16 @@
 {% assign tut = include.material.url | default: page.url %}
 {% assign id-tutorial = tut | remove: '/topics/' | remove: "/tutorials" | remove: '.html' %}
 {% assign id-slides = id-tutorial | replace: '/tutorial', '/slides' %}
+{% assign id-demo = id-tutorial | replace: '/tutorial', '/demo' %}
 {% assign id-both = id-tutorial | replace: '/tutorial', '' %}
 
 {% assign hasvideo-tutorial = site.data['video-library'][id-tutorial] %}
 {% assign hasvideo-slides = site.data['video-library'][id-slides] %}
+{% assign hasvideo-demo = site.data['video-library'][id-demo] %}
 {% assign hasvideo-both = site.data['video-library'][id-both]%}
 {% assign hassession = site.data['session-library'][id-tutorial]%}
 
-  {% if hasvideo-tutorial or hasvideo-slides or hasvideo-both or hassession %}
+  {% if hasvideo-tutorial or hasvideo-slides or hasvideo-both or hasvideo-demo or hassession %}
   <li class="btn btn-default supporting_material">
     <a href="#" class="btn btn-default dropdown-toggle topic-icon" data-toggle="dropdown" aria-expanded="false" title="Latest recordings of this tutorial in the GTN Video Library">
         {% icon video %} {% if include.label %}Recordings{% endif %}
@@ -48,6 +50,17 @@
         <li>
             <a class="dropdown-item" href="https://gallantries.github.io/video-library/videos/{{id-slides}}" title="View GTN Video Library for these Slides">
                 {% icon video %} Lecture ({{sortedversions[0].date | date: "%B %Y" }})
+            </a>
+        </li>
+        {% endif %}
+        {% if hasvideo-demo %}
+          {% assign allversions = "" | split: ',' %}
+          {% for vid in site.data['video-library'][id-demo].versions %}{% assign allversions = allversions | push: vid %}{% endfor %}
+          {% assign sortedversions = allversions | sort: 'date' | reverse %}
+
+        <li>
+            <a class="dropdown-item" href="https://gallantries.github.io/video-library/videos/{{id-demo}}" title="View GTN Video Library for these Slides">
+                {% icon video %} Demo ({{sortedversions[0].date | date: "%B %Y" }})
             </a>
         </li>
         {% endif %}

--- a/_includes/resource-video-library.html
+++ b/_includes/resource-video-library.html
@@ -15,7 +15,7 @@
   {% if hasvideo-tutorial or hasvideo-slides or hasvideo-both or hasvideo-demo or hassession %}
   <li class="btn btn-default supporting_material">
     <a href="#" class="btn btn-default dropdown-toggle topic-icon" data-toggle="dropdown" aria-expanded="false" title="Latest recordings of this tutorial in the GTN Video Library">
-        {% icon video %} {% if include.label %}Recordings{% endif %}
+        {% icon video %}{% if include.label %}&nbsp;Recordings{% endif %}
     </a>
     <ul class="dropdown-menu">
         {% if hasvideo-both %}


### PR DESCRIPTION
Some videos are neither covering the slides or the tutorial directly, but are more of a quick demo or background video. We can now support these kinds of videos as well 