### PR TITLE
WIP: Add support for learning pathways

### DIFF
--- a/_includes/tutorial_list.html
+++ b/_includes/tutorial_list.html
@@ -18,7 +18,7 @@
   </thead>
   <tbody class="list">
 
-  {% assign subtopic_materials = include.sub[1].materials %}
+  {% assign subtopic_materials = include.sub[1].materials | default: include.sub %}
   {% for material in subtopic_materials %}
         <!-- MAT: {{ material.id }} -->
       {% if material.draft != true or jekyll.environment != "production" %}

--- a/_layouts/learning-path.html
+++ b/_layouts/learning-path.html
@@ -1,0 +1,56 @@
+---
+layout: base
+---
+
+{% assign pathway = page %}
+
+<!-- Gitter -->
+{% if topic.gitter %}
+  {% assign gitter = topic.gitter %}
+{% else %}
+  {% assign gitter = site.gitter_url %}
+{% endif %}
+
+<script>
+  ((window.gitter = {}).chat = {}).options = {
+  room: '{{ gitter | remove: "https://gitter.im/" }}'
+  };
+</script>
+<script src="https://sidecar.gitter.im/dist/sidecar.v1.js" async defer></script>
+
+
+<section>
+<h3> GTN Learning Pathway </h3>
+<p> We recommend you follow the tutorials in the order presented on this page. They have been selected to fit together and build up your knowledge step by step. If a lesson has both slides and a tutorial, we recommend you start with the slides, then proceed with the tutorial.</p>
+</section>
+
+<section class="tutorials-list {{ page.topic_name }} topic-type-{{ topic.type }}">
+    <h1>{{ pathway.title }}</h1>
+    <p>{{ content | markdownify }}</p>
+
+    {% if pathway.requirements %}
+    <h2 id="requirements">Requirements</h2>
+    <p>Before diving into this learning pathway, we recommend you to have a look at:</p>
+
+    <ul>
+        {% include _includes/display_extra_training.md extra_trainings=pathway.requirements %}
+    </ul>
+    {% endif %}
+
+
+
+    {% for section in page.pathway %}
+        <h3 id="st-{{ section.section | slugify }}">{{ section.section }}</h3>
+        <p>{{ section.description }}</p>
+
+        {% assign material_list = "" | split: "" %}
+        {% for tut in section.tutorials %}
+          <!-- TODO: make more efficient!-->
+          {% assign topic_material = site | topic_filter:tut.topic %}
+          {% assign m = topic_material | where: "tutorial_name", tut.name %}
+          {% assign material_list = material_list | concat: m %}
+
+        {% endfor %}
+        {% include _includes/tutorial_list.html sub=material_list %}
+    {% endfor %}
+

--- a/learning-paths/admin-training.md
+++ b/learning-paths/admin-training.md
@@ -1,0 +1,94 @@
+---
+layout: learning-path
+title: Admin Training Course
+description: |
+  This learning path covers all the topics usually taught during the regular 5-day admin
+  training workshops. Each module represents what is usually roughly taught in one day during the events.
+
+pathway:
+  - section: "Module 1: Setting up Galaxy with Ansible"
+    description: This module covers getting a Galaxy server setup with Ansible, a server you will develop furhter in the rest of the modules
+    tutorials:
+      - name: introduction
+        topic: admin
+      - name: ansible
+        topic: admin
+      - name: ansible-galaxy
+        topic: admin
+      - name: database
+        topic: admin
+      - name: uwsgi
+        topic: admin
+      - name: systemd-supervisor
+        topic: admin
+      - name: production
+        topic: admin
+      - name: toolshed
+        topic: admin
+      - name: management
+        topic: admin
+
+  - section: "Module 2: Making the server useful"
+    description: |
+      Here we pivot to focus on making our server useful; adding tools and data,
+      configuring quotas and authentication
+    tutorials:
+      - name: users-groups-quotas
+        topic: admin
+      - name: external-auth
+        topic: admin
+      - name: cvmfs
+        topic: admin
+      - name: connect-to-compute-cluster
+        topic: admin
+
+  - section: "Module 3 "
+    description: blabla
+    tutorials:
+      - name: bioblend-api
+        topic: dev
+      - name: heterogeneous-compute
+        topic: admin
+      - name: object-store
+        topic: admin
+      - name: reports
+        topic: admin
+      - name: gxadmin
+        topic: admin
+      - name: monitoring
+        topic: admin
+
+  - section: "Module 4"
+    description: ""
+    tutorials:
+      - name: maintenance
+        topic: admin
+      - name: tiaas
+        topic: admin
+      - name: job-metrics
+        topic: admin
+      - name: interactive-tools
+        topic: admin
+      - name: jenkins
+        topic: admin
+      - name: advanced-galaxy-customisation
+        topic: admin
+
+  - section: "Module 5: Grab bag"
+    description: |
+      Here we have some additional topics, some of which are not admin related.
+      Please feel free to pick and choose the tutorials that are interesting for you.
+    tutorials:
+      - name: troubleshooting
+        topic: admin
+      - name: tool-integration
+        topic: dev
+      - name: processing-many-samples-at-once
+        topic: galaxy-interface
+      - name: upload-rules
+        topic: galaxy-interface
+      - name: create-new-tutorial
+        topic: contributing
+
+---
+

