### PR TITLE
Move nginx logging to syslog/journalctl

### DIFF
--- a/topics/admin/tutorials/ansible-galaxy/tutorial.md
+++ b/topics/admin/tutorials/ansible-galaxy/tutorial.md
@@ -2045,8 +2045,8 @@ For this, we will use NGINX. It is possible to configure Galaxy with Apache and 
 >    +    server_name   "{{ inventory_hostname }}";
 >    +
 >    +    # Our log files will go here.
->    +    access_log  /var/log/nginx/access.log;
->    +    error_log   /var/log/nginx/error.log;
+>    +    access_log  syslog:server=unix:/dev/log;
+>    +    error_log   syslog:server=unix:/dev/log;
 >    +
 >    +    # The most important location block, by default all requests are sent to gunicorn
 >    +    # If you serve galaxy at a path like /galaxy, change that below (and all other locations!)

--- a/topics/admin/tutorials/ansible-galaxy/tutorial.md
+++ b/topics/admin/tutorials/ansible-galaxy/tutorial.md
@@ -2145,6 +2145,13 @@ For this, we will use NGINX. It is possible to configure Galaxy with Apache and 
 >
 > 7. Check out the changes made to your server in `/etc/nginx/sites-enabled/`, particularly the directory containing the Galaxy virtualhost.
 >
+> 8. Check out the nginx logs with `journalctl`
+>
+>    > <code-in-title>Bash</code-in-title>
+>    > ```bash
+>    > journalctl -fu nginx
+>    > ```
+>    {: .code-in}
 {: .hands_on}
 
 > <details-title>"Potential Security Risk" / LetsEncrypt Staging Environment</details-title>

--- a/topics/admin/tutorials/ansible-galaxy/tutorial.md
+++ b/topics/admin/tutorials/ansible-galaxy/tutorial.md
@@ -2126,7 +2126,7 @@ For this, we will use NGINX. It is possible to configure Galaxy with Apache and 
 >    > > ```
 >    > > ...
 >    > > RUNNING HANDLER [restart galaxy] ****************************************
->    > > changed: [gat-88.training.galaxyproject.eu]
+>    > > changed: [gat-0.training.galaxyproject.eu]
 >    > > ```
 >    > {: .code-out}
 >    {: .code-2col}
@@ -2322,7 +2322,7 @@ Firstly, the plugins section contains a plugin called "local" which is of type "
 >    > > ```
 >    > > ...
 >    > > RUNNING HANDLER [restart galaxy] ****************************************
->    > > changed: [gat-88.training.galaxyproject.eu]
+>    > > changed: [gat-0.training.galaxyproject.eu]
 >    > > ```
 >    > {: .code-out}
 >    {: .code-2col}

--- a/topics/admin/tutorials/interactive-tools/tutorial.md
+++ b/topics/admin/tutorials/interactive-tools/tutorial.md
@@ -337,8 +337,8 @@ As explained in the previous section, we will proxy the Interactive Tools Proxy 
 >        server_name  *.interactivetool.{{ inventory_hostname }};
 >
 >        # Our log files will go here.
->        access_log  /var/log/nginx/galaxy-gie-proxy-access.log;
->        error_log   /var/log/nginx/galaxy-gie-proxy-error.log;
+>        access_log  syslog:server=unix:/dev/log;
+>        error_log   syslog:server=unix:/dev/log;
 >
 >        # Proxy all requests to the GIE Proxy application
 >        location / {

--- a/topics/dev/tutorials/interactive-environments/slides.html
+++ b/topics/dev/tutorials/interactive-environments/slides.html
@@ -433,7 +433,6 @@ CMD /startup.sh
 server {
     listen 80;
     server_name localhost;
-    access_log /var/log/nginx/localhost.access.log;
 
     # Note the trailing slash used everywhere!
     location PROXY_PREFIX/helloworld/ {


### PR DESCRIPTION
So students can now check truly *all* logs from one place (gravity/systemd pending)

- galaxy
- slurm
- nginx
- pulsar
- rabbitmq
- etc

(I guess if we move to dockerized rabbitmq, that would be a step backwards in logging unification)