### PR TITLE
Add substitution of example website name wih hostname

### DIFF
--- a/bin/knit-frog.py
+++ b/bin/knit-frog.py
@@ -167,6 +167,7 @@ for idx, diff in enumerate(diffs):
             else:
                 line = line.strip()
                 line = line.replace('https://your-galaxy', 'https://$(hostname -f)')
+                line = line.replace('https://galaxy.example.org', 'https://$(hostname -f)')
                 line = line.replace('<api-key>', 'adminkey')
                 cmdhandle.write(line + "\n")
     elif 'data-test' in diff[-1]:


### PR DESCRIPTION
Automated test scripts [tool-management-run.sh](https://github.com/hexylena/git-gat/blob/main/.scripts/15-tool-management-run.sh), and [data-library-run.sh](https://github.com/hexylena/git-gat/blob/main/.scripts/16-data-library-run.sh) fails because the placeholder website name 'https://galaxy.example.org' does not get replaced by the hostname.