### PR TITLE
Improve GTN link previews by showing content / custom image previews

### DIFF
--- a/_layouts/base.html
+++ b/_layouts/base.html
@@ -30,12 +30,24 @@
         {% if topic.summary %}
           {% assign og_desc = topic.summary %}
         {% endif %}
-        <meta name="description" content="{{ og_desc | strip_html | truncate: 60}}" />
-        <meta property="og:site_name" content="Galaxy Training Network" />
-        <meta property="og:title" content="Galaxy Training{% if og_title %}: {{ og_title | truncate: 60}}{% endif %}" />
-        <meta property="og:description" content="{{ og_desc | strip_html | truncate: 60}}" />
-        <meta property="og:image" content="{{ "/assets/images/GTNLogo1000.png" | prepend: site.baseurl }}" />
+        {% assign og_image = "/assets/images/GTNLogo1000.png" | prepend: site.baseurl %}
+        {% if page.contributors or page.contributions %}
+            {% capture og_page_desc %}{{ page.content }}{% endcapture %}
+            {% assign og_desc = og_page_desc %}
 
+            {% capture og_image_tmp %}{{ page.content | markdownify | first_image:page.url }}{% endcapture %}
+
+            {% if og_image_tmp %}
+                {% assign og_image = og_image_tmp %}
+            {% endif %}
+        {% endif %}
+
+        <meta name="description" content="{{ og_desc | truncate:600 | markdownify | strip_html | remove_newlines |truncate: 300}}" />
+        <meta property="og:description" content="{{ og_desc | truncate:600 | markdownify | strip_html | remove_newlines | truncate: 300}}" />
+
+        <meta property="og:site_name" content="Galaxy Training Network" />
+        <meta property="og:title" content="Galaxy Training{% if og_title %}: {{ og_title | truncate: 100}}{% endif %}" />
+        <meta property="og:image" content="{{ og_image }}" />
     </head>
     <body data-spy="scroll" data-target="#toc">
         {% include _includes/default-header.html %}


### PR DESCRIPTION
This replaces our existing link preview data which was pretty boring (just the topic 'about') and the GTN image always being used, for more customised previews which include more data:

x | Before | After
 -- | -- | --
 title | Galaxy Training: RAD-Seq de-novo data analysis | Galaxy Training: RAD-Seq de-novo data analysis
description | Learn to analyse Ecological data through Galaxy | Introduction In the study of Hohenlohe et al. 2010, a genome scan of nucleotide diversity and differentiation in natural populations of threespine stickleback Gasterosteus aculeatus was conducted.
image | /training-material/assets/images/GTNLogo1000.png | https://training.galaxyproject.org/training-material/topics/ecology/images/RAD4_Population_Genomics/Hohenlohe_et_al_2010.png

open to further suggestions or improvements!

I can imagine we can use this "text preview" and "first image" as useful filters elsewhere in the GTN, maybe with hovercards or just providing tutorial blurbs in a future tutorial list interface.