### PR TITLE
Run tusd with gravity

### DIFF
--- a/topics/admin/tutorials/ansible-galaxy/tutorial.md
+++ b/topics/admin/tutorials/ansible-galaxy/tutorial.md
@@ -863,7 +863,7 @@ The configuration is quite simple thanks to the many sensible defaults that are 
 >    +  pre_tasks:
 >    +    - name: Install Dependencies
 >    +      package:
->    +        name: ['acl', 'bzip2', 'git', 'make', 'tar', 'python3-setuptools']
+>    +        name: ['acl', 'bzip2', 'git', 'make', 'tar', 'python3-venv', 'python3-setuptools']
 >    +  roles:
 >    +    - galaxyproject.galaxy
 >    +    - role: galaxyproject.miniconda

--- a/topics/admin/tutorials/apptainer/tutorial.md
+++ b/topics/admin/tutorials/apptainer/tutorial.md
@@ -109,10 +109,10 @@ First, we will install Apptainer using Ansible. Since there is a package availab
 >    ```diff
 >    --- a/galaxy.yml
 >    +++ b/galaxy.yml
->    @@ -30,6 +30,7 @@
->             name: ['tmpreaper']
+>    @@ -31,6 +31,7 @@
 >           when: ansible_os_family == 'Debian'
 >       roles:
+>         - galaxyproject.tusd
 >    +    - usegalaxy_eu.apptainer
 >         - galaxyproject.galaxy
 >         - role: galaxyproject.miniconda
@@ -178,8 +178,8 @@ Now, we will configure Galaxy to run tools using Apptainer containers, which wil
 >    ```diff
 >    --- a/group_vars/galaxyservers.yml
 >    +++ b/group_vars/galaxyservers.yml
->    @@ -69,6 +69,9 @@ galaxy_config:
->         tus_upload_store: /data/tus
+>    @@ -70,6 +70,9 @@ galaxy_config:
+>         tus_upload_store: "{{ galaxy_tus_upload_store }}"
 >         # CVMFS
 >         tool_data_table_config_path: /cvmfs/data.galaxyproject.org/byhand/location/tool_data_table_conf.xml,/cvmfs/data.galaxyproject.org/managed/location/tool_data_table_conf.xml
 >    +    # Tool Dependencies
@@ -188,7 +188,7 @@ Now, we will configure Galaxy to run tools using Apptainer containers, which wil
 >       gravity:
 >         process_manager: systemd
 >         galaxy_root: "{{ galaxy_root }}/server"
->    @@ -104,6 +107,12 @@ galaxy_config_files:
+>    @@ -109,6 +112,12 @@ galaxy_config_files:
 >       - src: files/galaxy/themes.yml
 >         dest: "{{ galaxy_config.galaxy.themes_config_file }}"
 >     

--- a/topics/admin/tutorials/backup-cleanup/tutorial.md
+++ b/topics/admin/tutorials/backup-cleanup/tutorial.md
@@ -158,7 +158,7 @@ Before we begin backing up our Galaxy data, let's set up automated cleanups to e
 >    @@ -21,6 +21,14 @@
 >         - name: Install Dependencies
 >           package:
->             name: ['acl', 'bzip2', 'git', 'make', 'tar', 'python3-setuptools']
+>             name: ['acl', 'bzip2', 'git', 'make', 'tar', 'python3-venv', 'python3-setuptools']
 >    +    - name: Install RHEL/CentOS/Rocky specific dependencies
 >    +      package:
 >    +        name: ['tmpwatch']

--- a/topics/admin/tutorials/backup-cleanup/tutorial.md
+++ b/topics/admin/tutorials/backup-cleanup/tutorial.md
@@ -124,7 +124,7 @@ tutorial]({% link topics/admin/tutorials/gxadmin/tutorial.md %}).
 >    +        user: galaxy # Run as the Galaxy user
 >    +        minute: "0"
 >    +        hour: "0"
