### PR TITLE
[Dev] Generic Viz Plugins: remove broken links

### DIFF
--- a/topics/dev/tutorials/visualization-generic/tutorial.md
+++ b/topics/dev/tutorials/visualization-generic/tutorial.md
@@ -47,12 +47,8 @@ However, for this tutorial we will keep it basic.
 
 Additional documentation about Galaxy visualizations can be found here:
 
-- [VisualizationsRegistry](https://galaxyproject.org/visualizations-registry)
-- [VisualizationsRegistry/Cookbook](https://galaxyproject.org/visualizations-registry/cookbook)
-- [VisualizationsRegistry/Code](https://galaxyproject.org/visualizations-registry/code)
 - [DataProviders](https://galaxyproject.org/data-providers)
 - [DataProviders/Cookbook](https://galaxyproject.org/data-providers/cookbook)
-- [Develop/Visualizations](https://galaxyproject.org/develop/visualizations)
 
 > <agenda-title></agenda-title>
 >


### PR DESCRIPTION
fixes https://github.com/galaxyproject/training-material/issues/3288

@beatrizserrano I removed the links that are not working. I left two that still looked ok. Do you think these are still helpful of should I just remove them too?