### PR TITLE
[Tutorial Template] Use new-style details box for BibTex citation

### DIFF
--- a/_layouts/tutorial_hands_on.html
+++ b/_layouts/tutorial_hands_on.html
@@ -354,12 +354,12 @@ download.file("{{ site.url }}{{ site.baseurl }}/{{ page.path | replace: ".md", "
                     </ol>
                 </p>
 
-                <!-- collapsible boxcontaining the BibTexx-formatted citation -->
+                <!-- collapsible boxcontaining the BibTeX-formatted citation -->
                 <blockquote class="details">
                   <div id="citation-bibtex" class="box-title">
-                    <button type="button" aria-controls="citation-bibtex" aria-expanded="false" aria-label="Toggle details box: BibTex for citing this tutorial">
+                    <button type="button" aria-controls="citation-bibtex" aria-expanded="false" aria-label="Toggle details box: BibTeX for citing this tutorial">
                       <i class="fas fa-info-circle" aria-hidden="true"></i>
-                      <span class="visually-hidden"></span> BibTex<span role="button" class="fold-unfold fa fa-minus-square" aria-hidden="true"></span>
+                      <span class="visually-hidden"></span> BibTeX<span role="button" class="fold-unfold fa fa-minus-square" aria-hidden="true"></span>
                     </button>
                    </div>
                    <p style="display: none;">

--- a/_layouts/tutorial_hands_on.html
+++ b/_layouts/tutorial_hands_on.html
@@ -354,8 +354,7 @@ download.file("{{ site.url }}{{ site.baseurl }}/{{ page.path | replace: ".md", "
                     </ol>
                 </p>
 
-
-
+                <!-- collapsible boxcontaining the BibTexx-formatted citation -->
                 <blockquote class="details">
                   <div id="citation-bibtex" class="box-title">
                     <button type="button" aria-controls="citation-bibtex" aria-expanded="false" aria-label="Toggle details box: BibTex for citing this tutorial">
@@ -363,9 +362,9 @@ download.file("{{ site.url }}{{ site.baseurl }}/{{ page.path | replace: ".md", "
                       <span class="visually-hidden"></span> BibTex<span role="button" class="fold-unfold fa fa-minus-square" aria-hidden="true"></span>
                     </button>
                    </div>
-                  <p style="display: none;">
+                   <p style="display: none;">
 
-                  <div class="highlighter-rouge"><div class="highlight"><pre class="highlight">
+                   <div class="highlighter-rouge"><div class="highlight"><pre class="highlight">
 <code id="citation-code">@misc{% raw %}{{% endraw %}{{topic.name}}-{{page.tutorial_name}},
 {% assign authors = page.contributors | filter_authors:page.contributions -%}
 author = "{%- include _includes/contributor-list.html contributors=authors sep=" and " -%}",
@@ -389,8 +388,8 @@ note = "[Online; accessed TODAY]"
     title = {Community-Driven Data Analysis Training for Biology},
     journal = {Cell Systems}
 }</code>
-                </pre></div></div>
-                </p>
+                   </pre></div></div>
+                   </p>
                 </blockquote>
 
                 {% if page.contributions %}

--- a/_layouts/tutorial_hands_on.html
+++ b/_layouts/tutorial_hands_on.html
@@ -355,11 +355,17 @@ download.file("{{ site.url }}{{ site.baseurl }}/{{ page.path | replace: ".md", "
                 </p>
 
 
+
                 <blockquote class="details">
-                  <div class="box-title" aria-label="details box">BibTeX</div>
+                  <div id="citation-bibtex" class="box-title">
+                    <button type="button" aria-controls="citation-bibtex" aria-expanded="false" aria-label="Toggle details box: BibTex for citing this tutorial">
+                      <i class="fas fa-info-circle" aria-hidden="true"></i>
+                      <span class="visually-hidden"></span> BibTex<span role="button" class="fold-unfold fa fa-minus-square" aria-hidden="true"></span>
+                    </button>
+                   </div>
                   <p style="display: none;">
 
-                <div class="highlighter-rouge"><div class="highlight"><pre class="highlight">
+                  <div class="highlighter-rouge"><div class="highlight"><pre class="highlight">
 <code id="citation-code">@misc{% raw %}{{% endraw %}{{topic.name}}-{{page.tutorial_name}},
 {% assign authors = page.contributors | filter_authors:page.contributions -%}
 author = "{%- include _includes/contributor-list.html contributors=authors sep=" and " -%}",

--- a/assets/css/main.scss
+++ b/assets/css/main.scss
@@ -59,7 +59,7 @@ $code-out-color: #fb99d0;
 $hyperlink: #0067d6;
 
 @mixin tutorial-box ($bg-color, $color: rgba(255,255,255,.75)) {
-    margin-top: 3 * $tutorial-box-spacing;
+    margin-top: 4 * $tutorial-box-spacing;
     margin-bottom: 2 * $tutorial-box-spacing;
 
     // Legacy


### PR DESCRIPTION
currently it is not collapsible anymore, this brings it in line with all the other new and accessible boxes

ping @hexylena 