### PR TITLE
Don't use job_conf.yml.j2 in the Apptainer tutorial

### DIFF
--- a/topics/admin/tutorials/apptainer/tutorial.md
+++ b/topics/admin/tutorials/apptainer/tutorial.md
@@ -249,13 +249,13 @@ Now, we will configure Galaxy to run tools using Apptainer containers, which wil
 >    ```
 >    {: data-commit="Configure the container resolver"}
 >
-> 3. Now, we want to make Galaxy run jobs using Apptainer. Modify the file `templates/galaxy/config/job_conf.yml.j2`, by adding the `singularity_enabled` parameter:
+> 3. Now, we want to make Galaxy run jobs using Apptainer. Modify the file `group_vars/galaxyservers.yml`, by adding the `singularity_enabled` parameter:
 >
 >    {% raw %}
 >    ```diff
 >    --- a/group_vars/galaxyservers.yml
 >    +++ b/group_vars/galaxyservers.yml
->    @@ -21,11 +21,24 @@ galaxy_job_config:
+>    @@ -30,11 +30,24 @@ galaxy_job_config:
 >       handling:
 >         assign: ['db-skip-locked']
 >       execution:
@@ -273,15 +273,14 @@ Now, we will configure Galaxy to run tools using Apptainer containers, which wil
 >    +        - name: LC_ALL
 >    +          value: C
 >    +        # The cache directory holds the docker containers that get converted
->    +        - name: SINGULARITY_CACHEDIR
+>    +        - name: APPTAINER_CACHEDIR
 >    +          value: /tmp/singularity
 >    +        # Apptainer uses a temporary directory to build the squashfs filesystem
->    +        - name: SINGULARITY_TMPDIR
+>    +        - name: APPTAINER_TMPDIR
 >    +          value: /tmp
 >       tools:
 >         - class: local # these special tools that aren't parameterized for remote execution - expression tools, upload, etc
->           environment: local_env
->    {% endraw %}
+>           environment: local_env>    {% endraw %}
 >    ```
 >    {: data-commit="Update the job_conf.yml with singularity destination"}
 >


### PR DESCRIPTION
# Thank you for contributing to the GTN! :yellow_heart:

## Please check that:

- [x] Your pull request has a **good title**, e.g.
    - "Fix typo in ansible-galaxy tutorial"
    - "Add new transcriptomics tutorial covering a new sequencing technology"
- [x] Please **replace this entire pull request message** with a *description of your changes*, it will help us review your pull request faster

Now that the Ansible-Galaxy tutorial does not use job_conf.yml.j2, neither should the Apptainer tutorial.