### PR TITLE
Fix truly cursed parsing failure

### DIFF
--- a/faqs/galaxy/account_create.md
+++ b/faqs/galaxy/account_create.md
@@ -1,13 +1,11 @@
 ---
-redirect_from:
-- /faqs/galaxy/galaxy_creating_an_account
+redirect_from: [/faqs/galaxy/galaxy_creating_an_account]
 title: How do I create an account on a public Galaxy instance?
 area: account
 layout: faq
 box_type: tip
 contributors: [jennaj, bernandez, samanthaanjei, wm75]
 ---
-
 
 1. To create an account at any public Galaxy instance, choose your server from the available [list of Galaxy Platforms](https://galaxyproject.org/use/).
 

--- a/faqs/galaxy/account_reduce_quota_usage.md
+++ b/faqs/galaxy/account_reduce_quota_usage.md
@@ -1,6 +1,5 @@
 ---
-redirect_from:
-- /faqs/galaxy/reduce_quota_usage
+redirect_from: [/faqs/galaxy/reduce_quota_usage]
 title: How can I reduce quota usage while still retaining prior work (data, tools, methods)?
 area: account
 layout: faq

--- a/faqs/galaxy/analysis_differential_expression_help.md
+++ b/faqs/galaxy/analysis_differential_expression_help.md
@@ -1,6 +1,5 @@
 ---
-redirect_from:
-- /faqs/galaxy/analysis_extended_Extended_help_differential_expression_analysis_tools
+redirect_from: [/faqs/galaxy/analysis_extended_Extended_help_differential_expression_analysis_tools]
 title: Extended Help for Differential Expression Analysis Tools
 area: analysis
 box_type: tip

--- a/faqs/galaxy/troubleshooting_cluster_failure.md
+++ b/faqs/galaxy/troubleshooting_cluster_failure.md
@@ -1,6 +1,5 @@
 ---
-redirect_from:
-- /faqs/galaxy/analysis_job_failure_cluster_failure
+redirect_from: [/faqs/galaxy/analysis_job_failure_cluster_failure]
 title: Understanding 'canceled by admin' or cluster failure error messages
 area: troubleshooting
 box_type: tip

--- a/faqs/galaxy/troubleshooting_excess_memory.md
+++ b/faqs/galaxy/troubleshooting_excess_memory.md
@@ -1,6 +1,5 @@
 ---
-redirect_from:
-- /faqs/galaxy/analysis_job_failure_excess_memory
+redirect_from: [/faqs/galaxy/analysis_job_failure_excess_memory]
 title: Understanding 'exceeds memory allocation' error messages
 area: troubleshooting
 box_type: tip

--- a/faqs/galaxy/troubleshooting_input_problem.md
+++ b/faqs/galaxy/troubleshooting_input_problem.md
@@ -1,6 +1,5 @@
 ---
-redirect_from:
-- /faqs/galaxy/analysis_job_failure_input_problem
+redirect_from: [/faqs/galaxy/analysis_job_failure_input_problem]
 title: Understanding input error messages
 area: troubleshooting
 box_type: tip

--- a/faqs/galaxy/troubleshooting_value_error.md
+++ b/faqs/galaxy/troubleshooting_value_error.md
@@ -1,6 +1,5 @@
 ---
-redirect_from:
-- /faqs/galaxy/analysis_job_failure_value_error
+redirect_from: [/faqs/galaxy/analysis_job_failure_value_error]
 title: Understanding ValueError error messages
 area: troubleshooting
 box_type: tip

--- a/faqs/galaxy/troubleshooting_walltime.md
+++ b/faqs/galaxy/troubleshooting_walltime.md
@@ -1,6 +1,5 @@
 ---
-redirect_from:
-- /faqs/galaxy/analysis_job_failure_walltime
+redirect_from: [/faqs/galaxy/analysis_job_failure_walltime]
 title: Understanding walltime error messages
 area: troubleshooting
 box_type: tip


### PR DESCRIPTION
Due to how we strip metadata from the compiled content object in the template. The list based redirect_from, combined with some of the whitespace led to the rest of the content being in a UL and the regex replace not capturing it properly