### PR TITLE
A nicer layout for mobile

### DIFF
--- a/_includes/resource-handson.html
+++ b/_includes/resource-handson.html
@@ -35,5 +35,6 @@
         <a class="dropdown-item" href="https://translate.google.com/translate?hl=jp&sl=en&tl=&u=https%3A%2F%2Ftraining.galaxyproject.org%2Ftopics%2F{{ include.topic }}%2Ftutorials%2F{{ include.material.tutorial_name }}%2Ftutorial.html&edit-text=&act=url" title="{{ inst[0] }}">
             More Languages
         </a>
+        </ul>
     </span>
 {% endif %}

--- a/_includes/resource-workflows.html
+++ b/_includes/resource-workflows.html
@@ -1,7 +1,7 @@
 {% assign locale = site.data.lang[page.lang] %}
 
 {% if include.material.workflows %}
-    <a class="topic-icon" href="{{ site.baseurl }}/topics/{{ include.topic }}/tutorials/{{ include.material.tutorial_name }}/workflows/" title="Workflows" alt="{{ include.material.title }} workflows">
+    <a class="btn btn-default topic-icon" href="{{ site.baseurl }}/topics/{{ include.topic }}/tutorials/{{ include.material.tutorial_name }}/workflows/" title="Workflows" alt="{{ include.material.title }} workflows">
         {% icon workflow aria=false %}{% if include.label %} {{locale['workflows'] | default: "Workflows"}}{% endif %}
     </a>
 {% endif %}

--- a/_includes/resource-zenodo.html
+++ b/_includes/resource-zenodo.html
@@ -1,7 +1,7 @@
 {% assign locale = site.data.lang[page.lang] %}
 
 {% if include.material.zenodo_link != nil and include.material.zenodo_link != "" %}
-<a class="topic-icon" title="Zenodo datasets used in this tutorial" href="{{ include.material.zenodo_link }}">
+<a class="btn btn-default topic-icon" title="Zenodo datasets used in this tutorial" href="{{ include.material.zenodo_link }}">
     {% icon zenodo_link aria=false %}{% if include.label %} {{ locale['datasets'] | default: "Datasets"}}{% endif %}
 </a>
 {% endif %}

--- a/_includes/tutorial_list.html
+++ b/_includes/tutorial_list.html
@@ -38,17 +38,10 @@
 
         <tr>
           <td class="tutorial_title">
-            {% if material.slides and material.hands_on %}
-            <a href="{{ site.baseurl }}/topics/{{ topic.name }}/tutorials/{{ material.tutorial_name }}/tutorial.html">
+            {% assign default_resource_url = material | get_default_link %}
+            {% if default_resource_url %}
+            <a href="{{ site.baseurl }}/{{ default_resource_url }}">
                 {{ material.title }}
-            </a>
-            {% elsif material.slides %}
-            <a href="{{ site.baseurl }}/topics/{{ topic.name }}/{{subfolder}}/{{ material.tutorial_name }}{% unless material.type == 'introduction' %}/slides{% endunless %}.html">
-                {{ material.title }}
-            </a>
-            {% elsif material.hands_on %}
-            <a href="{{ site.baseurl }}/topics/{{ topic.name }}/tutorials/{{ material.tutorial_name }}/tutorial.html">
-                {{ material.title}}
             </a>
             {% else %}
                 {{ material.title }}

--- a/_includes/tutorial_list.html
+++ b/_includes/tutorial_list.html
@@ -68,21 +68,24 @@
           </div>
 
           <div class="duplicate">
+          <!-- m.t:{{ material.type }} -->
           {% if material.type == "introduction" %}
             {% if material.slides %}
               {% include _includes/resource-slides.html material=material topic=topic.name %}
             {% endif %}
           {% elsif material.type == "tutorial" %}
-            {% include _includes/resource-slides.html material=material topic=topic.name %} 
-            {% include _includes/resource-handson.html material=material topic=topic.name %} 
+            <div class="btn-group" role="group" aria-label="Supporting materials for this resource">
+            {% include _includes/resource-slides.html material=material topic=topic.name %}
+            {% include _includes/resource-handson.html material=material topic=topic.name %}
+            <!-- video  {{ topic.type }} {{topic.name}} -->
             {% include _includes/resource-video-library.html material=material topic=topic.name %}
