### PR TITLE
Workflow Reports: update worfklow to not hide PNG output

### DIFF
--- a/topics/galaxy-interface/tutorials/workflow-reports/workflows/galaxy-101-everyone.ga
+++ b/topics/galaxy-interface/tutorials/workflow-reports/workflows/galaxy-101-everyone.ga
@@ -2,7 +2,7 @@
     "a_galaxy_workflow": "true",
     "annotation": "introduction",
     "format-version": "0.1",
-    "name": "GTN Training: Galaxy 101 For Everyone",
+    "name": "GTN Training: Workflow Reports - Galaxy 101 For Everyone",
     "steps": {
         "0": {
             "annotation": "",
@@ -13,21 +13,21 @@
             "inputs": [
                 {
                     "description": "",
-                    "name": "iris"
+                    "name": "Iris Dataset"
                 }
             ],
             "label": "Iris Dataset",
             "name": "Input dataset",
             "outputs": [],
             "position": {
-                "bottom": 210.20000839233398,
-                "height": 61.79999923706055,
-                "left": 296.5,
-                "right": 496.5,
-                "top": 148.40000915527344,
+                "bottom": 205.8000030517578,
+                "height": 61.80000305175781,
+                "left": 292,
+                "right": 492,
+                "top": 144,
                 "width": 200,
-                "x": 296.5,
-                "y": 148.40000915527344
+                "x": 292,
+                "y": 144
             },
             "tool_id": null,
             "tool_state": "{\"optional\": false, \"tag\": null}",
@@ -57,14 +57,14 @@
                 }
             ],
             "position": {
-                "bottom": 253.4000015258789,
+                "bottom": 249,
                 "height": 134,
-                "left": 535.5,
-                "right": 735.5,
-                "top": 119.4000015258789,
+                "left": 531,
+                "right": 731,
+                "top": 115,
                 "width": 200,
-                "x": 535.5,
-                "y": 119.4000015258789
+                "x": 531,
+                "y": 115
             },
             "post_job_actions": {
                 "HideDatasetActiontabular": {
@@ -101,14 +101,14 @@
                 }
             ],
             "position": {
-                "bottom": 56.99374771118164,
-                "height": 113.5999984741211,
-                "left": 643.5,
-                "right": 843.5,
-                "top": -56.60625076293945,
+                "bottom": 52.600006103515625,
+                "height": 113.60000610351562,
+                "left": 639,
+                "right": 839,
+                "top": -61,
                 "width": 200,
-                "x": 643.5,
-                "y": -56.60625076293945
+                "x": 639,
+                "y": -61
             },
             "post_job_actions": {},
             "tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/datamash_ops/datamash_ops/1.1.0",
@@ -126,7 +126,7 @@
                 {
                     "label": "datamash_output",
                     "output_name": "out_file",
-                    "uuid": "254f1b4b-d466-4f0e-8c46-0e97bbedae4d"
+                    "uuid": "5fc8c705-b9e2-4008-aa85-e84504b8395f"
                 }
             ]
         },
@@ -151,14 +151,14 @@
                 }
             ],
             "position": {
-                "bottom": 245.00000762939453,
-                "height": 113.5999984741211,
-                "left": 836.5,
-                "right": 1036.5,
-                "top": 131.40000915527344,
+                "bottom": 240.60000610351562,
+                "height": 113.60000610351562,
+                "left": 832,
+                "right": 1032,
+                "top": 127,
                 "width": 200,
-                "x": 836.5,
-                "y": 131.40000915527344
+                "x": 832,
+                "y": 127
             },
             "post_job_actions": {
                 "HideDatasetActionout_file1": {
@@ -195,14 +195,14 @@
                 }
             ],
             "position": {
-                "bottom": 380.5999984741211,
-                "height": 93.20000457763672,
-                "left": 1063.5,
-                "right": 1263.5,
-                "top": 287.3999938964844,
+                "bottom": 376.1999969482422,
+                "height": 93.19999694824219,
+                "left": 1059,
+                "right": 1259,
+                "top": 283,
                 "width": 200,
-                "x": 1063.5,
-                "y": 287.3999938964844
+                "x": 1059,
+                "y": 283
             },
             "post_job_actions": {
                 "HideDatasetActionout_file1": {
@@ -239,14 +239,14 @@
                 }
             ],
             "position": {
-                "bottom": 500.5999984741211,
-                "height": 93.20000457763672,
-                "left": 1063.5,
-                "right": 1263.5,
-                "top": 407.3999938964844,
+                "bottom": 496.1999969482422,
+                "height": 93.19999694824219,
+                "left": 1059,
+                "right": 1259,
+                "top": 403,
                 "width": 200,
-                "x": 1063.5,
-                "y": 407.3999938964844
+                "x": 1059,
+                "y": 403
             },
             "post_job_actions": {},
             "tool_id": "Grouping1",
