### PR TITLE
Reference-based RNA-Seq data analysis: fix DEG workflow

### DIFF
--- a/topics/transcriptomics/tutorials/ref-based/workflows/deg-analysis.ga
+++ b/topics/transcriptomics/tutorials/ref-based/workflows/deg-analysis.ga
@@ -20,17 +20,17 @@
             "name": "Input dataset collection",
             "outputs": [],
             "position": {
-                "bottom": 293.6999969482422,
-                "height": 82.19999694824219,
-                "left": -590.5,
-                "right": -390.5,
-                "top": 211.5,
+                "bottom": 511.0625,
+                "height": 82.171875,
+                "left": -392.5,
+                "right": -192.5,
+                "top": 428.890625,
                 "width": 200,
-                "x": -590.5,
-                "y": 211.5
+                "x": -392.5,
+                "y": 428.890625
             },
             "tool_id": null,
-            "tool_state": "{\"optional\": false, \"collection_type\": \"list\"}",
+            "tool_state": "{\"optional\": false, \"tag\": null, \"collection_type\": \"list\"}",
             "tool_version": null,
             "type": "data_collection_input",
             "uuid": "7e7436a6-e408-4941-81c2-7a86c0c9235a",
@@ -45,27 +45,27 @@
             "inputs": [
                 {
                     "description": "",
-                    "name": "Drosophila_melanogaster.BDGP6.87.gtf"
+                    "name": "KEGG pathways to plot"
                 }
             ],
-            "label": "Drosophila_melanogaster.BDGP6.87.gtf",
+            "label": "KEGG pathways to plot",
             "name": "Input dataset",
             "outputs": [],
             "position": {
-                "bottom": 228.10000610351562,
-                "height": 102.60000610351562,
-                "left": 1077.5,
-                "right": 1277.5,
-                "top": 125.5,
+                "bottom": 110.0625,
+                "height": 82.171875,
+                "left": 1275.5,
+                "right": 1475.5,
+                "top": 27.890625,
                 "width": 200,
-                "x": 1077.5,
-                "y": 125.5
+                "x": 1275.5,
+                "y": 27.890625
             },
             "tool_id": null,
-            "tool_state": "{\"optional\": false}",
+            "tool_state": "{\"optional\": false, \"tag\": null}",
             "tool_version": null,
             "type": "data_input",
-            "uuid": "4f6df6ae-39ac-4a5e-98df-a0cb082a44fe",
+            "uuid": "1910edc3-5a7e-493b-8545-10cf0f78f7ba",
             "workflow_outputs": []
         },
         "2": {
@@ -77,27 +77,27 @@
             "inputs": [
                 {
                     "description": "",
-                    "name": "KEGG pathways to plot"
+                    "name": "Drosophila_melanogaster.BDGP6.87.gene_lengths"
                 }
             ],
-            "label": "KEGG pathways to plot",
+            "label": "Drosophila_melanogaster.BDGP6.87.gene_lengths",
             "name": "Input dataset",
             "outputs": [],
             "position": {
-                "bottom": -107.30000305175781,
-                "height": 82.19999694824219,
-                "left": 1077.5,
-                "right": 1277.5,
-                "top": -189.5,
+                "bottom": -164.546875,
+                "height": 102.5625,
+                "left": 1275.5,
+                "right": 1475.5,
+                "top": -267.109375,
                 "width": 200,
-                "x": 1077.5,
-                "y": -189.5
+                "x": 1275.5,
+                "y": -267.109375
             },
             "tool_id": null,
-            "tool_state": "{\"optional\": false}",
+            "tool_state": "{\"optional\": false, \"tag\": null}",
             "tool_version": null,
             "type": "data_input",
-            "uuid": "1910edc3-5a7e-493b-8545-10cf0f78f7ba",
+            "uuid": "7e28ac8c-f297-4235-a42d-341e1d53b8e9",
             "workflow_outputs": []
         },
         "3": {
@@ -109,27 +109,27 @@
             "inputs": [
                 {
                     "description": "",
-                    "name": "Drosophila_melanogaster.BDGP6.87.gene_lengths"
+                    "name": "Drosophila_melanogaster.BDGP6.87.gtf"
                 }
             ],
-            "label": "Drosophila_melanogaster.BDGP6.87.gene_lengths",
+            "label": "Drosophila_melanogaster.BDGP6.87.gtf",
             "name": "Input dataset",
             "outputs": [],
             "position": {
-                "bottom": -381.8999938964844,
-                "height": 102.60000610351562,
-                "left": 1077.5,
-                "right": 1277.5,
-                "top": -484.5,
+                "bottom": 445.453125,
+                "height": 102.5625,
+                "left": 1275.5,
+                "right": 1475.5,
+                "top": 342.890625,
                 "width": 200,
-                "x": 1077.5,
-                "y": -484.5
+                "x": 1275.5,
+                "y": 342.890625
             },
             "tool_id": null,
-            "tool_state": "{\"optional\": false}",
+            "tool_state": "{\"optional\": false, \"tag\": null}",
             "tool_version": null,
             "type": "data_input",
-            "uuid": "7e28ac8c-f297-4235-a42d-341e1d53b8e9",
+            "uuid": "4f6df6ae-39ac-4a5e-98df-a0cb082a44fe",
             "workflow_outputs": []
         },
         "4": {
@@ -148,17 +148,17 @@
             "name": "Input dataset",
             "outputs": [],
             "position": {
-                "bottom": 78.30000305175781,
-                "height": 61.80000305175781,
-                "left": 1355.5,
-                "right": 1555.5,
-                "top": 16.5,
+                "bottom": 295.671875,
+                "height": 61.78125,
+                "left": 1553.5,
+                "right": 1753.5,
+                "top": 233.890625,
                 "width": 200,
-                "x": 1355.5,
-                "y": 16.5
+                "x": 1553.5,
+                "y": 233.890625
             },
             "tool_id": null,
-            "tool_state": "{\"optional\": false}",
+            "tool_state": "{\"optional\": false, \"tag\": null}",
             "tool_version": null,
             "type": "data_input",
             "uuid": "1e56ca57-4228-46ff-9db8-bb13c939f976",
@@ -175,12 +175,7 @@
                     "output_name": "output"
                 }
             },
-            "inputs": [
-                {
-                    "description": "runtime parameter for tool Extract element identifiers",
-                    "name": "input_collection"
-                }
-            ],
+            "inputs": [],
             "label": "Extract samples' name",
             "name": "Extract element identifiers",
             "outputs": [
@@ -190,14 +185,14 @@
                 }
             ],
             "position": {
-                "bottom": 447.1000061035156,
-                "height": 113.60000610351562,
-                "left": -326.5,
-                "right": -126.5,
-                "top": 333.5,
+                "bottom": 664.453125,
+                "height": 113.5625,
+                "left": -128.5,
+                "right": 71.5,
+                "top": 550.890625,
                 "width": 200,
-                "x": -326.5,
-                "y": 333.5
+                "x": -128.5,
+                "y": 550.890625
             },
             "post_job_actions": {},
             "tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/collection_element_identifiers/collection_element_identifiers/0.0.2",
@@ -207,7 +202,7 @@
                 "owner": "iuc",
                 "tool_shed": "toolshed.g2.bx.psu.edu"
             },
-            "tool_state": "{\"input_collection\": {\"__class__\": \"RuntimeValue\"}, \"__page__\": null, \"__rerun_remap_job_id__\": null}",
+            "tool_state": "{\"input_collection\": {\"__class__\": \"ConnectedValue\"}, \"__page__\": null, \"__rerun_remap_job_id__\": null}",
             "tool_version": "0.0.2",
             "type": "tool",
             "uuid": "cd471d23-0d9e-4765-8b22-05d3ca227369",
@@ -215,7 +210,7 @@
                 {
                     "label": null,
                     "output_name": "output",
-                    "uuid": "ac26a882-dd0e-4e42-ba4d-205d0b58adfe"
+                    "uuid": "381625fd-c928-469d-a356-1d3ec2ba1eb4"
                 }
             ]
         },
@@ -226,7 +221,7 @@
             "id": 6,
             "input_connections": {
                 "input": {
-                    "id": 3,
+                    "id": 2,
                     "output_name": "output"
                 }
             },
@@ -240,14 +235,14 @@
                 }
             ],
             "position": {
-                "bottom": -375.8999938964844,
-                "height": 113.60000610351562,
-                "left": 1355.5,
-                "right": 1555.5,
-                "top": -489.5,
+                "bottom": -158.546875,
+                "height": 113.5625,
+                "left": 1553.5,
+                "right": 1753.5,
+                "top": -272.109375,
                 "width": 200,
-                "x": 1355.5,
-                "y": -489.5
+                "x": 1553.5,
+                "y": -272.109375
             },
             "post_job_actions": {},
             "tool_id": "ChangeCase",
@@ -259,7 +254,7 @@
                 {
                     "label": null,
                     "output_name": "out_file1",
-                    "uuid": "cb44a580-dfbd-44eb-b5a4-c23d20ffd135"
+                    "uuid": "a5d6ea05-fcc3-4801-9039-32d221beee2f"
                 }
             ]
         },
@@ -274,12 +269,7 @@
                     "output_name": "output"
                 }
             },
-            "inputs": [
-                {
-                    "description": "runtime parameter for tool Replace Text",
-                    "name": "infile"
-                }
-            ],
+            "inputs": [],
             "label": "Extract groups",
             "name": "Replace Text",
             "outputs": [
@@ -289,14 +279,14 @@
                 }
             ],
             "position": {
-                "bottom": 450.1000061035156,
-                "height": 113.60000610351562,
-                "left": -59.5,
-                "right": 140.5,
-                "top": 336.5,
+                "bottom": 667.453125,
+                "height": 113.5625,
+                "left": 138.5,
+                "right": 338.5,
+                "top": 553.890625,
                 "width": 200,
-                "x": -59.5,
-                "y": 336.5
+                "x": 138.5,
+                "y": 553.890625
             },
             "post_job_actions": {
                 "ChangeDatatypeActionoutfile": {
@@ -314,7 +304,7 @@
                 "owner": "bgruening",
                 "tool_shed": "toolshed.g2.bx.psu.edu"
             },
-            "tool_state": "{\"infile\": {\"__class__\": \"RuntimeValue\"}, \"replacements\": [{\"__index__\": 0, \"find_pattern\": \"(.*)_(.*)_(.*)\", \"replace_pattern\": \"\\\\1_\\\\2_\\\\3\\\\tgroup:\\\\2\\\\tgroup:\\\\3\"}], \"__page__\": null, \"__rerun_remap_job_id__\": null}",
+            "tool_state": "{\"infile\": {\"__class__\": \"ConnectedValue\"}, \"replacements\": [{\"__index__\": 0, \"find_pattern\": \"(.*)_(.*)_(.*)\", \"replace_pattern\": \"\\\\1_\\\\2_\\\\3\\\\tgroup:\\\\2\\\\tgroup:\\\\3\"}], \"__page__\": null, \"__rerun_remap_job_id__\": null}",
             "tool_version": "1.1.2",
             "type": "tool",
             "uuid": "42d65a53-4937-42d4-bfc5-49a7767da9b6",
@@ -322,7 +312,7 @@
                 {
                     "label": null,
                     "output_name": "outfile",
-                    "uuid": "1b187cdc-ac58-40de-821a-465675f294b9"
+                    "uuid": "0d18038b-86f5-4cb6-8b3c-4e711c8a4d32"
                 }
             ]
         },
@@ -351,14 +341,14 @@
                 }
             ],
             "position": {
-                "bottom": 378.3000030517578,
-                "height": 184.8000030517578,
-                "left": 243.5,
-                "right": 443.5,
-                "top": 193.5,
+                "bottom": 595.625,
+                "height": 184.734375,
+                "left": 441.5,
+                "right": 641.5,
+                "top": 410.890625,
                 "width": 200,
-                "x": 243.5,
-                "y": 193.5
+                "x": 441.5,
+                "y": 410.890625
             },
             "post_job_actions": {},
             "tool_id": "__TAG_FROM_FILE__",
@@ -370,7 +360,7 @@
                 {
                     "label": "input dataset(s) (Tagged)",
                     "output_name": "output",
-                    "uuid": "78241c39-ca9a-4fa0-957b-646fa75bc56c"
+                    "uuid": "28dbf589-e0e7-40dc-b76b-dc3f652520f4"
                 }
             ]
         },
@@ -412,14 +402,14 @@
                 }
             ],
             "position": {
-                "bottom": 521.2999877929688,
-                "height": 306.79998779296875,
-                "left": 521.5,
-                "right": 721.5,
-                "top": 214.5,
+                "bottom": 738.578125,
+                "height": 306.6875,
+                "left": 719.5,
+                "right": 919.5,
+                "top": 431.890625,
                 "width": 200,
-                "x": 521.5,
-                "y": 214.5
+                "x": 719.5,
+                "y": 431.890625
             },
             "post_job_actions": {},
             "tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/deseq2/deseq2/2.11.40.7+galaxy1",
@@ -429,77 +419,33 @@
                 "owner": "iuc",
                 "tool_shed": "toolshed.g2.bx.psu.edu"
             },
