### PR TITLE
[Metagenomics] 16S tutorial: add a layout so it is recognized as a page for boxify plugin

### DIFF
--- a/topics/metagenomics/tutorials/mothur-miseq-sop/content.md
+++ b/topics/metagenomics/tutorials/mothur-miseq-sop/content.md
@@ -1,3 +1,6 @@
+---
+layout: none
+---
 {% if include.short %}
   {% assign other_tutorial = "../mothur-miseq-sop/tutorial.html" %}
   {% assign other_tutorial_name = "extended" %}


### PR DESCRIPTION
currently the new style boxes are broken in the 16S tutorials because of it's custom file structure

fixes https://github.com/galaxyproject/training-material/issues/3746