-            {% if topic.type == "use" %}
-              {% include _includes/resource-zenodo.html material=material topic=topic.name %} 
-              {% include _includes/resource-workflows.html material=material topic=topic.name %} 
-            {% endif %}
+            <!--  {{ topic.type }} {{topic.name}} -->
+            {% include _includes/resource-zenodo.html material=material topic=topic.name %}
+            {% include _includes/resource-workflows.html material=material topic=topic.name %}
             {% if instances[topic.name].supported %}
-              {% include _includes/instance-dropdown.html instances=instances topic=topic.name tuto=material.tutorial_name %} 
+              {% include _includes/instance-dropdown.html instances=instances topic=topic.name tuto=material.tutorial_name %}
             {% endif %}
+            </div>
           {% endif %}
           </div>
 

--- a/_includes/tutorial_list.html
+++ b/_includes/tutorial_list.html
@@ -1,28 +1,5 @@
-<style type="text/css">
-/* Big */
-@media (min-width:768px) {
-    .duplicate {
-        display: none;
-    }
-}
-
-/* Skinny */
-@media (max-width:767px) {
-    table.table.table-responsive {
-        display: inline-table;
-    }
-    tr th:not(:first-child) {
-        display: none;
-    }
-    tr td:not(:first-child) {
-        display: none;
-    }
-    .duplicate {
-        display: unset;
-    }
-}
-</style>
-<table class="table table-responsive table-striped" >
+<!-- {{ include.sub }} -->
+<table class="table table-responsive table-striped">
   <thead>
     <tr>
       <th>Lesson</th>

--- a/_includes/tutorial_list.html
+++ b/_includes/tutorial_list.html
@@ -1,4 +1,3 @@
-<!-- {{ include.sub }} -->
 <table class="table table-responsive table-striped">
   <thead>
     <tr>
@@ -68,7 +67,6 @@
           </div>
 
           <div class="duplicate">
-          <!-- m.t:{{ material.type }} -->
           {% if material.type == "introduction" %}
             {% if material.slides %}
               {% include _includes/resource-slides.html material=material topic=topic.name %}
@@ -77,9 +75,7 @@
             <div class="btn-group" role="group" aria-label="Supporting materials for this resource">
             {% include _includes/resource-slides.html material=material topic=topic.name %}
             {% include _includes/resource-handson.html material=material topic=topic.name %}
-            <!-- video  {{ topic.type }} {{topic.name}} -->
             {% include _includes/resource-video-library.html material=material topic=topic.name %}
-            <!--  {{ topic.type }} {{topic.name}} -->
             {% include _includes/resource-zenodo.html material=material topic=topic.name %}
             {% include _includes/resource-workflows.html material=material topic=topic.name %}
             {% if instances[topic.name].supported %}

--- a/_includes/tutorial_list.html
+++ b/_includes/tutorial_list.html
@@ -1,3 +1,27 @@
+<style type="text/css">
+/* Big */
+@media (min-width:768px) {
+    .duplicate {
+        display: none;
+    }
+}
+
+/* Skinny */
+@media (max-width:767px) {
+    table.table.table-responsive {
+        display: inline-table;
+    }
+    tr th:not(:first-child) {
+        display: none;
+    }
+    tr td:not(:first-child) {
+        display: none;
+    }
+    .duplicate {
+        display: unset;
+    }
+}
+</style>
 <table class="table table-responsive table-striped" >
   <thead>
     <tr>
@@ -30,9 +54,31 @@
 
     {% if include.sub == nil or show == true %}
       {% if material.enable != false or jekyll.environment != "production" %}
+        {% if material.type == 'introduction' %}
+          {% assign subfolder = 'slides' %}
+        {% else %}
+          {% assign subfolder = 'tutorials' %}
+        {% endif %}
+
         <tr>
           <td class="tutorial_title">