-            "tool_state": "{\"__input_ext\": \"tabular\", \"advanced_options\": {\"esf\": \"\", \"fit_type\": \"1\", \"outlier_replace_off\": \"false\", \"outlier_filter_off\": \"false\", \"auto_mean_filter_off\": \"false\"}, \"batch_factors\": null, \"header\": \"false\", \"output_options\": {\"output_selector\": [\"pdf\", \"normCounts\"], \"alpha_ma\": \"0.1\"}, \"select_data\": {\"how\": \"group_tags\", \"__current_case__\": 0, \"countsFile\": null, \"rep_factorName\": [{\"__index__\": 0, \"factorName\": \"Treatment\", \"rep_factorLevel\": [{\"__index__\": 0, \"factorLevel\": \"treated\", \"groups\": [\"treat\"]}, {\"__index__\": 1, \"factorLevel\": \"untreated\", \"groups\": [\"untreat\"]}]}, {\"__index__\": 1, \"factorName\": \"Sequencing\", \"rep_factorLevel\": [{\"__index__\": 0, \"factorLevel\": \"PE\", \"groups\": [\"paired\"]}, {\"__index__\": 1, \"factorLevel\": \"SE\", \"groups\": [\"single\"]}]}]}, \"tximport\": {\"tximport_selector\": \"count\", \"__current_case__\": 1}, \"__page__\": null, \"__rerun_remap_job_id__\": null}",
+            "tool_state": "{\"advanced_options\": {\"esf\": \"\", \"fit_type\": \"1\", \"outlier_replace_off\": \"false\", \"outlier_filter_off\": \"false\", \"auto_mean_filter_off\": \"false\"}, \"batch_factors\": {\"__class__\": \"RuntimeValue\"}, \"header\": \"false\", \"output_options\": {\"output_selector\": [\"pdf\", \"normCounts\"], \"alpha_ma\": \"0.1\"}, \"select_data\": {\"how\": \"group_tags\", \"__current_case__\": 0, \"countsFile\": {\"__class__\": \"RuntimeValue\"}, \"rep_factorName\": [{\"__index__\": 0, \"factorName\": \"Treatment\", \"rep_factorLevel\": [{\"__index__\": 0, \"factorLevel\": \"treated\", \"groups\": \"treat\\n\"}, {\"__index__\": 1, \"factorLevel\": \"untreated\", \"groups\": \"untreat\\n\"}]}, {\"__index__\": 1, \"factorName\": \"Sequencing\", \"rep_factorLevel\": [{\"__index__\": 0, \"factorLevel\": \"PE\", \"groups\": \"paired.counts\\n\"}, {\"__index__\": 1, \"factorLevel\": \"SE\", \"groups\": \"single.counts\\n\"}]}]}, \"tximport\": {\"tximport_selector\": \"count\", \"__current_case__\": 1}, \"__page__\": null, \"__rerun_remap_job_id__\": null}",
             "tool_version": "2.11.40.7+galaxy1",
             "type": "tool",
             "uuid": "45883538-b692-4e35-8dee-d08974682a9c",
             "workflow_outputs": [
                 {
-                    "label": "deseq_out",
-                    "output_name": "deseq_out",
-                    "uuid": "8b284d25-e98e-4807-9f05-33c23352f447"
-                },
-                {
                     "label": null,
                     "output_name": "counts_out",
-                    "uuid": "1f80c413-cd95-4166-a29a-d6ec386b06f3"
+                    "uuid": "55bfabaf-6f89-4d14-a0e6-0ed601601dbd"
+                },
+                {
+                    "label": "deseq_out",
+                    "output_name": "deseq_out",
+                    "uuid": "1ae60cf4-5fae-4855-8622-dee8adf8b8a3"
                 },
                 {
                     "label": null,
                     "output_name": "plots",
-                    "uuid": "ea528892-c2f9-4440-bd5c-49ba323fb63a"
+                    "uuid": "a39e4066-77c0-444a-9482-44c38a63ec68"
                 }
             ]
         },
         "10": {
             "annotation": "",
-            "content_id": "Filter1",
-            "errors": null,
-            "id": 10,
-            "input_connections": {
-                "input": {
-                    "id": 9,
-                    "output_name": "deseq_out"
-                }
-            },
-            "inputs": [],
-            "label": null,
-            "name": "Filter",
-            "outputs": [
-                {
-                    "name": "out_file1",
-                    "type": "input"
-                }
-            ],
-            "position": {
-                "bottom": 359.6999969482422,
-                "height": 93.19999694824219,
-                "left": 799.5,
-                "right": 999.5,
-                "top": 266.5,
-                "width": 200,
-                "x": 799.5,
-                "y": 266.5
-            },
-            "post_job_actions": {},
-            "tool_id": "Filter1",
-            "tool_state": "{\"__input_ext\": \"tabular\", \"chromInfo\": \"/opt/galaxy/tool-data/shared/ucsc/chrom/dm6.len\", \"cond\": \"c7 < 0.05\", \"header_lines\": \"0\", \"input\": {\"__class__\": \"ConnectedValue\"}, \"__page__\": null, \"__rerun_remap_job_id__\": null}",
-            "tool_version": "1.1.1",
-            "type": "tool",
-            "uuid": "9cf4c012-7a52-4b47-bbec-4ad8275542ea",
-            "workflow_outputs": [
-                {
-                    "label": null,
-                    "output_name": "out_file1",
-                    "uuid": "ce499182-bae2-4463-a29c-321bc8a45792"
-                }
-            ]
-        },
-        "11": {
-            "annotation": "",
             "content_id": "toolshed.g2.bx.psu.edu/repos/devteam/column_maker/Add_a_column1/1.6",
             "errors": null,
-            "id": 11,
+            "id": 10,
             "input_connections": {
                 "input": {
                     "id": 9,
@@ -516,14 +462,14 @@
                 }
             ],
             "position": {
-                "bottom": -234.3000030517578,
-                "height": 93.19999694824219,
-                "left": 799.5,
-                "right": 999.5,
-                "top": -327.5,
+                "bottom": -16.9375,
+                "height": 93.171875,
+                "left": 997.5,
+                "right": 1197.5,
+                "top": -110.109375,
                 "width": 200,
-                "x": 799.5,
-                "y": -327.5
+                "x": 997.5,
+                "y": -110.109375
             },
             "post_job_actions": {},
             "tool_id": "toolshed.g2.bx.psu.edu/repos/devteam/column_maker/Add_a_column1/1.6",
@@ -541,7 +487,51 @@
                 {
                     "label": null,
                     "output_name": "out_file1",
-                    "uuid": "bb893d13-0a2d-42ca-8ec9-0f042c4e1d1e"
+                    "uuid": "ef1534c5-2cdd-4cdf-93d4-a0c9d48bc5fd"
+                }
+            ]
+        },
+        "11": {
+            "annotation": "",
+            "content_id": "Filter1",
+            "errors": null,
+            "id": 11,
+            "input_connections": {
+                "input": {
+                    "id": 9,
+                    "output_name": "deseq_out"
+                }
+            },
+            "inputs": [],
+            "label": null,
+            "name": "Filter",
+            "outputs": [
+                {
+                    "name": "out_file1",
+                    "type": "input"
+                }
+            ],
+            "position": {
+                "bottom": 577.0625,
+                "height": 93.171875,
+                "left": 997.5,
+                "right": 1197.5,
+                "top": 483.890625,
+                "width": 200,
+                "x": 997.5,
+                "y": 483.890625
+            },
+            "post_job_actions": {},
+            "tool_id": "Filter1",
+            "tool_state": "{\"__input_ext\": \"tabular\", \"chromInfo\": \"/opt/galaxy/tool-data/shared/ucsc/chrom/dm6.len\", \"cond\": \"c7 < 0.05\", \"header_lines\": \"0\", \"input\": {\"__class__\": \"ConnectedValue\"}, \"__page__\": null, \"__rerun_remap_job_id__\": null}",
+            "tool_version": "1.1.1",
+            "type": "tool",
+            "uuid": "9cf4c012-7a52-4b47-bbec-4ad8275542ea",
+            "workflow_outputs": [
+                {
+                    "label": null,
+                    "output_name": "out_file1",
+                    "uuid": "0d857485-7122-4748-ae4a-09b0b2bc8a56"
                 }
             ]
         },
@@ -566,14 +556,14 @@
                 }
             ],
             "position": {
-                "bottom": 617.8999938964844,
-                "height": 170.39999389648438,
-                "left": 799.5,
-                "right": 999.5,
-                "top": 447.5,
+                "bottom": 835.234375,
+                "height": 170.34375,
+                "left": 997.5,
+                "right": 1197.5,
+                "top": 664.890625,
                 "width": 200,
-                "x": 799.5,
-                "y": 447.5
+                "x": 997.5,
+                "y": 664.890625
             },
             "post_job_actions": {},
             "tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/table_compute/table_compute/1.2.4+galaxy0",
@@ -591,7 +581,7 @@
                 {
                     "label": null,
                     "output_name": "table",
-                    "uuid": "c1e24b41-d56a-4606-9bc8-65c2b1307c80"
+                    "uuid": "f2b530ef-f155-42ff-a4dc-a652f91d9441"
                 }
             ]
         },
@@ -616,78 +606,34 @@
                 }
             ],
             "position": {
-                "bottom": 87.69999694824219,
-                "height": 93.19999694824219,
-                "left": 1077.5,
-                "right": 1277.5,
-                "top": -5.5,
+                "bottom": -16.9375,
+                "height": 93.171875,
+                "left": 1275.5,
+                "right": 1475.5,
+                "top": -110.109375,
                 "width": 200,
-                "x": 1077.5,
-                "y": -5.5
+                "x": 1275.5,
+                "y": -110.109375
             },
             "post_job_actions": {},
             "tool_id": "Cut1",
-            "tool_state": "{\"__input_ext\": \"tabular\", \"chromInfo\": \"/opt/galaxy/tool-data/shared/ucsc/chrom/dm6.len\", \"columnList\": \"c1,c3\", \"delimiter\": \"T\", \"input\": {\"__class__\": \"ConnectedValue\"}, \"__page__\": null, \"__rerun_remap_job_id__\": null}",
+            "tool_state": "{\"__input_ext\": \"tabular\", \"chromInfo\": \"/opt/galaxy/tool-data/shared/ucsc/chrom/dm6.len\", \"columnList\": \"c1,c8\", \"delimiter\": \"T\", \"input\": {\"__class__\": \"ConnectedValue\"}, \"__page__\": null, \"__rerun_remap_job_id__\": null}",
             "tool_version": "1.0.2",
             "type": "tool",
-            "uuid": "6c4d62a9-3f57-488d-8e8f-8809fdd12084",
+            "uuid": "711bdb93-d388-49fc-aab1-455095628805",
             "workflow_outputs": [
                 {
                     "label": null,
                     "output_name": "out_file1",
-                    "uuid": "f07d1bbe-4dec-4372-8ac7-0e6068c18916"
+                    "uuid": "b0dc6243-44d8-416e-a635-8f7d73159807"
                 }
             ]
         },
         "14": {
             "annotation": "",
-            "content_id": "Filter1",
-            "errors": null,
-            "id": 14,
-            "input_connections": {
-                "input": {
-                    "id": 10,
-                    "output_name": "out_file1"
-                }
-            },
-            "inputs": [],
-            "label": null,
-            "name": "Filter",
-            "outputs": [
-                {
-                    "name": "out_file1",
-                    "type": "input"
-                }
-            ],
-            "position": {
-                "bottom": 359.6999969482422,
-                "height": 93.19999694824219,
-                "left": 1077.5,
-                "right": 1277.5,
-                "top": 266.5,
-                "width": 200,
-                "x": 1077.5,
-                "y": 266.5
-            },
-            "post_job_actions": {},
-            "tool_id": "Filter1",
-            "tool_state": "{\"__input_ext\": \"tabular\", \"chromInfo\": \"/opt/galaxy/tool-data/shared/ucsc/chrom/dm6.len\", \"cond\": \"abs(c3)>1\", \"header_lines\": \"0\", \"input\": {\"__class__\": \"ConnectedValue\"}, \"__page__\": null, \"__rerun_remap_job_id__\": null}",
-            "tool_version": "1.1.1",
-            "type": "tool",
-            "uuid": "1f787252-7a94-43b6-bb66-9624923ed05c",
-            "workflow_outputs": [
-                {
-                    "label": null,
-                    "output_name": "out_file1",
-                    "uuid": "67275c4e-88a3-453a-bd27-8a8ce3a36ae9"
-                }
-            ]
-        },
-        "15": {
-            "annotation": "",
             "content_id": "Cut1",
             "errors": null,
-            "id": 15,
+            "id": 14,
             "input_connections": {
                 "input": {
                     "id": 11,
@@ -704,26 +650,70 @@
                 }
             ],
             "position": {
-                "bottom": -234.3000030517578,
-                "height": 93.19999694824219,
-                "left": 1077.5,
-                "right": 1277.5,
-                "top": -327.5,
+                "bottom": 305.0625,
+                "height": 93.171875,
+                "left": 1275.5,
+                "right": 1475.5,
+                "top": 211.890625,
                 "width": 200,
-                "x": 1077.5,
-                "y": -327.5
+                "x": 1275.5,
+                "y": 211.890625
             },
             "post_job_actions": {},
             "tool_id": "Cut1",
-            "tool_state": "{\"__input_ext\": \"tabular\", \"chromInfo\": \"/opt/galaxy/tool-data/shared/ucsc/chrom/dm6.len\", \"columnList\": \"c1,c8\", \"delimiter\": \"T\", \"input\": {\"__class__\": \"ConnectedValue\"}, \"__page__\": null, \"__rerun_remap_job_id__\": null}",
+            "tool_state": "{\"__input_ext\": \"tabular\", \"chromInfo\": \"/opt/galaxy/tool-data/shared/ucsc/chrom/dm6.len\", \"columnList\": \"c1,c3\", \"delimiter\": \"T\", \"input\": {\"__class__\": \"ConnectedValue\"}, \"__page__\": null, \"__rerun_remap_job_id__\": null}",
             "tool_version": "1.0.2",
             "type": "tool",
-            "uuid": "711bdb93-d388-49fc-aab1-455095628805",
+            "uuid": "6c4d62a9-3f57-488d-8e8f-8809fdd12084",
             "workflow_outputs": [
                 {
                     "label": null,
                     "output_name": "out_file1",
-                    "uuid": "36bf2367-3f8c-4439-9d35-f82f1dd90cce"
+                    "uuid": "d6649442-5662-4a19-98dc-1f2ef72615b1"
+                }
+            ]
+        },
+        "15": {
+            "annotation": "",
+            "content_id": "Filter1",
+            "errors": null,
+            "id": 15,
+            "input_connections": {
+                "input": {
+                    "id": 11,
+                    "output_name": "out_file1"
+                }
+            },
+            "inputs": [],
+            "label": null,
+            "name": "Filter",
+            "outputs": [
+                {
+                    "name": "out_file1",
+                    "type": "input"
+                }
+            ],
+            "position": {
+                "bottom": 577.0625,
+                "height": 93.171875,
+                "left": 1275.5,
+                "right": 1475.5,
+                "top": 483.890625,
+                "width": 200,
+                "x": 1275.5,
+                "y": 483.890625
+            },
+            "post_job_actions": {},
+            "tool_id": "Filter1",
+            "tool_state": "{\"__input_ext\": \"tabular\", \"chromInfo\": \"/opt/galaxy/tool-data/shared/ucsc/chrom/dm6.len\", \"cond\": \"abs(c3)>1\", \"header_lines\": \"0\", \"input\": {\"__class__\": \"ConnectedValue\"}, \"__page__\": null, \"__rerun_remap_job_id__\": null}",
+            "tool_version": "1.1.1",
+            "type": "tool",
+            "uuid": "1f787252-7a94-43b6-bb66-9624923ed05c",
+            "workflow_outputs": [
+                {
+                    "label": null,
+                    "output_name": "out_file1",
+                    "uuid": "40e3604b-aa27-43aa-91be-0e4d085c28bb"
                 }
             ]
         },
