### PR TITLE
add write permissions for pdfs to video action

### DIFF
--- a/.github/workflows/video.yml
+++ b/.github/workflows/video.yml
@@ -83,7 +83,7 @@ jobs:
       - name: Build Videos
         run: |
           # Override permissions on _site to allow docker access.
-          chmod ugo+rx _site
+          chmod ugo+rwx _site
           # Then we can build the slides
           xvfb-run --auto-servernum --server-args="-screen 0 1920x1080x24" bundle exec bash bin/ari-make.sh
         env:


### PR DESCRIPTION
Allow the docker image to write out pdfs - failing at present.