### PR TITLE
keep local_env in galaxy_job_config when tpv_dispatcher is added

### DIFF
--- a/topics/admin/tutorials/celery/tutorial.md
+++ b/topics/admin/tutorials/celery/tutorial.md
@@ -149,7 +149,7 @@ First we need to add our new Ansible Roles to the `requirements.yml`:
 >        ```diff
 >        --- a/group_vars/galaxyservers.yml
 >        +++ b/group_vars/galaxyservers.yml
->        @@ -272,3 +272,7 @@ rabbitmq_users:
+>        @@ -275,3 +275,7 @@ rabbitmq_users:
 >         # TUS
 >         galaxy_tusd_port: 1080
 >         galaxy_tus_upload_store: /data/tus
@@ -248,7 +248,7 @@ First we need to add our new Ansible Roles to the `requirements.yml`:
 >        ```diff
 >        --- a/group_vars/galaxyservers.yml
 >        +++ b/group_vars/galaxyservers.yml
->        @@ -259,6 +259,7 @@ rabbitmq_config:
+>        @@ -262,6 +262,7 @@ rabbitmq_config:
 >         
 >         rabbitmq_vhosts:
 >           - /pulsar/pulsar_au
@@ -256,7 +256,7 @@ First we need to add our new Ansible Roles to the `requirements.yml`:
 >         
 >         rabbitmq_users:
 >           - user: admin
->        @@ -268,6 +269,13 @@ rabbitmq_users:
+>        @@ -271,6 +272,13 @@ rabbitmq_users:
 >           - user: pulsar_au
 >             password: "{{ vault_rabbitmq_password_vhost }}"
 >             vhost: /pulsar/pulsar_au
@@ -299,7 +299,7 @@ First we need to add our new Ansible Roles to the `requirements.yml`:
 >        ```diff
 >        --- a/group_vars/galaxyservers.yml
 >        +++ b/group_vars/galaxyservers.yml
->        @@ -284,3 +284,22 @@ galaxy_tus_upload_store: /data/tus
+>        @@ -287,3 +287,22 @@ galaxy_tus_upload_store: /data/tus
 >         #Redis
 >         galaxy_additional_venv_packages:
 >           - redis
@@ -373,7 +373,7 @@ First we need to add our new Ansible Roles to the `requirements.yml`:
 >    ```diff
 >    --- a/group_vars/galaxyservers.yml
 >    +++ b/group_vars/galaxyservers.yml
->    @@ -121,6 +121,11 @@ galaxy_config:
+>    @@ -124,6 +124,11 @@ galaxy_config:
 >           preload: true
 >         celery:
 >           concurrency: 2
@@ -394,7 +394,7 @@ First we need to add our new Ansible Roles to the `requirements.yml`:
 >    ```diff
 >    --- a/group_vars/galaxyservers.yml
 >    +++ b/group_vars/galaxyservers.yml
->    @@ -102,6 +102,11 @@ galaxy_config:
+>    @@ -105,6 +105,11 @@ galaxy_config:
 >         # Data Library Directories
 >         library_import_dir: /libraries/admin
 >         user_library_import_dir: /libraries/user

--- a/topics/admin/tutorials/ftp/tutorial.md
+++ b/topics/admin/tutorials/ftp/tutorial.md
@@ -111,7 +111,7 @@ If the terms "Ansible", "role" and "playbook" mean nothing to you, please checko
 >    ```diff
 >    --- a/group_vars/galaxyservers.yml
 >    +++ b/group_vars/galaxyservers.yml
->    @@ -194,11 +194,13 @@ certbot_environment: staging
+>    @@ -197,11 +197,13 @@ certbot_environment: staging
 >     certbot_well_known_root: /srv/nginx/_well-known_root
 >     certbot_share_key_users:
 >       - www-data
@@ -137,7 +137,7 @@ If the terms "Ansible", "role" and "playbook" mean nothing to you, please checko
 >    ```diff
 >    --- a/group_vars/galaxyservers.yml
 >    +++ b/group_vars/galaxyservers.yml
->    @@ -110,6 +110,9 @@ galaxy_config:
+>    @@ -113,6 +113,9 @@ galaxy_config:
 >         # Monitoring
 >         statsd_host: localhost
 >         statsd_influxdb: true
@@ -159,7 +159,7 @@ If the terms "Ansible", "role" and "playbook" mean nothing to you, please checko
 >    ```diff
 >    --- a/group_vars/galaxyservers.yml
 >    +++ b/group_vars/galaxyservers.yml