@@ -752,14 +742,14 @@
                 }
             ],
             "position": {
-                "bottom": 622.8999938964844,
-                "height": 180.39999389648438,
-                "left": 1077.5,
-                "right": 1277.5,
-                "top": 442.5,
+                "bottom": 840.234375,
+                "height": 180.34375,
+                "left": 1275.5,
+                "right": 1475.5,
+                "top": 659.890625,
                 "width": 200,
-                "x": 1077.5,
-                "y": 442.5
+                "x": 1275.5,
+                "y": 659.890625
             },
             "post_job_actions": {},
             "tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/table_compute/table_compute/1.2.4+galaxy0",
@@ -777,22 +767,66 @@
                 {
                     "label": "z_score",
                     "output_name": "table",
-                    "uuid": "b4a55296-9689-4fb9-a04b-cfe65132c092"
+                    "uuid": "95a46a53-eb81-4a77-9695-01872ad279fc"
                 }
             ]
         },
         "17": {
             "annotation": "",
-            "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/pathview/pathview/1.24.0+galaxy2",
+            "content_id": "ChangeCase",
             "errors": null,
             "id": 17,
             "input_connections": {
-                "gene_data|tabular": {
+                "input": {
                     "id": 13,
+                    "output_name": "out_file1"
+                }
+            },
+            "inputs": [],
+            "label": null,
+            "name": "Change Case",
+            "outputs": [
+                {
+                    "name": "out_file1",
+                    "type": "tabular"
+                }
+            ],
+            "position": {
+                "bottom": -6.546875,
+                "height": 113.5625,
+                "left": 1553.5,
+                "right": 1753.5,
+                "top": -120.109375,
+                "width": 200,
+                "x": 1553.5,
+                "y": -120.109375
+            },
+            "post_job_actions": {},
+            "tool_id": "ChangeCase",
+            "tool_state": "{\"__input_ext\": \"tabular\", \"casing\": \"up\", \"chromInfo\": \"/opt/galaxy/tool-data/shared/ucsc/chrom/dm6.len\", \"cols\": \"c1\", \"delimiter\": \"TAB\", \"input\": {\"__class__\": \"ConnectedValue\"}, \"__page__\": null, \"__rerun_remap_job_id__\": null}",
+            "tool_version": "1.0.0",
+            "type": "tool",
+            "uuid": "dbe396ed-f5f9-4310-a514-bac9d86ccf6d",
+            "workflow_outputs": [
+                {
+                    "label": null,
+                    "output_name": "out_file1",
+                    "uuid": "296a1e10-6451-477a-a2fb-54a1c84e91cd"
+                }
+            ]
+        },
+        "18": {
+            "annotation": "",
+            "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/pathview/pathview/1.24.0+galaxy2",
+            "errors": null,
+            "id": 18,
+            "input_connections": {
+                "gene_data|tabular": {
+                    "id": 14,
                     "output_name": "out_file1"
                 },
                 "pathway|tabular": {
-                    "id": 2,
+                    "id": 1,
                     "output_name": "output"
                 }
             },
@@ -806,14 +840,14 @@
                 }
             ],
             "position": {
-                "bottom": -21.100006103515625,
-                "height": 164.39999389648438,
-                "left": 1355.5,
-                "right": 1555.5,
-                "top": -185.5,
+                "bottom": 196.234375,
+                "height": 164.34375,
+                "left": 1553.5,
+                "right": 1753.5,
+                "top": 31.890625,
                 "width": 200,
-                "x": 1355.5,
-                "y": -185.5
+                "x": 1553.5,
+                "y": 31.890625
             },
             "post_job_actions": {},
             "tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/pathview/pathview/1.24.0+galaxy2",
@@ -831,22 +865,22 @@
                 {
                     "label": null,
                     "output_name": "multiple_kegg_native",
-                    "uuid": "8e314c37-3ca7-4164-842a-495ae6c76576"
+                    "uuid": "cc052bab-f350-42ba-8a9f-547ae55f8df0"
                 }
             ]
         },
-        "18": {
+        "19": {
             "annotation": "",
             "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/deg_annotate/deg_annotate/1.1.0",
             "errors": null,
-            "id": 18,
+            "id": 19,
             "input_connections": {
                 "annotation": {
-                    "id": 1,
+                    "id": 3,
                     "output_name": "output"
                 },
                 "input_table": {
-                    "id": 14,
+                    "id": 15,
                     "output_name": "out_file1"
                 }
             },
@@ -860,14 +894,14 @@
                 }
             ],
             "position": {
-                "bottom": 403.29998779296875,
-                "height": 286.79998779296875,
-                "left": 1355.5,
-                "right": 1555.5,
-                "top": 116.5,
+                "bottom": 620.578125,
+                "height": 286.6875,
+                "left": 1553.5,
+                "right": 1753.5,
+                "top": 333.890625,
                 "width": 200,
-                "x": 1355.5,
-                "y": 116.5
+                "x": 1553.5,
+                "y": 333.890625
             },
             "post_job_actions": {},
             "tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/deg_annotate/deg_annotate/1.1.0",
@@ -885,116 +919,18 @@
                 {
                     "label": null,
                     "output_name": "output",
-                    "uuid": "c18f9fe5-8fee-443d-ad90-9ba15b5d3da2"
-                }
-            ]
-        },
-        "19": {
-            "annotation": "",
-            "content_id": "ChangeCase",
-            "errors": null,
-            "id": 19,
-            "input_connections": {
-                "input": {
-                    "id": 15,
-                    "output_name": "out_file1"
-                }
-            },
-            "inputs": [],
-            "label": null,
-            "name": "Change Case",
-            "outputs": [
-                {
-                    "name": "out_file1",
-                    "type": "tabular"
-                }
-            ],
-            "position": {
-                "bottom": -223.89999389648438,
-                "height": 113.60000610351562,
-                "left": 1355.5,
-                "right": 1555.5,
-                "top": -337.5,
-                "width": 200,
-                "x": 1355.5,
-                "y": -337.5
-            },
-            "post_job_actions": {},
-            "tool_id": "ChangeCase",
-            "tool_state": "{\"__input_ext\": \"tabular\", \"casing\": \"up\", \"chromInfo\": \"/opt/galaxy/tool-data/shared/ucsc/chrom/dm6.len\", \"cols\": \"c1\", \"delimiter\": \"TAB\", \"input\": {\"__class__\": \"ConnectedValue\"}, \"__page__\": null, \"__rerun_remap_job_id__\": null}",
-            "tool_version": "1.0.0",
-            "type": "tool",
-            "uuid": "dbe396ed-f5f9-4310-a514-bac9d86ccf6d",
-            "workflow_outputs": [
-                {
-                    "label": null,
-                    "output_name": "out_file1",
-                    "uuid": "c0693129-cf5a-450c-bb86-e96d4bae8643"
+                    "uuid": "02c4b2ac-fe88-49f1-9654-e1515341d843"
                 }
             ]
         },
         "20": {
             "annotation": "",
-            "content_id": "toolshed.g2.bx.psu.edu/repos/bgruening/text_processing/tp_cat/0.1.1",
+            "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/goseq/goseq/1.44.0+galaxy0",
             "errors": null,
             "id": 20,
             "input_connections": {
-                "inputs": {
-                    "id": 4,
-                    "output_name": "output"
-                },
-                "queries_0|inputs2": {
-                    "id": 18,
-                    "output_name": "output"
-                }
-            },
-            "inputs": [],
-            "label": null,
-            "name": "Concatenate datasets",
-            "outputs": [
-                {
-                    "name": "out_file1",
-                    "type": "input"
-                }
-            ],
-            "position": {
-                "bottom": 305.5,
-                "height": 144,
-                "left": 1643.5,
-                "right": 1843.5,
-                "top": 161.5,
-                "width": 200,
-                "x": 1643.5,
-                "y": 161.5
-            },
-            "post_job_actions": {},
-            "tool_id": "toolshed.g2.bx.psu.edu/repos/bgruening/text_processing/tp_cat/0.1.1",
-            "tool_shed_repository": {
-                "changeset_revision": "f46f0e4f75c4",
-                "name": "text_processing",
-                "owner": "bgruening",
-                "tool_shed": "toolshed.g2.bx.psu.edu"
-            },
-            "tool_state": "{\"__input_ext\": \"tabular\", \"chromInfo\": \"/opt/galaxy/tool-data/shared/ucsc/chrom/dm6.len\", \"inputs\": {\"__class__\": \"ConnectedValue\"}, \"queries\": [{\"__index__\": 0, \"inputs2\": {\"__class__\": \"ConnectedValue\"}}], \"__page__\": null, \"__rerun_remap_job_id__\": null}",
-            "tool_version": "0.1.1",
-            "type": "tool",
-            "uuid": "5aca8071-b7e2-48b6-ba2e-ef258852578c",
-            "workflow_outputs": [
-                {
-                    "label": null,
-                    "output_name": "out_file1",
-                    "uuid": "1e2d1fe6-0283-47db-9bad-2fd7015786be"
-                }
-            ]
-        },
-        "21": {
-            "annotation": "",
-            "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/goseq/goseq/1.44.0+galaxy0",
-            "errors": null,
-            "id": 21,
-            "input_connections": {
                 "dge_file": {
-                    "id": 19,
+                    "id": 17,
                     "output_name": "out_file1"
                 },
                 "length_file": {
@@ -1016,14 +952,14 @@
                 }
             ],
             "position": {
-                "bottom": 108.10000610351562,
-                "height": 235.60000610351562,
-                "left": 1643.5,
-                "right": 1843.5,
-                "top": -127.5,
+                "bottom": 325.40625,
+                "height": 235.515625,
+                "left": 1841.5,
+                "right": 2041.5,
+                "top": 89.890625,
                 "width": 200,
-                "x": 1643.5,
-                "y": -127.5
+                "x": 1841.5,
+                "y": 89.890625
             },
             "post_job_actions": {},
             "tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/goseq/goseq/1.44.0+galaxy0",
@@ -1039,25 +975,25 @@
             "uuid": "4321eeeb-3486-4b8a-bf4d-15b43462f7bb",
             "workflow_outputs": [
                 {
-                    "label": "kegg_pathways",
-                    "output_name": "wallenius_tab",
-                    "uuid": "8a3422d4-fcff-48a6-9e9a-5b8829606f63"
-                },
-                {
                     "label": null,
                     "output_name": "cat_genes_tab",
-                    "uuid": "83a61305-a9da-443e-a541-ccb951c23ad2"
+                    "uuid": "a84ba5d9-0f4a-484c-9d33-1f18e6937f1f"
+                },
+                {
+                    "label": "kegg_pathways",
+                    "output_name": "wallenius_tab",
+                    "uuid": "a61a3495-b46e-4158-81c2-a2a74f9156e8"
                 }
             ]
         },
-        "22": {
+        "21": {
             "annotation": "",
             "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/goseq/goseq/1.44.0+galaxy0",
             "errors": null,
-            "id": 22,
+            "id": 21,
             "input_connections": {
                 "dge_file": {
-                    "id": 19,
+                    "id": 17,
                     "output_name": "out_file1"
                 },
                 "length_file": {
@@ -1083,14 +1019,14 @@
                 }
             ],
             "position": {
-                "bottom": -165.29998779296875,
-                "height": 327.20001220703125,
-                "left": 1643.5,
-                "right": 1843.5,
-                "top": -492.5,
+                "bottom": 51.96875,
+                "height": 327.078125,
+                "left": 1841.5,
+                "right": 2041.5,
+                "top": -275.109375,
                 "width": 200,
-                "x": 1643.5,
-                "y": -492.5
+                "x": 1841.5,
+                "y": -275.109375
             },
             "post_job_actions": {},
             "tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/goseq/goseq/1.44.0+galaxy0",
@@ -1107,77 +1043,83 @@
             "workflow_outputs": [
                 {
                     "label": null,
+                    "output_name": "cat_genes_tab",
+                    "uuid": "d90f3bdd-d92f-4637-b581-8cfaacb234c1"
+                },
+                {
+                    "label": null,
                     "output_name": "top_plot",
-                    "uuid": "22dbbc68-a957-4e08-9955-9a0e4b2359c7"
+                    "uuid": "98000f56-4626-4087-8b55-a04d9d7532e5"
                 },
                 {
                     "label": "go_terms",
                     "output_name": "wallenius_tab",
-                    "uuid": "a6d0f76e-8bd2-4039-9da0-4a4956ba8d94"
+                    "uuid": "0480840d-705f-44fe-a560-ce5ad0026a98"
+                }
+            ]
+        },
+        "22": {
+            "annotation": "",
+            "content_id": "toolshed.g2.bx.psu.edu/repos/bgruening/text_processing/tp_cat/0.1.1",
+            "errors": null,
+            "id": 22,
+            "input_connections": {
+                "inputs": {
+                    "id": 4,
+                    "output_name": "output"
                 },
+                "queries_0|inputs2": {
+                    "id": 19,
+                    "output_name": "output"
+                }
+            },
+            "inputs": [],
+            "label": null,
+            "name": "Concatenate datasets",
+            "outputs": [
+                {
+                    "name": "out_file1",
+                    "type": "input"
+                }
+            ],
+            "position": {
+                "bottom": 522.84375,
+                "height": 143.953125,
+                "left": 1841.5,
+                "right": 2041.5,
+                "top": 378.890625,
+                "width": 200,
+                "x": 1841.5,
+                "y": 378.890625
+            },
+            "post_job_actions": {},
+            "tool_id": "toolshed.g2.bx.psu.edu/repos/bgruening/text_processing/tp_cat/0.1.1",
+            "tool_shed_repository": {
+                "changeset_revision": "f46f0e4f75c4",
+                "name": "text_processing",
+                "owner": "bgruening",
+                "tool_shed": "toolshed.g2.bx.psu.edu"
+            },
+            "tool_state": "{\"__input_ext\": \"tabular\", \"chromInfo\": \"/opt/galaxy/tool-data/shared/ucsc/chrom/dm6.len\", \"inputs\": {\"__class__\": \"ConnectedValue\"}, \"queries\": [{\"__index__\": 0, \"inputs2\": {\"__class__\": \"ConnectedValue\"}}], \"__page__\": null, \"__rerun_remap_job_id__\": null}",
+            "tool_version": "0.1.1",
+            "type": "tool",
+            "uuid": "5aca8071-b7e2-48b6-ba2e-ef258852578c",
+            "workflow_outputs": [
                 {
                     "label": null,
-                    "output_name": "cat_genes_tab",
-                    "uuid": "964338a0-7425-4b51-ae1c-fe8528630620"
+                    "output_name": "out_file1",
+                    "uuid": "a0b9f482-e58f-43e0-a2eb-a7a20788321e"
                 }
             ]
         },
         "23": {
             "annotation": "",
-            "content_id": "join1",
+            "content_id": "Filter1",
             "errors": null,
             "id": 23,
             "input_connections": {
-                "input1": {
-                    "id": 9,
-                    "output_name": "counts_out"
-                },
-                "input2": {
-                    "id": 20,
-                    "output_name": "out_file1"
-                }
-            },
-            "inputs": [],
-            "label": null,
-            "name": "Join two Datasets",
-            "outputs": [
-                {
-                    "name": "out_file1",
-                    "type": "tabular"
-                }
-            ],
-            "position": {
-                "bottom": 467.5,
-                "height": 144,
-                "left": 1921.5,
-                "right": 2121.5,
-                "top": 323.5,
-                "width": 200,
-                "x": 1921.5,
-                "y": 323.5
-            },
-            "post_job_actions": {},
-            "tool_id": "join1",
-            "tool_state": "{\"__input_ext\": \"tabular\", \"chromInfo\": \"/opt/galaxy/tool-data/shared/ucsc/chrom/dm6.len\", \"field1\": \"1\", \"field2\": \"1\", \"fill_empty_columns\": {\"fill_empty_columns_switch\": \"no_fill\", \"__current_case__\": 0}, \"header\": \"-H\", \"input1\": {\"__class__\": \"ConnectedValue\"}, \"input2\": {\"__class__\": \"ConnectedValue\"}, \"partial\": \"\", \"unmatched\": \"\", \"__page__\": null, \"__rerun_remap_job_id__\": null}",
-            "tool_version": "2.1.3",
-            "type": "tool",
-            "uuid": "672e150d-ae77-41ae-9b66-2c3bf55bc701",
-            "workflow_outputs": [
-                {
-                    "label": null,
-                    "output_name": "out_file1",
-                    "uuid": "ac42c5ff-d84f-4aba-9710-0610fbc1cef6"
-                }
-            ]
-        },
-        "24": {
-            "annotation": "",
-            "content_id": "Filter1",
-            "errors": null,
-            "id": 24,
-            "input_connections": {
                 "input": {
-                    "id": 21,
+                    "id": 20,
                     "output_name": "wallenius_tab"
                 }
             },
@@ -1191,14 +1133,14 @@
                 }
             ],
             "position": {
-                "bottom": 55.69999694824219,
-                "height": 93.19999694824219,
-                "left": 1921.5,
-                "right": 2121.5,
-                "top": -37.5,
+                "bottom": 273.0625,
+                "height": 93.171875,
+                "left": 2119.5,
+                "right": 2319.5,
+                "top": 179.890625,
                 "width": 200,
-                "x": 1921.5,
-                "y": -37.5
+                "x": 2119.5,
+                "y": 179.890625
             },
             "post_job_actions": {},
             "tool_id": "Filter1",