->    +        job: "GALAXY_LOG_DIR=/tmp/gxadmin/ GALAXY_ROOT={{ galaxy_root }}/server /usr/bin/gxadmin galaxy cleanup 60"
+>    +        job: "GALAXY_LOG_DIR=/tmp/gxadmin/ GALAXY_ROOT={{ galaxy_root }}/server /usr/local/bin/gxadmin galaxy cleanup 60"
 >    {% endraw %}
 >    ```
 >    {: data-commit="Configure gxadmin to cleanup data"}

--- a/topics/admin/tutorials/celery/tutorial.md
+++ b/topics/admin/tutorials/celery/tutorial.md
@@ -149,10 +149,10 @@ First we need to add our new Ansible Roles to the `requirements.yml`:
 >        ```diff
 >        --- a/group_vars/galaxyservers.yml
 >        +++ b/group_vars/galaxyservers.yml
->        @@ -273,3 +273,7 @@ tusd_instances:
->               - "-upload-dir={{ galaxy_config.galaxy.tus_upload_store }}"
->               - "-hooks-http=https://{{ inventory_hostname }}/api/upload/hooks"
->               - "-hooks-http-forward-headers=X-Api-Key,Cookie"
+>        @@ -269,3 +269,7 @@ rabbitmq_users:
+>         # TUS
+>         galaxy_tusd_port: 1080
+>         galaxy_tus_upload_store: /data/tus
 >        +
 >        +#Redis
 >        +galaxy_additional_venv_packages:
@@ -166,7 +166,7 @@ First we need to add our new Ansible Roles to the `requirements.yml`:
 >        ```diff
 >        --- a/galaxy.yml
 >        +++ b/galaxy.yml
->        @@ -45,6 +45,7 @@
+>        @@ -46,6 +46,7 @@
 >             - role: galaxyproject.miniconda
 >               become: true
 >               become_user: "{{ galaxy_user_name }}"
@@ -248,7 +248,7 @@ First we need to add our new Ansible Roles to the `requirements.yml`:
 >        ```diff
 >        --- a/group_vars/galaxyservers.yml
 >        +++ b/group_vars/galaxyservers.yml
->        @@ -251,6 +251,7 @@ rabbitmq_config:
+>        @@ -256,6 +256,7 @@ rabbitmq_config:
 >         
 >         rabbitmq_vhosts:
 >           - /pulsar/pulsar_au
@@ -256,7 +256,7 @@ First we need to add our new Ansible Roles to the `requirements.yml`:
 >         
 >         rabbitmq_users:
 >           - user: admin
->        @@ -260,6 +261,13 @@ rabbitmq_users:
+>        @@ -265,6 +266,13 @@ rabbitmq_users:
 >           - user: pulsar_au
 >             password: "{{ vault_rabbitmq_password_vhost }}"
 >             vhost: /pulsar/pulsar_au
@@ -299,7 +299,7 @@ First we need to add our new Ansible Roles to the `requirements.yml`:
 >        ```diff
 >        --- a/group_vars/galaxyservers.yml
 >        +++ b/group_vars/galaxyservers.yml
->        @@ -285,3 +285,22 @@ tusd_instances:
+>        @@ -281,3 +281,22 @@ galaxy_tus_upload_store: /data/tus
 >         #Redis
 >         galaxy_additional_venv_packages:
 >           - redis
@@ -355,7 +355,7 @@ First we need to add our new Ansible Roles to the `requirements.yml`:
 >        ```diff
 >        --- a/galaxy.yml
 >        +++ b/galaxy.yml
->        @@ -46,6 +46,7 @@
+>        @@ -47,6 +47,7 @@
 >               become: true
 >               become_user: "{{ galaxy_user_name }}"
 >             - geerlingguy.redis
@@ -373,7 +373,7 @@ First we need to add our new Ansible Roles to the `requirements.yml`:
 >    ```diff
 >    --- a/group_vars/galaxyservers.yml
 >    +++ b/group_vars/galaxyservers.yml
->    @@ -118,6 +118,11 @@ galaxy_config:
+>    @@ -119,6 +119,11 @@ galaxy_config:
 >           preload: true
 >         celery:
 >           concurrency: 2
@@ -383,8 +383,8 @@ First we need to add our new Ansible Roles to the `requirements.yml`:
 >    +      pool: threads
 >    +      memory_limit: 2
 >           loglevel: DEBUG
->         handlers:
->           handler:
+>         tusd:
+>           enable: true
 >    {% endraw %}
 >    ```
 >    {: data-commit="Add celery" data-ref="add-req"}
