### PR TITLE
Updates to *Installing Galaxy with Ansible*

### DIFF
--- a/topics/admin/faqs/ansible_define-once.md
+++ b/topics/admin/faqs/ansible_define-once.md
@@ -8,6 +8,7 @@ contributors: [natefoo, shiltemann]
 
 Using variables, either by defining them ahead of time, or simply accessing them via existing data structures that have been defined, e.g.:
 
+{% raw %}
 ```yaml
 # defining a variable that gets reused is great!
 galaxy_user: galaxy
@@ -16,15 +17,15 @@ galaxy_config:
   galaxy:
     # Re-using the galaxy_config_dir variable saves time and ensures everything
     # is in sync!
-    datatypes_config_file: "{{ galaxy_config_dir  }}/datatypes_conf.xml"
+    datatypes_config_file: "{{ galaxy_config_dir }}/datatypes_conf.xml"
 
 # and now we can re-use "{{ galaxy_config.galaxy.datatypes_config_file }}"
 # in other places!
-
 
 galaxy_config_templates:
   - src: templates/galaxy/config/datatypes_conf.xml
     dest: "{{ galaxy_config.galaxy.datatypes_config_file }}"
 ```
+{% endraw %}
 
 Practices like those shown above help to avoid problems caused when paths are defined differently in multiple places. The datatypes config file will be copied to the same path as Galaxy is configured to find it in, because that path is only defined in one place. Everything else is a reference to the original definition! If you ever need to update that definition, everything else will be updated accordingly.


### PR DESCRIPTION
Still WIP but I wanted to get it out there for comment. This tutorial is the foundation for basically all the other admin tutorials and some changes could be controversial, such as:

- The job conf is now inline instead of in a separate file
- Diff mode by default means lots of verbosity (but also should make mistakes after the first run more apparent)

I probably broke git-gat stitching please don't hate me @hexylena.

Depends on as-yet unmerged changes to the role in https://github.com/galaxyproject/ansible-galaxy/tree/gravity-systemd. My plan is also to update this for the monolithic role so there is a 23.0 version using the stuff that everyone already knows and loves, and then I'll update it to use [the collection](https://github.com/galaxyproject/ansible-collection-galaxy), which I think will be the best way forward (removing all the remote_user/become/become_user stuff entirely).

TODO: #3939