@@ -1210,7 +1152,51 @@
                 {
                     "label": null,
                     "output_name": "out_file1",
-                    "uuid": "9bde6c32-1193-48e0-a16e-143c75dc590c"
+                    "uuid": "e3c724bc-d49c-43a6-9f7e-7455b6a1c427"
+                }
+            ]
+        },
+        "24": {
+            "annotation": "",
+            "content_id": "Filter1",
+            "errors": null,
+            "id": 24,
+            "input_connections": {
+                "input": {
+                    "id": 20,
+                    "output_name": "wallenius_tab"
+                }
+            },
+            "inputs": [],
+            "label": null,
+            "name": "Filter",
+            "outputs": [
+                {
+                    "name": "out_file1",
+                    "type": "input"
+                }
+            ],
+            "position": {
+                "bottom": 404.0625,
+                "height": 93.171875,
+                "left": 2119.5,
+                "right": 2319.5,
+                "top": 310.890625,
+                "width": 200,
+                "x": 2119.5,
+                "y": 310.890625
+            },
+            "post_job_actions": {},
+            "tool_id": "Filter1",
+            "tool_state": "{\"__input_ext\": \"tabular\", \"chromInfo\": \"/opt/galaxy/tool-data/shared/ucsc/chrom/dm6.len\", \"cond\": \"c6<0.05\", \"header_lines\": \"0\", \"input\": {\"__class__\": \"ConnectedValue\"}, \"__page__\": null, \"__rerun_remap_job_id__\": null}",
+            "tool_version": "1.1.1",
+            "type": "tool",
+            "uuid": "227ef320-a0ab-4f25-ba28-ca1182d95ab1",
+            "workflow_outputs": [
+                {
+                    "label": null,
+                    "output_name": "out_file1",
+                    "uuid": "8d7ca29c-0326-4ebb-bb5f-a4cffc150455"
                 }
             ]
         },
@@ -1235,58 +1221,14 @@
                 }
             ],
             "position": {
-                "bottom": 186.6999969482422,
-                "height": 93.19999694824219,
-                "left": 1921.5,
-                "right": 2121.5,
-                "top": 93.5,
+                "bottom": 66.0625,
+                "height": 93.171875,
+                "left": 2119.5,
+                "right": 2319.5,
+                "top": -27.109375,
                 "width": 200,
-                "x": 1921.5,
-                "y": 93.5
-            },
-            "post_job_actions": {},
-            "tool_id": "Filter1",
-            "tool_state": "{\"__input_ext\": \"tabular\", \"chromInfo\": \"/opt/galaxy/tool-data/shared/ucsc/chrom/dm6.len\", \"cond\": \"c6<0.05\", \"header_lines\": \"0\", \"input\": {\"__class__\": \"ConnectedValue\"}, \"__page__\": null, \"__rerun_remap_job_id__\": null}",
-            "tool_version": "1.1.1",
-            "type": "tool",
-            "uuid": "227ef320-a0ab-4f25-ba28-ca1182d95ab1",
-            "workflow_outputs": [
-                {
-                    "label": null,
-                    "output_name": "out_file1",
-                    "uuid": "7abad748-cd1c-461b-82e5-ddbc0cd82e4d"
-                }
-            ]
-        },
-        "26": {
-            "annotation": "",
-            "content_id": "Filter1",
-            "errors": null,
-            "id": 26,
-            "input_connections": {
-                "input": {
-                    "id": 22,
-                    "output_name": "wallenius_tab"
-                }
-            },
-            "inputs": [],
-            "label": null,
-            "name": "Filter",
-            "outputs": [
-                {
-                    "name": "out_file1",
-                    "type": "input"
-                }
-            ],
-            "position": {
-                "bottom": -151.3000030517578,
-                "height": 93.19999694824219,
-                "left": 1921.5,
-                "right": 2121.5,
-                "top": -244.5,
-                "width": 200,
-                "x": 1921.5,
-                "y": -244.5
+                "x": 2119.5,
+                "y": -27.109375
             },
             "post_job_actions": {},
             "tool_id": "Filter1",
@@ -1298,18 +1240,18 @@
                 {
                     "label": null,
                     "output_name": "out_file1",
-                    "uuid": "83e91cc5-a2f4-45e0-814a-631310dcff37"
+                    "uuid": "a2df9285-44bf-4f30-9b86-086b8711175b"
                 }
             ]
         },
-        "27": {
+        "26": {
             "annotation": "",
             "content_id": "Filter1",
             "errors": null,
-            "id": 27,
+            "id": 26,
             "input_connections": {
                 "input": {
-                    "id": 22,
+                    "id": 21,
                     "output_name": "wallenius_tab"
                 }
             },
@@ -1323,14 +1265,14 @@
                 }
             ],
             "position": {
-                "bottom": -282.3000030517578,
-                "height": 93.19999694824219,
-                "left": 1921.5,
-                "right": 2121.5,
-                "top": -375.5,
+                "bottom": -64.9375,
+                "height": 93.171875,
+                "left": 2119.5,
+                "right": 2319.5,
+                "top": -158.109375,
                 "width": 200,
-                "x": 1921.5,
-                "y": -375.5
+                "x": 2119.5,
+                "y": -158.109375
             },
             "post_job_actions": {},
             "tool_id": "Filter1",
@@ -1342,24 +1284,28 @@
                 {
                     "label": null,
                     "output_name": "out_file1",
-                    "uuid": "14022419-2a23-448a-9f29-80bca8bbff24"
+                    "uuid": "28a8df17-70e2-4d63-abdc-ab6a6328aa02"
                 }
             ]
         },
-        "28": {
+        "27": {
             "annotation": "",
-            "content_id": "Cut1",
+            "content_id": "join1",
             "errors": null,
-            "id": 28,
+            "id": 27,
             "input_connections": {
-                "input": {
-                    "id": 23,
+                "input1": {
+                    "id": 9,
+                    "output_name": "counts_out"
+                },
+                "input2": {
+                    "id": 22,
                     "output_name": "out_file1"
                 }
             },
             "inputs": [],
             "label": null,
-            "name": "Cut",
+            "name": "Join two Datasets",
             "outputs": [
                 {
                     "name": "out_file1",
@@ -1367,26 +1313,70 @@
                 }
             ],
             "position": {
-                "bottom": 441.6999969482422,
-                "height": 93.19999694824219,
-                "left": 2199.5,
-                "right": 2399.5,
-                "top": 348.5,
+                "bottom": 684.84375,
+                "height": 143.953125,
+                "left": 2119.5,
+                "right": 2319.5,
+                "top": 540.890625,
                 "width": 200,
-                "x": 2199.5,
-                "y": 348.5
+                "x": 2119.5,
+                "y": 540.890625
             },
             "post_job_actions": {},
-            "tool_id": "Cut1",
-            "tool_state": "{\"__input_ext\": \"tabular\", \"chromInfo\": \"/opt/galaxy/tool-data/shared/ucsc/chrom/dm6.len\", \"columnList\": \"c1-c8\", \"delimiter\": \"T\", \"input\": {\"__class__\": \"ConnectedValue\"}, \"__page__\": null, \"__rerun_remap_job_id__\": null}",
-            "tool_version": "1.0.2",
+            "tool_id": "join1",
+            "tool_state": "{\"__input_ext\": \"tabular\", \"chromInfo\": \"/opt/galaxy/tool-data/shared/ucsc/chrom/dm6.len\", \"field1\": \"1\", \"field2\": \"1\", \"fill_empty_columns\": {\"fill_empty_columns_switch\": \"no_fill\", \"__current_case__\": 0}, \"header\": \"-H\", \"input1\": {\"__class__\": \"ConnectedValue\"}, \"input2\": {\"__class__\": \"ConnectedValue\"}, \"partial\": \"\", \"unmatched\": \"\", \"__page__\": null, \"__rerun_remap_job_id__\": null}",
+            "tool_version": "2.1.3",
             "type": "tool",
-            "uuid": "699a7dd8-e3d0-42b9-bf2d-02e92d208c14",
+            "uuid": "672e150d-ae77-41ae-9b66-2c3bf55bc701",
             "workflow_outputs": [
                 {
                     "label": null,
                     "output_name": "out_file1",
-                    "uuid": "3d49bce3-68bc-4c1c-bc98-79cfc12d67fc"
+                    "uuid": "fb844dfb-9177-4923-92b3-3daf4af25349"
+                }
+            ]
+        },
+        "28": {
+            "annotation": "",
+            "content_id": "Grouping1",
+            "errors": null,
+            "id": 28,
+            "input_connections": {
+                "input1": {
+                    "id": 25,
+                    "output_name": "out_file1"
+                }
+            },
+            "inputs": [],
+            "label": null,
+            "name": "Group",
+            "outputs": [
+                {
+                    "name": "out_file1",
+                    "type": "tabular"
+                }
+            ],
+            "position": {
+                "bottom": 85.0625,
+                "height": 93.171875,
+                "left": 2397.5,
+                "right": 2597.5,
+                "top": -8.109375,
+                "width": 200,
+                "x": 2397.5,
+                "y": -8.109375
+            },
+            "post_job_actions": {},
+            "tool_id": "Grouping1",
+            "tool_state": "{\"__input_ext\": \"tabular\", \"chromInfo\": \"/opt/galaxy/tool-data/shared/ucsc/chrom/dm6.len\", \"groupcol\": \"7\", \"ignorecase\": \"false\", \"ignorelines\": null, \"input1\": {\"__class__\": \"ConnectedValue\"}, \"operations\": [{\"__index__\": 0, \"optype\": \"length\", \"opcol\": \"1\", \"opround\": \"no\", \"opdefault\": null}], \"__page__\": null, \"__rerun_remap_job_id__\": null}",
+            "tool_version": "2.1.4",
+            "type": "tool",
+            "uuid": "ef6f7670-e427-4244-9ce9-c42cee9e6c8c",
+            "workflow_outputs": [
+                {
+                    "label": null,
+                    "output_name": "out_file1",
+                    "uuid": "9b20a55a-9308-440d-b526-e0a2299d0f86"
                 }
             ]
         },
@@ -1411,58 +1401,14 @@
                 }
             ],
             "position": {
-                "bottom": -132.3000030517578,
-                "height": 93.19999694824219,
-                "left": 2199.5,
-                "right": 2399.5,
-                "top": -225.5,
+                "bottom": -45.9375,
+                "height": 93.171875,
+                "left": 2397.5,
+                "right": 2597.5,
+                "top": -139.109375,
                 "width": 200,
-                "x": 2199.5,
-                "y": -225.5
-            },
-            "post_job_actions": {},
-            "tool_id": "Grouping1",
-            "tool_state": "{\"__input_ext\": \"tabular\", \"chromInfo\": \"/opt/galaxy/tool-data/shared/ucsc/chrom/dm6.len\", \"groupcol\": \"7\", \"ignorecase\": \"false\", \"ignorelines\": null, \"input1\": {\"__class__\": \"ConnectedValue\"}, \"operations\": [{\"__index__\": 0, \"optype\": \"length\", \"opcol\": \"1\", \"opround\": \"no\", \"opdefault\": null}], \"__page__\": null, \"__rerun_remap_job_id__\": null}",
-            "tool_version": "2.1.4",
-            "type": "tool",
-            "uuid": "ef6f7670-e427-4244-9ce9-c42cee9e6c8c",
-            "workflow_outputs": [
-                {
-                    "label": null,
-                    "output_name": "out_file1",
-                    "uuid": "29d0852e-1004-4a16-b7ef-129c9eb67ee5"
-                }
-            ]
-        },
-        "30": {
-            "annotation": "",
-            "content_id": "Grouping1",
-            "errors": null,
-            "id": 30,
-            "input_connections": {
-                "input1": {
-                    "id": 27,
-                    "output_name": "out_file1"
-                }
-            },
-            "inputs": [],
-            "label": null,
-            "name": "Group",
-            "outputs": [
-                {
-                    "name": "out_file1",
-                    "type": "tabular"
-                }
-            ],
-            "position": {
-                "bottom": -263.3000030517578,
-                "height": 93.19999694824219,
-                "left": 2199.5,
-                "right": 2399.5,
-                "top": -356.5,
-                "width": 200,
-                "x": 2199.5,
-                "y": -356.5
+                "x": 2397.5,
+                "y": -139.109375
             },
             "post_job_actions": {},
             "tool_id": "Grouping1",
@@ -1474,7 +1420,51 @@
                 {
                     "label": null,
                     "output_name": "out_file1",
-                    "uuid": "86ddb508-8251-43e8-a7fc-3dc3c1ae32f1"
+                    "uuid": "757fa7f3-3582-4edc-a94b-31b499bb3d99"
+                }
+            ]
+        },
+        "30": {
+            "annotation": "",
+            "content_id": "Cut1",
+            "errors": null,
+            "id": 30,
+            "input_connections": {
+                "input": {
+                    "id": 27,
+                    "output_name": "out_file1"
+                }
+            },
+            "inputs": [],
+            "label": null,
+            "name": "Cut",
+            "outputs": [
+                {
+                    "name": "out_file1",
+                    "type": "tabular"
+                }
+            ],
+            "position": {
+                "bottom": 659.0625,
+                "height": 93.171875,
+                "left": 2397.5,
+                "right": 2597.5,
+                "top": 565.890625,
+                "width": 200,
+                "x": 2397.5,
+                "y": 565.890625
+            },
+            "post_job_actions": {},
+            "tool_id": "Cut1",
+            "tool_state": "{\"__input_ext\": \"tabular\", \"chromInfo\": \"/opt/galaxy/tool-data/shared/ucsc/chrom/dm6.len\", \"columnList\": \"c1-c8\", \"delimiter\": \"T\", \"input\": {\"__class__\": \"ConnectedValue\"}, \"__page__\": null, \"__rerun_remap_job_id__\": null}",
+            "tool_version": "1.0.2",
+            "type": "tool",
+            "uuid": "699a7dd8-e3d0-42b9-bf2d-02e92d208c14",
+            "workflow_outputs": [
+                {
+                    "label": null,
+                    "output_name": "out_file1",
+                    "uuid": "22a8a71f-66ee-423e-98cf-1d86f0cde769"
                 }
             ]
         },