@@ -394,7 +394,7 @@ First we need to add our new Ansible Roles to the `requirements.yml`:
 >    ```diff
 >    --- a/group_vars/galaxyservers.yml
 >    +++ b/group_vars/galaxyservers.yml
->    @@ -99,6 +99,11 @@ galaxy_config:
+>    @@ -100,6 +100,11 @@ galaxy_config:
 >         # Data Library Directories
 >         library_import_dir: /libraries/admin
 >         user_library_import_dir: /libraries/user

--- a/topics/admin/tutorials/connect-to-compute-cluster/tutorial.md
+++ b/topics/admin/tutorials/connect-to-compute-cluster/tutorial.md
@@ -109,10 +109,10 @@ be taken into consideration when choosing where to run jobs and what parameters 
 >    ```diff
 >    --- a/galaxy.yml
 >    +++ b/galaxy.yml
->    @@ -33,6 +33,8 @@
->             repo: 'https://github.com/usegalaxy-eu/libraries-training-repo'
+>    @@ -34,6 +34,8 @@
 >             dest: /libraries/
 >       roles:
+>         - galaxyproject.tusd
 >    +    - galaxyproject.repos
 >    +    - galaxyproject.slurm
 >         - usegalaxy_eu.apptainer
@@ -128,7 +128,7 @@ be taken into consideration when choosing where to run jobs and what parameters 
 >    ```diff
 >    --- a/group_vars/galaxyservers.yml
 >    +++ b/group_vars/galaxyservers.yml
->    @@ -184,6 +184,16 @@ nginx_ssl_role: usegalaxy_eu.certbot
+>    @@ -189,6 +189,16 @@ nginx_ssl_role: usegalaxy_eu.certbot
 >     nginx_conf_ssl_certificate: /etc/ssl/certs/fullchain.pem
 >     nginx_conf_ssl_certificate_key: /etc/ssl/user/privkey-www-data.pem
 >     
@@ -144,7 +144,7 @@ be taken into consideration when choosing where to run jobs and what parameters 
 >    +
 >     # TUS
 >     galaxy_tusd_port: 1080
->     tusd_instances:
+>     galaxy_tus_upload_store: /data/tus
 >    {% endraw %}
 >    ```
 >    {: data-commit="Add slurm configuration"}
@@ -338,8 +338,8 @@ Above Slurm in the stack is slurm-drmaa, a library that provides a translational
 >    +      package:
 >    +        name: slurm-drmaa1
 >       roles:
+>         - galaxyproject.tusd
 >         - galaxyproject.repos
->         - galaxyproject.slurm
 >    {% endraw %}
 >    ```
 >    {: data-commit="Add post task to install slurm-drmaa"}

--- a/topics/admin/tutorials/cvmfs/tutorial.md
+++ b/topics/admin/tutorials/cvmfs/tutorial.md
@@ -311,9 +311,9 @@ If the terms "Ansible", "role" and "playbook" mean nothing to you, please checko
 >    --- a/galaxy.yml
 >    +++ b/galaxy.yml
 >    @@ -37,6 +37,7 @@
+>           become_user: "{{ galaxy_user_name }}"
 >         - galaxyproject.nginx
 >         - galaxyproject.gxadmin
->         - galaxyproject.tusd
 >    +    - galaxyproject.cvmfs
 >       post_tasks:
 >         - name: Setup gxadmin cleanup task
@@ -507,10 +507,10 @@ Now all we need to do is tell Galaxy how to find it! This tutorial assumes that 
 >    ```diff
 >    --- a/group_vars/galaxyservers.yml
 >    +++ b/group_vars/galaxyservers.yml
->    @@ -67,6 +67,8 @@ galaxy_config:
->         new_user_dataset_access_role_default_private: true # Make datasets private by default
+>    @@ -68,6 +68,8 @@ galaxy_config:
 >         # TUS
->         tus_upload_store: /data/tus
+>         galaxy_infrastructure_url: "https://{{ inventory_hostname }}"
+>         tus_upload_store: "{{ galaxy_tus_upload_store }}"
 >    +    # CVMFS
 >    +    tool_data_table_config_path: /cvmfs/data.galaxyproject.org/byhand/location/tool_data_table_conf.xml,/cvmfs/data.galaxyproject.org/managed/location/tool_data_table_conf.xml
 >       gravity:

