### PR TITLE
Moving IGV introduction tutorial to draft mode

### DIFF
--- a/topics/introduction/tutorials/igv-introduction/tutorial.md
+++ b/topics/introduction/tutorials/igv-introduction/tutorial.md
@@ -2,6 +2,7 @@
 layout: tutorial_hands_on
 
 title: "IGV Introduction"
+enable: false
 zenodo_link: ""
 questions:
 objectives:


### PR DESCRIPTION
as more up to date resources to learn IGV exist like their website, and this particular tutorial is not up to GTN standards.

Fixes https://github.com/galaxyproject/training-material/issues/1892