### PR TITLE
Accelerate theme loading, experiment collecting "top cited papers"

### DIFF
--- a/_includes/extras.html
+++ b/_includes/extras.html
@@ -59,7 +59,7 @@
                     <button class="btn" data-theme="blm">✊🏿</button>
                     <button class="btn" data-theme="progress" >🏳️‍🌈</button>
                     <button class="btn" data-theme="halloween">🎃</button>
-                    <button class="btn" data-theme="downunder">🇦🇺</button>
+                    <button class="btn" data-theme="straya">🇦🇺</button>
             </div>
 
         </div>

--- a/_layouts/base.html
+++ b/_layouts/base.html
@@ -41,6 +41,7 @@
         {% endif %}
     </head>
     <body data-spy="scroll" data-target="#toc">
+        <script type="text/javascript" src="{{ "/assets/js/theme.js" | prepend: site.baseurl }}"></script>
         {% include _includes/default-header.html %}
         <div class="container main-content" role="main">
         {{ content }}
@@ -55,7 +56,6 @@
         <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.1/MathJax.js?config=TeX-AMS-MML_HTMLorMML"></script>
         <script type="text/javascript" src="{{ "/assets/js/bootstrap-toc.min.js" | prepend: site.baseurl }}"></script>
         <script type="text/javascript" src="{{ "/assets/js/main.js" | prepend: site.baseurl }}"></script>
-        <script type="text/javascript" src="{{ "/assets/js/theme.js" | prepend: site.baseurl }}"></script>
         <script type="text/javascript" src="{{ "/assets/js/clipboard.min.js" | prepend: site.baseurl }}"></script>
         <script type="text/javascript">
         var snippets=document.querySelectorAll('div.highlight');

--- a/_layouts/base_slides.html
+++ b/_layouts/base_slides.html
@@ -37,6 +37,7 @@
         </script>
     </head>
   <body>
+    <script type="text/javascript" src="{{ "/assets/js/theme.js" | prepend: site.baseurl }}"></script>
     <textarea id="source">
 name: inverse
 layout: true
@@ -164,7 +165,6 @@ Useful when presenting."
 {% endif %}
     </textarea>
 	<script src="{{ "/assets/js/remark-latest.min.js" | prepend: site.baseurl }}" type="text/javascript"></script>
-    <script type="text/javascript" src="{{ "/assets/js/theme.js" | prepend: site.baseurl }}"></script>
     <script type="text/javascript" src="{{ "/assets/js/clipboard.min.js" | prepend: site.baseurl }}"></script>
     <script type="text/javascript">
       var slideshow = remark.create({navigation: {scroll: false}, ratio: '16:9'});

--- a/_plugins/gtn.rb
+++ b/_plugins/gtn.rb
@@ -41,6 +41,16 @@ module Jekyll
       ELIXIR_NODES[name]
     end
 
