### PR TITLE
Change to import history text

### DIFF
--- a/topics/single-cell/tutorials/scrna-case_alevin-combine-datasets/tutorial.md
+++ b/topics/single-cell/tutorials/scrna-case_alevin-combine-datasets/tutorial.md
@@ -87,7 +87,9 @@ You can access the data for this tutorial in multiple ways:
 
    {% snippet faqs/galaxy/histories_copy_dataset.md %}
 
-2. **Importing from a history** - You can import [this history](https://usegalaxy.eu/u/wendi.bacon.training/h/cs2combining-datasets-after-pre-processing---input-1)
+2. **Importing from a history** 
+    - You can import [this history for usegalaxy.eu](https://usegalaxy.eu/u/wendi.bacon.training/h/cs2combining-datasets-after-pre-processing---input-1)
+    - You can import [this history for usegalaxy.org](https://usegalaxy.org/u/hrukkudyr_us/h/cs2combining-datasets-after-pre-processing---input)
 
    {% snippet faqs/galaxy/histories_import.md %}
 


### PR DESCRIPTION
I'm currently proofing this tutorial for Smorgasbord 2023 and experiencing difficulties in getting the dataset into galaxy.org.
- Zenodo transfers are failing on the transfer files
- importing a history from usegalaxy.eu is complicated 
Workaround: propose additional link to a newly created history on galaxy.org This holds the data from @nomadscientist usegalaxy.eu history including the #tags 