--- a/topics/admin/tutorials/data-library/tutorial.md
+++ b/topics/admin/tutorials/data-library/tutorial.md
@@ -68,8 +68,8 @@ Before we can import local data, we need to configure Galaxy to permit this. Add
 >    +        repo: 'https://github.com/usegalaxy-eu/libraries-training-repo'
 >    +        dest: /libraries/
 >       roles:
+>         - galaxyproject.tusd
 >         - usegalaxy_eu.apptainer
->         - galaxyproject.galaxy
 >    {% endraw %}
 >    ```
 >    {: data-commit="Add the git repository to the pre-tasks"}
@@ -84,7 +84,7 @@ Before we can import local data, we need to configure Galaxy to permit this. Add
 >    ```diff
 >    --- a/group_vars/galaxyservers.yml
 >    +++ b/group_vars/galaxyservers.yml
->    @@ -85,6 +85,9 @@ galaxy_config:
+>    @@ -86,6 +86,9 @@ galaxy_config:
 >         # Tool Dependencies
 >         dependency_resolvers_config_file: "{{ galaxy_config_dir }}/dependency_resolvers_conf.xml"
 >         containers_resolvers_config_file: "{{ galaxy_config_dir }}/container_resolvers_conf.yml"

--- a/topics/admin/tutorials/ftp/tutorial.md
+++ b/topics/admin/tutorials/ftp/tutorial.md
@@ -111,7 +111,7 @@ If the terms "Ansible", "role" and "playbook" mean nothing to you, please checko
 >    ```diff
 >    --- a/group_vars/galaxyservers.yml
 >    +++ b/group_vars/galaxyservers.yml
->    @@ -186,11 +186,13 @@ certbot_environment: staging
+>    @@ -191,11 +191,13 @@ certbot_environment: staging
 >     certbot_well_known_root: /srv/nginx/_well-known_root
 >     certbot_share_key_users:
 >       - www-data
@@ -137,7 +137,7 @@ If the terms "Ansible", "role" and "playbook" mean nothing to you, please checko
 >    ```diff
 >    --- a/group_vars/galaxyservers.yml
 >    +++ b/group_vars/galaxyservers.yml
->    @@ -107,6 +107,9 @@ galaxy_config:
+>    @@ -108,6 +108,9 @@ galaxy_config:
 >         # Monitoring
 >         statsd_host: localhost
 >         statsd_influxdb: true
@@ -159,7 +159,7 @@ If the terms "Ansible", "role" and "playbook" mean nothing to you, please checko
 >    ```diff
 >    --- a/group_vars/galaxyservers.yml
 >    +++ b/group_vars/galaxyservers.yml
->    @@ -350,3 +350,24 @@ telegraf_plugins_extra:
+>    @@ -346,3 +346,24 @@ telegraf_plugins_extra:
 >     tiaas_dir: /srv/tiaas
 >     tiaas_admin_user: admin
 >     tiaas_admin_pass: changeme
@@ -216,7 +216,7 @@ If the terms "Ansible", "role" and "playbook" mean nothing to you, please checko
 >    ```diff
 >    --- a/galaxy.yml
 >    +++ b/galaxy.yml
->    @@ -48,6 +48,7 @@
+>    @@ -49,6 +49,7 @@
 >         - geerlingguy.redis
 >         - usegalaxy_eu.flower
 >         - galaxyproject.nginx

--- a/topics/admin/tutorials/job-destinations/tutorial.md
+++ b/topics/admin/tutorials/job-destinations/tutorial.md
@@ -106,7 +106,7 @@ To demonstrate a real-life scenario and {TPV}'s role in it, let's plan on settin
 >    ```diff
 >    --- a/group_vars/galaxyservers.yml
 >    +++ b/group_vars/galaxyservers.yml
->    @@ -145,6 +145,9 @@ galaxy_config_templates:
+>    @@ -150,6 +150,9 @@ galaxy_config_templates:
 >     galaxy_extra_dirs:
 >       - /data
 >     
@@ -185,7 +185,7 @@ And of course, Galaxy has an Ansible Role for that.
 >    ```diff
 >    --- a/group_vars/galaxyservers.yml
 >    +++ b/group_vars/galaxyservers.yml
->    @@ -128,6 +128,8 @@ galaxy_config:
+>    @@ -133,6 +133,8 @@ galaxy_config:
 >               - job-handlers
 >               - workflow-schedulers
 >     