@@ -258,7 +258,7 @@
                 {
                     "label": "group1",
                     "output_name": "out_file1",
-                    "uuid": "a689bddf-14d0-4a72-b1f9-c34d8f50d2b3"
+                    "uuid": "7e07839c-e8ca-4692-8b8e-6eb3607066de"
                 }
             ]
         },
@@ -283,14 +283,14 @@
                 }
             ],
             "position": {
-                "bottom": 620.6000289916992,
-                "height": 93.20000457763672,
-                "left": 1063.5,
-                "right": 1263.5,
-                "top": 527.4000244140625,
+                "bottom": 616.1999969482422,
+                "height": 93.19999694824219,
+                "left": 1059,
+                "right": 1259,
+                "top": 523,
                 "width": 200,
-                "x": 1063.5,
-                "y": 527.4000244140625
+                "x": 1059,
+                "y": 523
             },
             "post_job_actions": {},
             "tool_id": "Grouping1",
@@ -302,7 +302,7 @@
                 {
                     "label": "group2",
                     "output_name": "out_file1",
-                    "uuid": "ac7c73b2-58dd-4c6e-85ce-ddf49323b206"
+                    "uuid": "9cb98227-aa5b-4b77-933c-ffba1e98566e"
                 }
             ]
         },
@@ -317,7 +317,12 @@
                     "output_name": "out_file1"
                 }
             },
-            "inputs": [],
+            "inputs": [
+                {
+                    "description": "runtime parameter for tool Scatterplot with ggplot2",
+                    "name": "input1"
+                }
+            ],
             "label": null,
             "name": "Scatterplot with ggplot2",
             "outputs": [
@@ -331,20 +336,20 @@
                 }
             ],
             "position": {
-                "bottom": 873.0000305175781,
-                "height": 225.60000610351562,
-                "left": 1063.5,
-                "right": 1263.5,
-                "top": 647.4000244140625,
+                "bottom": 889,
+                "height": 246,
+                "left": 1059,
+                "right": 1259,
+                "top": 643,
                 "width": 200,
-                "x": 1063.5,
-                "y": 647.4000244140625
+                "x": 1059,
+                "y": 643
             },
             "post_job_actions": {
-                "HideDatasetActionoutput1": {
+                "HideDatasetActionoutput2": {
                     "action_arguments": {},
                     "action_type": "HideDatasetAction",
-                    "output_name": "output1"
+                    "output_name": "output2"
                 }
             },
             "tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/ggplot2_point/ggplot2_point/3.3.5+galaxy0",
@@ -354,15 +359,15 @@
                 "owner": "iuc",
                 "tool_shed": "toolshed.g2.bx.psu.edu"
             },
