### PR TITLE
Document all schemas

### DIFF
--- a/_includes/schema-render.html
+++ b/_includes/schema-render.html
@@ -1,0 +1,121 @@
+<blockquote class="{% if include.value.required %}comment{% else %}tip{% endif %}">
+<h3>
+	{% if include.key == "=" %}
+		Any key permitted
+	{% else %}
+		<code>{{ include.key }}</code>
+	{% endif %}
+	{% if include.value.required %} <b>required</b>{% endif %}</h3>
+
+<b>{{ include.value.type | humanize_types }}</b>
+
+<p>
+{{ include.value.description | markdownify }}
+</p>
+
+
+
+{% if include.value.enum %}
+<p>
+<b>Possible Values:</b>
+<ul>
+{% for enum in include.value.enum %}
+	<li><code>{{ enum }}</code></li>
+{% endfor %}
+</ul>
+</p>
+{% endif %}
+
+
+
+{% if include.value.examples or include.value.enum %}
+<p>
+	<b>Example(s)</b>
+
+{%- if include.value.type == "seq" -%}
+<div markdown=1>
+```yaml
+{{include.key}}:
+{%- for ex in include.value.examples %}
+- {{ ex | replace_newline_doublespace }}
+{%- endfor %}
+{%- for ex in include.value.enum %}
+- {{ ex | replace_newline_doublespace }}
+{%- endfor %}
+```
+</div>
+{%- elsif include.value.type == "map" -%}
+<div markdown=1>
+```yaml
+{{ include.value.examples }}
+```
+</div>
+{%- else -%}
+	{% for ex in include.value.examples %}
+<div markdown=1>
+```yaml
+{{ include.key }}: {{ ex }}
+```
+</div>
+	{% endfor %}
+	{% for ex in include.value.enum %}
+<div markdown=1>
+```yaml
+{{ include.key }}: {% if include.value.type == "str" or include.value.sequence[0].type == "str" %}"{% endif %}{{ ex }}{% if include.value.type == "str" %}"{% endif %}
+```
+</div>
+	{% endfor %}
+{%- endif -%}
+</p>
+{% endif %}
+
+
+
+{% if include.value.pattern %}
+<p>
+<b>Required Pattern:</b> Must match the following regular expression
+
+<div markdown=1>
+```yaml
+{{ include.value.pattern }}
+```
+</div>
+
+</p>
+{% endif %}
+
+
+
+{% if include.value.type == "seq" %}
+	{% if include.value.sequence[0].type != "str" %}
+		{% assign kid_key = "Sequence Value" %}
+		{% assign kid_val = include.value.sequence[0] %}
+		{% assign kid_depth = include.depth | plus: 1 %}
+		{% include _includes/schema-render.html key=kid_key value=kid_val depth=kid_depth %}
+	{% else %}
+
+	{% endif %}
+{% elsif include.value.type == "map" %}
+	{% assign kv2 = include.value.mapping %}
+	{% for kv in kv2 %}
+		{% if kv[1].required %}
+			{% assign kid_key = kv[0] %}
+			{% assign kid_val = kv[1] %}
+			{% assign kid_depth = include.depth | plus: 1 %}
+
+			{% include _includes/schema-render.html key=kid_key value=kid_val depth=kid_depth %}
+		{% endif %}
+	{% endfor %}
+
+	{% assign kv2 = include.value.mapping | sort %}
+	{% for kv in kv2 %}
+		{% unless kv[1].required %}
+			{% assign kid_key = kv[0] %}
+			{% assign kid_val = kv[1] %}
+			{% assign kid_depth = include.depth | plus: 1 %}
+
+			{% include _includes/schema-render.html key=kid_key value=kid_val depth=kid_depth %}
+		{% endunless %}
+	{% endfor %}
+{% endif %}
+</blockquote>

--- a/_plugins/jekyll-topic-filter.rb
+++ b/_plugins/jekyll-topic-filter.rb
@@ -277,6 +277,21 @@ module Jekyll
       TopicFilter.topic_filter(site, topic_name)
     end
 
+    def humanize_types(type)
+      data = {
+        "seq" => "List of Items",
+        "str" => "Free Text",
+        "map" => "A dictionary/map",
+        "float" => "Decimal Number",
+        "int" => "Integer Number",
+        "bool" => "Boolean"
+      }
+      data[type]
+    end
+
+    def replace_newline_doublespace(text)
+      text.gsub(/\n/, "\n  ")
+    end
   end
 end
 

--- a/bin/schema-contributors.yaml
+++ b/bin/schema-contributors.yaml
@@ -1,45 +1,98 @@
 ---
 type: map
+examples: |
+    hexylena:
+        name: Helena
+        twitter: hexylena
+        bio: I wrote this documentation! I do super cool things.
 mapping:
     "=":
         type: map
+        description: |
+            This ideally is your GitHub handle. If you do not have, or do not wish to provide a GitHub username, you may make up another identifier here, but then you must set `github: false` as described below.
         mapping:
             name:
                 type: str
                 required: true
+                description: |
+                    Your preferred name. If you prefer an alias or another name, this is welcome, it does not need to be your legal name.
+                examples:
+                    - 张三
+                    - Alice
+                    - Jane Doe
+                    - Madame Tout-le-Monde
+                    - Γιάννης Παπαδόπουλος
             email:
                 type: str
                 pattern: /@/
+                description: |
+                    Your email address, if you wish to provide it.
+                examples:
+                    - jane.doe@gmail.com
             twitter:
                 type: str
                 pattern: /[0-9a-zA-Z]+/
+                description: Your twitter handle, without the `@`
+                examples:
+                    - gxytraining
             bio:
                 type: str
