### PR TITLE
[FAQs] add an FAQ for creating a GTN news post

### DIFF
--- a/faqs/gtn/gtn_news_create_post.md
+++ b/faqs/gtn/gtn_news_create_post.md
@@ -1,0 +1,46 @@
+---
+title: Creating a GTN News post
+area: contributors
+layout: faq
+box_type: tip
+contributors: [shiltemann]
+---
+
+If you have created a new tutorial, running an event, published a paper around training, or have anything else interesting to share with the GTN community, we encourage you to write a **News item** about it!
+
+News items will show up on the [GTN homepage]({% link index.md %}) and in the [GTN news feed]({% link news.md %}).
+
+**Creating the news post**
+
+Have a look at the existing news items in the [`news/_posts/` folder](https://github.com/galaxyproject/training-material/tree/main/news/_posts) for the GTN repository for some examples.
+
+A news post is a markdown file that looks as follows:
+
+
+```markdown
+---
+layout: news
+
+title: "New Tutorial: My tutorial title"
+tags:
+  - new tutorial
+  - transcriptomics
+contributors:
+  - shiltemann
+  - hexylena
+
+tutorial: "topics/introduction/tutorials/data-manipulation-olympics/tutorial.html"
+cover: "path/to/cover-image.jpg"  # usually an image from your tutorial
+coveralt: "description of the cover image"
+
+---
+
+A bit of text containing your news, this is all markdown formatted,
+so you can do **bold** and *italic* text like this, and links look
+like [this](https://example.com) etc.
+
+Describe everything you want to convey here, can be as long as you
+need.
+```
+
+Make sure the filename is structured as follows: `year-month-day-title.md`, so for example: `2022-10-28-my-new-tutorial.md`

--- a/faqs/gtn/gtn_news_create_post.md
+++ b/faqs/gtn/gtn_news_create_post.md
@@ -12,7 +12,7 @@ News items will show up on the [GTN homepage]({% link index.md %}) and in the [G
 
 **Creating the news post**
 
-Have a look at the existing news items in the [`news/_posts/` folder](https://github.com/galaxyproject/training-material/tree/main/news/_posts) for the GTN repository for some examples.
+Have a look at the existing news items in the [`news/_posts/` folder](https://github.com/galaxyproject/training-material/tree/main/news/_posts) of the GTN repository for some examples.
 
 A news post is a markdown file that looks as follows:
 

--- a/news.md
+++ b/news.md
@@ -8,6 +8,7 @@ layout: page
 
 Keep an eye on this page for the latest news around the GTN. New tutorials, GTN features, upcoming training events, and much much more!
 
+Want to add your own news here (e.g. new tutorial, event, publication, anything else training related)? Check out how to do that in [this FAQ]({% link faqs/gtn/gtn_news_create_post.md %})
 
 <div class="newslist">
 {% for n in site.categories['news'] %}

--- a/topics/contributing/tutorials/create-new-tutorial-content/tutorial.md
+++ b/topics/contributing/tutorials/create-new-tutorial-content/tutorial.md
@@ -1258,6 +1258,8 @@ Would you like to add a different language to the GTN? Please contact us first (
 
 # Conclusion
 
+If you have created a new tutorial, please also consider writing a [GTN news post]({% link faqs/gtn/gtn_news_create_post.md %}) about it to let people know about it (and make it easy for us to tweet about)!
+
 
 ## Footnotes (Rendered)
 

--- a/topics/contributing/tutorials/create-new-tutorial-content/tutorial.md
+++ b/topics/contributing/tutorials/create-new-tutorial-content/tutorial.md
@@ -183,7 +183,7 @@ All tutorials and slides must give credit to all contributors. This can be any t
        - carpentries
      testing:
        - userX
-     ux:/
+     ux:
        - userY
      infrastructure:
        - userZ

--- a/topics/contributing/tutorials/create-new-tutorial-content/tutorial.md
+++ b/topics/contributing/tutorials/create-new-tutorial-content/tutorial.md
@@ -183,7 +183,7 @@ All tutorials and slides must give credit to all contributors. This can be any t
        - carpentries
      testing:
        - userX
-     ux:
+     ux:/
        - userY
      infrastructure:
        - userZ
@@ -461,7 +461,7 @@ In most tutorials, the second box is the agenda box, placed at the end of the in
 
 There is no need to fill out the list; this will be done automatically based off of your tutorial's section titles. First and second level headings (lines starting with `#` and `##` in markdown) will be shown in the agenda.
 
-To avoid adding a particular section in the agenda, you can add `{:.no_toc}` below the section name. However, it is not recommended to use this too often; if a section is not important enough to be shown in the agenda, consider making it a third-level heading (`###`) instead.
+If a section is not important enough to be shown in the agenda, consider making it a third-level heading (`###`) instead.
 
 The agenda will be rendered as follows:
 


### PR DESCRIPTION
realized we don't have good instructions for this yet, and would be great to get contributors to write news posts when new tutorials are added, so now we have something to point them to