@@ -194,7 +194,7 @@ And of course, Galaxy has an Ansible Role for that.
 >     galaxy_config_files_public:
 >       - src: files/galaxy/welcome.html
 >         dest: "{{ galaxy_mutable_config_dir }}/welcome.html"
->    @@ -143,7 +145,10 @@ galaxy_config_templates:
+>    @@ -148,7 +150,10 @@ galaxy_config_templates:
 >         dest: "{{ galaxy_config.galaxy.dependency_resolvers_config_file }}"
 >     
 >     galaxy_extra_dirs:
@@ -214,7 +214,7 @@ And of course, Galaxy has an Ansible Role for that.
 >    ```diff
 >    --- a/galaxy.yml
 >    +++ b/galaxy.yml
->    @@ -41,6 +41,7 @@
+>    @@ -42,6 +42,7 @@
 >         - galaxyproject.slurm
 >         - usegalaxy_eu.apptainer
 >         - galaxyproject.galaxy
@@ -290,7 +290,7 @@ We want our tool to run with more than one core. To do this, we need to instruct
 >       tools:
 >         - class: local # these special tools that aren't parameterized for remote execution - expression tools, upload, etc
 >           environment: local_env
->    @@ -137,6 +118,8 @@ galaxy_config_files_public:
+>    @@ -142,6 +123,8 @@ galaxy_config_files_public:
 >     galaxy_config_files:
 >       - src: files/galaxy/themes.yml
 >         dest: "{{ galaxy_config.galaxy.themes_config_file }}"
@@ -634,7 +634,7 @@ Such form elements can be added to tools without modifying each tool's configura
 >         # SQL Performance
 >         slow_query_log_threshold: 5
 >         enable_per_request_sql_debugging: true
->    @@ -127,6 +133,8 @@ galaxy_config_templates:
+>    @@ -132,6 +138,8 @@ galaxy_config_templates:
 >         dest: "{{ galaxy_config.galaxy.containers_resolvers_config_file }}"
 >       - src: templates/galaxy/config/dependency_resolvers_conf.xml
 >         dest: "{{ galaxy_config.galaxy.dependency_resolvers_config_file }}"

--- a/topics/admin/tutorials/monitoring/tutorial.md
+++ b/topics/admin/tutorials/monitoring/tutorial.md
@@ -442,8 +442,8 @@ Setting up Telegraf is again very simple. We just add a single role to our playb
 >    --- a/galaxy.yml
 >    +++ b/galaxy.yml
 >    @@ -53,6 +53,7 @@
+>         - usegalaxy_eu.rabbitmqserver
 >         - galaxyproject.gxadmin
->         - galaxyproject.tusd
 >         - galaxyproject.cvmfs
 >    +    - dj-wasabi.telegraf
 >       post_tasks:
@@ -504,7 +504,7 @@ Setting up Telegraf is again very simple. We just add a single role to our playb
 >    ```diff
 >    --- a/group_vars/galaxyservers.yml
 >    +++ b/group_vars/galaxyservers.yml
->    @@ -314,3 +314,12 @@ flower_ui_users:
+>    @@ -310,3 +310,12 @@ flower_ui_users:
 >     
 >     flower_environment_variables:
 >       GALAXY_CONFIG_FILE: "{{ galaxy_config_file }}"
@@ -531,7 +531,7 @@ Setting up Telegraf is again very simple. We just add a single role to our playb
 >    ```diff
 >    --- a/group_vars/galaxyservers.yml
 >    +++ b/group_vars/galaxyservers.yml
->    @@ -104,6 +104,9 @@ galaxy_config:
+>    @@ -105,6 +105,9 @@ galaxy_config:
 >         celery_conf:
 >           result_backend: "redis://localhost:6379/0"
 >         enable_celery_tasks: true
@@ -796,7 +796,7 @@ You can run the playbook now, or wait until you have configured Telegraf below:
 >    ```diff
 >    --- a/group_vars/galaxyservers.yml
 >    +++ b/group_vars/galaxyservers.yml
->    @@ -326,3 +326,10 @@ telegraf_plugins_extra:
+>    @@ -322,3 +322,10 @@ telegraf_plugins_extra:
 >           - service_address = ":8125"
 >           - metric_separator = "."
 >           - allowed_pending_messages = 10000

