### PR TITLE
Update Compute tool to latest version

### DIFF
--- a/topics/transcriptomics/tutorials/ref-based/tutorial.md
+++ b/topics/transcriptomics/tutorials/ref-based/tutorial.md
@@ -1880,9 +1880,15 @@ We have extracted genes that are differentially expressed in treated (PS gene-de
 
 > <hands-on-title>Prepare the first dataset for goseq</hands-on-title>
 >
-> 1. {% tool [Compute](toolshed.g2.bx.psu.edu/repos/devteam/column_maker/Add_a_column1/1.6) %} an expression on every row with the following parameters:
->    - *"Add expression"*: `bool(c7<0.05)`
->    - {% icon param-file %} *"as a new column to"*: the `DESeq2 result file` (output of **DESeq2** {% icon tool %})
+> 1. {% tool [Compute](toolshed.g2.bx.psu.edu/repos/devteam/column_maker/Add_a_column1/2.0) %} an expression on every row with the following parameters:
+>    - {% icon param-file %} *"Input file"*: the `DESeq2 result file` (output of **DESeq2** {% icon tool %})
+>    - In *"Expressions"*:
+>      - {% icon param-text %} *"Add expression"*: `bool(float(c7)<0.05)`
+>      - {% icon param-select %} *"Mode of the operation?"*: `Append`
+>    - Under *"Error handling"*:
+>      - {% icon param-toggle %} *"Autodetect column types"*: `No`
+>      - {% icon param-select %} *"If an expression cannot be computed for a row"*: `Fill in a replacement value`
+>      - {% icon param-select %} *"Replacement value"*: `False`
 >
 > 2. {% tool [Cut](Cut1) %} columns from a table with the following parameters:
 >    - *"Cut columns"*: `c1,c8`

--- a/topics/transcriptomics/tutorials/ref-based/tutorial.md
+++ b/topics/transcriptomics/tutorials/ref-based/tutorial.md
@@ -1880,7 +1880,7 @@ We have extracted genes that are differentially expressed in treated (PS gene-de
 
 > <hands-on-title>Prepare the first dataset for goseq</hands-on-title>
 >
-> 1. {% tool [Compute](toolshed.g2.bx.psu.edu/repos/devteam/column_maker/Add_a_column1/2.0) %} an expression on every row with the following parameters:
+> 1. {% tool [Compute](toolshed.g2.bx.psu.edu/repos/devteam/column_maker/Add_a_column1/2.0) %} on rows with the following parameters:
 >    - {% icon param-file %} *"Input file"*: the `DESeq2 result file` (output of **DESeq2** {% icon tool %})
 >    - In *"Expressions"*:
 >      - {% icon param-text %} *"Add expression"*: `bool(float(c7)<0.05)`

--- a/topics/transcriptomics/tutorials/ref-based/workflows/deg-analysis.ga
+++ b/topics/transcriptomics/tutorials/ref-based/workflows/deg-analysis.ga
@@ -439,7 +439,7 @@
         },
         "10": {
             "annotation": "",
-            "content_id": "toolshed.g2.bx.psu.edu/repos/devteam/column_maker/Add_a_column1/1.6",
+            "content_id": "toolshed.g2.bx.psu.edu/repos/devteam/column_maker/Add_a_column1/2.0",
             "errors": null,
             "id": 10,
             "input_connections": {
@@ -458,25 +458,19 @@
                 }
             ],
             "position": {
-                "bottom": 219.6928750792546,
-                "height": 62.425148010253906,
                 "left": 1039.2725702541977,
-                "right": 1173.272631289354,
-                "top": 157.2677270690007,
-                "width": 134.00006103515625,
-                "x": 1039.2725702541977,
-                "y": 157.2677270690007
+                "top": 157.2677270690007
             },
             "post_job_actions": {},
-            "tool_id": "toolshed.g2.bx.psu.edu/repos/devteam/column_maker/Add_a_column1/1.6",
+            "tool_id": "toolshed.g2.bx.psu.edu/repos/devteam/column_maker/Add_a_column1/2.0",
             "tool_shed_repository": {
-                "changeset_revision": "02026300aa45",
+                "changeset_revision": "6595517c2dd8",
                 "name": "column_maker",
                 "owner": "devteam",
                 "tool_shed": "toolshed.g2.bx.psu.edu"
             },
-            "tool_state": "{\"__input_ext\": \"tabular\", \"avoid_scientific_notation\": \"false\", \"chromInfo\": \"/opt/galaxy/tool-data/shared/ucsc/chrom/dm6.len\", \"cond\": \"bool(c7<0.05)\", \"header_lines_conditional\": {\"header_lines_select\": \"no\", \"__current_case__\": 0}, \"input\": {\"__class__\": \"ConnectedValue\"}, \"round\": \"false\", \"__page__\": null, \"__rerun_remap_job_id__\": null}",
-            "tool_version": "1.6",
+            "tool_state": "{\"avoid_scientific_notation\": \"false\", \"error_handling\": {\"auto_col_types\": \"false\", \"fail_on_non_existent_columns\": \"true\", \"non_computable\": {\"action\": \"--non-computable-default\", \"__current_case__\": 4, \"default_value\": \"False\"}}, \"input\": {\"__class__\": \"RuntimeValue\"}, \"ops\": {\"header_lines_select\": \"no\", \"__current_case__\": 0, \"expressions\": [{\"__index__\": 0, \"cond\": \"bool(float(c7)<0.05)\", \"add_column\": {\"mode\": \"\", \"__current_case__\": 0, \"pos\": \"\"}}]}, \"__page__\": null, \"__rerun_remap_job_id__\": null}",
+            "tool_version": "2.0",
             "type": "tool",
             "uuid": "275d0da1-c552-4322-8308-04c14259ca12",
             "workflow_outputs": [


### PR DESCRIPTION
At usegalaxy.eu we have received several bug reports of users trying to run the Compute step of the tutorial with version 2.0 of the tool instead of the desrcibed version 1.6.
Turns out the newer version catches a bug in the tutorial that the old version swallowed silently: for the goseq step you want True/False classification of *all* gene IDs investigated, but DeSeq2 emiits adjusted p-values of "NA" for the least significant genes and for those the expression `bool(c7<0.05)` cannot be computed. The old tool version just skips these lines meaning not all gene IDs were making it into the goseq analysis.
The new tool version can be configured to retain all lines and classify them correctly.