### PR TITLE
Fix `\\n` appearing in JSON-LD rather than `\n`

### DIFF
--- a/_plugins/jekyll-jsonld.rb
+++ b/_plugins/jekyll-jsonld.rb
@@ -355,7 +355,7 @@ module Jekyll
           })
         end
       end
-      data['description'] = description.join('\n')
+      data['description'] = description.join("\n")
 
       if material.key?("lang") then
         data['inLanguage'] = {


### PR DESCRIPTION
Example:
```
  "description": "The questions this  addresses are:\n - What is typing?\n - How does it improve code?\n - Can it help me?\n\n\\nThe objectives are:\n - Understand the utility of annotating types on one's code\n - Understand the limits of type annotations in python\n\n",
```
https://tess.elixir-europe.org/materials/hands-on-for-python-type-annotations-tutorial