### PR TITLE
Add support for details type box for FAQs

### DIFF
--- a/_plugins/snippet.rb
+++ b/_plugins/snippet.rb
@@ -87,6 +87,11 @@ module Jekyll
                 box_start = '> ### '+get_icon(icon_text)+' ' + metadata['title']
                 box_end   = "\n{: .question}"
             end
+            if box_type == 'details'
+                icon_text = icons['details']
+                box_start = '> ### '+get_icon(icon_text)+' ' + metadata['title']
+                box_end   = "\n{: .details}"
+            end
           end
           y = x.gsub(/\A---(.|\n)*?---/, '')
           #if y =~ /contribute/


### PR DESCRIPTION
This should allow setting `box_type: details` on FAQs per @bebatut request