### PR TITLE
Arabidopsis transcription training: fix missing details

### DIFF
--- a/topics/transcriptomics/tutorials/mirna-target-finder/tutorial.md
+++ b/topics/transcriptomics/tutorials/mirna-target-finder/tutorial.md
@@ -1,7 +1,7 @@
 ---
 layout: tutorial_hands_on
 
-title: 'Whole transcriptome analysis of Arabidopsis thaliana'
+title: 'Identification of genes involved in plant stress tolerance'
 zenodo_link: 'https://zenodo.org/record/4710649'
 tags:
     - miRNA

--- a/topics/transcriptomics/tutorials/mirna-target-finder/tutorial.md
+++ b/topics/transcriptomics/tutorials/mirna-target-finder/tutorial.md
@@ -765,4 +765,4 @@ Upregulated miRNA   https://zenodo.org/record/4710649/files/upregulated_miRNA_BR
 # Conclusion
 
 
-In this tutorial, we have analyzed RNA sequencing data to extract information about potential genes regulated by brassinosteroids. For this purpose, the approach chosen was the identification of genes complementary to miRNAs upregulated in response by brassinosteroids. The final result has been the identification of five potential miRNA targets.
+In this tutorial, we have analyzed RNA sequencing data to extract information about potential genes regulated by brassinosteroids. For this purpose, the approach chosen was the identification of genes complementary to miRNAs upregulated in response by brassinosteroids. The final result has been the identification of three potential miRNA targets.

--- a/topics/transcriptomics/tutorials/mirna-target-finder/tutorial.md
+++ b/topics/transcriptomics/tutorials/mirna-target-finder/tutorial.md
@@ -331,7 +331,7 @@ __DESeq2__ is a tool for differential gene expression analysis based on a negati
 >
 {: .comment}
 
-> <hands-on-title>Differential expression analysis using __DESeq2__</hands-on-title>
+> <hands-on-title>Differential expression analysis using DESeq2</hands-on-title>
 >
 > 1. {% tool [DESeq2](toolshed.g2.bx.psu.edu/repos/iuc/deseq2/deseq2/2.11.40.6+galaxy1) %} with the following parameters:
 >    - *"How"*: `Select datasets per level`
@@ -501,7 +501,7 @@ After determining the best mapping for each read, __Salmon__  generates the fina
 {: .details}
 
 
-> <hands-on-title>Quantify gene expression with __Salmon__</hands-on-title>
+> <hands-on-title>Quantify gene expression with Salmon</hands-on-title>
 >
 > 1. {% tool [Salmon quant](toolshed.g2.bx.psu.edu/repos/bgruening/salmon/salmon/0.14.1.2+galaxy1) %} with the following parameters:
 >    - *"Select salmon quantification mode:"*: `Reads`
@@ -556,7 +556,9 @@ NumReads          | The number of reads mapping to each transcript that was quan
 
 ## Differential expression analysis of mRNAs: **DESeq2**
 
-> <hands-on-title>DEA using __DEseq2__</hands-on-title>
+Now, let's analyze which genes show statistically significant differential expression in response to brassinosteoids.
+
+> <hands-on-title>Differential expression analysis using DEseq2</hands-on-title>
 >
 > 1. {% tool [DESeq2](toolshed.g2.bx.psu.edu/repos/iuc/deseq2/deseq2/2.11.40.6+galaxy1) %} with the following parameters:
 >    - *"How"*: `Select datasets per level`

--- a/topics/transcriptomics/tutorials/mirna-target-finder/tutorial.md
+++ b/topics/transcriptomics/tutorials/mirna-target-finder/tutorial.md
@@ -1,7 +1,7 @@
 ---
 layout: tutorial_hands_on
 
-title: 'Identification of genes involved in plant stress tolerance'
+title: 'Whole transcriptome analysis of Arabidopsis thaliana'
 zenodo_link: 'https://zenodo.org/record/4710649'
 tags:
     - miRNA

--- a/topics/transcriptomics/tutorials/mirna-target-finder/tutorial.md
+++ b/topics/transcriptomics/tutorials/mirna-target-finder/tutorial.md
@@ -621,12 +621,12 @@ Now we continue with the DE genes analysis.
 > 2. Rename the output as `Differentially expressed mRNAs`
 >
 > 3. {% tool [Filter](Filter1) %}data on any column using simple expressions (Galaxy Version 1.1.1) with the following parameters:
->    - {% icon param-file %} *"Filter"*: `Differentially expressed miRNAs`
+>    - {% icon param-file %} *"Filter"*: `Differentially expressed mRNAs`
 >    - *"With following condition"*: `c3<-1`
 > 4. Rename it as `Upregulated mRNAs`
 >
 > 5. {% tool [Filter](Filter1) %} data on any column using simple expressions (Galaxy Version 1.1.1) with the following parameters:
->    - {% icon param-file %} *"Filter"*: `Differentially expressed miRNAs`
+>    - {% icon param-file %} *"Filter"*: `Differentially expressed mRNAs`
 >    - *"With following condition"*: `c3>1`
 > 6. Rename it as `Downregulated mRNAs`
 >

--- a/topics/transcriptomics/tutorials/mirna-target-finder/tutorial.md
+++ b/topics/transcriptomics/tutorials/mirna-target-finder/tutorial.md
@@ -622,12 +622,12 @@ Now we continue with the DE genes analysis.
 >
 > 3. {% tool [Filter](Filter1) %}data on any column using simple expressions (Galaxy Version 1.1.1) with the following parameters:
 >    - {% icon param-file %} *"Filter"*: `Differentially expressed miRNAs`
->    - *"With following condition"*: `c3>1`
+>    - *"With following condition"*: `c3<-1`
 > 4. Rename it as `Upregulated mRNAs`
 >
 > 5. {% tool [Filter](Filter1) %} data on any column using simple expressions (Galaxy Version 1.1.1) with the following parameters:
 >    - {% icon param-file %} *"Filter"*: `Differentially expressed miRNAs`
->    - *"With following condition"*: `c3<-1`
+>    - *"With following condition"*: `c3>1`
 > 6. Rename it as `Downregulated mRNAs`
 >
 {: .hands_on}

--- a/topics/transcriptomics/tutorials/mirna-target-finder/tutorial.md
+++ b/topics/transcriptomics/tutorials/mirna-target-finder/tutorial.md
@@ -6,6 +6,7 @@ zenodo_link: 'https://zenodo.org/record/4710649'
 tags:
     - miRNA
     - plants
+    - stress tolerance
 questions:
 - Which miRNAs are upregulated in response to brassinosteroids?
 - Which genes are potential target of brassinosteroid-induced miRNAs?


### PR DESCRIPTION
The overexpressed/repressed transcripts were swapped in the former version. It fixes the mRNA section (sorry, I forgot to include it in the previos PR https://github.com/galaxyproject/training-material/pull/3775).