+    def top_citations(citations)
+      if citations.nil?
+        {}
+      else
+        citations.sort_by{|k, v| v}.reverse.to_h.first(20).map{|k, v| 
+          [k, {"count" => v, "text" => Gtn::Scholar.render_citation(k)}]
+        }.to_h
+      end
+    end
+
     def slugify_unsafe(text)
       # Gets rid of *most* things without making it completely unusable?
       text.gsub(/["'\\\/-;:,.!@#$%^&*()-]/, '').gsub(/\s/, '-')

--- a/_plugins/jekyll-scholar.rb
+++ b/_plugins/jekyll-scholar.rb
@@ -22,6 +22,14 @@ module Jekyll
 
       # Which page is rendering this tag?
       source_page = page['path']
+
+      # Citation Frequency
+      if ! site.config.has_key?("citation_count")
+        site.config["citation_count"] = Hash.new(0)
+      end
+      site.config["citation_count"][@text] += 1
+
+
       # If the overall cache is nil, create it
       if site.config['citation_cache'].nil?
         site.config['citation_cache'] = Hash.new
@@ -71,7 +79,6 @@ module Jekyll
 
     private
   end
-
   class BibTag < Liquid::Tag
 
     def initialize(tag_name, text, tokens)
@@ -101,21 +108,7 @@ module Jekyll
 
       out = "<ol class=\"bibliography\">"
       out += sorted_citations.map{|c|
-        r = citeproc.render(:bibliography, id: c)[0]
-        entry = global_bib[c]
-        if entry.note
-          r += " #{entry.note}."
-        end
-        doi = entry.fetch('doi', nil)
-        if doi
-          r += " <a href=\"https://doi.org/#{doi}\">#{doi}</a>"
-        end
-        url = entry.fetch('url', nil)
-        if url
-          if ! (url.index('doi.org') and entry.doi)
-            r += " <a href=\"#{url}\">#{url}</a>"
-          end
-        end
+        r = Gtn::Scholar.render_citation(c)
         %Q(<li id="#{c}">#{r}</li>)
       }.join("\n")
       out += "</ol>"

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -155,3 +155,14 @@ function fixDiffPresentation(codeBlock){
 <!--  For admin training -->
 document.querySelectorAll("section.tutorial.topic-admin div.language-diff pre code").forEach(codeBlock => fixDiffPresentation(codeBlock))
 document.querySelectorAll("section.tutorial.topic-data-science div.language-diff pre code").forEach(codeBlock => fixDiffPresentation(codeBlock))
+
+$("#theme-selector button").click(function(evt){
+	var theme = $(evt.target).data('theme');
+	setTheme(theme);
+	if(theme === "straya"){
+		$("body").addClass('downunder');
+		setTimeout(function(){
+			$("body").removeClass('downunder');
+		}, 8000);
+	}
+})

--- a/assets/js/theme.js
+++ b/assets/js/theme.js
@@ -14,47 +14,23 @@ function setThemePreference(newValue) {
 
 
 function setTheme(theme){
-	var old_classes = $("body").attr("class");
-	if (old_classes === undefined){
+	var old_classes = document.getElementsByTagName("body")[0].getAttribute("class")
+	if (old_classes === undefined || old_classes === null){
 		old_classes = "";
 	}
 	var new_classes = old_classes.split(' ').filter(function(x){ return x.substring(0, 6) !== "theme-" })
 	new_classes.push('theme-' + theme)
 
-	$("body").attr('class', new_classes.join(' '))
+	document.getElementsByTagName("body")[0].setAttribute("class", new_classes.join(' '))
 	setThemePreference(theme);
 }
 
-(function (window, document) {
-	function onDocumentReady(fn) {
-		if (document.attachEvent ? document.readyState === "complete" : document.readyState !== "loading") {
-			fn();
-		} else {
-			document.addEventListener('DOMContentLoaded', fn);
-		}
-	}
+training_theme_cookie = getThemePreference()
+if(training_theme_cookie){
+	setTheme(training_theme_cookie);
+}
 
-	onDocumentReady(function () {
-		$("#theme-selector button").click(function(evt){
-			var theme = $(evt.target).data('theme');
-			setTheme(theme);
-			if(theme === "straya"){
-				$("body").addClass('downunder');
-				setTimeout(function(){
-					$("body").removeClass('downunder');
-				}, 8000);
-			}
-		})
-
-		training_theme_cookie = getThemePreference()
-		if(training_theme_cookie){
-			setTheme(training_theme_cookie);
-		}
-
-                // Just for february
-                if(getThemePreference() === null || getThemePreference() === "undefined" || getThemePreference() === undefined){
-                        setTheme("blm");
-                }
-
-	});
-})(window, document);
+// Just for february
+if(getThemePreference() === null || getThemePreference() === "undefined" || getThemePreference() === undefined){
+	setTheme("blm");
+}

--- a/references.md
+++ b/references.md
@@ -1,0 +1,15 @@
+---
+layout: base
+title: GTN Top Cited Papers
+---
+
+{% assign topcitations = site.citation_count | top_citations %}
+<pre>
+{{ site.citation_count | jsonify }}
+</pre>
+
+<ol>
+{% for cite in topcitations %}
+    <li>{{ cite[1]['count'] }} - {{cite[1]['text']}}</li>
+{% endfor %}
+</ol>

--- a/references.md
+++ b/references.md
@@ -3,10 +3,7 @@ layout: base
 title: GTN Top Cited Papers
 ---
 
-{% assign topcitations = site.citation_count | top_citations %}
-<pre>
-{{ site.citation_count | jsonify }}
-</pre>
+This page lists the top cited papers, based on citations used throughout the GTN.
 
 <ol>
 {% for cite in topcitations %}


### PR DESCRIPTION
This prevents the flash of white between page loads by changing around how the theme is set. Before we waited for the document to be loaded to change the theme (bad)

Now we change it as soon as the `<body>` element is there, and then handle setting up buttons later on once jquery is loaded (not time sensitive.)