@@ -1485,7 +1475,7 @@
             "id": 31,
             "input_connections": {
                 "input1": {
-                    "id": 28,
+                    "id": 30,
                     "output_name": "out_file1"
                 }
             },
@@ -1499,14 +1489,14 @@
                 }
             ],
             "position": {
-                "bottom": 501.8999938964844,
-                "height": 154.39999389648438,
-                "left": 2477.5,
-                "right": 2677.5,
-                "top": 347.5,
+                "bottom": 719.234375,
+                "height": 154.34375,
+                "left": 2675.5,
+                "right": 2875.5,
+                "top": 564.890625,
                 "width": 200,
-                "x": 2477.5,
-                "y": 347.5
+                "x": 2675.5,
+                "y": 564.890625
             },
             "post_job_actions": {},
             "tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/ggplot2_heatmap2/ggplot2_heatmap2/3.1.1+galaxy1",
@@ -1524,7 +1514,7 @@
                 {
                     "label": null,
                     "output_name": "output1",
-                    "uuid": "0c8b82b4-47fd-48ec-9bd3-03435d04bac2"
+                    "uuid": "d54b19c1-90e8-4d9c-8988-7ac2466966b9"
                 }
             ]
         },
@@ -1535,7 +1525,7 @@
             "id": 32,
             "input_connections": {
                 "input1": {
-                    "id": 28,
+                    "id": 30,
                     "output_name": "out_file1"
                 }
             },
@@ -1549,14 +1539,14 @@
                 }
             ],
             "position": {
-                "bottom": 693.8999938964844,
-                "height": 154.39999389648438,
-                "left": 2477.5,
-                "right": 2677.5,
-                "top": 539.5,
+                "bottom": 911.234375,
+                "height": 154.34375,
+                "left": 2675.5,
+                "right": 2875.5,
+                "top": 756.890625,
                 "width": 200,
-                "x": 2477.5,
-                "y": 539.5
+                "x": 2675.5,
+                "y": 756.890625
             },
             "post_job_actions": {},
             "tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/ggplot2_heatmap2/ggplot2_heatmap2/3.1.1+galaxy1",
@@ -1574,7 +1564,7 @@
                 {
                     "label": null,
                     "output_name": "output1",
-                    "uuid": "e78a8fbb-3a69-4d20-83db-833c307e55ec"
+                    "uuid": "6ac2cb11-75b4-4127-b8e1-ac723f7a4256"
                 }
             ]
         }
@@ -1582,6 +1572,6 @@
     "tags": [
         "transcriptomics"
     ],
-    "uuid": "26cf9fa6-a927-4545-afea-82f5f6ca0ae1",
-    "version": 5
+    "uuid": "0b79cb37-2648-4024-ad78-614d99cf5698",
+    "version": 1
 }

--- a/topics/transcriptomics/tutorials/ref-based/workflows/deg-analysis.ga
+++ b/topics/transcriptomics/tutorials/ref-based/workflows/deg-analysis.ga
@@ -20,14 +20,14 @@
             "name": "Input dataset collection",
             "outputs": [],
             "position": {
-                "bottom": 511.0625,
-                "height": 82.171875,
-                "left": -392.5,
-                "right": -192.5,
-                "top": 428.890625,
-                "width": 200,
-                "x": -392.5,
-                "y": 428.890625
+                "bottom": 751.3229215251865,
+                "height": 55.05517578125,
+                "left": -350.75865788246267,
+                "right": -216.75862736488455,
+                "top": 696.2677457439365,
+                "width": 134.00003051757812,
+                "x": -350.75865788246267,
+                "y": 696.2677457439365
             },
             "tool_id": null,
             "tool_state": "{\"optional\": false, \"tag\": null, \"collection_type\": \"list\"}",
@@ -45,27 +45,27 @@
             "inputs": [
                 {
                     "description": "",
-                    "name": "KEGG pathways to plot"
+                    "name": "Drosophila_melanogaster.BDGP6.87.gene_lengths"
                 }
             ],
-            "label": "KEGG pathways to plot",
+            "label": "Drosophila_melanogaster.BDGP6.87.gene_lengths",
             "name": "Input dataset",
             "outputs": [],
             "position": {
-                "bottom": 110.0625,
-                "height": 82.171875,
-                "left": 1275.5,
-                "right": 1475.5,
-                "top": 27.890625,
-                "width": 200,
-                "x": 1275.5,
-                "y": 27.890625
+                "bottom": 68.98460422345062,
+                "height": 68.71688079833984,
+                "left": 1317.2725848297573,
+                "right": 1451.2725848297573,
+                "top": 0.26772342511077424,
+                "width": 134,
+                "x": 1317.2725848297573,
+                "y": 0.26772342511077424
             },
             "tool_id": null,
             "tool_state": "{\"optional\": false, \"tag\": null}",
             "tool_version": null,
             "type": "data_input",
-            "uuid": "1910edc3-5a7e-493b-8545-10cf0f78f7ba",
+            "uuid": "7e28ac8c-f297-4235-a42d-341e1d53b8e9",
             "workflow_outputs": []
         },
         "2": {
@@ -77,27 +77,27 @@
             "inputs": [
                 {
                     "description": "",
-                    "name": "Drosophila_melanogaster.BDGP6.87.gene_lengths"
+                    "name": "KEGG pathways to plot"
                 }
             ],
-            "label": "Drosophila_melanogaster.BDGP6.87.gene_lengths",
+            "label": "KEGG pathways to plot",
             "name": "Input dataset",
             "outputs": [],
             "position": {
-                "bottom": -164.546875,
-                "height": 102.5625,
-                "left": 1275.5,
-                "right": 1475.5,
-                "top": -267.109375,
-                "width": 200,
-                "x": 1275.5,
-                "y": -267.109375
+                "bottom": 350.3072477881588,
+                "height": 55.055145263671875,
+                "left": 1317.2725848297573,
+                "right": 1451.2725848297573,
+                "top": 295.25210252448693,
+                "width": 134,
+                "x": 1317.2725848297573,
+                "y": 295.25210252448693
             },
             "tool_id": null,
             "tool_state": "{\"optional\": false, \"tag\": null}",
             "tool_version": null,
             "type": "data_input",
-            "uuid": "7e28ac8c-f297-4235-a42d-341e1d53b8e9",
+            "uuid": "1910edc3-5a7e-493b-8545-10cf0f78f7ba",
             "workflow_outputs": []
         },
         "3": {
@@ -116,14 +116,14 @@
             "name": "Input dataset",
             "outputs": [],
             "position": {
-                "bottom": 445.453125,
-                "height": 102.5625,
-                "left": 1275.5,
-                "right": 1475.5,
-                "top": 342.890625,
-                "width": 200,
-                "x": 1275.5,
-                "y": 342.890625
+                "bottom": 678.9845959108267,
+                "height": 68.71688842773438,
+                "left": 1317.2725848297573,
+                "right": 1451.2725848297573,
+                "top": 610.2677074830923,
+                "width": 134,
+                "x": 1317.2725848297573,
+                "y": 610.2677074830923
             },
             "tool_id": null,
             "tool_state": "{\"optional\": false, \"tag\": null}",
@@ -148,14 +148,14 @@
             "name": "Input dataset",
             "outputs": [],
             "position": {
-                "bottom": 295.671875,
-                "height": 61.78125,
-                "left": 1553.5,
-                "right": 1753.5,
-                "top": 233.890625,
-                "width": 200,
-                "x": 1553.5,
-                "y": 233.890625
+                "bottom": 542.6455642927938,
+                "height": 41.3934326171875,
+                "left": 1595.2725994053171,
+                "right": 1729.2725994053171,
+                "top": 501.25213167560634,
+                "width": 134,
+                "x": 1595.2725994053171,
+                "y": 501.25213167560634
             },
             "tool_id": null,
             "tool_state": "{\"optional\": false, \"tag\": null}",
@@ -185,14 +185,14 @@
                 }
             ],
             "position": {
-                "bottom": 664.453125,
-                "height": 113.5625,
-                "left": -128.5,
-                "right": 71.5,
-                "top": 550.890625,
-                "width": 200,
-                "x": -128.5,
-                "y": 550.890625
+                "bottom": 894.3546452308768,
+                "height": 76.0869140625,
+                "left": -86.78989695079291,
+                "right": 47.210118307996154,
+                "top": 818.2677311683768,
+                "width": 134.00001525878906,
+                "x": -86.78989695079291,
+                "y": 818.2677311683768
             },
             "post_job_actions": {},
             "tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/collection_element_identifiers/collection_element_identifiers/0.0.2",
@@ -210,7 +210,7 @@
                 {
                     "label": null,
                     "output_name": "output",
-                    "uuid": "381625fd-c928-469d-a356-1d3ec2ba1eb4"
+                    "uuid": "1fa08f6c-89ac-4e78-b9a5-8f8a9ab82532"
                 }
             ]
         },
@@ -221,7 +221,7 @@
             "id": 6,
             "input_connections": {
                 "input": {
-                    "id": 2,
+                    "id": 1,
                     "output_name": "output"
                 }
             },
@@ -235,14 +235,14 @@
                 }
             ],
             "position": {
-                "bottom": -158.546875,
-                "height": 113.5625,
-                "left": 1553.5,
-                "right": 1753.5,
-                "top": -272.109375,
-                "width": 200,
-                "x": 1553.5,
-                "y": -272.109375
+                "bottom": 71.3545939886748,
+                "height": 76.08686828613281,
+                "left": 1595.2725994053171,
+                "right": 1729.2725994053171,
+                "top": -4.732274297458022,
+                "width": 134,
+                "x": 1595.2725994053171,
+                "y": -4.732274297458022
             },
             "post_job_actions": {},
             "tool_id": "ChangeCase",
@@ -254,7 +254,7 @@
                 {
                     "label": null,
                     "output_name": "out_file1",
-                    "uuid": "a5d6ea05-fcc3-4801-9039-32d221beee2f"
+                    "uuid": "a47d18a3-aa68-4f77-bc8a-913b82f3e8af"
                 }
             ]
         },
@@ -279,14 +279,14 @@
                 }
             ],
             "position": {
-                "bottom": 667.453125,
-                "height": 113.5625,
-                "left": 138.5,
-                "right": 338.5,
-                "top": 553.890625,
-                "width": 200,
-                "x": 138.5,
-                "y": 553.890625
+                "bottom": 897.3545987712803,
+                "height": 76.08685302734375,
+                "left": 180.2413712686567,
+                "right": 314.24137126865674,
+                "top": 821.2677457439365,
+                "width": 134,
+                "x": 180.2413712686567,
+                "y": 821.2677457439365
             },
             "post_job_actions": {
                 "ChangeDatatypeActionoutfile": {
@@ -312,7 +312,7 @@
                 {
                     "label": null,
                     "output_name": "outfile",
-                    "uuid": "0d18038b-86f5-4cb6-8b3c-4e711c8a4d32"
+                    "uuid": "e77f76dc-5c9b-4863-b6ba-fe8a81ecee5b"
                 }
             ]
         },
@@ -341,14 +341,14 @@
                 }
             ],
             "position": {
-                "bottom": 595.625,
-                "height": 184.734375,
-                "left": 441.5,
-                "right": 641.5,
-                "top": 410.890625,
-                "width": 200,
-                "x": 441.5,
-                "y": 410.890625
+                "bottom": 802.0397680481867,
+                "height": 123.77206420898438,
+                "left": 483.2726322003265,
+                "right": 617.2726322003265,
+                "top": 678.2677038392023,
+                "width": 134,
+                "x": 483.2726322003265,
+                "y": 678.2677038392023
             },
             "post_job_actions": {},
             "tool_id": "__TAG_FROM_FILE__",
