### PR TITLE
Feedback: add links back to tutorial, fix links from tutorial/topic pages to the feedback

### DIFF
--- a/_includes/extras.html
+++ b/_includes/extras.html
@@ -16,11 +16,16 @@
         <a class="dropdown-item" href="https://plausible.galaxyproject.eu/training.galaxyproject.org?period=12mo&page={{site.baseurl}}{{ page.url }}" title="Show view statistics of this page">
             {% icon galaxy-barchart %} Page Metrics
         </a>
-        {% if page.layout == 'topic' %}
+
+        <!-- link to feedback -->
+        {% assign fdbk= site.data['feedback'] %}
+        {% assign fdbk_by_topic = fdbk | group_by: 'topic' | where: "name", site.data[page.topic_name]  %}
+        {% assign fdbk_by_tutorial = fdbk | group_by: 'tutorial' | where: "name", page.title %}
+        {% if page.layout == 'topic' and fdbk_by_topic.size > 0 %}
             <a class="dropdown-item" href="{{ site.baseurl }}/feedback.html#topic-{{ page.topic_name }}" title="Show feedback statistics about this topic">
                 {% icon galaxy-barchart %} Topic feedback
             </a>
-        {% elsif page.layout == 'tutorial_hands_on' %}
+        {% elsif page.layout == 'tutorial_hands_on' and fdbk_by_tutorial.size > 0 %}
 
             <a class="dropdown-item" href="{{ site.baseurl }}/feedback.html#tutorial-{{ page.tutorial_name }}" title="Show feedback statistics about this tutorial">
                 {% icon galaxy-barchart %} Tutorial feedback

--- a/_includes/extras.html
+++ b/_includes/extras.html
@@ -16,12 +16,12 @@
         <a class="dropdown-item" href="https://plausible.galaxyproject.eu/training.galaxyproject.org?period=12mo&page={{site.baseurl}}{{ page.url }}" title="Show view statistics of this page">
             {% icon galaxy-barchart %} Page Metrics
         </a>
-
-        {% if page.layout == 'topic' and site.data['feedback'].topic contains page.topic_name %}
+        {% if page.layout == 'topic' %}
             <a class="dropdown-item" href="{{ site.baseurl }}/feedback.html#topic-{{ page.topic_name }}" title="Show feedback statistics about this topic">
                 {% icon galaxy-barchart %} Topic feedback
             </a>
-        {% elsif page.layout == 'tutorial_hands_on' and site.data['feedback'].tutorial contains page.tutorial_name %}
+        {% elsif page.layout == 'tutorial_hands_on' %}
+
             <a class="dropdown-item" href="{{ site.baseurl }}/feedback.html#tutorial-{{ page.tutorial_name }}" title="Show feedback statistics about this tutorial">
                 {% icon galaxy-barchart %} Tutorial feedback
             </a>

--- a/_includes/extras.html
+++ b/_includes/extras.html
@@ -19,7 +19,7 @@
 
         <!-- link to feedback -->
         {% assign fdbk= site.data['feedback'] %}
-        {% assign fdbk_by_topic = fdbk | group_by: 'topic' | where: "name", site.data[page.topic_name]  %}
+        {% assign fdbk_by_topic = fdbk | group_by: 'topic' | where: "name", site.data[page.topic_name].title %}
         {% assign fdbk_by_tutorial = fdbk | group_by: 'tutorial' | where: "name", page.title %}
         {% if page.layout == 'topic' and fdbk_by_topic.size > 0 %}
             <a class="dropdown-item" href="{{ site.baseurl }}/feedback.html#topic-{{ page.topic_name }}" title="Show feedback statistics about this topic">