-            "tool_state": "{\"adv\": {\"type_conditional\": {\"type_options\": \"points\", \"__current_case__\": 0, \"points\": {\"pointoptions\": \"default\", \"__current_case__\": 0}}, \"factor\": {\"factoring\": \"Single\", \"__current_case__\": 1, \"factorcol\": \"5\", \"colors\": \"Set2\", \"colororder\": \"1\"}, \"axis_title_customization\": {\"axis_customization\": \"default\", \"__current_case__\": 0}, \"axis_text_customization\": {\"axis_customization\": \"default\", \"__current_case__\": 0}, \"plot_title_customization\": {\"axis_customization\": \"default\", \"__current_case__\": 0}, \"gridlinecust\": \"default\", \"transform\": \"none\", \"scaling\": {\"plot_scaling\": \"Automatic\", \"__current_case__\": 0}, \"theme\": \"bw\", \"legend\": \"yes\"}, \"input1\": {\"__class__\": \"ConnectedValue\"}, \"out\": {\"unit_output_dim\": \"in\", \"width_output_dim\": \"7.0\", \"height_output_dim\": \"7.0\", \"dpi_output_dim\": \"300.0\", \"additional_output_format\": \"pdf\"}, \"title\": \"Sepal length as a function of sepal width\", \"xlab\": \"Sepal length\", \"xplot\": \"1\", \"ylab\": \"Sepal width\", \"yplot\": \"2\", \"__page__\": null, \"__rerun_remap_job_id__\": null}",
+            "tool_state": "{\"adv\": {\"type_conditional\": {\"type_options\": \"points\", \"__current_case__\": 0, \"points\": {\"pointoptions\": \"default\", \"__current_case__\": 0}}, \"factor\": {\"factoring\": \"Single\", \"__current_case__\": 1, \"factorcol\": \"5\", \"colors\": \"Set2\", \"colororder\": \"1\"}, \"axis_title_customization\": {\"axis_customization\": \"default\", \"__current_case__\": 0}, \"axis_text_customization\": {\"axis_customization\": \"default\", \"__current_case__\": 0}, \"plot_title_customization\": {\"axis_customization\": \"default\", \"__current_case__\": 0}, \"gridlinecust\": \"default\", \"transform\": \"none\", \"scaling\": {\"plot_scaling\": \"Automatic\", \"__current_case__\": 0}, \"theme\": \"bw\", \"legend\": \"yes\"}, \"input1\": {\"__class__\": \"RuntimeValue\"}, \"out\": {\"unit_output_dim\": \"in\", \"width_output_dim\": \"7.0\", \"height_output_dim\": \"7.0\", \"dpi_output_dim\": \"300.0\", \"additional_output_format\": \"pdf\"}, \"title\": \"Sepal length as a function of sepal width\", \"xlab\": \"Sepal length\", \"xplot\": \"1\", \"ylab\": \"Sepal width\", \"yplot\": \"2\", \"__page__\": null, \"__rerun_remap_job_id__\": null}",
             "tool_version": "3.3.5+galaxy0",
             "type": "tool",
             "uuid": "fa412209-5e3a-448e-8b0b-fa88870e19c1",
             "workflow_outputs": [
                 {
                     "label": null,
-                    "output_name": "output2",
-                    "uuid": "08954537-18c1-4fa5-8093-b2ec90c0eb5c"
+                    "output_name": "output1",
+                    "uuid": "edb75294-0687-433e-821e-cffc03c7c103"
                 }
             ]
         },
@@ -377,7 +382,12 @@
                     "output_name": "out_file1"
                 }
             },
-            "inputs": [],
+            "inputs": [
+                {
+                    "description": "runtime parameter for tool Scatterplot with ggplot2",
+                    "name": "input1"
+                }
+            ],
             "label": null,
             "name": "Scatterplot with ggplot2",
             "outputs": [
@@ -391,20 +401,20 @@
                 }
             ],
             "position": {
-                "bottom": 993.0000305175781,
-                "height": 225.60000610351562,
-                "left": 1063.5,
-                "right": 1263.5,
-                "top": 767.4000244140625,
+                "bottom": 1009,
+                "height": 246,
+                "left": 1059,
+                "right": 1259,
+                "top": 763,
                 "width": 200,
-                "x": 1063.5,
-                "y": 767.4000244140625
+                "x": 1059,
+                "y": 763
             },
             "post_job_actions": {
-                "HideDatasetActionoutput1": {
+                "HideDatasetActionoutput2": {
                     "action_arguments": {},
                     "action_type": "HideDatasetAction",
-                    "output_name": "output1"
+                    "output_name": "output2"
                 }
             },
             "tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/ggplot2_point/ggplot2_point/3.3.5+galaxy0",
@@ -414,15 +424,15 @@
                 "owner": "iuc",
                 "tool_shed": "toolshed.g2.bx.psu.edu"
             },