@@ -360,7 +360,7 @@
                 {
                     "label": "input dataset(s) (Tagged)",
                     "output_name": "output",
-                    "uuid": "28dbf589-e0e7-40dc-b76b-dc3f652520f4"
+                    "uuid": "ac3be7c6-775b-434c-9d44-6a572e56bcdc"
                 }
             ]
         },
@@ -379,10 +379,6 @@
                 {
                     "description": "runtime parameter for tool DESeq2",
                     "name": "batch_factors"
-                },
-                {
-                    "description": "runtime parameter for tool DESeq2",
-                    "name": "select_data"
                 }
             ],
             "label": "Differential Analysis",
@@ -402,14 +398,14 @@
                 }
             ],
             "position": {
-                "bottom": 738.578125,
-                "height": 306.6875,
-                "left": 719.5,
-                "right": 919.5,
-                "top": 431.890625,
-                "width": 200,
-                "x": 719.5,
-                "y": 431.890625
+                "bottom": 904.7483361087628,
+                "height": 205.48062133789062,
+                "left": 761.2726467758862,
+                "right": 895.2725857407299,
+                "top": 699.2677147708722,
+                "width": 133.99993896484375,
+                "x": 761.2726467758862,
+                "y": 699.2677147708722
             },
             "post_job_actions": {},
             "tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/deseq2/deseq2/2.11.40.7+galaxy1",
@@ -419,25 +415,25 @@
                 "owner": "iuc",
                 "tool_shed": "toolshed.g2.bx.psu.edu"
             },
-            "tool_state": "{\"advanced_options\": {\"esf\": \"\", \"fit_type\": \"1\", \"outlier_replace_off\": \"false\", \"outlier_filter_off\": \"false\", \"auto_mean_filter_off\": \"false\"}, \"batch_factors\": {\"__class__\": \"RuntimeValue\"}, \"header\": \"false\", \"output_options\": {\"output_selector\": [\"pdf\", \"normCounts\"], \"alpha_ma\": \"0.1\"}, \"select_data\": {\"how\": \"group_tags\", \"__current_case__\": 0, \"countsFile\": {\"__class__\": \"RuntimeValue\"}, \"rep_factorName\": [{\"__index__\": 0, \"factorName\": \"Treatment\", \"rep_factorLevel\": [{\"__index__\": 0, \"factorLevel\": \"treated\", \"groups\": \"treat\\n\"}, {\"__index__\": 1, \"factorLevel\": \"untreated\", \"groups\": \"untreat\\n\"}]}, {\"__index__\": 1, \"factorName\": \"Sequencing\", \"rep_factorLevel\": [{\"__index__\": 0, \"factorLevel\": \"PE\", \"groups\": \"paired.counts\\n\"}, {\"__index__\": 1, \"factorLevel\": \"SE\", \"groups\": \"single.counts\\n\"}]}]}, \"tximport\": {\"tximport_selector\": \"count\", \"__current_case__\": 1}, \"__page__\": null, \"__rerun_remap_job_id__\": null}",
+            "tool_state": "{\"advanced_options\": {\"esf\": \"\", \"fit_type\": \"1\", \"outlier_replace_off\": \"false\", \"outlier_filter_off\": \"false\", \"auto_mean_filter_off\": \"false\"}, \"batch_factors\": {\"__class__\": \"RuntimeValue\"}, \"header\": \"false\", \"output_options\": {\"output_selector\": [\"pdf\", \"normCounts\"], \"alpha_ma\": \"0.1\"}, \"select_data\": {\"how\": \"group_tags\", \"__current_case__\": 0, \"countsFile\": {\"__class__\": \"ConnectedValue\"}, \"rep_factorName\": [{\"__index__\": 0, \"factorName\": \"Treatment\", \"rep_factorLevel\": [{\"__index__\": 0, \"factorLevel\": \"treated\", \"groups\": \"treat\\n\"}, {\"__index__\": 1, \"factorLevel\": \"untreated\", \"groups\": \"untreat\\n\"}]}, {\"__index__\": 1, \"factorName\": \"Sequencing\", \"rep_factorLevel\": [{\"__index__\": 0, \"factorLevel\": \"PE\", \"groups\": \"paired.counts\\n\"}, {\"__index__\": 1, \"factorLevel\": \"SE\", \"groups\": \"single.counts\\n\"}]}]}, \"tximport\": {\"tximport_selector\": \"count\", \"__current_case__\": 1}, \"__page__\": null, \"__rerun_remap_job_id__\": null}",
             "tool_version": "2.11.40.7+galaxy1",
             "type": "tool",
             "uuid": "45883538-b692-4e35-8dee-d08974682a9c",
             "workflow_outputs": [
                 {
-                    "label": null,
-                    "output_name": "counts_out",
-                    "uuid": "55bfabaf-6f89-4d14-a0e6-0ed601601dbd"
-                },
-                {
                     "label": "deseq_out",
                     "output_name": "deseq_out",
-                    "uuid": "1ae60cf4-5fae-4855-8622-dee8adf8b8a3"
+                    "uuid": "0a62d2e1-43d8-448a-81d3-73b6333a7e40"
                 },
                 {
                     "label": null,
                     "output_name": "plots",
-                    "uuid": "a39e4066-77c0-444a-9482-44c38a63ec68"
+                    "uuid": "f71aae1f-b50f-4627-a2ad-90c64a416bb3"
+                },
+                {
+                    "label": null,
+                    "output_name": "counts_out",
+                    "uuid": "45c22139-7433-4593-ba79-6720330b2865"
                 }
             ]
         },
@@ -462,14 +458,14 @@
                 }
             ],
             "position": {
-                "bottom": -16.9375,
-                "height": 93.171875,
-                "left": 997.5,
-                "right": 1197.5,
-                "top": -110.109375,
-                "width": 200,
-                "x": 997.5,
-                "y": -110.109375
+                "bottom": 219.6928750792546,
+                "height": 62.425148010253906,
+                "left": 1039.2725702541977,
+                "right": 1173.272631289354,
+                "top": 157.2677270690007,
+                "width": 134.00006103515625,
+                "x": 1039.2725702541977,
+                "y": 157.2677270690007
             },
             "post_job_actions": {},
             "tool_id": "toolshed.g2.bx.psu.edu/repos/devteam/column_maker/Add_a_column1/1.6",
@@ -487,7 +483,7 @@
                 {
                     "label": null,
                     "output_name": "out_file1",
-                    "uuid": "ef1534c5-2cdd-4cdf-93d4-a0c9d48bc5fd"
+                    "uuid": "14452e47-8216-4df4-b7c2-442a33f52146"
                 }
             ]
         },
@@ -512,14 +508,14 @@
                 }
             ],
             "position": {
-                "bottom": 577.0625,
-                "height": 93.171875,
-                "left": 997.5,
-                "right": 1197.5,
-                "top": 483.890625,
-                "width": 200,
-                "x": 997.5,
-                "y": 483.890625
+                "bottom": 813.6928802034747,
+                "height": 62.4251708984375,
+                "left": 1039.2725702541977,
+                "right": 1173.272631289354,
+                "top": 751.2677093050372,
+                "width": 134.00006103515625,
+                "x": 1039.2725702541977,
+                "y": 751.2677093050372
             },
             "post_job_actions": {},
             "tool_id": "Filter1",
@@ -531,7 +527,7 @@
                 {
                     "label": null,
                     "output_name": "out_file1",
-                    "uuid": "0d857485-7122-4748-ae4a-09b0b2bc8a56"
+                    "uuid": "855c9899-5fa0-4743-9a8d-64ca306fea9e"
                 }
             ]
         },
@@ -556,14 +552,14 @@
                 }
             ],
             "position": {
-                "bottom": 835.234375,
-                "height": 170.34375,
-                "left": 997.5,
-                "right": 1197.5,
-                "top": 664.890625,
-                "width": 200,
-                "x": 997.5,
-                "y": 664.890625
+                "bottom": 1046.3980485147504,
+                "height": 114.13031005859375,
+                "left": 1039.2725702541977,
+                "right": 1173.272631289354,
+                "top": 932.2677384561566,
+                "width": 134.00006103515625,
+                "x": 1039.2725702541977,
+                "y": 932.2677384561566
             },
             "post_job_actions": {},
             "tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/table_compute/table_compute/1.2.4+galaxy0",
@@ -581,7 +577,7 @@
                 {
                     "label": null,
                     "output_name": "table",
-                    "uuid": "f2b530ef-f155-42ff-a4dc-a652f91d9441"
+                    "uuid": "68d12a55-1f51-4a92-8bb5-f88e6fbbc79d"
                 }
             ]
         },
@@ -606,14 +602,14 @@
                 }
             ],
             "position": {
-                "bottom": -16.9375,
-                "height": 93.171875,
-                "left": 1275.5,
-                "right": 1475.5,
-                "top": -110.109375,
-                "width": 200,
-                "x": 1275.5,
-                "y": -110.109375
+                "bottom": 219.6928750792546,
+                "height": 62.425148010253906,
+                "left": 1317.2725848297573,
+                "right": 1451.2725848297573,
+                "top": 157.2677270690007,
+                "width": 134,
+                "x": 1317.2725848297573,
+                "y": 157.2677270690007
             },
             "post_job_actions": {},
             "tool_id": "Cut1",
@@ -625,7 +621,7 @@
                 {
                     "label": null,
                     "output_name": "out_file1",
-                    "uuid": "b0dc6243-44d8-416e-a635-8f7d73159807"
+                    "uuid": "ba41b252-c855-4621-8540-05e7b66ca42d"
                 }
             ]
         },
@@ -650,14 +646,14 @@
                 }
             ],
             "position": {
-                "bottom": 305.0625,
-                "height": 93.171875,
-                "left": 1275.5,
-                "right": 1475.5,
-                "top": 211.890625,
-                "width": 200,
-                "x": 1275.5,
-                "y": 211.890625
+                "bottom": 541.6928947790345,
+                "height": 62.4251708984375,
+                "left": 1317.2725848297573,
+                "right": 1451.2725848297573,
+                "top": 479.267723880597,
+                "width": 134,
+                "x": 1317.2725848297573,
+                "y": 479.267723880597
             },
             "post_job_actions": {},
             "tool_id": "Cut1",
@@ -669,7 +665,7 @@
                 {
                     "label": null,
                     "output_name": "out_file1",
-                    "uuid": "d6649442-5662-4a19-98dc-1f2ef72615b1"
+                    "uuid": "a6a66e45-28c9-4ad7-830f-90b510d6d39d"
                 }
             ]
         },
@@ -694,14 +690,14 @@
                 }
             ],
             "position": {
-                "bottom": 577.0625,
-                "height": 93.171875,
-                "left": 1275.5,
-                "right": 1475.5,
-                "top": 483.890625,
-                "width": 200,
-                "x": 1275.5,
-                "y": 483.890625
+                "bottom": 813.6928802034747,
+                "height": 62.4251708984375,
+                "left": 1317.2725848297573,
+                "right": 1451.2725848297573,
+                "top": 751.2677093050372,
+                "width": 134,
+                "x": 1317.2725848297573,
+                "y": 751.2677093050372
             },
             "post_job_actions": {},
             "tool_id": "Filter1",
@@ -713,7 +709,7 @@
                 {
                     "label": null,
                     "output_name": "out_file1",
-                    "uuid": "40e3604b-aa27-43aa-91be-0e4d085c28bb"
+                    "uuid": "5ccb167a-5780-4a11-bd26-f0556fd3470d"
                 }
             ]
         },
@@ -742,14 +738,14 @@
                 }
             ],
             "position": {
-                "bottom": 840.234375,
-                "height": 180.34375,
-                "left": 1275.5,
-                "right": 1475.5,
-                "top": 659.890625,
-                "width": 200,
-                "x": 1275.5,
-                "y": 659.890625
+                "bottom": 1048.0980361255247,
+                "height": 120.83026123046875,
+                "left": 1317.2725848297573,
+                "right": 1451.2725848297573,
+                "top": 927.2677748950559,
+                "width": 134,
+                "x": 1317.2725848297573,
+                "y": 927.2677748950559
             },
             "post_job_actions": {},
             "tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/table_compute/table_compute/1.2.4+galaxy0",
@@ -767,7 +763,7 @@
                 {
                     "label": "z_score",
                     "output_name": "table",
-                    "uuid": "95a46a53-eb81-4a77-9695-01872ad279fc"
+                    "uuid": "32004d23-7c99-4405-a65f-fd861b40c949"
                 }
             ]
         },
@@ -792,14 +788,14 @@
                 }
             ],
             "position": {
-                "bottom": -6.546875,
-                "height": 113.5625,
-                "left": 1553.5,
-                "right": 1753.5,
-                "top": -120.109375,
-                "width": 200,
-                "x": 1553.5,
-                "y": -120.109375
+                "bottom": 223.35460378162895,
+                "height": 76.08688354492188,
+                "left": 1595.2725994053171,
+                "right": 1729.2725994053171,
+                "top": 147.26772023670708,
+                "width": 134,
+                "x": 1595.2725994053171,
+                "y": 147.26772023670708
             },
             "post_job_actions": {},
             "tool_id": "ChangeCase",
@@ -811,7 +807,7 @@
                 {
                     "label": null,
                     "output_name": "out_file1",
-                    "uuid": "296a1e10-6451-477a-a2fb-54a1c84e91cd"
+                    "uuid": "95a60e4d-2e37-49f9-9e52-0faf399c9427"
                 }
             ]
         },
@@ -826,7 +822,7 @@
                     "output_name": "out_file1"
                 },
                 "pathway|tabular": {
-                    "id": 1,
+                    "id": 2,
                     "output_name": "output"
                 }
             },
@@ -840,14 +836,14 @@
                 }
             ],
             "position": {
-                "bottom": 196.234375,
-                "height": 164.34375,
-                "left": 1553.5,
-                "right": 1753.5,
-                "top": 31.890625,
-                "width": 200,
-                "x": 1553.5,
-                "y": 31.890625
+                "bottom": 409.362412637739,
+                "height": 110.11032104492188,
+                "left": 1595.2725994053171,
+                "right": 1729.2725994053171,
+                "top": 299.2520915928171,
+                "width": 134,
+                "x": 1595.2725994053171,
+                "y": 299.2520915928171
             },
             "post_job_actions": {},
             "tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/pathview/pathview/1.24.0+galaxy2",
