### PR TITLE
Tweak for external tutorials

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -81,6 +81,7 @@ icon-tag:
   docker_image: fab fa-docker
   email: far fa-envelope
   exchange: fas fa-exchange-alt
+  external-link: fas fa-external-link-alt
   switch-histories: fas fa-exchange-alt
   event: far fa-calendar
   feedback: far fa-comments
@@ -231,7 +232,7 @@ announcement:
   title: GTN Smörgåsbord 2023
   text: |
     The Galaxy Training Network is happy to announce the 3rd annual edition of the GTN Smörgåsbord global training event!
-    This 5-day, 24/7 training event is completely free, and covers a wide range of topics! During the week, **you** decide your own schedule, pick and choose the topics that are interesting to you, and learn at your own pace, with support from the global community of over 100 Galaxy instructors available on Slack 24/7 to answer your questions! 
+    This 5-day, 24/7 training event is completely free, and covers a wide range of topics! During the week, **you** decide your own schedule, pick and choose the topics that are interesting to you, and learn at your own pace, with support from the global community of over 100 Galaxy instructors available on Slack 24/7 to answer your questions!
 
     [Register today!](https://gallantries.github.io/video-library/events/smorgasbord3/?utm_source=gtn-button&utm_medium=website&utm_campaign=smorgasbord2023){: .btn.btn-success}
 

--- a/_includes/resource-handson.html
+++ b/_includes/resource-handson.html
@@ -1,11 +1,15 @@
 {% if include.material.hands_on == "external" %}
-<a class="topic-icon" href="{{ include.material.hands_on_url }}" title="Link to external materials">
-    {% icon tutorial aria=false %}
+<div class="btn-group">
+<a class="btn btn-default" href="{{ include.material.hands_on_url }}" title="Link to external materials">
+    {% icon external-link aria=false %}
 </a>
+</div>
 {% elsif include.material.hands_on == "github" %}
-<a href="{{ site.github_repository }}/tree/main/topics/{{ include.material.topic_name }}/tutorials/{{ include.material.tutorial_name }}/tutorial.md" title="Materials on github">
-    {% icon tutorial aria=false %}
+<div class="btn-group">
+<a class="btn btn-default" href="{{ site.github_repository }}/tree/main/topics/{{ include.material.topic_name }}/tutorials/{{ include.material.tutorial_name }}/tutorial.md" title="Materials on github">
+    {% icon github aria=false %}
 </a>
+</div>
 {% elsif include.material.hands_on %}
     <div class="btn-group">
         <a href="{{ site.baseurl }}/topics/{{ include.material.topic_name }}/tutorials/{{ include.material.tutorial_name }}/tutorial.html" class="btn btn-default" title="Follow the tutorial">

--- a/_includes/tutorial_list.html
+++ b/_includes/tutorial_list.html
@@ -30,6 +30,10 @@
             <a href="{{ site.baseurl }}/{{ default_resource_url }}">
                 {{ material.title }}
             </a>
+            {% else if material.external %}
+            <a href="{{ material.link }}">
+                {{ material.title }} {% icon external-link %}
+            </a>
             {% else %}
                 {{ material.title }}
             {% endif %}


### PR DESCRIPTION
Use a different icon for external tutorials, add a link to the title to be more in line with other tutorials and fix layout of icon

used to be:
![image](https://user-images.githubusercontent.com/2563865/231989372-641ab600-54e7-4885-947f-15715534312d.png)

now:

![image](https://user-images.githubusercontent.com/2563865/231989616-d86776c4-92d6-4627-bea6-c0624dd2a55b.png)

ping @hexylena