--- a/learning-paths/index.md
+++ b/learning-paths/index.md
@@ -1,0 +1,11 @@
+---
+layout: base
+---
+
+# Learning Pathways
+
+Learning pathways are sets of tutorials curated for you by community experts to form a coherent set of lessons around a topic, building knowledge as you go. We always recommend to follow the tutorials in the order they are listed in the pathway.
+
+<!-- TODO: present as cards? -->
+
+[Intro to Galaxy and Genomics](intro-to-galaxy-and-genomics.html)

--- a/learning-paths/intro-to-galaxy-and-genomics.md
+++ b/learning-paths/intro-to-galaxy-and-genomics.md
@@ -1,0 +1,39 @@
+---
+layout: learning-path
+type: use
+
+title: Introduction to Galaxy and -Omics analysis
+description: |
+  This learning path aims to teach you the basics of Galaxy and -omics data analysis
+  (e.g. genomics, transcriptomics, proteomics)
+
+requirements:
+  - type: "internal"
+    topic_name: introduction
+
+pathway:
+  - section: "Module 1: Introduction to Galaxy"
+    description: Get a first look at the Galaxy platform for data analysis.
+    tutorials:
+      - name: galaxy-intro-short
+        topic: introduction
+      - name: galaxy-101
+        topic: introduction
+
+  - section: "Module 2: Basics of Genome Sequence Analysis"
+    description: blabla
+    tutorials:
+      - name: quality-control
+        topic: sequence-analysis
+      - name: mapping
+        topic: sequence-analysis
+
+  - section: "Module 3: Dive a bit Deeper"
+    description:
+    tutorials:
+      - name: ref-based
+        topic: transcriptomics
+---
+
+New to Galaxy and/or the field of genomics? Follow this learning path to get familiar with the basics!
+


### PR DESCRIPTION
Support defining of learning pathways. These can include tutorials from different topics.

![image](https://user-images.githubusercontent.com/2563865/231483863-22eff2dc-ba98-4577-b8ca-2965396a235f.png)

A learning pathway is defined via a yaml file in the `learning-paths/` folder that looks similar to a topic page:

```yaml
---
layout: learning-path
title: Pathway Title
description: In this learning path..

requirements:
  - type: "internal"
    topic_name: introduction

pathway:
  - section: "Module 1: Title"
    description: In this module we will..
    tutorials:
      - name: galaxy-intro-short
        topic: introduction
      - name: quality-control
        topic: sequence analysis
      - name: ref-based
        topic: transcriptomics

  - section: "Module 2: Title"
    description: In this module..
    tutorials:
      - name: barcodes
        topic: single-cell
      - name: ansible-galaxy
        topic: admin     
 ---
```

Still WIP but feedback welcome

TODOs:
- [ ] index page listing all available learning paths (as cards like the news maybe?)
- [ ] link from home page (perhaps on top bar instead of "languages" ?)
- [ ] support for external tutorials (sometimes you want to include something outside of GTN)
- [ ] refine the example "intro to Galaxy and -omics" pathway
- [ ] update the admin pathway to correspond with the upcomin admin training in Ghent (@hexylena)
