### PR TITLE
More pulsar tutorial updates for GAT2023

### DIFF
--- a/topics/admin/tutorials/pulsar/tutorial.md
+++ b/topics/admin/tutorials/pulsar/tutorial.md
@@ -145,11 +145,11 @@ Firstly we will add and configure another *role* to our Galaxy playbook - a comm
 >       version: 0.0.2
 >     - src: galaxyproject.slurm
 >       version: 0.1.3
->    +- name: geerlingguy.docker
+>    +- src: geerlingguy.docker
 >    +  version: 6.1.0
->    +- name: usegalaxy_eu.rabbitmqserver
+>    +- src: usegalaxy_eu.rabbitmqserver
 >    +  version: 1.4.1
->    +- name: galaxyproject.pulsar
+>    +- src: galaxyproject.pulsar
 >    +  version: 1.0.10
 >    {% endraw %}
 >    ```

--- a/topics/admin/tutorials/pulsar/tutorial.md
+++ b/topics/admin/tutorials/pulsar/tutorial.md
@@ -180,10 +180,12 @@ Users need to be defined, given passwords and access to the various queues. We w
 
 
 ```yaml
+{% raw %}
 rabbitmq_users:
   - user: username
     password: "{{ rabbitmq_password_username }}"
     vhost: /vhostname
+{% endraw %}
 ```
 
 Notice the variable we used instead of directly placing the password there. It will be read from vault instead.
@@ -305,6 +307,7 @@ More information about the rabbitmq ansible role can be found [in the repository
 >    +    fail_if_no_peer_cert: 'false'
 >    +  management_agent:
 >    +    disable_metrics_collector: "false"
+>    +  consumer_timeout: 21600000 # 6 hours in milliseconds
 >    +
 >    +rabbitmq_vhosts:
 >    +  - /pulsar/galaxy_au
@@ -340,9 +343,9 @@ More information about the rabbitmq ansible role can be found [in the repository
 >         - role: galaxyproject.miniconda
 >           become: true
 >           become_user: "{{ galaxy_user_name }}"
+>         - galaxyproject.nginx
 >    +    - geerlingguy.docker
 >    +    - usegalaxy_eu.rabbitmqserver
->         - galaxyproject.nginx
 >         - galaxyproject.gxadmin
 >         - galaxyproject.tusd
 >    {% endraw %}

--- a/topics/admin/tutorials/pulsar/tutorial.md
+++ b/topics/admin/tutorials/pulsar/tutorial.md
@@ -149,6 +149,8 @@ Firstly we will add and configure another *role* to our Galaxy playbook - a comm
 >    +  version: 6.1.0
 >    +- name: usegalaxy_eu.rabbitmqserver
 >    +  version: 1.4.1
+>    +- name: galaxyproject.pulsar
+>    +  version: 1.0.10
 >    {% endraw %}
 >    ```
 >    {: data-commit="Add requirements"}


### PR DESCRIPTION
Add consumer_timeout to rabbitmq_config and make sure rabbitmq role is run after nginx. There are still problems as the container continually restarts and the container log complains about not being able to read `/etc/ssl/user/privkey-rabbitmq.pem` which is owned by root with 640 permissions. After changing permissions on that file to 644, the docker container is able to stay up, but I imagine the proper solution is for the file to be owned by somebody else (rabbitmq?)

TODO: job conf diffs will be different as this takes place after the job destinations tutorial.