->    @@ -349,3 +349,24 @@ telegraf_plugins_extra:
+>    @@ -352,3 +352,24 @@ telegraf_plugins_extra:
 >     tiaas_dir: /srv/tiaas
 >     tiaas_admin_user: admin
 >     tiaas_admin_pass: changeme

--- a/topics/admin/tutorials/job-destinations/tutorial.md
+++ b/topics/admin/tutorials/job-destinations/tutorial.md
@@ -248,7 +248,7 @@ We want our tool to run with more than one core. To do this, we need to instruct
 >    ```diff
 >    --- a/group_vars/galaxyservers.yml
 >    +++ b/group_vars/galaxyservers.yml
->    @@ -24,34 +24,15 @@ galaxy_job_config:
+>    @@ -24,34 +24,18 @@ galaxy_job_config:
 >       handling:
 >         assign: ['db-skip-locked']
 >       execution:
@@ -291,7 +291,7 @@ We want our tool to run with more than one core. To do this, we need to instruct
 >       tools:
 >         - class: local # these special tools that aren't parameterized for remote execution - expression tools, upload, etc
 >           environment: local_env
->    @@ -144,6 +125,8 @@ galaxy_config_files_public:
+>    @@ -144,6 +128,8 @@ galaxy_config_files_public:
 >     galaxy_config_files:
 >       - src: files/galaxy/themes.yml
 >         dest: "{{ galaxy_config.galaxy.themes_config_file }}"
@@ -463,7 +463,7 @@ on settings that have worked well in the usegalaxy.* federation. The rule file c
 >    ```diff
 >    --- a/group_vars/galaxyservers.yml
 >    +++ b/group_vars/galaxyservers.yml
->    @@ -32,6 +32,7 @@ galaxy_job_config:
+>    @@ -35,6 +35,7 @@ galaxy_job_config:
 >             function: map_tool_to_destination
 >             rules_module: tpv.rules
 >             tpv_config_files:
@@ -615,7 +615,7 @@ Such form elements can be added to tools without modifying each tool's configura
 >    ```diff
 >    --- a/group_vars/galaxyservers.yml
 >    +++ b/group_vars/galaxyservers.yml
->    @@ -34,6 +34,11 @@ galaxy_job_config:
+>    @@ -37,6 +37,11 @@ galaxy_job_config:
 >             tpv_config_files:
 >               - https://raw.githubusercontent.com/galaxyproject/tpv-shared-database/main/tools.yml
 >               - "{{ tpv_config_dir }}/tpv_rules_local.yml"
@@ -627,7 +627,7 @@ Such form elements can be added to tools without modifying each tool's configura
 >       tools:
 >         - class: local # these special tools that aren't parameterized for remote execution - expression tools, upload, etc
 >           environment: local_env
->    @@ -53,6 +58,7 @@ galaxy_config:
+>    @@ -56,6 +61,7 @@ galaxy_config:
 >         object_store_store_by: uuid
 >         id_secret: "{{ vault_id_secret }}"
 >         job_config: "{{ galaxy_job_config }}" # Use the variable we defined above
@@ -635,7 +635,7 @@ Such form elements can be added to tools without modifying each tool's configura
 >         # SQL Performance
 >         slow_query_log_threshold: 5
 >         enable_per_request_sql_debugging: true
->    @@ -134,6 +140,8 @@ galaxy_config_templates:
+>    @@ -137,6 +143,8 @@ galaxy_config_templates:
 >         dest: "{{ galaxy_config.galaxy.containers_resolvers_config_file }}"
 >       - src: templates/galaxy/config/dependency_resolvers_conf.xml
 >         dest: "{{ galaxy_config.galaxy.dependency_resolvers_config_file }}"

--- a/topics/admin/tutorials/job-destinations/tutorial.md
+++ b/topics/admin/tutorials/job-destinations/tutorial.md
@@ -255,9 +255,9 @@ We want our tool to run with more than one core. To do this, we need to instruct
 >    -    default: slurm
 >    +    default: tpv_dispatcher
 >         environments:
->    -      local_env:
->    -        runner: local_runner
->    -        tmp_dir: true
+>           local_env:
+>             runner: local_runner
+>             tmp_dir: true
 >    -      slurm:
 >    -        runner: slurm
 >    -        singularity_enabled: true

--- a/topics/admin/tutorials/monitoring/tutorial.md
+++ b/topics/admin/tutorials/monitoring/tutorial.md
@@ -504,7 +504,7 @@ Setting up Telegraf is again very simple. We just add a single role to our playb
 >    ```diff
 >    --- a/group_vars/galaxyservers.yml
 >    +++ b/group_vars/galaxyservers.yml