+                description: |
+                    A short biography of yourself, if you wish to add additional details or context.
+                examples:
+                    - Research at the [South African National Bioinformatics Institute](https://www.sanbi.ac.za/)
             gitter:
                 type: str
                 pattern: /[0-9a-zA-Z]+/
+                description: Your gitter
+                examples:
+                    - hexylena
+            matrix:
+                type: str
+                pattern: /@[0-9a-zA-Z]+:.*/
+                description: Your matrix identifier
+                examples:
+                    - "@hexylena:matrix.org"
             linkedin:
                 type: str
                 pattern: /[0-9a-zA-Z]+/
             maintainer_contact:
                 type: str
+                description: Preferred contact method
             github:
                 type: bool
+                description: |
+                    If your identifier in this file is **not** a GitHub account (or not your account), then this **must** be set to true, so we do not link to that account.
             orcid:
                 type: str
                 pattern: /[0-9A-Z]{4}-[0-9A-Z]{4}-[0-9A-Z]{4}-[0-9A-Z]{4}/
+                description: Your identifier at orcid.org
+                examples:
+                    - 0000-0001-9760-8992
             joined:
                 type: str
                 required: true
-                pattern: /[0-9]{4}-[0-9]{2}/
+                pattern: /[0-9]{4,}-[0-9]{2}/
+                description: The year and month in which you joined
+                examples:
+                    - 2020-01
             halloffame:
                 type: str
-                pattern: /no/
-            funder:
-                type: bool
-            funding_statement:
-                type: str
-            funding_id:
-                type: str
+                enum:
+                    - no
+                description: Set this to `no` if you would like to be excluded from the hall of fame.
             avatar:
                 type: str
+            funder:
+                type: bool
+                description: Set this to true if this entity is a funding agency.
+            funding_id:
+                type: str
+                description: The short identifier for your grant.
+                examples:
+                    - 2020-1-NL01-KA203-064717
+            funding_statement:
+                type: str
+                description: A short statement about the funder, markdown is supported.
+                examples:
+                    - This project ([`2020-1-NL01-KA203-064717`](https://ec.europa.eu/programmes/erasmus-plus/projects/eplus-project-details/#project/2020-1-NL01-KA203-064717)) is funded with the support of the Erasmus+ programme of the European Union. Their funding has supported a large number of tutorials within the GTN across a wide array of topics.

--- a/bin/schema-faq.yaml
+++ b/bin/schema-faq.yaml
@@ -6,15 +6,35 @@ mapping:
         required: true
         enum:
             - faq
+        description: |
+            This must be set to `faq`
     title:
         type: str
         required: true
+        description: |
+            Title of the FAQ
+        examples:
+            - How does the GTN implement the 'Ten simple rules for collaborative lesson development'
+            - How can I give feedback?
+            - Ways to use Galaxy
     description:
         type: str
         required: false
+        description: |
+            A short, one line description to provide additional context of the FAQ
+        examples:
+        - Galaxy may have several reference genomes built-in, but you can also create your own.
+        - Quickly learn what the identifiers are in any **BAM** dataset that is the result from mapping
+        - Finding and Correcting Metadata
     area:
         type: str
         required: false
+        description: |
+            A text key used for sorting related FAQs together in the visual interface for users.
+        examples:
+            - contributors
+            - learners
+            - features
     box_type:
         type: str
         required: true
@@ -23,9 +43,16 @@ mapping:
             - hands_on
             - question
             - comment
+        description: |
+            The type of box that should be used when rendering this FAQ.
     contributors:
         type: seq
         required: true
+        description: |
+            Who contributed to this FAQ
+        examples:
+            - shiltemann
+            - hexylena
         sequence:
             - type: str
               required: true

--- a/bin/schema-faq.yaml
+++ b/bin/schema-faq.yaml
@@ -29,4 +29,6 @@ mapping:
         sequence:
             - type: str
               required: true
+              enum:
+              - CONTRIBUTORS
 ---

--- a/bin/schema-slides.yaml
+++ b/bin/schema-slides.yaml
@@ -63,6 +63,11 @@ mapping:
             - Galaxy workflows can download images from the IDR, selecting specific channels, time points, z-stack positions and crop the image in different ways.
     edam_ontology:
         type: str
+        pattern: /^topic_[0-9]+$/
+        description: |
+            An edam ontology id that describes the tutorial.
+        examples:
+            - topic_3173
     video:
         type: bool
         description: |
@@ -70,7 +75,6 @@ mapping:
             If enabled, you must provide good speaker notes for every single slide.
     contributors:
         type: seq
-        required: false
         sequence:
             - type: str
               required: true
@@ -82,9 +86,28 @@ mapping:
             - hexylena
             - shiltemann
     contributions:
+        required: true
+        description: |
+            List of slide contributors. Here we break them down into several broad categories to help contributors identify how they contributed to a specific tutorial.
+        examples: |
+            contributions:
+                authorship:
+                    - shiltemann
+                    - bebatut
+                editing:
+                    - hexylena
+                    - bebatut
+                    - natefoo
+                testing:
+                    - bebatut
+                infrastructure:
+                    - natefoo
+                funding:
+                    - erasmusplus
         type: map
         mapping:
             authorship:
+                description: These entities wrote the bulk of the training material, they may have done the analysis, built the workflow, and wrote the text themselves.
                 type: seq
                 sequence:
                 - type: str
@@ -92,30 +115,35 @@ mapping:
                   - CONTRIBUTORS
             editing:
                 type: seq
+                description: These entities edited the text, either for spelling and grammar, flow, GTN-fit, or other similar editing categories
                 sequence:
                 - type: str
                   enum:
                   - CONTRIBUTORS
             testing:
                 type: seq
+                description: These entities tested the tutorial to ensure it works correctly for students, or reported issues with the tutorial.
                 sequence:
                 - type: str
                   enum:
                   - CONTRIBUTORS
             ux:
                 type: seq
+                description: These entities contributed UX or Design improvements to this tutorial or the GTN as a whole
                 sequence:
                 - type: str
                   enum:
                   - CONTRIBUTORS
             infrastructure:
                 type: seq
+                description: These entities managed and provided infrastructure to the GTN or for training purposes
                 sequence:
                 - type: str
                   enum:
                   - CONTRIBUTORS
             funding:
                 type: seq
+                description: These entities provided funding support for the development of this resource
                 sequence:
                 - type: str
                   enum:
@@ -146,13 +174,24 @@ mapping:
     logo:
         type: str
         required: true
+        description: |
+            A logo identifier (e.g. GTN) should be used by default, but may be swapped out for special logos from the assets folder.
+        examples:
+            - GTN
+            - assets/images/gat.png
     class:
         type: str
+        description: A default CSS class applied to slides
     tags:
         type: seq
         sequence:
             - type: str
               required: true
+        description: |
+            A free form list of tags that are relevant for your tutorial.
+        examples:
+            - covid-19
+            - git-gat
     translations:
         type: seq
         sequence:

--- a/bin/schema-slides.yaml
+++ b/bin/schema-slides.yaml
@@ -8,39 +8,79 @@ mapping:
             - base_slides
             - tutorial_slides
             - rdmbites_slides
+        description: |
+            The layout to use. Generally you should use `tutorial_slides` and no other value.
     title:
         type: str
         required: true
+        description: |
+            Title of the slides (it will appear on the slides and the topic listing)
+        examples:
+            - Introduction to CRISPR screen analysis
+            - High Performance Computing for Pairwise Genome Comparison
+            - Circos
     questions:
         type: seq
-        required: false
         sequence:
             - type: str
               required: true
+        description: |
+            list of questions that will be addressed in the slides
+        examples:
+            - What is ATAC-Seq?
+            - What are Galaxy Interactive Environments (GIEs)?
+            - How to visualize your genome after automated annotations have been performed?
     objectives:
         type: seq
-        required: false
         sequence:
             - type: str
               required: true
+        description: |
+            list of learning objectives for the tutorial
+
+            A learning objective is a single sentence describing what a learner will be able to do once they have done the tutorial. Generally it is best to follow a 2C or 3C learning objective such as:
+
+            - Compute (Skill)
+            - multiple whole genome assemblies (Objective)
+            - in such a way to develop big data processing skills (Result)
+        examples:
+            - Understand the basic concepts behind phylogenetic trees, as applied to *Mycobacterium tuberculosis*
+            - Explore Biodiversity data with taxonomic, temporal and geographical informations
+            - Generate a DotPlot emulating the original paper using a different analysis tool
     key_points:
         type: seq
-        required: false
         sequence:
             - type: str
               required: true
+        description: |
+            List of take-home messages. This information will appear at the end
+            of the slides. These should really be a key point, something that
+            should stick in their mind; what you want them to take home from
+            the slides.
+        examples:
+            - Pangeo is an inclusive community promoting open, reproducible and scalable science.
+            - Balanced batches and replicates allow bioinformatic batch correction
+            - Galaxy workflows can download images from the IDR, selecting specific channels, time points, z-stack positions and crop the image in different ways.
     edam_ontology:
         type: str
-        required: false
     video:
         type: bool
-        required: false
+        description: |
+            This enables automatic slide-to-video conversion. See the [documentation of that feature](/training-material/topics/contributing/tutorials/slides-with-video/tutorial.html) for more information about this feature.
+            If enabled, you must provide good speaker notes for every single slide.
     contributors:
         type: seq
         required: false
         sequence:
             - type: str
               required: true
+              enum:
+              - CONTRIBUTORS
+        description: |
+            List of tutorial contributors. Please use `contributions` instead as it provides more detailed accounting of tutorial history.
+        examples:
+            - hexylena
+            - shiltemann
     contributions:
         type: map
         mapping:
@@ -48,77 +88,111 @@ mapping:
                 type: seq
                 sequence:
                 - type: str
+                  enum:
+                  - CONTRIBUTORS
             editing:
                 type: seq
                 sequence:
                 - type: str
+                  enum:
+                  - CONTRIBUTORS
             testing:
                 type: seq
                 sequence:
                 - type: str
+                  enum:
+                  - CONTRIBUTORS
             ux:
                 type: seq
                 sequence:
                 - type: str
+                  enum:
+                  - CONTRIBUTORS
             infrastructure:
                 type: seq
                 sequence:
                 - type: str
+                  enum:
+                  - CONTRIBUTORS
             funding:
                 type: seq
                 sequence:
                 - type: str
+                  enum:
+                  - CONTRIBUTORS
     hands_on:
         type: str
-        required: false
         enum:
             - external
     hands_on_url:
         type: str
-        required: false
     subtopic:
         type: str
-        required: false
+        description: |
+            if the topic has [multiple subtopics defined](/training-material/topics/contributing/tutorials/create-new-topic/tutorial.html#adapt-the-metadata-for-your-topic), you can assign your tutorial to one of those subtopics here. Without this, the tutorial will appear in the "Other tutorials" section on the topic page.
+        examples:
+            - single-cell
     priority:
         type: int
-        required: false
+        description: |
+            This field allows ordering resources within the topic list. Learning resources with lower numbered priority come before those with higher numbers.
+        examples: 1
     zenodo_link:
         type: str
-        required: false
+        description: |
+            link on Zenodo to the input data for the tutorial
+        examples:
+            - "https://zenodo.org/record/3706539"
     logo:
         type: str
         required: true
     class:
         type: str
-        required: false
     tags:
         type: seq
-        required: false
         sequence:
             - type: str
               required: true
+    translations:
+        type: seq
+        sequence:
+            - type: str
+        description: |
+            If alternative translations of a material are available, then use this key to indicate which languages have been manually translated.
+        examples:
+            - en
     level:
         type: str
-        required: false
         enum:
             - Introductory
             - Intermediate
             - Advanced
-    translations:
+        description: |
+            Here give a feeling of what level the material is at.
+    time_estimation:
+        type: str
+        pattern: /^(?:([0-9]*)[Hh])*(?:([0-9]*)[Mm])*(?:([0-9.]*)[Ss])*$/
+        description: |
+            An estimation of the time needed to complete the hands-on. It should look like 10M or 1H30M
+    redirect_from:
         type: seq
-        required: false
         sequence:
             - type: str
-              required: true
+        description: |
+            If a tutorial is renamed to a new location, use this field to list prior locations from which this tutorial was accessible.
+        examples:
+        - /topics/sequence-analysis/tutorials/de-novo-rad-seq/tutorial
     lang:
         type: str
-        required: false
-        enum:  # These are the only supported values currently
+        enum:
             - es
             - en
+        description: |
+            The document language.
     voice:
         type: map
-        required: false
+        description: |
+            For materials which are automatically converted into videos via the available mechanisms, this field declares which voice should be used. If this field is not declared, a random voice will be chosen from a list of the best available voices from AWS Polly.
         mapping:
             id:
                 type: str
@@ -131,22 +205,29 @@ mapping:
                 required: true
             endOfSentencePause:
                 type: float
-                required: false
             endOfSlidePause:
                 type: float
-                required: false
-    time_estimation:
-        type: str
-        required: false
-        pattern: /^(?:([0-9]*)[Hh])*(?:([0-9]*)[Mm])*(?:([0-9.]*)[Ss])*$/
-    redirect_from:
-        type: seq
-        sequence:
-            - type: str
-        required: false
+        examples: |
+            voice:
+                id: Lupe
+                lang: es-US
+                neural: true
     follow_up_training:
         type: seq
-        required: false
+        description: list of resources that the reader of the material could follow at the end of the tutorial
+        examples:
+            - |
+                type: internal
+                topic_name: statistics
+                tutorials:
+                    - age-prediction-with-ml
+            - |
+                type: external
+                title: The Unix Shell
+                link: "http://swcarpentry.github.io/shell-novice/"
+            - |
+                type: none
+                title: "A VM with at least 2 vCPUs and 4 GB RAM, preferably running Ubuntu 18.04 - 20.04."
         sequence:
             - type: map
               required: true
@@ -158,23 +239,42 @@ mapping:
                           - internal
                           - external
                           - none
+                      description: |
+                        the type of link
                   topic_name:
                       type: str
-                      required: false
+                      description: |
+                        [Internal Only] The name of the topic
                   tutorials:
                       type: seq
-                      required: false
                       sequence:
                           - type: str
+                      description: |
+                          [Internal Only] List of required tutorials inside that topic
                   title:
                       type: str
-                      required: false
+                      description: |
+                        Title of the external resource
                   link:
                       type: str
-                      required: false
+                      description: |
+                        URL of the external resource
     requirements:
         type: seq
-        required: false
+        description: List of resources that the reader of the material should be familiar with before starting this training. The structure is identical to `follow_up_training`.
+        examples:
+            - |
+                type: internal
+                topic_name: statistics
+                tutorials:
+                    - age-prediction-with-ml
+            - |
+                type: external
+                title: The Unix Shell
+                link: "http://swcarpentry.github.io/shell-novice/"
+            - |
+                type: none
+                title: "A VM with at least 2 vCPUs and 4 GB RAM, preferably running Ubuntu 18.04 - 20.04."
         sequence:
             - type: map
               required: true
@@ -186,20 +286,27 @@ mapping:
                           - internal
                           - external
                           - none
+                      description: |
+                        the type of link
                   topic_name:
                       type: str
-                      required: false
+                      description: |
+                        [Internal Only] The name of the topic
                   tutorials:
                       type: seq
-                      required: false
                       sequence:
                           - type: str
+                      description: |
+                          [Internal Only] List of required tutorials inside that topic
                   title:
                       type: str
-                      required: false
+                      description: |
+                        Title of the external resource
                   link:
                       type: str
-                      required: false
+                      description: |
+                        URL of the external resource
     enable:
         type: bool
-        required: false
+        description: |
+            `false` to hide your tutorial from the topic page (optional). This is useful if you need a tutorial for a workshop, but have not finished making it up to GTN standards.

--- a/bin/schema-topic.yaml
+++ b/bin/schema-topic.yaml
@@ -4,6 +4,13 @@ mapping:
     name:
         type: str
         required: true
+        pattern: /^[a-z0-9_-]$/
+        description: |
+            The internal identifier for a topic, it should be the same as the folder name.
+        examples:
+            - epigenetics
+            - sequence-analysis
+            - admin
     type:
         type: str
         required: true
@@ -13,31 +20,82 @@ mapping:
             - data-science
             - use
             - instructors
+        description: |
+            The type of topic, some have subtly different behaviours.
+
+            `admin-dev`
+            :  should be used for admin and developer topics that are not scientifically focused.
+
+            `basics`
+            :  Only used for galaxy-interface type topics
+
+            `data-science`
+            :  Topics which are not necessarily Galaxy focused but expand into broader communities
+
+            `use`
+            :  These topics use galaxy for some analysis
+
+            `instructors`
+            :  Specific to topics related to instruction of Galaxy
     title:
         type: str
         required: true
+        description: |
+            Title of the topic, this is displayed for users to see.
+        examples:
+            - Proteomics
+            - Variant Analysis
     summary:
         type: str
         required: true
+        description: |
+            A longer description of the contents of this topic
+        examples:
+            - Statistical Analyses for omics data and machine learning using Galaxy tools
     docker_image:
         type: str
+        description: |
+            The image ID for an image which contains all of the tools and data for this topic.
+        examples:
+            - quay.io/galaxy/sequence-analysis-training
     subtopics:
         type: seq
         required: false
+        description: |
+            For large topics, we can define subtopics and create multiple tutorial lists, which separates the tutorials to help users find content that interests them more quickly.
         sequence:
             - type: map
               mapping:
                   id:
                       type: str
                       required: true
+                      pattern: /^[a-z0-9_-]$/
+                      description: |
+                          Subtopic ID, this should match what is used in tutorials.
+                      examples:
+                          - single-cell
                   title:
                       type: str
                       required: true
+                      description: |
+                          Subtopic title, which is displayed for users to see.
+                      examples:
+                          - Maintaining a Production Galaxy
+                          - Single-cell RNA-seq
                   description:
                       type: str
                       required: true
+                      description: |
+                          A human readable textual description of a subtopic.
+                      examples: |
+                        - "Start here if you are new to RNA-Seq analysis in Galaxy"
+                        - "These tutorials take you from raw sequencing reads to pathway analysis"
+                        - "Tutorials about analysis of single-cell RNA-seq data"
+                        - "Tutorials using a single published single-cell RNA-seq dataset for a variety of analyses"
                   enable:
                       type: bool
+                      description: |
+                        `false` to hide your topic from the production GTN. This is useful if you need a topic for a workshop, but have not finished making it up to GTN standards.
 
     maintainers:
         type: seq
@@ -45,14 +103,25 @@ mapping:
         sequence:
             - type: str
               required: true
+              description: A contributor's ID in the CONTRIBUTORS.yaml file.
               enum:
               - CONTRIBUTORS
     edam_ontology:
         type: str
-        # todo validate format
+        pattern: /^topic_[0-9]+$/
+        description: |
+            An edam ontology id that describes the topic.
+        examples:
+            - topic_3173
     requirements:
         type: seq
-        required: false
+        description: List of resources that the reader of the material should be familiar with before starting this training. The structure is identical to `follow_up_training`.
+        examples:
+            - |
+                type: internal
+                topic_name: statistics
+                tutorials:
+                    - age-prediction-with-ml
         sequence:
             - type: map
               required: true
@@ -60,18 +129,29 @@ mapping:
                   type:
                       type: str
                       required: true
+                      enum:
+                          - internal
+                      description: |
+                        the type of link
                   topic_name:
                       type: str
-                      required: true
+                      description: |
+                        The name of the topic
                   tutorials:
                       type: seq
-                      required: false
                       sequence:
                           - type: str
+                      description: |
+                        List of required tutorials inside that topic
 
     references:
         type: seq
-        required: false
+        examples: |
+          - |
+            authors: "Vaudel M, et al."
+            title: "Shedding light on black boxes in protein identification."
+            link: "https://www.ncbi.nlm.nih.gov/pubmed/24678044"
+            summary: "An extensive tutorial for peptide and protein identification, available at http://compomics.com/bioinformatics-for-proteomics. The material is completely based on freely available and open-source tools."
         sequence:
             - type: map
               required: true
@@ -89,7 +169,12 @@ mapping:
                       type: str
     gitter:
         type: str
-        required: false
+            Link to a gitter channel that is more relevant for this topic than the default. E.g. a single cell topic, you could use `Galaxy-Training-Network/galaxy-single-cell` to link to their specific chat room in all of the child tutorials by default.
+        examples:
+            - Galaxy-Training-Network/galaxy-single-cell
+            - galaxy-genome-annotation/Lobby
     enable:
         type: bool
         required: false
+        description: |
+            `false` to hide your topic from the production GTN. This is useful if you need a topic for a workshop, but have not finished making it up to GTN standards.

--- a/bin/schema-topic.yaml
+++ b/bin/schema-topic.yaml
@@ -45,6 +45,8 @@ mapping:
         sequence:
             - type: str
               required: true
+              enum:
+              - CONTRIBUTORS
     edam_ontology:
         type: str
         # todo validate format

--- a/bin/schema-tutorial.yaml
+++ b/bin/schema-tutorial.yaml
@@ -19,7 +19,6 @@ mapping:
             - Pangeo ecosystem 101 for everyone - Introduction to Xarray Galaxy Tools
     questions:
         type: seq
-        required: false
         sequence:
             - type: str
               required: true
@@ -32,7 +31,6 @@ mapping:
             - What kinds of data do programs store?
     objectives:
         type: seq
-        required: false
         sequence:
             - type: str
               required: true
@@ -50,7 +48,6 @@ mapping:
             - Generate a DotPlot emulating the original paper using a different analysis tool
     key_points:
         type: seq
-        required: false
         sequence:
             - type: str
               required: true
@@ -65,7 +62,6 @@ mapping:
             - It can drastically simplify management of large numbers of VMs
     edam_ontology:
         type: str
-        required: false
         pattern: /^topic_[0-9]+$/
         description: |
             An edam ontology id that describes the topic or tutorial.
@@ -73,7 +69,6 @@ mapping:
             - topic_3173
     gitter:
         type: str
-        required: false
         description: |
             Link to a gitter channel that is more relevant for the tutorial than the default. E.g. a single cell tutorial could use `Galaxy-Training-Network/galaxy-single-cell` to link to their specific chat room.
         examples:
@@ -81,7 +76,6 @@ mapping:
             - galaxy-genome-annotation/Lobby
     contributors:
         type: seq
-        required: false
         sequence:
             - type: str
               required: true
@@ -93,55 +87,87 @@ mapping:
             - hexylena
             - shiltemann
     contributions:
+        required: true
+        description: |
+            List of tutorial contributors. Here we break them down into several broad categories to help contributors identify how they contributed to a specific tutorial.
+        examples: |
+            contributions:
+                authorship:
+                    - shiltemann
+                    - bebatut
+                editing:
+                    - hexylena
+                    - bebatut
+                    - natefoo
+                testing:
+                    - bebatut
+                infrastructure:
+                    - natefoo
+                funding:
+                    - erasmusplus
         type: map
         mapping:
             authorship:
+                description: These entities wrote the bulk of the training material, they may have done the analysis, built the workflow, and wrote the text themselves.
                 type: seq
                 sequence:
                 - type: str
+                  enum:
+                  - CONTRIBUTORS
             editing:
                 type: seq
+                description: These entities edited the text, either for spelling and grammar, flow, GTN-fit, or other similar editing categories
                 sequence:
                 - type: str
+                  enum:
+                  - CONTRIBUTORS
             testing:
                 type: seq
+                description: These entities tested the tutorial to ensure it works correctly for students, or reported issues with the tutorial.
                 sequence:
                 - type: str
+                  enum:
+                  - CONTRIBUTORS
             ux:
                 type: seq
+                description: These entities contributed UX or Design improvements to this tutorial or the GTN as a whole
                 sequence:
                 - type: str
+                  enum:
+                  - CONTRIBUTORS
             infrastructure:
                 type: seq
+                description: These entities managed and provided infrastructure to the GTN or for training purposes
                 sequence:
                 - type: str
+                  enum:
+                  - CONTRIBUTORS
             funding:
                 type: seq
+                description: These entities provided funding support for the development of this resource
                 sequence:
                 - type: str
+                  enum:
+                  - CONTRIBUTORS
     subtopic:
         type: str
-        required: false
         description: |
             if the topic has [multiple subtopics defined](/training-material/topics/contributing/tutorials/create-new-topic/tutorial.html#adapt-the-metadata-for-your-topic), you can assign your tutorial to one of those subtopics here. Without this, the tutorial will appear in the "Other tutorials" section on the topic page.
         examples:
             - single-cell
     priority:
         type: int
-        required: false
         description: |
             This field allows ordering tutorials within the tutorial list. Tutorials with lower numbered priority come before tutorials with higher numbers.
         examples: 1
     zenodo_link:
         type: str
-        required: false
         description: |
             link on Zenodo to the input data for the tutorial
         examples:
             - "https://zenodo.org/record/3706539"
     tags:
         type: seq
-        required: false
         sequence:
             - type: str
               required: true
@@ -152,7 +178,6 @@ mapping:
             - git-gat
     translations:
         type: seq
-        required: false
         sequence:
             - type: str
               required: true
@@ -175,7 +200,6 @@ mapping:
                 API: Application Programming Interface
     galaxy_version:
         type: float
-        required: false
         description: |
             Currently unused.
     level:
@@ -191,19 +215,20 @@ mapping:
         required: true
         pattern: /^(?:([0-9]*)[Hh])*(?:([0-9]*)[Mm])*(?:([0-9.]*)[Ss])*$/
         description: |
-            An estimation of the time needed to complete the hands-on. It should look like 10M or 1H30M
+            An estimation of the time needed to complete the hands-on.
+        examples:
+            - 10M
+            - 1H30M
     redirect_from:
         type: seq
         sequence:
             - type: str
-        required: false
         description: |
             If a tutorial is renamed to a new location, use this field to list prior locations from which this tutorial was accessible.
         examples:
         - /topics/sequence-analysis/tutorials/de-novo-rad-seq/tutorial
     notebook:
         type: map
-        required: false
         examples: |
             notebook:
                 language: python
@@ -215,7 +240,6 @@ mapping:
         mapping:
             snippet:
                 type: str
-                required: false
                 description: |
                     If you have an alternative preamble for your notebook that students should know before following (e.g. they must load X datasets in their history), it can be listed here.
 
@@ -224,7 +248,6 @@ mapping:
                     - topics/climate/tutorials/pangeo-notebook/preamble.md
             pyolite:
                 type: bool
-                required: false
                 description: |
                     The GTN has support for JupyterLite and the Pyodide kernel which runs [Python in the browser via webassembly/javascript](https://pyodide.org/en/stable/). This comes with some restrictions:
 
@@ -249,7 +272,6 @@ mapping:
                     - sql
     lang:
         type: str
-        required: false
         enum:
             - es
             - en
@@ -257,7 +279,6 @@ mapping:
             The document language.
     voice:
         type: map
-        required: false
         description: |
             For materials which are automatically converted into videos via the available mechanisms, this field declares which voice should be used. If this field is not declared, a random voice will be chosen from a list of the best available voices from AWS Polly.
         mapping:
@@ -277,7 +298,6 @@ mapping:
                 neural: true
     follow_up_training:
         type: seq
-        required: false
         description: list of resources that the reader of the material could follow at the end of the tutorial
         examples:
             - |
@@ -307,29 +327,24 @@ mapping:
                         the type of link
                   topic_name:
                       type: str
-                      required: false
                       description: |
                         [Internal Only] The name of the topic
                   tutorials:
                       type: seq
-                      required: false
                       sequence:
                           - type: str
                       description: |
                           [Internal Only] List of required tutorials inside that topic
                   title:
                       type: str
-                      required: false
                       description: |
                         Title of the external resource
                   link:
                       type: str
-                      required: false
                       description: |
                         URL of the external resource
     requirements:
         type: seq
-        required: false
         description: List of resources that the reader of the material should be familiar with before starting this training. The structure is identical to `follow_up_training`.
         examples:
             - |
@@ -359,35 +374,29 @@ mapping:
                         the type of link
                   topic_name:
                       type: str
-                      required: false
                       description: |
                         [Internal Only] The name of the topic
                   tutorials:
                       type: seq
-                      required: false
                       sequence:
                           - type: str
                       description: |
                           [Internal Only] List of required tutorials inside that topic
                   title:
                       type: str
-                      required: false
                       description: |
                         Title of the external resource
                   link:
                       type: str
-                      required: false
                       description: |
                         URL of the external resource
     license:
         type: str
-        required: false
         description: |
             An [SPDX](https://spdx.org/) identifier for the alternative license that is used for that particular material. This is **only** relevant for materials which have been imported from an external source and were originally licensed under another license. For new materials we strongly encourage contributors to not use this key as materials are CC-BY, by default.
         examples:
             - MIT
     enable:
         type: bool
-        required: false
         description: |
             `false` to hide your tutorial from the topic page (optional). This is useful if you need a tutorial for a workshop, but have not finished making it up to GTN standards.

--- a/bin/schema-tutorial.yaml
+++ b/bin/schema-tutorial.yaml
@@ -6,39 +6,92 @@ mapping:
         required: true
         enum:
             - tutorial_hands_on
+        description: |
+            This must be set to `tutorial_hands_on`
     title:
         type: str
         required: true
+        description: |
+            Title of the tutorial (it will appear on the tutorial page and the topic page)
+        examples:
+            - Clustering in Machine Learning
+            - Breve introducción a Galaxy - en español
+            - Pangeo ecosystem 101 for everyone - Introduction to Xarray Galaxy Tools
     questions:
         type: seq
         required: false
         sequence:
             - type: str
               required: true
+        description: |
+            list of questions that will be addressed in the tutorial
+        examples:
+            - How does Genome assembly work?
+            - How do I change Galaxy configs?
+            - How to detect and quantify differentially abundant proteins in a HEK-Ecoli Benchmark DIA datatset?
+            - What kinds of data do programs store?
     objectives:
         type: seq
         required: false
         sequence:
             - type: str
               required: true
+        description: |
+            list of learning objectives for the tutorial
+
+            A learning objective is a single sentence describing what a learner will be able to do once they have done the tutorial. Generally it is best to follow a 2C or 3C learning objective such as:
+
+            - Compute (Skill)
+            - multiple whole genome assemblies (Objective)
+            - in such a way to develop big data processing skills (Result)
+        examples:
+            - Understand the basic concepts behind phylogenetic trees, as applied to *Mycobacterium tuberculosis*
+            - Explore Biodiversity data with taxonomic, temporal and geographical informations
+            - Generate a DotPlot emulating the original paper using a different analysis tool
     key_points:
         type: seq
         required: false
         sequence:
             - type: str
               required: true
+        description: |
+            List of take-home messages. This information will appear at the end
+            of the tutorial. These should really be a key point, something that
+            should stick in their mind; what you want them to take home from
+            the tutorial.
+        examples:
+            - Pangeo ecosystem enables big data analysis in geosciences
+            - "The MiModD suite of tools bundles most of the functionality required to perform mapping-by-sequencing analyses with Galaxy"
+            - It can drastically simplify management of large numbers of VMs
     edam_ontology:
         type: str
         required: false
+        pattern: /^topic_[0-9]+$/
+        description: |
+            An edam ontology id that describes the topic or tutorial.
+        examples:
+            - topic_3173
     gitter:
         type: str
         required: false
+        description: |
+            Link to a gitter channel that is more relevant for the tutorial than the default. E.g. a single cell tutorial could use `Galaxy-Training-Network/galaxy-single-cell` to link to their specific chat room.
+        examples:
+            - Galaxy-Training-Network/galaxy-single-cell
+            - galaxy-genome-annotation/Lobby
     contributors:
         type: seq
         required: false
         sequence:
             - type: str
               required: true
+              enum:
+              - CONTRIBUTORS
+        description: |
+            List of tutorial contributors. Please use `contributions` instead as it provides more detailed accounting of tutorial history.
+        examples:
+            - hexylena
+            - shiltemann
     contributions:
         type: map
         mapping:
@@ -69,57 +122,123 @@ mapping:
     subtopic:
         type: str
         required: false
+        description: |
+            if the topic has [multiple subtopics defined](/training-material/topics/contributing/tutorials/create-new-topic/tutorial.html#adapt-the-metadata-for-your-topic), you can assign your tutorial to one of those subtopics here. Without this, the tutorial will appear in the "Other tutorials" section on the topic page.
+        examples:
+            - single-cell
     priority:
         type: int
         required: false
+        description: |
+            This field allows ordering tutorials within the tutorial list. Tutorials with lower numbered priority come before tutorials with higher numbers.
+        examples: 1
     zenodo_link:
         type: str
         required: false
+        description: |
+            link on Zenodo to the input data for the tutorial
+        examples:
+            - "https://zenodo.org/record/3706539"
     tags:
         type: seq
         required: false
         sequence:
             - type: str
               required: true
+        description: |
+            A free form list of tags that are relevant for your tutorial.
+        examples:
+            - covid-19
+            - git-gat
     translations:
         type: seq
         required: false
         sequence:
             - type: str
               required: true
+        description: |
+            If alternative translations of a material are available, then use this key to indicate which languages have been manually translated.
+        examples:
+            - en
     abbreviations:
         type: map
         mapping:
             "=":
                 type: str
+                description: |
+                    The expansion of the abbreviated term.
+        description: |
+            A dictionary of abbreviations and their expansions.
+        examples: |
+            abbreviations:
+                SQL: Structured Query Language
+                API: Application Programming Interface
     galaxy_version:
         type: float
         required: false
+        description: |
+            Currently unused.
     level:
         type: str
         enum:
             - Introductory
             - Intermediate
             - Advanced
+        description: |
+            Here give a feeling of what level the material is at.
     time_estimation:
         type: str
         required: true
         pattern: /^(?:([0-9]*)[Hh])*(?:([0-9]*)[Mm])*(?:([0-9.]*)[Ss])*$/
+        description: |
+            An estimation of the time needed to complete the hands-on. It should look like 10M or 1H30M
     redirect_from:
         type: seq
         sequence:
             - type: str
         required: false
+        description: |
+            If a tutorial is renamed to a new location, use this field to list prior locations from which this tutorial was accessible.
+        examples:
+        - /topics/sequence-analysis/tutorials/de-novo-rad-seq/tutorial
     notebook:
         type: map
         required: false
+        examples: |
+            notebook:
+                language: python
+                pyolite: true
+
+            notebook:
+                language: python
+                snippet: topics/climate/tutorials/pangeo-notebook/preamble.md
         mapping:
             snippet:
                 type: str
                 required: false
+                description: |
+                    If you have an alternative preamble for your notebook that students should know before following (e.g. they must load X datasets in their history), it can be listed here.
+
+                    This text will be shown in the GTN tutorial, but it will **not** be included in the notebook, giving you a bit better control over mixing setup content which is relevant for Galaxy, with notebook content that can be easy to run for students.
+                examples:
+                    - topics/climate/tutorials/pangeo-notebook/preamble.md
             pyolite:
                 type: bool
                 required: false
+                description: |
+                    The GTN has support for JupyterLite and the Pyodide kernel which runs [Python in the browser via webassembly/javascript](https://pyodide.org/en/stable/). This comes with some restrictions:
+
+                    - Python only
+                    - No filesystem access (so no `wget` prep steps)
+                    - Little to no cell magic
+
+                    However, it means we can run a lot of our Python training
+                    directly in the GTN! And in the future, hopefully, we will
+                    be able to embed individual cells of the notebook directly
+                    in the Python training, so the user doesn't even need to
+                    switch pages.
+
+                    Enabling this field will enable pyolite links for this notebook.
             language:
                 type: str
                 required: true
@@ -131,12 +250,16 @@ mapping:
     lang:
         type: str
         required: false
-        enum:  # These are the only supported values currently
+        enum:
             - es
             - en
+        description: |
+            The document language.
     voice:
         type: map
         required: false
+        description: |
+            For materials which are automatically converted into videos via the available mechanisms, this field declares which voice should be used. If this field is not declared, a random voice will be chosen from a list of the best available voices from AWS Polly.
         mapping:
             id:
                 type: str
@@ -147,9 +270,28 @@ mapping:
             neural:
                 type: bool
                 required: true
+        examples: |
+            voice:
+                id: Lupe
+                lang: es-US
+                neural: true
     follow_up_training:
         type: seq
         required: false
+        description: list of resources that the reader of the material could follow at the end of the tutorial
+        examples:
+            - |
+                type: internal
+                topic_name: statistics
+                tutorials:
+                    - age-prediction-with-ml
+            - |
+                type: external
+                title: The Unix Shell
+                link: "http://swcarpentry.github.io/shell-novice/"
+            - |
+                type: none
+                title: "A VM with at least 2 vCPUs and 4 GB RAM, preferably running Ubuntu 18.04 - 20.04."
         sequence:
             - type: map
               required: true
@@ -161,23 +303,47 @@ mapping:
                           - internal
                           - external
                           - none
+                      description: |
+                        the type of link
                   topic_name:
                       type: str
                       required: false
+                      description: |
+                        [Internal Only] The name of the topic
                   tutorials:
                       type: seq
                       required: false
                       sequence:
                           - type: str
+                      description: |
+                          [Internal Only] List of required tutorials inside that topic
                   title:
                       type: str
                       required: false
+                      description: |
+                        Title of the external resource
                   link:
                       type: str
                       required: false
+                      description: |
+                        URL of the external resource
     requirements:
         type: seq
         required: false
+        description: List of resources that the reader of the material should be familiar with before starting this training. The structure is identical to `follow_up_training`.
+        examples:
+            - |
+                type: internal
+                topic_name: statistics
+                tutorials:
+                    - age-prediction-with-ml
+            - |
+                type: external
+                title: The Unix Shell
+                link: "http://swcarpentry.github.io/shell-novice/"
+            - |
+                type: none
+                title: "A VM with at least 2 vCPUs and 4 GB RAM, preferably running Ubuntu 18.04 - 20.04."
         sequence:
             - type: map
               required: true
@@ -189,24 +355,39 @@ mapping:
                           - internal
                           - external
                           - none
+                      description: |
+                        the type of link
                   topic_name:
                       type: str
                       required: false
+                      description: |
+                        [Internal Only] The name of the topic
                   tutorials:
                       type: seq
                       required: false
                       sequence:
                           - type: str
+                      description: |
+                          [Internal Only] List of required tutorials inside that topic
                   title:
                       type: str
                       required: false
+                      description: |
+                        Title of the external resource
                   link:
                       type: str
                       required: false
-    # This permits overriding the default CC-BY icon we add everywhere.
+                      description: |
+                        URL of the external resource
     license:
         type: str
         required: false
+        description: |
+            An [SPDX](https://spdx.org/) identifier for the alternative license that is used for that particular material. This is **only** relevant for materials which have been imported from an external source and were originally licensed under another license. For new materials we strongly encourage contributors to not use this key as materials are CC-BY, by default.
+        examples:
+            - MIT
     enable:
         type: bool
         required: false
+        description: |
+            `false` to hide your tutorial from the topic page (optional). This is useful if you need a tutorial for a workshop, but have not finished making it up to GTN standards.

--- a/bin/validate-frontmatter.rb
+++ b/bin/validate-frontmatter.rb
@@ -39,6 +39,9 @@ SLIDES_SCHEMA = automagic_loading(SLIDES_SCHEMA_UNSAFE)
 TOPIC_SCHEMA = automagic_loading(TOPIC_SCHEMA_UNSAFE)
 FAQ_SCHEMA = automagic_loading(FAQ_SCHEMA_UNSAFE)
 
+TUTORIAL_SCHEMA['mapping']['contributions']['required'] = false
+SLIDES_SCHEMA['mapping']['contributions']['required'] = false
+
 
 # Build validators now that we've filled out the subtopic enum
 $topic_validator = Kwalify::Validator.new(TOPIC_SCHEMA)

--- a/metadata/schema-contributors.yaml
+++ b/metadata/schema-contributors.yaml
@@ -1,0 +1,1 @@
+../bin/schema-contributors.yaml

--- a/metadata/schema-faq.yaml
+++ b/metadata/schema-faq.yaml
@@ -1,0 +1,1 @@
+../bin/schema-faq.yaml

--- a/metadata/schema-slides.yaml
+++ b/metadata/schema-slides.yaml
@@ -1,0 +1,1 @@
+../bin/schema-slides.yaml

--- a/metadata/schema-topic.yaml
+++ b/metadata/schema-topic.yaml
@@ -1,0 +1,1 @@
+../bin/schema-topic.yaml

--- a/metadata/schema-tutorial.yaml
+++ b/metadata/schema-tutorial.yaml
@@ -1,0 +1,1 @@
+../bin/schema-tutorial.yaml

--- a/news/_posts/2022-05-20-schema.md
+++ b/news/_posts/2022-05-20-schema.md
@@ -1,0 +1,10 @@
+---
+title: GTN Metadata Schemas
+tags: [new feature]
+contributors: [hexylena]
+layout: news
+---
+
+Within the GTN we have had schemas for the various metadata we keep for a long time. It helps us automatically check community contributions to ensure they conform to all of the GTN standards, and will work correctly in our environment.
+
+Until now the available metadata was not described in a single location, but potentially spread across multiple tutorials or undocumented. We have updated our documentation to include descriptions and examples of each field, and [they are now available to browse]({% link topics/contributing/tutorials/schemas/tutorial.md %}). You do not need to know anything about schemas or their implementation to use our user friendly and well documented examples.

--- a/topics/contributing/tutorials/create-new-topic/tutorial.md
+++ b/topics/contributing/tutorials/create-new-topic/tutorial.md
@@ -10,8 +10,11 @@ objectives:
 time_estimation: "30m"
 key_points:
   - "A new topic can be easily added for new tutorials"
-contributors:
+contributions:
+  authorship:
   - bebatut
+  editing:
+  - hexylena
 ---
 
 # Introduction
@@ -148,23 +151,9 @@ Once the topic name has been chosen, we can create it.
 
 Several metadata are defined in `metadata.yaml` file in your topic folder to :
 
-- `name`: name of the topic (name of the folder)
-- `title`: title of the topic (the one displayed on the webpage)
-- `type`: target for the topic ('use', 'admin-dev', 'instructors')
-- `summary`: summary of the focus of the topic
-- `requirements`: list of resources that the reader of the material should be familiar with before starting any tutorial in this topic:
-    - `type`: the type of link (`internal` or `external`)
-
-    For internal, i.e. inside the Galaxy Training Material:
-    - `topic_name`: name of the topic
-    - `tutorials`: list of required tutorials inside of the topic
-
-    For external:
-    - `title`: title of the external resource
-    - `link`: URL to the external resource
-
-- `docker_image`: name of the Docker image for the topic
-    If no Docker image exists for this topic, let this information empty
+{% assign kid_key = "Topic Schema" %}
+{% assign kid_val = site.data['schema-topic'] %}
+{% include _includes/schema-render.html key=kid_key value=kid_val %}
 
 - `subtopics`: for large topics, we can define subtopics and create multiple tutorial lists:
   ```
@@ -177,9 +166,6 @@ Several metadata are defined in `metadata.yaml` file in your topic folder to :
       description: "These Tutorial"
   ```
   tutorials can be assigned to subtopics by adding e.g. `subtopic: singlecell` to the tutorial metadata. An example of this subtopic division can be found in the [admin section]({{site.baseurl}}/topics/admin/ )
-
-- `maintainers`: GitHub username of people maintaining the topic
-- `gitter`: The name of the chatroom on Gitter, if enabled, it will be embedded on the topic and tutorial pages. Should be formatted like `../..`, without the `https://gitter.im`, e.g. `galaxyproject/dev`
 
 > ### {% icon hands_on %} Hands-on: Update the new topic to the website
 >

--- a/topics/contributing/tutorials/create-new-tutorial-content/tutorial.md
+++ b/topics/contributing/tutorials/create-new-tutorial-content/tutorial.md
@@ -14,8 +14,10 @@ key_points:
   - "You can highlight questions, tools and hints with a special syntax"
   - "Self-learning can be done by questions and hidden answers"
 subtopic: writing
-contributors:
+contributions:
+  authorship:
   - bebatut
+  editing:
   - bgruening
   - shiltemann
   - hexylena
@@ -98,9 +100,8 @@ The `tutorial.md` needs to start with some metadata at the top:
 - `layout: tutorial_hands_on`: keep the default
 - `title`: title of the tutorial (it will appear on the tutorial page and the topic page)
 - `level`: `Introductory`, `Intermediate` or `Advanced`
-- `enable`: `false` to hide your tutorial from the topic page (optional)
 - `zenodo_link`: link on Zenodo to the input data for the tutorial
-- `contribuors`: eveybody who has contributed to this tutorial (usernames must match those in `CONTRIBUTORS.yaml` file)
+- `contributions`: eveybody who has contributed to this tutorial (usernames must match those in `CONTRIBUTORS.yaml` file)
 
 > ### {% icon hands_on %} Hands-on: Fill the basic metadata
 >
@@ -117,40 +118,9 @@ This information is used to display the data from the topic and tutorial page. T
 
 We also define metadata related to the pedagogical content of the tutorial, which will appear at the top ("Overview" box) and bottom of the online tutorial:
 
-- `requirements`: list of resources that the reader of the material should be familiar with before starting this training:
-    - `type`: the type of link (`internal` or `external`)
-
-    For internal, i.e. inside the Galaxy Training Material:
-    - `topic_name`: name of the topic
-    - `tutorials`: list of required tutorials inside of the topic
-
-    For external:
-    - `title`: title of the external resource
-    - `link`: URL to the external resource
-- `time_estimation`: an estimation of the time needed to complete the hands-on
-- `questions`: list of questions that will be addressed in the tutorial
-- `objectives`: list of learning objectives for the tutorial
-
-    A learning objective is a single sentence describing what a learner will be able to do once they have done the tutorial
-
-- `key_points`: list of take-home messages
-
-    This information will appear at the end of the tutorial
-
-- `follow_up_training`: list of resources that the reader of the material could follow at the end of the tutorial
-
-    - `type`: the type of link (`internal` or `external`)
-
-    For internal, i.e. inside the Galaxy Training Material:
-    - `topic_name`: name of the topic
-    - `tutorials`: list of required tutorials inside of the topic
-
-    For external:
-    - `title`: title of the external resource
-    - `link`: URL to the external resource
-
-    They will be displayed at the end of the tutorial.
-- `subtopic`: if the topic has [multiple subtopics defined]({{ site.baseurl }}/topics/contributing/tutorials/create-new-topic/tutorial.html#adapt-the-metadata-for-your-topic), you can assign your tutorial to one of those subtopics here. Without this, the tutorial will appear in the "Other tutorials" section on the topic page.
+{% assign kid_key = "Tutorial Schema" %}
+{% assign kid_val = site.data['schema-tutorial'] %}
+{% include _includes/schema-render.html key=kid_key value=kid_val %}
 
 For this category of metadata, we have taken inspiration from what Software Carpentry has done and particularly what they described in their [Instructor training](https://swcarpentry.github.io/instructor-training/).
 
@@ -235,6 +205,13 @@ All tutorials and slides must give credit to all contributors. This can be any t
 
    For an example of how this all looks, see the [R basics tutorial]({% link topics/data-science/tutorials/r-basics/tutorial.md %}) (top and bottom of the tutorial).
 
+{% assign kid_key = "Contributions Schema" %}
+{% assign kid_val = site.data['schema-tutorial']['mapping']['contributions'] %}
+{% include _includes/schema-render.html key=kid_key value=kid_val %}
+
+{% assign kid_key = "CONTRIBUTORS Schema" %}
+{% assign kid_val = site.data['schema-contributors'] %}
+{% include _includes/schema-render.html key=kid_key value=kid_val %}
 
 # Content
 
@@ -945,6 +922,10 @@ Here you can write the snippet / answer to the FAQ in Markdown
 
 ```
 
+{% assign kid_key = "FAQ Schema" %}
+{% assign kid_val = site.data['schema-faq'] %}
+{% include _includes/schema-render.html key=kid_key value=kid_val %}
+
 ### FAQ pages
 
 All FAQs will also be collected on their own page, this makes it easy for and teachers to prepare the session, and for participants to quickly find the answers to common questions.
@@ -1034,6 +1015,10 @@ And in your text you can use braces to refer to the term
 > >
 > {: .code-out}
 {: .code-2col}
+
+{% assign kid_key = "Abbreviations Schema" %}
+{% assign kid_val = site.data['schema-tutorial']['mapping']['abbreviations'] %}
+{% include _includes/schema-render.html key=kid_key value=kid_val %}
 
 ## Choose Your Own Tutorial
 
@@ -1162,6 +1147,12 @@ If your tutorial is primarily focused on teaching students how to write code (Ba
     ```python
     some_code += f"that students {should execute}"
     ```
+
+## Notebook Schema
+
+{% assign kid_key = "Notebook Schema" %}
+{% assign kid_val = site.data['schema-tutorial']['mapping']['notebook'] %}
+{% include _includes/schema-render.html key=kid_key value=kid_val %}
 
 ## Currently Supported Languages
 

--- a/topics/contributing/tutorials/schemas/tutorial.md
+++ b/topics/contributing/tutorials/schemas/tutorial.md
@@ -1,0 +1,31 @@
+---
+layout: tutorial_hands_on
+questions:
+- What metadata is required or possible to set in a Tutorial, Slide, Topic, or FAQ
+objectives:
+- Know where to find all of the available metadata, so you can reference it later.
+title: "GTN Metadata"
+time_estimation: "10m"
+contributors:
+  - hexylena
+---
+
+{% assign kid_key = "Tutorial Schema" %}
+{% assign kid_val = site.data['schema-tutorial'] %}
+{% include _includes/schema-render.html key=kid_key value=kid_val %}
+
+{% assign kid_key = "Contributor Schema" %}
+{% assign kid_val = site.data['schema-contributors'] %}
+{% include _includes/schema-render.html key=kid_key value=kid_val %}
+
+{% assign kid_key = "Slides Schema" %}
+{% assign kid_val = site.data['schema-slides'] %}
+{% include _includes/schema-render.html key=kid_key value=kid_val %}
+
+{% assign kid_key = "FAQ Schema" %}
+{% assign kid_val = site.data['schema-faq'] %}
+{% include _includes/schema-render.html key=kid_key value=kid_val %}
+
+{% assign kid_key = "Topic Schema" %}
+{% assign kid_val = site.data['schema-topic'] %}
+{% include _includes/schema-render.html key=kid_key value=kid_val %}

--- a/topics/epigenetics/tutorials/hicexplorer/tutorial.md
+++ b/topics/epigenetics/tutorials/hicexplorer/tutorial.md
@@ -3,7 +3,6 @@ layout: tutorial_hands_on
 
 title: "Hi-C analysis of Drosophila melanogaster cells using HiCExplorer"
 zenodo_link: "https://doi.org/10.5281/zenodo.1183661"
-edam_ontology: ""
 questions:
   - "Why is a Hi-C analysis useful?"
   - "What is 'chromosome conformation capture'?"
@@ -298,7 +297,7 @@ As an output we get the boundaries, domains and scores separated files. We will 
 
 ![Pearson PC2](../../images/pearson_pc2.png)
 
-The first principal component correlates with the chromosome arms, while the second component correlates with A/B compartments. 
+The first principal component correlates with the chromosome arms, while the second component correlates with A/B compartments.
 
 # Integrating Hi-C and other data
 
@@ -388,7 +387,7 @@ To compute loops, we have to import a new data set from the shared library to ou
 
 This dataset is from the human cell GM12878, mapped to hg19 and of 10 kb resolution. We use a new file because to detect loop structures the read coverage is required to be in the hunderts of million; this was not the case for the previous used drosophila dataset.
 
-> ### {% icon hands_on %} Hands-on: Matrix information 
+> ### {% icon hands_on %} Hands-on: Matrix information
 >
 > 1. **hicInfo** {% icon tool %}: Run hicInfo adjusting the parameters:
 >    - "Select" `Multiple datasets`


### PR DESCRIPTION
We've got a number of schemas (tutorial, topic, faq, contributor, slides) and they weren't really documented so if you wanted to use a feature, how would you know? You wouldn't. Now they're available as beautiful documentation, and integrated within our existing documentation as well, which is an improvement.

Please ignore the missing icons - train wifi.
![image](https://user-images.githubusercontent.com/458683/169545243-c75207e4-d44e-4bae-84ef-884c77eecdd8.png)


