### PR TITLE
Update tutorial.md - suggested rewording to match figure 5

### DIFF
--- a/topics/single-cell/tutorials/scrna-umis/tutorial.md
+++ b/topics/single-cell/tutorials/scrna-umis/tutorial.md
@@ -151,7 +151,7 @@ This information is false, because it shows that Red has twice the expression th
 > |--|-------------|-----------------|
 > | Gene Red | Pink | 2 |
 > |          | Blue | 4 |
-> | Gene Blue | Brown | 1 |
+> | Gene Blue | Pink | 1 |
 > |           | Green | 2 |
 {: .matrix}
 
@@ -160,7 +160,7 @@ From this we can then make the decision to ignore the frequencies of these UMIs,
 > |  | Set of UMIs in Gene | UMIs in Cell 1 |
 > |--|---------------------|----------------|
 > | Gene Red | {Pink, Blue} | 2 |
-> | Gene Blue | {Brown, Green} | 2 |
+> | Gene Blue | {Pink, Green} | 2 |
 {: .matrix}
 
 This then provides us with the true count of the number of true transcripts for each gene as given by our original figure.


### PR DESCRIPTION
Figure 5 in this tutorial shows two genes each with two transcripts. gene 1 has UMI coloured pink and blue. Gene 2 has pink and green. The text, though, describes Gene 2 as being brown and green. This may be confusing to some students. The commit here changes the tutorial text so that Gene two is described as pink and green. The alternative would be to edit Figure 5?