### PR TITLE
Change default job runner to slurm in "Connecting Galaxy to a compute cluster tutorial"

### DIFF
--- a/topics/admin/tutorials/connect-to-compute-cluster/tutorial.md
+++ b/topics/admin/tutorials/connect-to-compute-cluster/tutorial.md
@@ -394,7 +394,8 @@ At the top of the stack sits Galaxy. Galaxy must now be configured to use the cl
 >    +    load: galaxy.jobs.runners.slurm:SlurmJobRunner
 >     
 >     execution:
->       default: singularity
+>     - default: singularity
+>     + default: slurm
 >       environments:
 >         local_dest:
 >           runner: local_runner


### PR DESCRIPTION
Just going through some of the admin tutorials and it seems to me that this change is needed as well? But feel free to close if I'm wrong.