--- a/topics/admin/tutorials/pulsar/tutorial.md
+++ b/topics/admin/tutorials/pulsar/tutorial.md
@@ -271,7 +271,7 @@ More information about the rabbitmq ansible role can be found [in the repository
 >    ```diff
 >    --- a/group_vars/galaxyservers.yml
 >    +++ b/group_vars/galaxyservers.yml
->    @@ -156,8 +156,11 @@ certbot_environment: staging
+>    @@ -161,8 +161,11 @@ certbot_environment: staging
 >     certbot_well_known_root: /srv/nginx/_well-known_root
 >     certbot_share_key_users:
 >       - www-data
@@ -283,7 +283,7 @@ More information about the rabbitmq ansible role can be found [in the repository
 >     certbot_domains:
 >      - "{{ inventory_hostname }}"
 >     certbot_agree_tos: --agree-tos
->    @@ -207,6 +210,47 @@ slurm_config:
+>    @@ -212,6 +215,47 @@ slurm_config:
 >       SelectType: select/cons_res
 >       SelectTypeParameters: CR_CPU_Memory  # Allocate individual cores/memory instead of entire node
 >     
@@ -330,7 +330,7 @@ More information about the rabbitmq ansible role can be found [in the repository
 >    +
 >     # TUS
 >     galaxy_tusd_port: 1080
->     tusd_instances:
+>     galaxy_tus_upload_store: /data/tus
 >    {% endraw %}
 >    ```
 >    {: data-commit="Configure RabbitMQ"}
@@ -345,15 +345,15 @@ More information about the rabbitmq ansible role can be found [in the repository
 >    ```diff
 >    --- a/galaxy.yml
 >    +++ b/galaxy.yml
->    @@ -46,6 +46,8 @@
+>    @@ -47,6 +47,8 @@
 >           become: true
 >           become_user: "{{ galaxy_user_name }}"
 >         - galaxyproject.nginx
 >    +    - geerlingguy.docker
 >    +    - usegalaxy_eu.rabbitmqserver
 >         - galaxyproject.gxadmin
->         - galaxyproject.tusd
 >         - galaxyproject.cvmfs
+>       post_tasks:
 >    {% endraw %}
 >    ```
 >    {: data-commit="Add role"}

--- a/topics/admin/tutorials/reports/tutorial.md
+++ b/topics/admin/tutorials/reports/tutorial.md
@@ -70,7 +70,7 @@ The reports application is included with the Galaxy codebase and this tutorial a
 >    ```diff
 >    --- a/group_vars/galaxyservers.yml
 >    +++ b/group_vars/galaxyservers.yml
->    @@ -138,6 +138,11 @@ galaxy_config:
+>    @@ -143,6 +143,11 @@ galaxy_config:
 >             pools:
 >               - job-handlers
 >               - workflow-schedulers
@@ -82,7 +82,7 @@ The reports application is included with the Galaxy codebase and this tutorial a
 >     
 >     galaxy_job_config_file: "{{ galaxy_config_dir }}/galaxy.yml"
 >     
->    @@ -158,6 +163,8 @@ galaxy_config_templates:
+>    @@ -163,6 +168,8 @@ galaxy_config_templates:
 >         dest: "{{ galaxy_config.galaxy.dependency_resolvers_config_file }}"
 >       - src: templates/galaxy/config/job_resource_params_conf.xml.j2
 >         dest: "{{ galaxy_config.galaxy.job_resource_params_file }}"

--- a/topics/admin/tutorials/tiaas/tutorial.md
+++ b/topics/admin/tutorials/tiaas/tutorial.md
@@ -91,7 +91,7 @@ This tutorial will go cover how to set up such a service on your own Galaxy serv
 >    ```diff
 >    --- a/group_vars/galaxyservers.yml
 >    +++ b/group_vars/galaxyservers.yml
->    @@ -333,3 +333,8 @@ telegraf_plugins_extra:
+>    @@ -329,3 +329,8 @@ telegraf_plugins_extra:
 >           - timeout = "10s"
 >           - data_format = "influx"
 >           - interval = "15s"
@@ -170,14 +170,14 @@ This tutorial will go cover how to set up such a service on your own Galaxy serv
 >    ```diff
 >    --- a/galaxy.yml
 >    +++ b/galaxy.yml
->    @@ -50,6 +50,7 @@
+>    @@ -51,6 +51,7 @@
 >         - galaxyproject.nginx
 >         - geerlingguy.docker
 >         - usegalaxy_eu.rabbitmqserver
 >    +    - galaxyproject.tiaas2
 >         - galaxyproject.gxadmin
->         - galaxyproject.tusd
 >         - galaxyproject.cvmfs
+>         - dj-wasabi.telegraf
 >    {% endraw %}
 >    ```
 >    {: data-commit="Add TIaaS role to the Galaxy playbook"}

--- a/topics/admin/tutorials/tus/tutorial.md
+++ b/topics/admin/tutorials/tus/tutorial.md
@@ -80,32 +80,35 @@ To allow your user to upload via TUS, you will need to:
 >    ```diff
 >    --- a/group_vars/galaxyservers.yml
 >    +++ b/group_vars/galaxyservers.yml
->    @@ -65,6 +65,8 @@ galaxy_config:
+>    @@ -65,6 +65,9 @@ galaxy_config:
 >         # Tool security
 >         outputs_to_working_directory: true
 >         new_user_dataset_access_role_default_private: true # Make datasets private by default
 >    +    # TUS
->    +    tus_upload_store: /data/tus
+>    +    galaxy_infrastructure_url: "https://{{ inventory_hostname }}"
+>    +    tus_upload_store: "{{ galaxy_tus_upload_store }}"
 >       gravity:
 >         process_manager: systemd
 >         galaxy_root: "{{ galaxy_root }}/server"
->    @@ -154,3 +156,16 @@ nginx_conf_http:
+>    @@ -85,6 +88,10 @@ galaxy_config:
+>         celery:
+>           concurrency: 2
+>           loglevel: DEBUG
+>    +    tusd:
+>    +      enable: true
+>    +      tusd_path: /usr/local/sbin/tusd
+>    +      upload_dir: "{{ galaxy_tus_upload_store }}"
+>         handlers:
+>           handler:
+>             processes: 2
+>    @@ -154,3 +161,7 @@ nginx_conf_http:
 >     nginx_ssl_role: usegalaxy_eu.certbot
 >     nginx_conf_ssl_certificate: /etc/ssl/certs/fullchain.pem
 >     nginx_conf_ssl_certificate_key: /etc/ssl/user/privkey-www-data.pem
 >    +
 >    +# TUS
 >    +galaxy_tusd_port: 1080
->    +tusd_instances:
->    +  - name: main
->    +    user: "{{ galaxy_user.name }}"
->    +    group: "galaxy"
->    +    args:
->    +      - "-host=localhost"
->    +      - "-port={{ galaxy_tusd_port }}"
->    +      - "-upload-dir={{ galaxy_config.galaxy.tus_upload_store }}"
->    +      - "-hooks-http=https://{{ inventory_hostname }}/api/upload/hooks"
->    +      - "-hooks-http-forward-headers=X-Api-Key,Cookie"
+>    +galaxy_tus_upload_store: /data/tus
 >    {% endraw %}
 >    ```
 >    {: data-commit="Configure TUS in your group variables"}
@@ -149,14 +152,14 @@ To allow your user to upload via TUS, you will need to:
 >    ```diff
 >    --- a/galaxy.yml
 >    +++ b/galaxy.yml
->    @@ -36,6 +36,7 @@
->           become_user: "{{ galaxy_user_name }}"
->         - galaxyproject.nginx
->         - galaxyproject.gxadmin
+>    @@ -30,6 +30,7 @@
+>             name: ['tmpreaper']
+>           when: ansible_os_family == 'Debian'
+>       roles:
 >    +    - galaxyproject.tusd
->       post_tasks:
->         - name: Setup gxadmin cleanup task
->           ansible.builtin.cron:
+>         - galaxyproject.galaxy
+>         - role: galaxyproject.miniconda
+>           become: true
 >    {% endraw %}
 >    ```
 >    {: data-commit="Add the role to the playbook"}


### PR DESCRIPTION
You unfortunately have to `sudo systemctl start gravity-tusd` for now after installation until I fix this in Gravity (`galaxyctl graceful` intentionally does not restart tusd, but it should start it if it's not running).