->    @@ -313,3 +313,12 @@ flower_ui_users:
+>    @@ -316,3 +316,12 @@ flower_ui_users:
 >     
 >     flower_environment_variables:
 >       GALAXY_CONFIG_FILE: "{{ galaxy_config_file }}"
@@ -531,7 +531,7 @@ Setting up Telegraf is again very simple. We just add a single role to our playb
 >    ```diff
 >    --- a/group_vars/galaxyservers.yml
 >    +++ b/group_vars/galaxyservers.yml
->    @@ -107,6 +107,9 @@ galaxy_config:
+>    @@ -110,6 +110,9 @@ galaxy_config:
 >         celery_conf:
 >           result_backend: "redis://localhost:6379/0"
 >         enable_celery_tasks: true
@@ -796,7 +796,7 @@ You can run the playbook now, or wait until you have configured Telegraf below:
 >    ```diff
 >    --- a/group_vars/galaxyservers.yml
 >    +++ b/group_vars/galaxyservers.yml
->    @@ -325,3 +325,10 @@ telegraf_plugins_extra:
+>    @@ -328,3 +328,10 @@ telegraf_plugins_extra:
 >           - service_address = ":8125"
 >           - metric_separator = "."
 >           - allowed_pending_messages = 10000

--- a/topics/admin/tutorials/pulsar/tutorial.md
+++ b/topics/admin/tutorials/pulsar/tutorial.md
@@ -271,7 +271,7 @@ More information about the rabbitmq ansible role can be found [in the repository
 >    ```diff
 >    --- a/group_vars/galaxyservers.yml
 >    +++ b/group_vars/galaxyservers.yml
->    @@ -164,8 +164,11 @@ certbot_environment: staging
+>    @@ -167,8 +167,11 @@ certbot_environment: staging
 >     certbot_well_known_root: /srv/nginx/_well-known_root
 >     certbot_share_key_users:
 >       - www-data
@@ -283,7 +283,7 @@ More information about the rabbitmq ansible role can be found [in the repository
 >     certbot_domains:
 >      - "{{ inventory_hostname }}"
 >     certbot_agree_tos: --agree-tos
->    @@ -215,6 +218,47 @@ slurm_config:
+>    @@ -218,6 +221,47 @@ slurm_config:
 >       SelectType: select/cons_res
 >       SelectTypeParameters: CR_CPU_Memory  # Allocate individual cores/memory instead of entire node
 >     

--- a/topics/admin/tutorials/reports/tutorial.md
+++ b/topics/admin/tutorials/reports/tutorial.md
@@ -70,7 +70,7 @@ The reports application is included with the Galaxy codebase and this tutorial a
 >    ```diff
 >    --- a/group_vars/galaxyservers.yml
 >    +++ b/group_vars/galaxyservers.yml
->    @@ -145,6 +145,11 @@ galaxy_config:
+>    @@ -148,6 +148,11 @@ galaxy_config:
 >             pools:
 >               - job-handlers
 >               - workflow-schedulers
@@ -82,7 +82,7 @@ The reports application is included with the Galaxy codebase and this tutorial a
 >     
 >     galaxy_job_config_file: "{{ galaxy_config_dir }}/galaxy.yml"
 >     
->    @@ -165,6 +170,8 @@ galaxy_config_templates:
+>    @@ -168,6 +173,8 @@ galaxy_config_templates:
 >         dest: "{{ galaxy_config.galaxy.dependency_resolvers_config_file }}"
 >       - src: templates/galaxy/config/job_resource_params_conf.xml.j2
 >         dest: "{{ galaxy_config.galaxy.job_resource_params_file }}"

--- a/topics/admin/tutorials/tiaas/tutorial.md
+++ b/topics/admin/tutorials/tiaas/tutorial.md
@@ -91,7 +91,7 @@ This tutorial will go cover how to set up such a service on your own Galaxy serv
 >    ```diff
 >    --- a/group_vars/galaxyservers.yml
 >    +++ b/group_vars/galaxyservers.yml
->    @@ -332,3 +332,8 @@ telegraf_plugins_extra:
+>    @@ -335,3 +335,8 @@ telegraf_plugins_extra:
 >           - timeout = "10s"
 >           - data_format = "influx"
 >           - interval = "15s"


### PR DESCRIPTION
When tpv is added, environments are removed, including local_env.

the mapping:
```
>       tools:
>         - class: local # these special tools that aren't parameterized for remote execution - expression tools, upload, etc
>           environment: local_env
```

needs to be removed at this point or data fetch jobs fail. Another mapping (testing tool to tpv_dispatcher) is added later in the tutorial.

Making this a draft PR as I'm not sure how to handle the diffs here and later on.  Can we leave the tools section empty like so?
```
tools:
```