### PR TITLE
[Slides] Also render author line for new "contributions:" syntax

### DIFF
--- a/_layouts/base_slides.html
+++ b/_layouts/base_slides.html
@@ -85,9 +85,7 @@ class: center, middle, inverse
 # {{ title }}
 
 
-{% if tutorial.contributors %}
 {% include _includes/contributors-line.html page=page authorsonly=true %}
-{% endif %}
 
 <!-- modified date -->
 <div class="footnote" style="bottom: 8em;">{% icon last_modification %} {{locale['last-modification'] | default: "Updated"}}: {{ page.last_modified_at | date: "%b %-d, %Y"}}</div>


### PR DESCRIPTION
The author line on slides was not showing when the slide deck uses the fancier `contributions:` syntax

ping @hexylena 