### PR TITLE
Add instructions to close pull request again

### DIFF
--- a/topics/contributing/tutorials/github-command-line-contribution/tutorial.md
+++ b/topics/contributing/tutorials/github-command-line-contribution/tutorial.md
@@ -355,6 +355,29 @@ You now want to work on a new tutorial or make some other new changes. However s
 
 You can now restart the GitHub flow to propose new changes: start by [creating a new branch](#create-a-new-branch).
 
+
+# Close the Pull Request
+
+Great! You now know how to make pull request on GitHub, and how to make changes after a review.
+Reviewers can now approve and merge your pull request.
+
+Because this was just a practice pull request, let's close it again.
+
+
+> ### {% icon hands_on %} Hands-on: Close the Pull Request
+>
+> Once you have run through all these steps, please close the pull request again.
+>
+> 1. Go to the [list of pull request tab on GitHub](https://github.com/galaxyproject/training-material/pulls)
+> 2. Click on your pull request
+> 3. Scroll to the bottom of the page
+> 3. Click on "Close pull request" button
+>
+> Whenever you add your first real contribution, you can add yourself to the `CONTRIBUTORS.yaml` file in that PR.
+>
+{: .hands_on}
+
+
 # Conclusion
 {:.no_toc}
 

--- a/topics/contributing/tutorials/github-interface-contribution/tutorial.md
+++ b/topics/contributing/tutorials/github-interface-contribution/tutorial.md
@@ -195,6 +195,29 @@ One of the reviewers of your pull request asked you to add your name after your 
 >
 {: .hands_on}
 
+
+# Close the Pull Request
+
+Great! You now know how to make pull request on GitHub, and how to make changes after a review.
+Reviewers can now approve and merge your pull request.
+
+Because this was just a practice pull request, let's close it again.
+
+
+> ### {% icon hands_on %} Hands-on: Close the Pull Request
+>
+> Once you have run through all these steps, please close the pull request again.
+>
+> 1. Go to the [list of pull request tab on GitHub](https://github.com/galaxyproject/training-material/pulls)
+> 2. Click on your pull request
+> 3. Scroll to the bottom of the page
+> 3. Click on *"Close pull request"* button
+>
+> Whenever you add your first real contribution, you can add yourself to the `CONTRIBUTORS.yaml` file in that PR.
+>
+{: .hands_on}
+
+
 # Conclusion
 {:.no_toc}
 


### PR DESCRIPTION
The contributing to GitHub tutorials teach about pull requests by adding themselves to the CONTRIBUTORS file, but since these are just for practice, also add a step to close it again.