### PR TITLE
Fix FTP links microbial-variants

### DIFF
--- a/topics/variant-analysis/tutorials/microbial-variants/tutorial.md
+++ b/topics/variant-analysis/tutorials/microbial-variants/tutorial.md
@@ -30,13 +30,13 @@ Variant calling is the process of identifying differences between two genome sam
 
 Imagine that you have been asked to find the differences between a sample that has been sequenced and a known genome. For example: You have a new sample from a patient and you want to see if it has any differences from a well known reference genome of the same species. Typically, you would have a couple of fastq read files sent back to you from the sequencing provider and either an annotated or non annotated reference genome.
 
-In this tutorial, we will use the tool “Snippy” ([link](https://github.com/tseemann/snippy)) to find high confidence differences (indels or SNPs) between our known genome and our reads. Snippy uses one tool to align the reads to the reference genome, and another tool to decide (“call”) if any of the resulting discrepancies are real variants or technical artifacts that can be ignored. Finally, Snippy uses another tool to check what effect these differences have on the predicted genes - truncation, frame shift or if the changes are synonymous.
+In this tutorial, we will use the tool “Snippy” (see [author development repository](https://github.com/tseemann/snippy)) to find high confidence differences (indels or SNPs) between our known genome and our reads. Snippy uses one tool to align the reads to the reference genome, and another tool to decide (“call”) if any of the resulting discrepancies are real variants or technical artifacts that can be ignored. Finally, Snippy uses another tool to check what effect these differences have on the predicted genes - truncation, frame shift or if the changes are synonymous.
 
 For the read alignment (read mapping) step, Snippy uses BWA MEM with a custom set of settings which are very suitable to aligning reads for microbial type data. For the variant calling step, Snippy uses Freebayes with a custom set of settings. snpeff is then used to describe what the predicted changes do in terms of the genes themselves.
 
 The Galaxy wrapper for Snippy has the ability to change some of the underlying tool settings in the advanced section but it is not recommended.
 
-Read more about SNP calling [link](https://en.wikipedia.org/wiki/SNV_calling_from_NGS_data)
+Read more about SNP calling [at Wikipedia](https://en.wikipedia.org/wiki/SNV_calling_from_NGS_data).
 
 > ### Agenda
 >

--- a/topics/variant-analysis/tutorials/microbial-variants/tutorial.md
+++ b/topics/variant-analysis/tutorials/microbial-variants/tutorial.md
@@ -76,11 +76,11 @@ This data is available at Zenodo using the following [link](https://doi.org/10.5
 >     - [wildtype.gff](https://zenodo.org/record/582600/files/wildtype.gff)
 >
 >     ```
->     https://zenodo.org/record/582600/files/mutant_R1.fastq
->     https://zenodo.org/record/582600/files/mutant_R2.fastq
->     https://zenodo.org/record/582600/files/wildtype.fna
->     https://zenodo.org/record/582600/files/wildtype.gbk
->     https://zenodo.org/record/582600/files/wildtype.gff
+>    https://zenodo.org/record/582600/files/mutant_R1.fastq
+>    https://zenodo.org/record/582600/files/mutant_R2.fastq
+>    https://zenodo.org/record/582600/files/wildtype.fna
+>    https://zenodo.org/record/582600/files/wildtype.gbk
+>    https://zenodo.org/record/582600/files/wildtype.gff
 >     ```
 >
 >    {% snippet faqs/galaxy/datasets_import_via_link.md %}

--- a/topics/variant-analysis/tutorials/microbial-variants/tutorial.md
+++ b/topics/variant-analysis/tutorials/microbial-variants/tutorial.md
@@ -30,13 +30,13 @@ Variant calling is the process of identifying differences between two genome sam
 
 Imagine that you have been asked to find the differences between a sample that has been sequenced and a known genome. For example: You have a new sample from a patient and you want to see if it has any differences from a well known reference genome of the same species. Typically, you would have a couple of fastq read files sent back to you from the sequencing provider and either an annotated or non annotated reference genome.
 
-In this tutorial, we will use the tool “Snippy” (link to Snippy is [here](https://github.com/tseemann/snippy)) to find high confidence differences (indels or SNPs) between our known genome and our reads. Snippy uses one tool to align the reads to the reference genome, and another tool to decide (“call”) if any of the resulting discrepancies are real variants or technical artifacts that can be ignored. Finally, Snippy uses another tool to check what effect these differences have on the predicted genes - truncation, frame shift or if the changes are synonymous.
+In this tutorial, we will use the tool “Snippy” ([link](https://github.com/tseemann/snippy)) to find high confidence differences (indels or SNPs) between our known genome and our reads. Snippy uses one tool to align the reads to the reference genome, and another tool to decide (“call”) if any of the resulting discrepancies are real variants or technical artifacts that can be ignored. Finally, Snippy uses another tool to check what effect these differences have on the predicted genes - truncation, frame shift or if the changes are synonymous.
 
 For the read alignment (read mapping) step, Snippy uses BWA MEM with a custom set of settings which are very suitable to aligning reads for microbial type data. For the variant calling step, Snippy uses Freebayes with a custom set of settings. snpeff is then used to describe what the predicted changes do in terms of the genes themselves.
 
 The Galaxy wrapper for Snippy has the ability to change some of the underlying tool settings in the advanced section but it is not recommended.
 
-More can be read about SNP calling [here](https://en.wikipedia.org/wiki/SNV_calling_from_NGS_data)
+Read more about SNP calling [link](https://en.wikipedia.org/wiki/SNV_calling_from_NGS_data)
 
 > ### Agenda
 >
@@ -75,13 +75,13 @@ This data is available at Zenodo using the following [link](https://doi.org/10.5
 >     - [wildtype.gbk](https://zenodo.org/record/582600/files/wildtype.gbk)
 >     - [wildtype.gff](https://zenodo.org/record/582600/files/wildtype.gff)
 >
->     ```
+>    ```
 >    https://zenodo.org/record/582600/files/mutant_R1.fastq
 >    https://zenodo.org/record/582600/files/mutant_R2.fastq
 >    https://zenodo.org/record/582600/files/wildtype.fna
 >    https://zenodo.org/record/582600/files/wildtype.gbk
 >    https://zenodo.org/record/582600/files/wildtype.gff
->     ```
+>    ```
 >
 >    {% snippet faqs/galaxy/datasets_import_via_link.md %}
 >

--- a/topics/variant-analysis/tutorials/microbial-variants/tutorial.md
+++ b/topics/variant-analysis/tutorials/microbial-variants/tutorial.md
@@ -24,7 +24,6 @@ contributors:
 ---
 
 # Introduction
-{:.no_toc}
 
 Variant calling is the process of identifying differences between two genome samples. Usually differences are limited to single nucleotide polymorphisms (SNPs) and small insertions and deletions (indels). Larger structural variation such as inversions, duplications and large deletions are not typically covered by “variant calling”.
 
@@ -64,7 +63,7 @@ The files we will be using are:
 - `wildtype.gbk` - The reference strain with gene and other annotations in genbank format.
 - `wildtype.gff` - The reference strain with gene and other annotations in gff3 format.
 
-This data is available at Zenodo using the following [link](https://doi.org/10.5281/zenodo.582600).
+[This data is available at Zenodo](https://doi.org/10.5281/zenodo.582600).
 
 > ### {% icon hands_on %} Hands-on: Get the data
 >
@@ -240,6 +239,5 @@ A new dataset will be created in your history, containing the JBrowse interactiv
 {: .hands_on}
 
 # Conclusion
-{:.no_toc}
 
 By running a tool such as Snippy on your read files and reference genome, we can find where the biologically important changes between genomes of different strains occur and perhaps what they mean to the phenotype.


### PR DESCRIPTION
Removed one extra leading space from each get data snippet's zenodo URL. Was five spaces, now four spaces, and fixes batch copy/paste into Upload tool.