-            "tool_state": "{\"adv\": {\"type_conditional\": {\"type_options\": \"points\", \"__current_case__\": 0, \"points\": {\"pointoptions\": \"default\", \"__current_case__\": 0}}, \"factor\": {\"factoring\": \"Single\", \"__current_case__\": 1, \"factorcol\": \"5\", \"colors\": \"Set2\", \"colororder\": \"1\"}, \"axis_title_customization\": {\"axis_customization\": \"default\", \"__current_case__\": 0}, \"axis_text_customization\": {\"axis_customization\": \"default\", \"__current_case__\": 0}, \"plot_title_customization\": {\"axis_customization\": \"default\", \"__current_case__\": 0}, \"gridlinecust\": \"default\", \"transform\": \"none\", \"scaling\": {\"plot_scaling\": \"Automatic\", \"__current_case__\": 0}, \"theme\": \"bw\", \"legend\": \"yes\"}, \"input1\": {\"__class__\": \"ConnectedValue\"}, \"out\": {\"unit_output_dim\": \"in\", \"width_output_dim\": \"7.0\", \"height_output_dim\": \"7.0\", \"dpi_output_dim\": \"300.0\", \"additional_output_format\": \"pdf\"}, \"title\": \"Petal length as a function of petal width\", \"xlab\": \"Petal length\", \"xplot\": \"3\", \"ylab\": \"Petal width\", \"yplot\": \"4\", \"__page__\": null, \"__rerun_remap_job_id__\": null}",
+            "tool_state": "{\"adv\": {\"type_conditional\": {\"type_options\": \"points\", \"__current_case__\": 0, \"points\": {\"pointoptions\": \"default\", \"__current_case__\": 0}}, \"factor\": {\"factoring\": \"Single\", \"__current_case__\": 1, \"factorcol\": \"5\", \"colors\": \"Set2\", \"colororder\": \"1\"}, \"axis_title_customization\": {\"axis_customization\": \"default\", \"__current_case__\": 0}, \"axis_text_customization\": {\"axis_customization\": \"default\", \"__current_case__\": 0}, \"plot_title_customization\": {\"axis_customization\": \"default\", \"__current_case__\": 0}, \"gridlinecust\": \"default\", \"transform\": \"none\", \"scaling\": {\"plot_scaling\": \"Automatic\", \"__current_case__\": 0}, \"theme\": \"bw\", \"legend\": \"yes\"}, \"input1\": {\"__class__\": \"RuntimeValue\"}, \"out\": {\"unit_output_dim\": \"in\", \"width_output_dim\": \"7.0\", \"height_output_dim\": \"7.0\", \"dpi_output_dim\": \"300.0\", \"additional_output_format\": \"pdf\"}, \"title\": \"Petal length as a function of petal width\", \"xlab\": \"Petal length\", \"xplot\": \"3\", \"ylab\": \"Petal width\", \"yplot\": \"4\", \"__page__\": null, \"__rerun_remap_job_id__\": null}",
             "tool_version": "3.3.5+galaxy0",
             "type": "tool",
             "uuid": "8e7b3f8d-2b8b-46cb-93d4-0d74bf54441e",
             "workflow_outputs": [
                 {
                     "label": null,
-                    "output_name": "output2",
-                    "uuid": "cc4e1426-f444-4fcd-960c-a868d98147ac"
+                    "output_name": "output1",
+                    "uuid": "9e55c569-0443-4b96-b34a-e37a8416cd22"
                 }
             ]
         },
@@ -447,14 +457,14 @@
                 }
             ],
             "position": {
-                "bottom": 281.00000762939453,
-                "height": 113.5999984741211,
-                "left": 1283.5,
-                "right": 1483.5,
-                "top": 167.40000915527344,
+                "bottom": 276.6000061035156,
+                "height": 113.60000610351562,
+                "left": 1279,
+                "right": 1479,
+                "top": 163,
                 "width": 200,
-                "x": 1283.5,
-                "y": 167.40000915527344
+                "x": 1279,
+                "y": 163
             },
             "post_job_actions": {},
             "tool_id": "toolshed.g2.bx.psu.edu/repos/bgruening/text_processing/tp_sorted_uniq/1.1.0",
@@ -472,12 +482,14 @@
                 {
                     "label": "unique_output",
                     "output_name": "outfile",
-                    "uuid": "8a2b5e30-d42a-4019-9674-4b4af00c820a"
+                    "uuid": "fc73409c-7878-4391-bc91-f99a5be0ba06"
                 }
             ]
         }
     },
-    "tags": ["galaxy-interface"],
-    "uuid": "342415eb-0cbe-4926-89f5-9f38a13b519b",
+    "tags": [
+        "galaxy-interface"
+    ],
+    "uuid": "59f5922f-3acd-4457-9a92-608491000db9",
     "version": 2
 }


### PR DESCRIPTION
we use the png output for the report but it appeared to be hidden by default