### PR TITLE
Add invisible border to tab

### DIFF
--- a/assets/css/main.scss
+++ b/assets/css/main.scss
@@ -81,7 +81,7 @@ $hyperlink: #0067d6;
         color: $color;
         vertical-align: 1em;
         float: left;
-        border: none;
+        border: 1px solid $color;
         border-top-left-radius: 8px;
         border-top-right-radius: 8px;
 


### PR DESCRIPTION
The `border: none` caused it to have no outline under firefox's high contrast mode.

By adding this invisible border, we can then be sure it'll get a black outline.

After | Before
--- | -- 
![image](https://user-images.githubusercontent.com/458683/207834740-b2c6066b-bf83-4dee-9ed2-0ee3a72f782d.png) | ![image](https://user-images.githubusercontent.com/458683/207834803-929fd031-dadf-411a-a979-9a58b5bbc4d2.png)

