### PR TITLE
Remove review_requested from list of ci triggers

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ on:
     branches:
       - main
   pull_request:
-    types: [opened, reopened, synchronize, ready_for_review, review_requested]
+    types: [opened, reopened, synchronize, ready_for_review]
     paths:
       - '**/*.md'
       - '**/*.html'


### PR DESCRIPTION
Turns out that ready_for_review is all we need. review_requested just causes an extra action run (that gets cancelled then) on opening regular PRs and on moving draft PRs out of draft stage.
