### PR TITLE
sort FAQs alphabetically within each area

### DIFF
--- a/_layouts/faq-page.html
+++ b/_layouts/faq-page.html
@@ -22,7 +22,7 @@ layout: faqs
     {% endif %}
   {% endfor %}
 {% else %}
-  {% assign topic_faqs_sorted = topic_faqs | sort: "area", "first" %}
+  {% assign topic_faqs_sorted = topic_faqs | sort: "title" | sort: "area", "first" %}
 {% endif %}
 
 


### PR DESCRIPTION
Originally suggested by @garimavs in the context of Outreachy, this sorts the FAQs alphabetically by title (within each area)

fixes https://github.com/galaxyproject/training-material/issues/3455