--- a/bin/prepare_feedback.py
+++ b/bin/prepare_feedback.py
@@ -29,7 +29,8 @@ new_tutorial_name = {
     'Workflows: Using Workflow Parameters': 'Using Workflow Parameters',
     'Exome sequencing data analysis': 'Exome sequencing data analysis for diagnosing a genetic disease',
     'Galaxy Tool Management': 'Galaxy Tool Management with Ephemeris',
-    'Virtual screening of the SARS-CoV-2 main protease with rDock and pose scoring': 'Virtual screening of the SARS-CoV-2 main protease with rxDock and pose scoring'
+    'Virtual screening of the SARS-CoV-2 main protease with rDock and pose scoring': 'Virtual screening of the SARS-CoV-2 main protease with rxDock and pose scoring',
+    'Refining Genome Annotations with Apollo':'Refining Genome Annotations with Apollo (prokaryotes)'
 }
 new_topic_for_tuto = {
     'Formation of the Super-Structures on the Inactive X': 'Epigenetics',

--- a/bin/prepare_feedback.py
+++ b/bin/prepare_feedback.py
@@ -30,7 +30,10 @@ new_tutorial_name = {
     'Exome sequencing data analysis': 'Exome sequencing data analysis for diagnosing a genetic disease',
     'Galaxy Tool Management': 'Galaxy Tool Management with Ephemeris',
     'Virtual screening of the SARS-CoV-2 main protease with rDock and pose scoring': 'Virtual screening of the SARS-CoV-2 main protease with rxDock and pose scoring',
-    'Refining Genome Annotations with Apollo':'Refining Genome Annotations with Apollo (prokaryotes)'
+    'Refining Genome Annotations with Apollo':'Refining Genome Annotations with Apollo (prokaryotes)',
+    'Mass spectrometry imaging 1: Loading and exploring MSI data':'Mass spectrometry imaging: Loading and exploring MSI data',
+    'Trajectory Analysis using Python (Jupyter Notebook) in Galaxy':'Inferring Trajectories using Python (Jupyter Notebook) in Galaxy',
+    'Submitting raw sequencing reads to ENA':'Submitting sequence data to ENA'
 }
 new_topic_for_tuto = {
     'Formation of the Super-Structures on the Inactive X': 'Epigenetics',

--- a/feedback.md
+++ b/feedback.md
@@ -346,7 +346,8 @@ layout: base
                                             </div>
                                         </div>
                                     </div>
-                                    <a href="{{site.baseurl}}/topics/{{topic_name}}/tutorials/{{tuto_name}}/tutorial.html">View this Tutorial</a>
+                                    {% if lang %} {% assign tuto_link = tuto_name | replace: 'tutorial_' , '/tutorial_' %} {% else %} {% assign tuto_link = tuto_name %} {% endif %}
+                                    <a href="{{site.baseurl}}/topics/{{topic_name}}/tutorials/{{tuto_link}}/tutorial.html">View this Tutorial</a>
 
                                     <div class="row">
                                         <div class="col">

--- a/feedback.md
+++ b/feedback.md
@@ -292,8 +292,10 @@ layout: base
                             <p>Tutorial "{{ tun.name }}" is not available anymore.</p>
                         </div>
                     {% else %}
+                        {% assign lang = '' %}
                         {% if tuto_metadata['name'] != 'tutorial.md' %}
                             {% assign lang = tuto_metadata['name'] | split: "." | first %}
+                            {% assign tuto_base = tuto_name %}
                             {% assign tuto_name = tuto_name | append: lang %}
                         {% endif %}
                         <div class="accordion-card card" id="tutorial-{{ tuto_name }}">
@@ -346,8 +348,11 @@ layout: base
                                             </div>
                                         </div>
                                     </div>
-                                    {% if lang %} {% assign tuto_link = tuto_name | replace: 'tutorial_' , '/tutorial_' %} {% else %} {% assign tuto_link = tuto_name %} {% endif %}
-                                    <a href="{{site.baseurl}}/topics/{{topic_name}}/tutorials/{{tuto_link}}/tutorial.html">View this Tutorial</a>
+                                    {% if lang != '' %}
+                                    <a href="{% link topics/{{topic_name}}/tutorials/{{tuto_base}}/{{tuto_metadata['name']}} %}">View this Tutorial</a>
+                                    {% else %}
+                                    <a href="{% link topics/{{topic_name}}/tutorials/{{tuto_name}}/tutorial.md %}">View this Tutorial</a>
+                                    {% endif %}
 
                                     <div class="row">
                                         <div class="col">

--- a/feedback.md
+++ b/feedback.md
@@ -346,11 +346,13 @@ layout: base
                                             </div>
                                         </div>
                                     </div>
+                                    <a href="{{site.baseurl}}/topics/{{topic_name}}/tutorials/{{tuto_name}}/tutorial.html">View this Tutorial</a>
 
                                     <div class="row">
                                         <div class="col">
                                             <div class="card">
                                                 <div class="card-body">
+
                                                     <h5 class="card-title">Detailed feedback</h5>
                                                     <table class="table table-striped">
                                                         <thead>

--- a/metadata/feedback.csv
+++ b/metadata/feedback.csv
@@ -1363,7 +1363,7 @@
 2196,5,The way one can understand the relation between different organism through the clades.,,,"Mutation calling, viral genome reconstruction and lineage/clade assignment from SARS-CoV-2 sequencing data",Variant Analysis,2021-08,2021-08-11
 2197,5,I liked how detailed every steps were taught !,,,"Mutation calling, viral genome reconstruction and lineage/clade assignment from SARS-CoV-2 sequencing data",Variant Analysis,2021-08,2021-08-11
 2198,3,,,,Virtual screening of the SARS-CoV-2 main protease with rxDock and pose scoring,Computational chemistry,2021-08,2021-08-11
-2199,3,,,,Submitting raw sequencing reads to ENA,Using Galaxy and Managing your Data,2021-08,2021-08-12
+2199,3,,,,Submitting sequence data to ENA,Using Galaxy and Managing your Data,2021-08,2021-08-12
 2200,5,Great flow of tutorial,Not much,,"Mutation calling, viral genome reconstruction and lineage/clade assignment from SARS-CoV-2 sequencing data",Variant Analysis,2021-08,2021-08-12
 2201,5,The tutorial is very detailed,,,"Mutation calling, viral genome reconstruction and lineage/clade assignment from SARS-CoV-2 sequencing data",Variant Analysis,2021-08,2021-08-12
 2202,4,Clear and systematic,Instructions can be more specific (e.g. names of tools),,NGS data logistics,Introduction to Galaxy Analyses,2021-08,2021-08-12
@@ -1373,12 +1373,12 @@
 2206,5,The details,,,Quality Control,Sequence analysis,2021-08,2021-08-12
 2207,5,,,,Mapping,Sequence analysis,2021-08,2021-08-12
 2208,5,,,,Using dataset collections,Using Galaxy and Managing your Data,2021-08,2021-08-12
-2209,4,,,,Submitting raw sequencing reads to ENA,Using Galaxy and Managing your Data,2021-08,2021-08-12
+2209,4,,,,Submitting sequence data to ENA,Using Galaxy and Managing your Data,2021-08,2021-08-12
 2210,5,the easy step by step guide ,nothing,,Galaxy 101,Introduction to Galaxy Analyses,2021-08,2021-08-12
 2211,5,your explanation of each plaot,,,Quality Control,Sequence analysis,2021-08,2021-08-12
 2212,3,,,,NGS data logistics,Introduction to Galaxy Analyses,2021-08,2021-08-12
 2213,5,,,,Removal of human reads from SARS-CoV-2 sequencing data,Sequence analysis,2021-08,2021-08-13
-2214,5,,,,Submitting raw sequencing reads to ENA,Using Galaxy and Managing your Data,2021-08,2021-08-13
+2214,5,,,,Submitting sequence data to ENA,Using Galaxy and Managing your Data,2021-08,2021-08-13
 2215,5,,,,Visualization of RNA-Seq results with Volcano Plot,Transcriptomics,2021-08,2021-08-13
 2216,5,The activity was very interactive with a good combination of theory and practical,The last step on NCBI BLAST search was not clear enough to a biginner like me,,Unicycler assembly of SARS-CoV-2 genome with preprocessing to remove human genome reads,Assembly,2021-08,2021-08-13
 2217,4,short but precise information about technique,little bit more information about difference in data analysis part of labelled vs label-free methods.,,Label-free versus Labelled - How to Choose Your Quantitation Method,Proteomics,2021-08,2021-08-14
@@ -1570,7 +1570,7 @@
 2409,5,An example full of information,no,,Introduction to Genomics and Galaxy,Introduction to Galaxy Analyses,2022-01,2022-01-27
 2410,5,The educational aspect and questions asked,The last question has no answer,,Galaxy 101,Introduction to Galaxy Analyses,2022-02,2022-02-02
 2411,5,,,,Visualization of RNA-Seq results with Volcano Plot,Transcriptomics,2022-02,2022-02-03
-2412,5,,,,Trajectory Analysis using Python (Jupyter Notebook) in Galaxy,Transcriptomics,2022-02,2022-02-04
+2412,5,,,,Inferring Trajectories using Python (Jupyter Notebook) in Galaxy,Transcriptomics,2022-02,2022-02-04
 2413,4,,,,Galaxy 101,Introduction to Galaxy Analyses,2022-02,2022-02-04
 2414,5,the simple and easy demonstration,,,Galaxy 101,Introduction to Galaxy Analyses,2022-02,2022-02-07
 2415,4,I liked the step by step follow up of results while doing the analysis,,,Galaxy 101,Introduction to Galaxy Analyses,2022-02,2022-02-07
@@ -1613,7 +1613,7 @@
 2453,5,,,,A short introduction to Galaxy,Introduction to Galaxy Analyses,2022-03,2022-03-07
 2454,5,"Easy to follow, user friendly for someone without background",,,Galaxy 101,Introduction to Galaxy Analyses,2022-03,2022-03-08
 2455,4,easy to understand with easy steps,,,From peaks to genes,Introduction to Galaxy Analyses,2022-03,2022-03-10
-2456,4,,,,Trajectory Analysis using Python (Jupyter Notebook) in Galaxy,Transcriptomics,2022-03,2022-03-11
+2456,4,,,,Inferring Trajectories using Python (Jupyter Notebook) in Galaxy,Transcriptomics,2022-03,2022-03-11
 2457,5,The tutorial was very informative and steps were defined clearly to perform the analysis...,"Overall, it was quite informative. However, it would be preferable to include a video tutorial for performing the analysis, where results can be thoroughly explained and the steps would be more easier to follow to perform the analysis for new users.",,Bulk RNA Deconvolution with MuSiC,Transcriptomics,2022-03,2022-03-12
 2458,4,,,,Galaxy 101,Introduction to Galaxy Analyses,2022-03,2022-03-12
 2459,5,Simplicity. ,"Considering this is an introduction to assembly, it would be helpful if the steps are complete as some steps may have been skipped. It would also be useful if pictures can be added for some steps.   When ran, the results stated in this tutorial doesnt match with the output even if the instructions is strictly followed",,An Introduction to Genome Assembly,Assembly,2022-03,2022-03-12
@@ -1944,7 +1944,7 @@
 2786,5,,,,Understanding Barcodes,Transcriptomics,2022-08,2022-08-22
 2787,5,everything.. thanks for this,"i cant find bowtie tools.. only bowtie 2, but the parameters described here are for bowtie.",,Essential genes detection with Transposon insertion sequencing,Genome Annotation,2022-08,2022-08-23
 2788,5,,,,Visualization of RNA-Seq results with heatmap2,Transcriptomics,2022-08,2022-08-23
-2789,4,,,,Mass spectrometry imaging 1: Loading and exploring MSI data,Proteomics,2022-08,2022-08-24
+2789,4,,,,Mass spectrometry imaging: Loading and exploring MSI data,Proteomics,2022-08,2022-08-24
 2790,4,"Most of the explanations and step were explained well but many icons in Galaxy have changed .  An update will be appreciated.  If USC browser is the main source , please have a detailed tutorial what all that stuff means .  Thanks",,,Introduction to Genomics and Galaxy,Introduction to Galaxy Analyses,2022-08,2022-08-25
 2791,4,,,,A short introduction to Galaxy,Introduction to Galaxy Analyses,2022-08,2022-08-30
 2792,5,Biological explanations after a command. ,"I think its great, but one improviment is add more image from Galaxy. ",,Introduction to Genomics and Galaxy,Introduction to Galaxy Analyses,2022-08,2022-08-30

--- a/metadata/feedback.csv
+++ b/metadata/feedback.csv
@@ -1265,7 +1265,7 @@
 1315,5,,,,Reference Data with CVMFS,Galaxy Server administration,2021-07,2021-07-01
 1316,5,The explanation was clear and I was able to follow the training without any problems.,the quality of the image was not so good,,Rule Based Uploader,Using Galaxy and Managing your Data,2021-07,2021-07-01
 1317,5,everything,with your YouTube channel guidance it difficult to understand in the beginning so also mention your link here too.,,Quality Control,Sequence analysis,2021-07,2021-07-01
-1318,4,nice talk and gives a rly good overview of apollo/galaxy interface. thank you!,"explain what are all the data you add as input inthefirst step, do u rly need that much? in the tutorial we only use some of them",,Refining Genome Annotations with Apollo,Genome Annotation,2021-07,2021-07-02
+1318,4,nice talk and gives a rly good overview of apollo/galaxy interface. thank you!,"explain what are all the data you add as input inthefirst step, do u rly need that much? in the tutorial we only use some of them",,Refining Genome Annotations with Apollo (prokaryotes),Genome Annotation,2021-07,2021-07-02
 1319,5,Clear explanation of the subject,"object_store_config_file: ""{{ galaxy_config_dir }}/object_store_conf.xml.j2"" should be object_store_config_file: ""{{ galaxy_config_dir }}/object_store_conf.xml""",,Distributed Object Storage,Galaxy Server administration,2021-07,2021-07-02
 1320,4,,,,Visualisation with Circos,Visualisation,2021-07,2021-07-02
 1321,5,,,,NGS data logistics,Introduction to Galaxy Analyses,2021-07,2021-07-02
@@ -1656,8 +1656,8 @@
 2496,5,Really liked the given details about each quality parameter,,,Quality Control,Sequence analysis,2022-03,2022-03-15
 2497,5,,,,Mapping,Sequence analysis,2022-03,2022-03-15
 2498,5,The IGV tutorial was great,,,Mapping,Sequence analysis,2022-03,2022-03-15
-2499,5,super interesting ! especially the sharing part !,,,Refining Genome Annotations with Apollo,Genome Annotation,2022-03,2022-03-15
-2500,5,,,,Refining Genome Annotations with Apollo,Genome Annotation,2022-03,2022-03-15
+2499,5,super interesting ! especially the sharing part !,,,Refining Genome Annotations with Apollo (prokaryotes),Genome Annotation,2022-03,2022-03-15
+2500,5,,,,Refining Genome Annotations with Apollo (prokaryotes),Genome Annotation,2022-03,2022-03-15
 2501,5,The options are pretty  intuitive.,,,Rule Based Uploader,Using Galaxy and Managing your Data,2022-03,2022-03-15
 2502,5,,,,Classification in Machine Learning,Statistics and machine learning,2022-03,2022-03-15
 2503,4,,For me it is not clear wether the apikey example use of vaults is the best. Might it be better to set an example about ssh passwords to connect remote servers?,,Ansible,Galaxy Server administration,2022-03,2022-03-15
@@ -1800,7 +1800,7 @@
 2640,2,not that much,reduce unnecessary details from the page ,,How to reproduce published Galaxy analyses,Introduction to Galaxy Analyses,2022-03,2022-03-31
 2641,5,,,,Genome annotation with Maker,Genome Annotation,2022-03,2022-03-31
 2642,5,Everything because all was new for me,The tutorial video would be more detailed in some parts.,,"Filter, Plot and Explore Single-cell RNA-seq Data",Transcriptomics,2022-03,2022-03-31
-2643,4,,"the sharing link is not working, so i couldnt share and create the group ",,Refining Genome Annotations with Apollo,Genome Annotation,2022-03,2022-03-31
+2643,4,,"the sharing link is not working, so i couldnt share and create the group ",,Refining Genome Annotations with Apollo (prokaryotes),Genome Annotation,2022-03,2022-03-31
 2644,4,,,,Reference-based RNA-Seq data analysis,Transcriptomics,2022-03,2022-03-31
 2645,5,,,,Visualization of RNA-Seq results with Volcano Plot,Transcriptomics,2022-03,2022-03-31
 2646,5,,,,Quality Control,Sequence analysis,2022-03,2022-03-31
@@ -1827,3 +1827,162 @@
 2668,5,Detailed and accurate.,I have no suggestions ,,A short introduction to Galaxy,Introduction to Galaxy Analyses,2022-04,2022-04-08
 2669,5,,,,Galaxy 101,Introduction to Galaxy Analyses,2022-04,2022-04-10
 2670,5,,,,A short introduction to Galaxy,Introduction to Galaxy Analyses,2022-04,2022-04-10
+2671,5,,,,3: RNA-seq genes to pathways,Transcriptomics,2022-04,2022-04-11
+2672,4,great explanation ,,,Reference-based RNA-Seq data analysis,Transcriptomics,2022-04,2022-04-11
+2673,5,Each step of the analysis is very well explained and I could use this tutorial to help student understand 16S microbiome analysis. ,"The trainsets need updating. I tried to do this myself but it did not work. Also, could you do a version for ITS analysis?",,16S Microbial Analysis with mothur (extended),Metagenomics,2022-04,2022-04-13
+2674,5,,,,Running molecular dynamics simulations using GROMACS,Computational chemistry,2022-04,2022-04-13
+2675,5,,,,High Throughput Molecular Dynamics and Analysis,Computational chemistry,2022-04,2022-04-13
+2676,5,,,,Ansible,Galaxy Server administration,2022-04,2022-04-14
+2677,5,,,,Understanding Barcodes,Transcriptomics,2022-04,2022-04-17
+2678,4,It was good and simple.,More indications on how to read the visualization with IGV and JBrowse. ,,Mapping,Sequence analysis,2022-04,2022-04-17
+2679,5,,,,Quality Control,Sequence analysis,2022-04,2022-04-18
+2680,5,,,,A short introduction to Galaxy,Introduction to Galaxy Analyses,2022-04,2022-04-18
+2681,5,,,,A short introduction to Galaxy,Introduction to Galaxy Analyses,2022-04,2022-04-20
+2682,5,,,,16S Microbial Analysis with mothur (short),Metagenomics,2022-04,2022-04-22
+2683,5,The tutorial is Practical and easy to understand,I think in will be usefull to include another ways to upload files,,A short introduction to Galaxy,Introduction to Galaxy Analyses,2022-04,2022-04-25
+2684,1,,,,De Bruijn Graph Assembly,Assembly,2022-04,2022-04-26
+2685,5,It is easy to follow up as you practice.,More examples to practice with.,,An Introduction to Genome Assembly,Assembly,2022-04,2022-04-26
+2686,4,,,,Genome Annotation,Genome Annotation,2022-04,2022-04-26
+2687,4,The tutorial is very comprehensive.,"The link for the Ensembl gene annotation for Drosophila melanogaster from Zenodo doesn't work. I think there are mistakes regarding the datasets and tools to be used in the ""Gene Ontology analysis"" section, more precisely in the ""Hands on: Get the gene length from previous history"" and ""Hands on: Adapt the gene length to goseq"" parts. ",,Reference-based RNA-Seq data analysis,Transcriptomics,2022-04,2022-04-26
+2688,5,"It was simple (great for the first aproach), really clear and usefull",,,A short introduction to Galaxy,Introduction to Galaxy Analyses,2022-04,2022-04-27
+2689,5,It was easy to follow but learn usefull things,,,Galaxy 101 for everyone,Introduction to Galaxy Analyses,2022-04,2022-04-27
+2690,4,,,,Deep Learning (Part 3) - Convolutional neural networks (CNN),Statistics and machine learning,2022-04,2022-04-28
+2691,5,,,,A short introduction to Galaxy,Introduction to Galaxy Analyses,2022-04,2022-04-28
+2692,5,,,,CRISPR screen analysis,Genome Annotation,2022-04,2022-04-28
+2693,5,The stages of preparing a workshop is very explicit on . Thanks.,The processes  are clear.and direct.,,Organizing a workshop,Teaching and Hosting Galaxy training,2022-04,2022-04-29
+2694,5,hands on,,,Galaxy 101 for everyone,Introduction to Galaxy Analyses,2022-04,2022-04-29
+2695,5,interactive,,,Introduction to Genomics and Galaxy,Introduction to Galaxy Analyses,2022-04,2022-04-29
+2696,5,easy explanations,,,A short introduction to Galaxy,Introduction to Galaxy Analyses,2022-04,2022-04-30
+2697,5,,,,From peaks to genes,Introduction to Galaxy Analyses,2022-05,2022-05-03
+2698,4,,,,A short introduction to Galaxy,Introduction to Galaxy Analyses,2022-05,2022-05-03
+2699,5,Its simplicity. It was easy to follow and didn't make me stressed.,,,Quality Control,Sequence analysis,2022-05,2022-05-04
+2700,5,,,,Reference-based RNA-Seq data analysis,Transcriptomics,2022-05,2022-05-06
+2701,1,topic is very important,"some steps are not cleared explained, workflow for this specific task and visualization tool is not working showing loading error",,From peaks to genes,Introduction to Galaxy Analyses,2022-05,2022-05-07
+2702,5,,,,A short introduction to Galaxy,Introduction to Galaxy Analyses,2022-05,2022-05-09
+2703,4,,,,Quality Control,Sequence analysis,2022-05,2022-05-10
+2704,4,Easy to understand,Pls provide dataset so that we can practice alongside,,Introduction to Machine Learning using R,Statistics and machine learning,2022-05,2022-05-11
+2705,1,,,,Proteogenomics 3: Novel peptide analysis,Proteomics,2022-05,2022-05-13
+2706,4,,,,How to reproduce published Galaxy analyses,Introduction to Galaxy Analyses,2022-05,2022-05-15
+2707,5,yes,,,Mapping,Sequence analysis,2022-05,2022-05-15
+2708,5,I like the clarity of the pictures used in describing the different steps,There is nothing needed to be improved. The tutorial is excellent,,A short introduction to Galaxy,Introduction to Galaxy Analyses,2022-05,2022-05-16
+2709,5,Simplicity of explaining complicate issue (-;,n.a.,,Analyses of metagenomics data - The global picture,Metagenomics,2022-05,2022-05-17
+2710,4,Easy to follow. Helpful examples. ,,,Galaxy 101,Introduction to Galaxy Analyses,2022-05,2022-05-18
+2711,5,The explanations,,,Visualization of RNA-Seq results with Volcano Plot,Transcriptomics,2022-05,2022-05-18
+2712,3,,,,Reference-based RNA-Seq data analysis,Transcriptomics,2022-05,2022-05-18
+2713,5,Platform is simple enough to follow and the steps are well-explained.,"When I run the tutorial with Windows as an OS everything ran smoothly, but when I was on Ubuntu linux I had issues with the window that I had to load the dataset. The options for pasting the data, etc. were not visible at all and I could not do anything for it. ",,A short introduction to Galaxy,Introduction to Galaxy Analyses,2022-05,2022-05-21
+2714,5,,,,Reference-based RNA-Seq data analysis,Transcriptomics,2022-05,2022-05-22
+2715,5,proper description and arrangement.,Results,,Genome Annotation,Genome Annotation,2022-05,2022-05-23
+2716,5,the details,,,A short introduction to Galaxy,Introduction to Galaxy Analyses,2022-05,2022-05-24
+2717,5,,,,Galaxy 101,Introduction to Galaxy Analyses,2022-05,2022-05-25
+2718,5,It explained everything in simple language!!,,,Introduction to Genomics and Galaxy,Introduction to Galaxy Analyses,2022-05,2022-05-25
+2719,4,,,,Mass spectrometry imaging: Examining the spatial distribution of analytes,Metabolomics,2022-05,2022-05-25
+2720,5,,,,A short introduction to Galaxy,Introduction to Galaxy Analyses,2022-05,2022-05-27
+2721,5,hashtags!,,,Understanding Galaxy history system,Using Galaxy and Managing your Data,2022-05,2022-05-28
+2722,5,,,,Pangeo Notebook in Galaxy - Introduction to Xarray,Climate,2022-05,2022-05-29
+2723,4,Good balance between some slightly more 'in depth topics' and simple and to the point hand-on instructions.,"The 'Available on these Galaxies' information should be updates. For exmple, the tutorial can not be completed as it is in the Australian server (for example, there are not locally installed snpEff databases, so a previous step with snpEff Download is needed and then use the option 'Downloaded snpEff database in your history'. Can be done but is confusing specially for novices). On the other hand, as far as I know, it can be conducted exactly as it is in the European server, but that one is not listed in the 'Available on these Galaxies' drop down menu.",,Calling variants in diploid systems,Variant Analysis,2022-05,2022-05-30
+2724,5,"I liked the real world data set, and the real world steps of exploration followed by the analysis. I thought the step wise progression made a lot of sense to me. I like having both predicting a categorical variable and the linear regression. It was great having both as many tutorials concentrate on predicting dichotomous outcomes and skip linear. I also like the exposure to handy R libraries, I am aware of quite a few (this isn't my first rodeo) but I learned of some more from this tutorial which was great.","Perhaps be explicit about the goals for the data analysis of the breast cancer dataset, that way the reader gets emotionally engaged in the analysis. I didn't realise till after looking at the source link that the measurements were from fine-needle biopsies of breast lesions, and the measurements were of cell nucleus radius, (I thought originally it might have been referring to tumour radius in mm). And that the goals were from the cell data from the fine needle aspiration we need to predict whether the patient has breast cancer or not. I appreciate you don't want the tutorial to be too long but perhaps using the cross table to show the positive predictive value or sensitivity and specificity and how increasing the number of clusters could improve the diagnostic accuracy.",,Introduction to Machine Learning using R,Statistics and machine learning,2022-06,2022-06-02
+2725,5,Well organized. Appreciated how the authors explained each QC graph. ,,,Quality Control,Sequence analysis,2022-06,2022-06-07
+2726,4,,,,Masking repeats with RepeatMasker,Genome Annotation,2022-06,2022-06-07
+2727,5,The questions that helped you look for the most relevant information in each Galaxy output in the history really made the tutorial engaging.,,,Library Generation for DIA Analysis,Proteomics,2022-06,2022-06-07
+2728,3,The interactive tools perspective,"The requirement for wildcard SSL certificate and the poor support for fulfilling this requirement. This is a major issue for the deployment of Galaxy servers. From a historical perspective, before 2019, there were IEs. Not super easy to deploy, but doable with motivation and investment in Docker knowledge. After launching the new ITs, IEs became progressively useless and ITs stay either nice demos or running on very few big public servers. Even the latter is not so clear: for instance, usegalaxy.org.au is not really providing ITs, usegalaxy.org (!) seems providing it at first glance, but the Rstudio interface - for instance - remains full blank forever. Only usegalaxy.eu to my knowledge provides effectively running and usable generalist ITs (Rstudio, Jupyter,). Thus, on that matter, where is the initial slogan ""data intensive analysis for everyone"" ? Of course, I am not blaming the trainers and contributors to this tutorial in any way ! But I really think that the technical strategy relying on wildcard SSL certificate to get the ITs running should be discussed with the community as a serious limitation to their use and thereby their active development. As it stands since 3 years now, ITs are out of the possibilities of a majority of Galaxy server instances because too complicated to install.",,Galaxy Interactive Tools,Galaxy Server administration,2022-06,2022-06-08
+2729,4,straightforward,"would have liked to have some practice viewing the assembly graphs and with visual methods for comparing genomes (e.g. dot, synteny plots)",,Genome assembly using PacBio data,Assembly,2022-06,2022-06-08
+2730,5,The explanation of every step which provide understanding even to beginners.,The different methods used in different steps of simulation should be explain in a such a way that the person can understand which method he should apply to his experiment.,,Running molecular dynamics simulations using GROMACS,Computational chemistry,2022-06,2022-06-08
+2731,5,,,,Galaxy 101,Introduction to Galaxy Analyses,2022-06,2022-06-08
+2732,1,nothing,everything,,DNA Methylation data analysis,Epigenetics,2022-06,2022-06-09
+2733,5,,,,Visualization of RNA-Seq results with Volcano Plot,Transcriptomics,2022-06,2022-06-10
+2734,4,it was clear ,maybe you could explain the file formats and what the tools do in a more clean way ,,Formation of the Super-Structures on the Inactive X,Epigenetics,2022-06,2022-06-13
+2735,5,,,,A short introduction to Galaxy,Introduction to Galaxy Analyses,2022-06,2022-06-15
+2736,5,,,,Formation of the Super-Structures on the Inactive X,Epigenetics,2022-06,2022-06-15
+2737,5,"Nice and understandable! I'm a software engineer tasked with setting up and administrating a Galaxy server, so I don't have a bioinformatics background. However, I was able to understand this tutorial and now know why Galaxy is such a powerful tool!",,,Galaxy 101 for everyone,Introduction to Galaxy Analyses,2022-06,2022-06-15
+2738,5,Ease of use,,,Galaxy 101 for everyone,Introduction to Galaxy Analyses,2022-06,2022-06-17
+2739,1,,it can be more better how do you get the end result was not clearly explained,,NGS data logistics,Introduction to Galaxy Analyses,2022-06,2022-06-18
+2740,5,,,,Introduction to Genomics and Galaxy,Introduction to Galaxy Analyses,2022-06,2022-06-20
+2741,3,,,,Quality Control,Sequence analysis,2022-06,2022-06-20
+2742,5,Well-detailed ,Alphadiversity,,16S Microbial Analysis with mothur (extended),Metagenomics,2022-06,2022-06-24
+2743,5,The clarity and flow of topics guidelines,so far so good,,16S Microbial Analysis with mothur (extended),Metagenomics,2022-06,2022-06-24
+2744,5,easy to follow & explained well,,,Quality Control,Sequence analysis,2022-06,2022-06-28
+2745,1,tree -l 2 was helpful as otherwise unclear which file goes where,"Current version of the tutorial is broken, consider rolling back to archive. Ansible errors very hard to troubleshoot - ideally add more tips where things can go wrong, for ex ansible vault seems to enter an unfixable state if you mess up the secret yml file and have to make it again",,Galaxy Installation with Ansible,Galaxy Server administration,2022-06,2022-06-29
+2746,5,,,,A short introduction to Galaxy,Introduction to Galaxy Analyses,2022-06,2022-06-29
+2747,5,"Very detailed, self explanatory",More examples maybe good,,Quality Control,Sequence analysis,2022-06,2022-06-29
+2748,5,learning how to use a workflow on a different dataset,,,Galaxy 101 for everyone,Introduction to Galaxy Analyses,2022-06,2022-06-30
+2749,1,most of the functionsare different what is given here,"please insert screen shorts of the results, how the output look like ",,An Introduction to Genome Assembly,Assembly,2022-06,2022-06-30
+2750,4,The way of presentation to make the tutorial easily understandable.,More numerical examples could be added.,,Deep Learning (Part 2) - Recurrent neural networks (RNN),Statistics and machine learning,2022-07,2022-07-01
+2751,4,The clear instructions on how to use the tools ,allowing learners to supply the solution and evaluating the answers,,M. tuberculosis Variant Analysis,Variant Analysis,2022-07,2022-07-02
+2752,2,It is a useful feature.,"The syntax of the ""Replace text"" tool is not explained. Thus, it is only useful with the data collection of the tutorial, but it does not teach how to aply it to other collections with different element identifiers. It would be great if it explained why the ""Find pattern"" and ""Replace with"" boxes are filled that way.",,Group tags for complex experimental designs,Using Galaxy and Managing your Data,2022-07,2022-07-05
+2754,5,Clear example of a great use case,What to do if pulling from an FTP server that requires credentials,,Rule Based Uploader,Using Galaxy and Managing your Data,2022-07,2022-07-08
+2755,5,Thorough guide with plenty of time for users to try. ,"To me it's simple enough to follow all the instructions, no improvement needed.",,A short introduction to Galaxy,Introduction to Galaxy Analyses,2022-07,2022-07-09
+2756,1,more detailed form example was not explained clearly,,,IGV Introduction,Introduction to Galaxy Analyses,2022-07,2022-07-09
+2757,4,it was information packed and tried to explain in details. ,"well , idk if i'm dumb but i couldn't find the gear icon to start the ctul tutorial. maybe the boxes in the instruction could be direct links instead?",,Quality Control,Sequence analysis,2022-07,2022-07-11
+2758,5,,,,A short introduction to Galaxy,Introduction to Galaxy Analyses,2022-07,2022-07-12
+2759,5,Easy to follow steps ,,,A short introduction to Galaxy,Introduction to Galaxy Analyses,2022-07,2022-07-14
+2760,5,,,,Galaxy 101,Introduction to Galaxy Analyses,2022-07,2022-07-19
+2761,4,The step by step guide and easy to operate,I facet some trouble with Database/Build section and I would like to info about them even it was not necessary for the analyse.,,Label-free data analysis using MaxQuant,Proteomics,2022-07,2022-07-19
+2762,5,It was easy to follow and very useful ,,,Reference-based RNA-Seq data analysis,Transcriptomics,2022-07,2022-07-19
+2763,5,clarity of each step,a short video can easy to complete this workflow and help peopless to learn it in much less time,,A short introduction to Galaxy,Introduction to Galaxy Analyses,2022-07,2022-07-20
+2764,5,,,,A short introduction to Galaxy,Introduction to Galaxy Analyses,2022-07,2022-07-20
+2765,5,,,,Clustering 3K PBMCs with Scanpy,Transcriptomics,2022-07,2022-07-21
+2766,4,,,,Peptide Library Data Analysis,Proteomics,2022-07,2022-07-24
+2767,5,,,,Machine Learning Modeling of Anticancer Peptides,Proteomics,2022-07,2022-07-24
+2768,5,,,,Microbial Variant Calling,Variant Analysis,2022-07,2022-07-26
+2769,5,the interaction of images and descriptions, more images of the interface step y step,,Galaxy 101 for everyone,Introduction to Galaxy Analyses,2022-07,2022-07-27
+2770,5,"relatively easy to follow, concept explanations are great ",,,Galaxy Installation with Ansible,Galaxy Server administration,2022-07,2022-07-28
+2771,5,,,,Visualization of RNA-Seq results with heatmap2,Transcriptomics,2022-07,2022-07-30
+2772,3,Great overview of ML and the basic models to start.,Many questions still lack solutions and there are some typos within the text.,,Introduction to Machine Learning using R,Statistics and machine learning,2022-08,2022-08-04
+2773,5,"I loved the fact that although this is not in-person, it was more interactive and practical. ",,,A short introduction to Galaxy,Introduction to Galaxy Analyses,2022-08,2022-08-04
+2774,5,Everything,Not much at all,,A short introduction to Galaxy,Introduction to Galaxy Analyses,2022-08,2022-08-04
+2775,5,It was explained in really easy to understand language for a novice like me with great diagrams. I've looked at a number of explanations about alpha and beta diversity and this was the most useful so far.,,,16S Microbial Analysis with mothur (extended),Metagenomics,2022-08,2022-08-04
+2776,3,List  elements identified during the process of genome annotation.,,,Genome Annotation,Genome Annotation,2022-08,2022-08-05
+2777,4,,,,A short introduction to Galaxy,Introduction to Galaxy Analyses,2022-08,2022-08-09
+2778,5,Things are explained in a simple and intuitive way,,,Quality Control,Sequence analysis,2022-08,2022-08-11
+2779,5,,,,16S Microbial analysis with Nanopore data,Metagenomics,2022-08,2022-08-12
+2780,1,,merge gromacs topologies doesn't exist in https://cheminformatics.usegalaxy.eu It was not possible to complete the tutorial without this tool,,High Throughput Molecular Dynamics and Analysis,Computational chemistry,2022-08,2022-08-14
+2781,5,,,,Quality Control,Sequence analysis,2022-08,2022-08-15
+2782,1,,,,Virtual screening of the SARS-CoV-2 main protease with rxDock and pose scoring,Computational chemistry,2022-08,2022-08-18
+2783,5,,Small typo at https://bit.ly/3dG17Er - tedious,,Reference-based RNA-Seq data analysis,Transcriptomics,2022-08,2022-08-18
+2784,5,,,,Reference-based RNA-Seq data analysis,Transcriptomics,2022-08,2022-08-18
+2785,5,The flow and easeness of usage and details.,,,Biomarker candidate identification,Proteomics,2022-08,2022-08-22
+2786,5,,,,Understanding Barcodes,Transcriptomics,2022-08,2022-08-22
+2787,5,everything.. thanks for this,"i cant find bowtie tools.. only bowtie 2, but the parameters described here are for bowtie.",,Essential genes detection with Transposon insertion sequencing,Genome Annotation,2022-08,2022-08-23
+2788,5,,,,Visualization of RNA-Seq results with heatmap2,Transcriptomics,2022-08,2022-08-23
+2789,4,,,,Mass spectrometry imaging 1: Loading and exploring MSI data,Proteomics,2022-08,2022-08-24
+2790,4,"Most of the explanations and step were explained well but many icons in Galaxy have changed .  An update will be appreciated.  If USC browser is the main source , please have a detailed tutorial what all that stuff means .  Thanks",,,Introduction to Genomics and Galaxy,Introduction to Galaxy Analyses,2022-08,2022-08-25
+2791,4,,,,A short introduction to Galaxy,Introduction to Galaxy Analyses,2022-08,2022-08-30
+2792,5,Biological explanations after a command. ,"I think its great, but one improviment is add more image from Galaxy. ",,Introduction to Genomics and Galaxy,Introduction to Galaxy Analyses,2022-08,2022-08-30
+2793,5,The instructions were clear and helpful (especially with the video alongside),"It would be super helpful if there were more subsection links! I set followed this tutorial to setup a server for my team, and when they had questions or wanted more info on why or how I did certain things it would have been nice to be able to link them more specifically to the step I wanted instead of the bigger section and then giving them key words to search for",,Galaxy Installation with Ansible,Galaxy Server administration,2022-08,2022-08-30
+2794,5,,,,Visualization of RNA-Seq results with heatmap2,Transcriptomics,2022-09,2022-09-01
+2795,4,"Learn about other tools to asses quality, it is often on software that we use, the one that is showed by the person that initiates us to galaxy. Here, we could see a panel of tools. ","I think maybe it is more pertinent to show one example of good and one of a bad data instead of a panel that increase the information a blur the message. Two images are easier to remember. I'd like that you showed us a panel of tools, but it is maybe too much information, too quickly within a short amount of time. Knowing that we have almost two weeks formations non stop, it could be valuable to synthesis more the message to slow down and make it more digestible. The specifics could be prospected by each user when they contact you. A fact that you could also remember people at the end of the presentation. ",,Quality Control,Sequence analysis,2022-09,2022-09-01
+2796,4,To test the tools of assembly in a control dataset,I think it could be valable to understand the tools and the parameters of the tools while using them: to not do it without thinking it through. I think it is better to understand to remember. ,,Genome assembly using PacBio data,Assembly,2022-09,2022-09-01
+2797,5,I really liked the amount of details,"Its perfect to me, but if you could add short videos in each topic, it can be complementary. ",,Quality Control,Sequence analysis,2022-09,2022-09-05
+2798,4,,,,A short introduction to Galaxy,Introduction to Galaxy Analyses,2022-09,2022-09-06
+2799,5,"Simple, clear",,,A short introduction to Galaxy,Introduction to Galaxy Analyses,2022-09,2022-09-12
+2800,5,It was doable by a wet lab scientist without prior experience in analysis!,,,A short introduction to Galaxy,Introduction to Galaxy Analyses,2022-09,2022-09-12
+2801,5,Easy to follow,"Couple of things out of date: view all histories is now in the menu and ""Click on galaxy-gear (History options) at the top of your history panel and select Extract workflow."" no longer a galaxy-gear icon but a drop down?",,A short introduction to Galaxy,Introduction to Galaxy Analyses,2022-09,2022-09-12
+2802,5,Simple and clear,,,Name tags for following complex histories,Using Galaxy and Managing your Data,2022-09,2022-09-12
+2803,5,Didn't know this feature!,tag=paired is incorrect - should be tag:paired ???,,Name tags for following complex histories,Using Galaxy and Managing your Data,2022-09,2022-09-12
+2804,5,,,,Extracting Workflows from Histories,Using Galaxy and Managing your Data,2022-09,2022-09-12
+2805,4,,,,Name tags for following complex histories,Using Galaxy and Managing your Data,2022-09,2022-09-12
+2806,5,,,,16S Microbial Analysis with mothur (extended),Metagenomics,2022-09,2022-09-14
+2807,5,,,,Quality Control,Sequence analysis,2022-09,2022-09-14
+2808,2,its step by step,"steps are not explained - for example: why do i need align left, why do i need to refilter quality levels...? Way to hard to understand. More Explanation why things are done a certain way. Its not explained why certain values are set and how to choose the right values. This tutorial is way to complicated.",,Identification of somatic and germline variants from tumor and normal sample pairs,Variant Analysis,2022-09,2022-09-14
+2809,5,"Clear, straight forward, but also information rich.",,,"Filter, Plot and Explore Single-cell RNA-seq Data",Transcriptomics,2022-09,2022-09-15
+2810,5,,,,"Filter, Plot and Explore Single-cell RNA-seq Data",Transcriptomics,2022-09,2022-09-15
+2811,5,"Easy to follow, encouraging to continue exploring","First time I run the QC analysis it took more than 1 hour, it would be great to have a time tracker so we can estimate the duration of each analysis (Second time I did the analysis it run in about 2 min)",,A short introduction to Galaxy,Introduction to Galaxy Analyses,2022-09,2022-09-15
+2812,5,,,,Inferring Trajectories using Python (Jupyter Notebook) in Galaxy,Transcriptomics,2022-09,2022-09-16
+2813,5,,,,Galaxy 101,Introduction to Galaxy Analyses,2022-09,2022-09-19
+2814,5,,,,Species distribution modeling,Ecology,2022-09,2022-09-21
+2815,5,,,,Quality Control,Sequence analysis,2022-09,2022-09-21
+2816,4,Data made small enough to process it together in class,"Could you please correct the following typos: ""Differentially expressed miRNAs"" into ""Differentially expressed mRNAs"" in the section ""mRNA data analysis > Filter.. Thanks!",,Whole transcriptome analysis of Arabidopsis thaliana,Transcriptomics,2022-09,2022-09-24
+2817,4,"I appreciated the descriptions and the format of it, like bullet points, etc.","I think more pictures would be valueable since it is a bit hard to navigate at first, especially during the 'workflow' i got a bit confused",,A short introduction to Galaxy,Introduction to Galaxy Analyses,2022-09,2022-09-25
+2818,5,"very comprehensive, needed for the data that doesn’t have annotation file (GTF)",please make a video with it. and a real data using in this tutorial from ncbi or else.,,"De novo transcriptome assembly, annotation, and differential expression analysis",Transcriptomics,2022-09,2022-09-25
+2819,5,,,,1: RNA-Seq reads to counts,Transcriptomics,2022-09,2022-09-26
+2820,5,"I really liked, that I could actually try it out.",,,A short introduction to Galaxy,Introduction to Galaxy Analyses,2022-09,2022-09-28
+2821,5,,,,A short introduction to Galaxy,Introduction to Galaxy Analyses,2022-10,2022-10-01
+2823,5,,,,16S Microbial analysis with Nanopore data,Metagenomics,2022-10,2022-10-07
+2824,5,,,,Visualization of RNA-Seq results with heatmap2,Transcriptomics,2022-10,2022-10-07
+2825,5,,,,A short introduction to Galaxy,Introduction to Galaxy Analyses,2022-10,2022-10-11
+2826,4,,"The wheel symbol in the history menu has changed to an arrow down. Also, the way to see the histories side by side has changed.",,A short introduction to Galaxy,Introduction to Galaxy Analyses,2022-10,2022-10-11
+2827,3,What I liked most about this tutorial was the existence of explanations that helped in the interpretation of the various outputs produced by the software.,"The tutorial could be updated because I found that there are discrepancies between the tutorial and the Galaxy platform. Namely, the name of some of the tools and their location on the website differ between the tutorial and the current platform.",,Genome annotation with Maker (short),Genome Annotation,2022-10,2022-10-11
+2828,5,"simple and easy to follow, although some of the icons have changed in the updated version",Just updated screen shots,,A short introduction to Galaxy,Introduction to Galaxy Analyses,2022-10,2022-10-12
+2829,5,,que explicara mas a fondo el uso de las demas herramientas con ejercicios,,A short introduction to Galaxy,Introduction to Galaxy Analyses,2022-10,2022-10-14
+2830,5,,,,1: RNA-Seq reads to counts,Transcriptomics,2022-10,2022-10-14
+2831,5,,,,A short introduction to Galaxy,Introduction to Galaxy Analyses,2022-10,2022-10-15


### PR DESCRIPTION
This adds a link back to the GTN tutorial from the cards on the feedback page (fixes https://github.com/galaxyproject/training-material/issues/2987)

![image](https://user-images.githubusercontent.com/2563865/194034433-9e38a19e-f39d-4f53-89a6-f35b4545d1fd.png)

And fixes the links from the "Extras" menu on tutorial and topic pages to just to the right section on the feedback page
