### PR TITLE
change enable_celery_beat to enable_beat in celery/tutorial.md

### DIFF
--- a/topics/admin/tutorials/celery/tutorial.md
+++ b/topics/admin/tutorials/celery/tutorial.md
@@ -377,7 +377,7 @@ First we need to add our new Ansible Roles to the `requirements.yml`:
 >           preload: true
 >         celery:
 >           concurrency: 2
->    +      enable_celery_beat: true
+>    +      enable_beat: true
 >    +      enable: true
 >    +      queues: celery,galaxy.internal,galaxy.external
 >    +      pool: threads


### PR DESCRIPTION
Hi @mira-miracoli I'm reading ahead because I was trying to work out whether Galaxy Aus has celery enabled anywhere (it doesn't). This tutorial is going to be incredibly helpful for us, thank you!

This PR is to change the key `enable_celery_beat` to `enable_beat` https://github.com/galaxyproject/galaxy/blob/release_23.0/lib/galaxy/config/sample/galaxy.yml.sample#L140