@@ -865,7 +861,7 @@
                 {
                     "label": null,
                     "output_name": "multiple_kegg_native",
-                    "uuid": "cc052bab-f350-42ba-8a9f-547ae55f8df0"
+                    "uuid": "c0b3c1ac-ac46-4dc8-82ef-c85569f0e3cd"
                 }
             ]
         },
@@ -894,14 +890,14 @@
                 }
             ],
             "position": {
-                "bottom": 620.578125,
-                "height": 286.6875,
-                "left": 1553.5,
-                "right": 1753.5,
-                "top": 333.890625,
-                "width": 200,
-                "x": 1553.5,
-                "y": 333.890625
+                "bottom": 793.3327440859666,
+                "height": 192.08065795898438,
+                "left": 1595.2725994053171,
+                "right": 1729.2725994053171,
+                "top": 601.2520861269822,
+                "width": 134,
+                "x": 1595.2725994053171,
+                "y": 601.2520861269822
             },
             "post_job_actions": {},
             "tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/deg_annotate/deg_annotate/1.1.0",
@@ -919,7 +915,7 @@
                 {
                     "label": null,
                     "output_name": "output",
-                    "uuid": "02c4b2ac-fe88-49f1-9654-e1515341d843"
+                    "uuid": "a52a2a8b-1d17-44bd-970d-d50ada8acee6"
                 }
             ]
         },
@@ -928,69 +924,6 @@
             "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/goseq/goseq/1.44.0+galaxy0",
             "errors": null,
             "id": 20,
-            "input_connections": {
-                "dge_file": {
-                    "id": 17,
-                    "output_name": "out_file1"
-                },
-                "length_file": {
-                    "id": 6,
-                    "output_name": "out_file1"
-                }
-            },
-            "inputs": [],
-            "label": null,
-            "name": "goseq",
-            "outputs": [
-                {
-                    "name": "wallenius_tab",
-                    "type": "tabular"
-                },
-                {
-                    "name": "cat_genes_tab",
-                    "type": "tabular"
-                }
-            ],
-            "position": {
-                "bottom": 325.40625,
-                "height": 235.515625,
-                "left": 1841.5,
-                "right": 2041.5,
-                "top": 89.890625,
-                "width": 200,
-                "x": 1841.5,
-                "y": 89.890625
-            },
-            "post_job_actions": {},
-            "tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/goseq/goseq/1.44.0+galaxy0",
-            "tool_shed_repository": {
-                "changeset_revision": "ef2ad746b589",
-                "name": "goseq",
-                "owner": "iuc",
-                "tool_shed": "toolshed.g2.bx.psu.edu"
-            },
-            "tool_state": "{\"__input_ext\": \"tabular\", \"adv\": {\"p_adj_method\": \"BH\", \"use_genes_without_cat\": \"false\"}, \"categorySource\": {\"catSource\": \"getgo\", \"__current_case__\": 0, \"genome\": \"dm6\", \"gene_id\": \"ensGene\", \"fetchcats\": [\"KEGG\"]}, \"chromInfo\": \"/opt/galaxy/tool-data/shared/ucsc/chrom/dm6.len\", \"dge_file\": {\"__class__\": \"ConnectedValue\"}, \"length_file\": {\"__class__\": \"ConnectedValue\"}, \"methods\": {\"wallenius\": \"true\", \"hypergeometric\": \"false\", \"repcnt\": \"0\"}, \"out\": {\"topgo_plot\": \"false\", \"make_plots\": \"false\", \"cat_genes\": \"true\", \"rdata_out\": \"false\"}, \"__page__\": null, \"__rerun_remap_job_id__\": null}",
-            "tool_version": "1.44.0+galaxy0",
-            "type": "tool",
-            "uuid": "4321eeeb-3486-4b8a-bf4d-15b43462f7bb",
-            "workflow_outputs": [
-                {
-                    "label": null,
-                    "output_name": "cat_genes_tab",
-                    "uuid": "a84ba5d9-0f4a-484c-9d33-1f18e6937f1f"
-                },
-                {
-                    "label": "kegg_pathways",
-                    "output_name": "wallenius_tab",
-                    "uuid": "a61a3495-b46e-4158-81c2-a2a74f9156e8"
-                }
-            ]
-        },
-        "21": {
-            "annotation": "",
-            "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/goseq/goseq/1.44.0+galaxy0",
-            "errors": null,
-            "id": 21,
             "input_connections": {
                 "dge_file": {
                     "id": 17,
@@ -1019,14 +952,14 @@
                 }
             ],
             "position": {
-                "bottom": 51.96875,
-                "height": 327.078125,
-                "left": 1841.5,
-                "right": 2041.5,
-                "top": -275.109375,
-                "width": 200,
-                "x": 1841.5,
-                "y": -275.109375
+                "bottom": 211.41006788566932,
+                "height": 219.142333984375,
+                "left": 1883.2727232975744,
+                "right": 2017.272601227262,
+                "top": -7.73226609870569,
+                "width": 133.9998779296875,
+                "x": 1883.2727232975744,
+                "y": -7.73226609870569
             },
             "post_job_actions": {},
             "tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/goseq/goseq/1.44.0+galaxy0",
@@ -1043,18 +976,81 @@
             "workflow_outputs": [
                 {
                     "label": null,
-                    "output_name": "cat_genes_tab",
-                    "uuid": "d90f3bdd-d92f-4637-b581-8cfaacb234c1"
+                    "output_name": "top_plot",
+                    "uuid": "95e4edea-003b-467c-bcef-09365646019b"
                 },
                 {
                     "label": null,
-                    "output_name": "top_plot",
-                    "uuid": "98000f56-4626-4087-8b55-a04d9d7532e5"
+                    "output_name": "cat_genes_tab",
+                    "uuid": "a9cab5d3-a7ec-41b2-bffa-5ff5129c3d06"
                 },
                 {
                     "label": "go_terms",
                     "output_name": "wallenius_tab",
-                    "uuid": "0480840d-705f-44fe-a560-ce5ad0026a98"
+                    "uuid": "c06c58d4-ab5d-49da-b481-baf668c6fc29"
+                }
+            ]
+        },
+        "21": {
+            "annotation": "",
+            "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/goseq/goseq/1.44.0+galaxy0",
+            "errors": null,
+            "id": 21,
+            "input_connections": {
+                "dge_file": {
+                    "id": 17,
+                    "output_name": "out_file1"
+                },
+                "length_file": {
+                    "id": 6,
+                    "output_name": "out_file1"
+                }
+            },
+            "inputs": [],
+            "label": null,
+            "name": "goseq",
+            "outputs": [
+                {
+                    "name": "wallenius_tab",
+                    "type": "tabular"
+                },
+                {
+                    "name": "cat_genes_tab",
+                    "type": "tabular"
+                }
+            ],
+            "position": {
+                "bottom": 515.0632096475629,
+                "height": 157.79547119140625,
+                "left": 1883.2727232975744,
+                "right": 2017.272601227262,
+                "top": 357.2677384561567,
+                "width": 133.9998779296875,
+                "x": 1883.2727232975744,
+                "y": 357.2677384561567
+            },
+            "post_job_actions": {},
+            "tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/goseq/goseq/1.44.0+galaxy0",
+            "tool_shed_repository": {
+                "changeset_revision": "ef2ad746b589",
+                "name": "goseq",
+                "owner": "iuc",
+                "tool_shed": "toolshed.g2.bx.psu.edu"
+            },
+            "tool_state": "{\"__input_ext\": \"tabular\", \"adv\": {\"p_adj_method\": \"BH\", \"use_genes_without_cat\": \"false\"}, \"categorySource\": {\"catSource\": \"getgo\", \"__current_case__\": 0, \"genome\": \"dm6\", \"gene_id\": \"ensGene\", \"fetchcats\": [\"KEGG\"]}, \"chromInfo\": \"/opt/galaxy/tool-data/shared/ucsc/chrom/dm6.len\", \"dge_file\": {\"__class__\": \"ConnectedValue\"}, \"length_file\": {\"__class__\": \"ConnectedValue\"}, \"methods\": {\"wallenius\": \"true\", \"hypergeometric\": \"false\", \"repcnt\": \"0\"}, \"out\": {\"topgo_plot\": \"false\", \"make_plots\": \"false\", \"cat_genes\": \"true\", \"rdata_out\": \"false\"}, \"__page__\": null, \"__rerun_remap_job_id__\": null}",
+            "tool_version": "1.44.0+galaxy0",
+            "type": "tool",
+            "uuid": "4321eeeb-3486-4b8a-bf4d-15b43462f7bb",
+            "workflow_outputs": [
+                {
+                    "label": "kegg_pathways",
+                    "output_name": "wallenius_tab",
+                    "uuid": "8d0ac5be-ac7d-4f10-85ac-d3461f561a50"
+                },
+                {
+                    "label": null,
+                    "output_name": "cat_genes_tab",
+                    "uuid": "ea7e39c3-ce69-458a-9ce3-a6732ce3cd74"
                 }
             ]
         },
@@ -1073,7 +1069,12 @@
                     "output_name": "output"
                 }
             },
-            "inputs": [],
+            "inputs": [
+                {
+                    "description": "runtime parameter for tool Concatenate datasets",
+                    "name": "inputs"
+                }
+            ],
             "label": null,
             "name": "Concatenate datasets",
             "outputs": [
@@ -1083,16 +1084,24 @@
                 }
             ],
             "position": {
-                "bottom": 522.84375,
-                "height": 143.953125,
-                "left": 1841.5,
-                "right": 2041.5,
-                "top": 378.890625,
-                "width": 200,
-                "x": 1841.5,
-                "y": 378.890625
+                "bottom": 742.716354142374,
+                "height": 96.4486083984375,
+                "left": 1883.2727232975744,
+                "right": 2017.272601227262,
+                "top": 646.2677457439365,
+                "width": 133.9998779296875,
+                "x": 1883.2727232975744,
+                "y": 646.2677457439365
             },
-            "post_job_actions": {},
+            "post_job_actions": {
+                "ChangeDatatypeActionout_file1": {
+                    "action_arguments": {
+                        "newtype": "tabular"
+                    },
+                    "action_type": "ChangeDatatypeAction",
+                    "output_name": "out_file1"
+                }
+            },
             "tool_id": "toolshed.g2.bx.psu.edu/repos/bgruening/text_processing/tp_cat/0.1.1",
             "tool_shed_repository": {
                 "changeset_revision": "f46f0e4f75c4",
@@ -1100,7 +1109,7 @@
                 "owner": "bgruening",
                 "tool_shed": "toolshed.g2.bx.psu.edu"
             },
-            "tool_state": "{\"__input_ext\": \"tabular\", \"chromInfo\": \"/opt/galaxy/tool-data/shared/ucsc/chrom/dm6.len\", \"inputs\": {\"__class__\": \"ConnectedValue\"}, \"queries\": [{\"__index__\": 0, \"inputs2\": {\"__class__\": \"ConnectedValue\"}}], \"__page__\": null, \"__rerun_remap_job_id__\": null}",
+            "tool_state": "{\"inputs\": {\"__class__\": \"RuntimeValue\"}, \"queries\": [{\"__index__\": 0, \"inputs2\": {\"__class__\": \"RuntimeValue\"}}], \"__page__\": null, \"__rerun_remap_job_id__\": null}",
             "tool_version": "0.1.1",
             "type": "tool",
             "uuid": "5aca8071-b7e2-48b6-ba2e-ef258852578c",
@@ -1108,7 +1117,7 @@
                 {
                     "label": null,
                     "output_name": "out_file1",
-                    "uuid": "a0b9f482-e58f-43e0-a2eb-a7a20788321e"
+                    "uuid": "2f2dff65-5d79-46c1-b90f-b18975c97453"
                 }
             ]
         },
@@ -1133,26 +1142,26 @@
                 }
             ],
             "position": {
-                "bottom": 273.0625,
-                "height": 93.171875,
-                "left": 2119.5,
-                "right": 2319.5,
-                "top": 179.890625,
-                "width": 200,
-                "x": 2119.5,
-                "y": 179.890625
+                "bottom": 171.69288487220877,
+                "height": 62.42516326904297,
+                "left": 2161.272555678638,
+                "right": 2295.272555678638,
+                "top": 109.26772160316581,
+                "width": 134,
+                "x": 2161.272555678638,
+                "y": 109.26772160316581
             },
             "post_job_actions": {},
             "tool_id": "Filter1",
-            "tool_state": "{\"__input_ext\": \"tabular\", \"chromInfo\": \"/opt/galaxy/tool-data/shared/ucsc/chrom/dm6.len\", \"cond\": \"c7<0.05\", \"header_lines\": \"0\", \"input\": {\"__class__\": \"ConnectedValue\"}, \"__page__\": null, \"__rerun_remap_job_id__\": null}",
+            "tool_state": "{\"__input_ext\": \"tabular\", \"chromInfo\": \"/opt/galaxy/tool-data/shared/ucsc/chrom/dm6.len\", \"cond\": \"c9<0.05\", \"header_lines\": \"0\", \"input\": {\"__class__\": \"ConnectedValue\"}, \"__page__\": null, \"__rerun_remap_job_id__\": null}",
             "tool_version": "1.1.1",
             "type": "tool",
-            "uuid": "aefea22f-0152-4501-b87a-36ba9959b314",
+            "uuid": "377b4b3f-763c-44c5-b199-ee2ecd85583d",
             "workflow_outputs": [
                 {
                     "label": null,
                     "output_name": "out_file1",
-                    "uuid": "e3c724bc-d49c-43a6-9f7e-7455b6a1c427"
+                    "uuid": "2b2945fc-806e-4ca8-9a62-7cae96c4d6ca"
                 }
             ]
         },
@@ -1177,26 +1186,26 @@
                 }
             ],
             "position": {
-                "bottom": 404.0625,
-                "height": 93.171875,
-                "left": 2119.5,
-                "right": 2319.5,
-                "top": 310.890625,
-                "width": 200,
-                "x": 2119.5,
-                "y": 310.890625
+                "bottom": 302.6928874912546,
+                "height": 62.4251708984375,
+                "left": 2161.272555678638,
+                "right": 2295.272555678638,
+                "top": 240.26771659281715,
+                "width": 134,
+                "x": 2161.272555678638,
+                "y": 240.26771659281715
             },
             "post_job_actions": {},
             "tool_id": "Filter1",
