### PR TITLE
Only activate theme on home page landing

### DIFF
--- a/assets/js/theme.js
+++ b/assets/js/theme.js
@@ -31,6 +31,8 @@ if(training_theme_cookie){
 }
 
 // Just for february
-if(getThemePreference() === null || getThemePreference() === "undefined" || getThemePreference() === undefined){
-	setTheme("blm");
+if(window.location.pathname === "/"){
+	if(getThemePreference() === null || getThemePreference() === "undefined" || getThemePreference() === undefined){
+		setTheme("blm");
+	}
 }


### PR DESCRIPTION
To avoid confusion experienced by e.g. @mvdbeek where I'm guessing he landed on a non-home page without the tip box.