### PR TITLE
Add instructions to make workflow accessible in the creating tutorial tutorial

### DIFF
--- a/faqs/galaxy/workflows_publish.md
+++ b/faqs/galaxy/workflows_publish.md
@@ -6,7 +6,8 @@ layout: faq
 contributors: [bebatut]
 ---
 
-- Click on *Workflow* on the top menu bar of Galaxy. You will see a list of all your workflows
+- Click on **Workflow** on the top menu bar of Galaxy. You will see a list of all your workflows
 - Click on the interesting workflow
 - Click on **Share**
-- Clik on *Make Workflow Accessible and Publish**
+- Click on **Make Workflow accessible**. This makes the workflow *publicly accessible* but *unlisted*.
+- To also list the workflow in the *Shared Data* section (in the top menu bar) of Galaxy, click **Make Workflow publicly available in Published Workflows**

--- a/topics/contributing/tutorials/create-new-tutorial/tutorial.md
+++ b/topics/contributing/tutorials/create-new-tutorial/tutorial.md
@@ -152,6 +152,10 @@ Before writing the tutorial, it is a good practice to get a workflow with the di
 >    For the Copernicus tutorial:
 >    - **Annotation**: `Retrieve climate data from Copernicus`
 >    - **Tag**: `climate`
+>
+> 4. Make the workflow accessible (publishing is not necessary)
+>
+>    {% snippet faqs/galaxy/workflows_publish.md %}
 >     
 {: .hands_on}
 


### PR DESCRIPTION
For completeness, technically you do have to publish it until galaxyproject/galaxy#14348 is deployed.