### PR TITLE
Icons in Automatic Jupyter Notebooks

### DIFF
--- a/topics/contributing/tutorials/create-new-tutorial-content/tutorial.md
+++ b/topics/contributing/tutorials/create-new-tutorial-content/tutorial.md
@@ -1187,7 +1187,7 @@ To use this system, you need to take care of a few things:
 
 - Do **not** use hands-on boxes for segments that should be executed (code needs to be left aligned!)
 - Do **not** use snippets
-- Do **not** use icons `{% icon X %}`
+- Do **not** use icons `{% raw %}{% icon X %}{% endraw %}`
 - Do not use a terminal or prompt character (that would be included in the execution.)
 - Avoid including output when you can, it doesn't render nicely especially when the cells will become runnable.
 

--- a/topics/contributing/tutorials/create-new-tutorial-content/tutorial.md
+++ b/topics/contributing/tutorials/create-new-tutorial-content/tutorial.md
@@ -1187,6 +1187,7 @@ To use this system, you need to take care of a few things:
 
 - Do **not** use hands-on boxes for segments that should be executed (code needs to be left aligned!)
 - Do **not** use snippets
+- Do **not** use icons `{% icon X %}`
 - Do not use a terminal or prompt character (that would be included in the execution.)
 - Avoid including output when you can, it doesn't render nicely especially when the cells will become runnable.
 


### PR DESCRIPTION
When icons are included in the text of the tutorial, there is an error with generated Jupyter Notebook which says: "The editor could not be opened due to an unexpected error: Unexpected token f in JSON at position XXXX".  I tested out that it's due to the icon symbols, so just wanted to point that out and save people's time on debugging :)