-            "tool_state": "{\"__input_ext\": \"tabular\", \"chromInfo\": \"/opt/galaxy/tool-data/shared/ucsc/chrom/dm6.len\", \"cond\": \"c6<0.05\", \"header_lines\": \"0\", \"input\": {\"__class__\": \"ConnectedValue\"}, \"__page__\": null, \"__rerun_remap_job_id__\": null}",
+            "tool_state": "{\"__input_ext\": \"tabular\", \"chromInfo\": \"/opt/galaxy/tool-data/shared/ucsc/chrom/dm6.len\", \"cond\": \"c8<0.05\", \"header_lines\": \"0\", \"input\": {\"__class__\": \"ConnectedValue\"}, \"__page__\": null, \"__rerun_remap_job_id__\": null}",
             "tool_version": "1.1.1",
             "type": "tool",
-            "uuid": "227ef320-a0ab-4f25-ba28-ca1182d95ab1",
+            "uuid": "e2e7918d-b71c-4ea5-a01f-ee5785795dce",
             "workflow_outputs": [
                 {
                     "label": null,
                     "output_name": "out_file1",
-                    "uuid": "8d7ca29c-0326-4ebb-bb5f-a4cffc150455"
+                    "uuid": "76687574-0633-4343-aefc-1fcf3d527146"
                 }
             ]
         },
@@ -1221,26 +1230,26 @@
                 }
             ],
             "position": {
-                "bottom": 66.0625,
-                "height": 93.171875,
-                "left": 2119.5,
-                "right": 2319.5,
-                "top": -27.109375,
-                "width": 200,
-                "x": 2119.5,
-                "y": -27.109375
+                "bottom": 509.6928911351446,
+                "height": 62.4251708984375,
+                "left": 2161.272555678638,
+                "right": 2295.272555678638,
+                "top": 447.2677202367071,
+                "width": 134,
+                "x": 2161.272555678638,
+                "y": 447.2677202367071
             },
             "post_job_actions": {},
             "tool_id": "Filter1",
-            "tool_state": "{\"__input_ext\": \"tabular\", \"chromInfo\": \"/opt/galaxy/tool-data/shared/ucsc/chrom/dm6.len\", \"cond\": \"c8<0.05\", \"header_lines\": \"0\", \"input\": {\"__class__\": \"ConnectedValue\"}, \"__page__\": null, \"__rerun_remap_job_id__\": null}",
+            "tool_state": "{\"__input_ext\": \"tabular\", \"chromInfo\": \"/opt/galaxy/tool-data/shared/ucsc/chrom/dm6.len\", \"cond\": \"c7<0.05\", \"header_lines\": \"0\", \"input\": {\"__class__\": \"ConnectedValue\"}, \"__page__\": null, \"__rerun_remap_job_id__\": null}",
             "tool_version": "1.1.1",
             "type": "tool",
-            "uuid": "e2e7918d-b71c-4ea5-a01f-ee5785795dce",
+            "uuid": "aefea22f-0152-4501-b87a-36ba9959b314",
             "workflow_outputs": [
                 {
                     "label": null,
                     "output_name": "out_file1",
-                    "uuid": "a2df9285-44bf-4f30-9b86-086b8711175b"
+                    "uuid": "873ebc7e-b235-45ae-9cd8-8236d4055d71"
                 }
             ]
         },
@@ -1265,26 +1274,26 @@
                 }
             ],
             "position": {
-                "bottom": -64.9375,
-                "height": 93.171875,
-                "left": 2119.5,
-                "right": 2319.5,
-                "top": -158.109375,
-                "width": 200,
-                "x": 2119.5,
-                "y": -158.109375
+                "bottom": 640.6928747376398,
+                "height": 62.4251708984375,
+                "left": 2161.272555678638,
+                "right": 2295.272555678638,
+                "top": 578.2677038392023,
+                "width": 134,
+                "x": 2161.272555678638,
+                "y": 578.2677038392023
             },
             "post_job_actions": {},
             "tool_id": "Filter1",
-            "tool_state": "{\"__input_ext\": \"tabular\", \"chromInfo\": \"/opt/galaxy/tool-data/shared/ucsc/chrom/dm6.len\", \"cond\": \"c9<0.05\", \"header_lines\": \"0\", \"input\": {\"__class__\": \"ConnectedValue\"}, \"__page__\": null, \"__rerun_remap_job_id__\": null}",
+            "tool_state": "{\"__input_ext\": \"tabular\", \"chromInfo\": \"/opt/galaxy/tool-data/shared/ucsc/chrom/dm6.len\", \"cond\": \"c6<0.05\", \"header_lines\": \"0\", \"input\": {\"__class__\": \"ConnectedValue\"}, \"__page__\": null, \"__rerun_remap_job_id__\": null}",
             "tool_version": "1.1.1",
             "type": "tool",
-            "uuid": "377b4b3f-763c-44c5-b199-ee2ecd85583d",
+            "uuid": "227ef320-a0ab-4f25-ba28-ca1182d95ab1",
             "workflow_outputs": [
                 {
                     "label": null,
                     "output_name": "out_file1",
-                    "uuid": "28a8df17-70e2-4d63-abdc-ab6a6328aa02"
+                    "uuid": "8bd52edd-0b2f-46d9-bc4b-eccaeb9404c9"
                 }
             ]
         },
@@ -1313,14 +1322,14 @@
                 }
             ],
             "position": {
-                "bottom": 684.84375,
-                "height": 143.953125,
-                "left": 2119.5,
-                "right": 2319.5,
-                "top": 540.890625,
-                "width": 200,
-                "x": 2119.5,
-                "y": 540.890625
+                "bottom": 904.7163213473647,
+                "height": 96.4486083984375,
+                "left": 2161.272555678638,
+                "right": 2295.272555678638,
+                "top": 808.2677129489272,
+                "width": 134,
+                "x": 2161.272555678638,
+                "y": 808.2677129489272
             },
             "post_job_actions": {},
             "tool_id": "join1",
@@ -1332,7 +1341,7 @@
                 {
                     "label": null,
                     "output_name": "out_file1",
-                    "uuid": "fb844dfb-9177-4923-92b3-3daf4af25349"
+                    "uuid": "ef2470c8-9f9a-4d72-ae28-9a9c7b3321cc"
                 }
             ]
         },
@@ -1343,7 +1352,7 @@
             "id": 28,
             "input_connections": {
                 "input1": {
-                    "id": 25,
+                    "id": 23,
                     "output_name": "out_file1"
                 }
             },
@@ -1357,58 +1366,14 @@
                 }
             ],
             "position": {
-                "bottom": 85.0625,
-                "height": 93.171875,
-                "left": 2397.5,
-                "right": 2597.5,
-                "top": -8.109375,
-                "width": 200,
-                "x": 2397.5,
-                "y": -8.109375
-            },
-            "post_job_actions": {},
-            "tool_id": "Grouping1",
-            "tool_state": "{\"__input_ext\": \"tabular\", \"chromInfo\": \"/opt/galaxy/tool-data/shared/ucsc/chrom/dm6.len\", \"groupcol\": \"7\", \"ignorecase\": \"false\", \"ignorelines\": null, \"input1\": {\"__class__\": \"ConnectedValue\"}, \"operations\": [{\"__index__\": 0, \"optype\": \"length\", \"opcol\": \"1\", \"opround\": \"no\", \"opdefault\": null}], \"__page__\": null, \"__rerun_remap_job_id__\": null}",
-            "tool_version": "2.1.4",
-            "type": "tool",
-            "uuid": "ef6f7670-e427-4244-9ce9-c42cee9e6c8c",
-            "workflow_outputs": [
-                {
-                    "label": null,
-                    "output_name": "out_file1",
-                    "uuid": "9b20a55a-9308-440d-b526-e0a2299d0f86"
-                }
-            ]
-        },
-        "29": {
-            "annotation": "",
-            "content_id": "Grouping1",
-            "errors": null,
-            "id": 29,
-            "input_connections": {
-                "input1": {
-                    "id": 26,
-                    "output_name": "out_file1"
-                }
-            },
-            "inputs": [],
-            "label": null,
-            "name": "Group",
-            "outputs": [
-                {
-                    "name": "out_file1",
-                    "type": "tabular"
-                }
-            ],
-            "position": {
-                "bottom": -45.9375,
-                "height": 93.171875,
-                "left": 2397.5,
-                "right": 2597.5,
-                "top": -139.109375,
-                "width": 200,
-                "x": 2397.5,
-                "y": -139.109375
+                "bottom": 190.69288225316288,
+                "height": 62.42515563964844,
+                "left": 2439.2725702541975,
+                "right": 2573.2725702541975,
+                "top": 128.26772661351444,
+                "width": 134,
+                "x": 2439.2725702541975,
+                "y": 128.26772661351444
             },
             "post_job_actions": {},
             "tool_id": "Grouping1",
@@ -1420,7 +1385,51 @@
                 {
                     "label": null,
                     "output_name": "out_file1",
-                    "uuid": "757fa7f3-3582-4edc-a94b-31b499bb3d99"
+                    "uuid": "0708f726-e329-44bb-94d4-f557fab5bb88"
+                }
+            ]
+        },
+        "29": {
+            "annotation": "",
+            "content_id": "Grouping1",
+            "errors": null,
+            "id": 29,
+            "input_connections": {
+                "input1": {
+                    "id": 24,
+                    "output_name": "out_file1"
+                }
+            },
+            "inputs": [],
+            "label": null,
+            "name": "Group",
+            "outputs": [
+                {
+                    "name": "out_file1",
+                    "type": "tabular"
+                }
+            ],
+            "position": {
+                "bottom": 321.67725019312616,
+                "height": 62.425140380859375,
+                "left": 2439.2725702541975,
+                "right": 2573.2725702541975,
+                "top": 259.2521098122668,
+                "width": 134,
+                "x": 2439.2725702541975,
+                "y": 259.2521098122668
+            },
+            "post_job_actions": {},
+            "tool_id": "Grouping1",
+            "tool_state": "{\"__input_ext\": \"tabular\", \"chromInfo\": \"/opt/galaxy/tool-data/shared/ucsc/chrom/dm6.len\", \"groupcol\": \"7\", \"ignorecase\": \"false\", \"ignorelines\": null, \"input1\": {\"__class__\": \"ConnectedValue\"}, \"operations\": [{\"__index__\": 0, \"optype\": \"length\", \"opcol\": \"1\", \"opround\": \"no\", \"opdefault\": null}], \"__page__\": null, \"__rerun_remap_job_id__\": null}",
+            "tool_version": "2.1.4",
+            "type": "tool",
+            "uuid": "ef6f7670-e427-4244-9ce9-c42cee9e6c8c",
+            "workflow_outputs": [
+                {
+                    "label": null,
+                    "output_name": "out_file1",
+                    "uuid": "05decfaa-246c-46af-a23c-cb5541d02572"
                 }
             ]
         },
@@ -1445,14 +1454,14 @@
                 }
             ],
             "position": {
-                "bottom": 659.0625,
-                "height": 93.171875,
-                "left": 2397.5,
-                "right": 2597.5,
-                "top": 565.890625,
-                "width": 200,
-                "x": 2397.5,
-                "y": 565.890625
+                "bottom": 895.6928838473647,
+                "height": 62.4251708984375,
+                "left": 2439.2725702541975,
+                "right": 2573.2725702541975,
+                "top": 833.2677129489272,
+                "width": 134,
+                "x": 2439.2725702541975,
+                "y": 833.2677129489272
             },
             "post_job_actions": {},
             "tool_id": "Cut1",
@@ -1464,7 +1473,7 @@
                 {
                     "label": null,
                     "output_name": "out_file1",
-                    "uuid": "22a8a71f-66ee-423e-98cf-1d86f0cde769"
+                    "uuid": "a28f2cb1-2273-4b8f-9363-4d239253c430"
                 }
             ]
         },
@@ -1489,14 +1498,14 @@
                 }
             ],
             "position": {
-                "bottom": 719.234375,
-                "height": 154.34375,
-                "left": 2675.5,
-                "right": 2875.5,
-                "top": 564.890625,
-                "width": 200,
-                "x": 2675.5,
-                "y": 564.890625
+                "bottom": 935.6780167764691,
+                "height": 103.4102783203125,
+                "left": 2717.2725848297573,
+                "right": 2851.2725848297573,
+                "top": 832.2677384561566,
+                "width": 134,
+                "x": 2717.2725848297573,
+                "y": 832.2677384561566
             },
             "post_job_actions": {},
             "tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/ggplot2_heatmap2/ggplot2_heatmap2/3.1.1+galaxy1",
@@ -1514,7 +1523,7 @@
                 {
                     "label": null,
                     "output_name": "output1",
-                    "uuid": "d54b19c1-90e8-4d9c-8988-7ac2466966b9"
+                    "uuid": "09d0b86c-9b64-49fd-9da1-b58dea18cac0"
                 }
             ]
         },
@@ -1539,14 +1548,14 @@
                 }
             ],
             "position": {
-                "bottom": 911.234375,
-                "height": 154.34375,
-                "left": 2675.5,
-                "right": 2875.5,
-                "top": 756.890625,
-                "width": 200,
-                "x": 2675.5,
-                "y": 756.890625
+                "bottom": 1127.6780386398086,
+                "height": 103.4102783203125,
+                "left": 2717.2725848297573,
+                "right": 2851.2725848297573,
+                "top": 1024.2677603194961,
+                "width": 134,
+                "x": 2717.2725848297573,
+                "y": 1024.2677603194961
             },
             "post_job_actions": {},
             "tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/ggplot2_heatmap2/ggplot2_heatmap2/3.1.1+galaxy1",
@@ -1564,7 +1573,7 @@
                 {
                     "label": null,
                     "output_name": "output1",
-                    "uuid": "6ac2cb11-75b4-4127-b8e1-ac723f7a4256"
+                    "uuid": "67d70a98-193d-4d9c-8819-b188979f66cf"
                 }
             ]
         }
@@ -1572,6 +1581,6 @@
     "tags": [
         "transcriptomics"
     ],
-    "uuid": "0b79cb37-2648-4024-ad78-614d99cf5698",
-    "version": 1
+    "uuid": "faea2719-3c8f-48d8-bb77-5b9997924e5b",
+    "version": 2
 }


### PR DESCRIPTION
This PR includes the following changes:

- modifies the DESeq2 factor level groups in order to fix the following error:

`parameter 'groups': invalid options ('paired') were selected (valid options: untreat,treat,single.counts,paired.counts)
`
- changes the output format to *tabular* of the Concatenate output in order to fix the following error:

`
parameter 'field2': requires a value, but no legal values defined
`