-          {{ material.title}}
+            {% if material.slides and material.hands_on %}
+            <a href="{{ site.baseurl }}/topics/{{ topic.name }}/tutorials/{{ material.tutorial_name }}/tutorial.html">
+                {{ material.title }}
+            </a>
+            {% elsif material.slides %}
+            <a href="{{ site.baseurl }}/topics/{{ topic.name }}/{{subfolder}}/{{ material.tutorial_name }}{% unless material.type == 'introduction' %}/slides{% endunless %}.html">
+                {{ material.title }}
+            </a>
+            {% elsif material.hands_on %}
+            <a href="{{ site.baseurl }}/topics/{{ topic.name }}/tutorials/{{ material.tutorial_name }}/tutorial.html">
+                {{ material.title}}
+            </a>
+            {% else %}
+                {{ material.title }}
+            {% endif %}
+
+
           <div class="">
           {% if material.level %}
             {% include _includes/difficulty-indicator.html level=material.level %}
@@ -43,6 +89,26 @@
             {% endfor %}
           {% endif %}
           </div>
+
+          <div class="duplicate">
+          {% if material.type == "introduction" %}
+            {% if material.slides %}
+              {% include _includes/resource-slides.html material=material topic=topic.name %}
+            {% endif %}
+          {% elsif material.type == "tutorial" %}
+            {% include _includes/resource-slides.html material=material topic=topic.name %} 
+            {% include _includes/resource-handson.html material=material topic=topic.name %} 
+            {% include _includes/resource-video-library.html material=material topic=topic.name %}
+            {% if topic.type == "use" %}
+              {% include _includes/resource-zenodo.html material=material topic=topic.name %} 
+              {% include _includes/resource-workflows.html material=material topic=topic.name %} 
+            {% endif %}
+            {% if instances[topic.name].supported %}
+              {% include _includes/instance-dropdown.html instances=instances topic=topic.name tuto=material.tutorial_name %} 
+            {% endif %}
+          {% endif %}
+          </div>
+
           </td>
           {% if material.type == "introduction" %}
             <td>

--- a/_plugins/jekyll-jsonld.rb
+++ b/_plugins/jekyll-jsonld.rb
@@ -28,6 +28,35 @@ module Jekyll
       end
     end
 
+    # todo: migrate somewhere else
+    def get_default_link(material)
+      url = nil
+
+      if material['type'] == "introduction"
+        subfolder = 'slides'
+      else
+        subfolder = 'tutorials'
+      end
+
+      if material['slides']
+        url = "topics/#{material['topic_name']}/#{subfolder}/#{material['tutorial_name']}"
+        if material['type'] != "introduction"
+          url += "/slides.html"
+        else
+          url += ".html"
+        end
+      end
+
+      if material['hands_on']
+        if material['hands_on'] != "external" && material['hands_on'] != ""
+          url = "topics/#{material['topic_name']}/tutorials/#{material['tutorial_name']}/tutorial.html"
+        end
+      end
+
+      puts "url=#{url}"
+      url
+    end
+
     def generate_dublin_core(material, site)
       if material.key?('data') && material['data'].fetch('type', 'none') != "tutorial_hands_on"
         return

--- a/assets/css/main.scss
+++ b/assets/css/main.scss
@@ -1491,3 +1491,28 @@ a[target="_blank"]::after {
   margin-left: 0.2em;
   height: 1em;
 }
+
+.tutorials-list {
+/* Big */
+@media (min-width:768px) {
+    .duplicate {
+        display: none;
+    }
+}
+
+/* Skinny */
+@media (max-width:767px) {
+    table.table.table-responsive {
+        display: inline-table;
+    }
+    tr th:not(:first-child) {
+        display: none;
+    }
+    tr td:not(:first-child) {
+        display: none;
+    }r
+    .duplicate {
+        display: unset;
+    }
+}
+}


### PR DESCRIPTION
This PR is borne of two separate instances:
- I was annoyed at trying to find the tutorial link on mobile, I had to scroll left and right which felt ridiculous
- I watched a novice user try and click the tutorial title and was surprised when it went nowhere.

It links to the hands on, if one is present, otherwise to the slides.


Small Screens | large screens
--- | ---
![screenshot of gtn, now the wide table is replaced on mobile with the normal tutorial titles plus the "extra stuff" icons below it](https://user-images.githubusercontent.com/458683/194356719-929fdd28-42f7-4a95-b2e6-2150a7a28c95.png) | ![Same interface on a desktop browser, the duplicate icons are gone and it returns to the normal current layout. Both screenshots also show that tutorial titles are now hyperlinks](https://user-images.githubusercontent.com/458683/194348945-b7cfb2f6-7ece-4dca-ba8c-2e6e76c8e89f.png)