### PR TITLE
Apollo slides: fix overlapping text

### DIFF
--- a/topics/genome-annotation/tutorials/apollo/slides.html
+++ b/topics/genome-annotation/tutorials/apollo/slides.html
@@ -83,9 +83,9 @@ contributors:
 
 - A Human finds problems algorithms can't
 
-.pull-left[.image-90[![Schema showing how automated annotation, experimental evidences (cDNAs, HMM domain searches, RNASeq, similarity with other species), and human analysis are used by Apollo to manually curate an annotation](../../images/apollo/apollo_workflow.png)]]
+.pull-left[.image-75[![Schema showing how automated annotation, experimental evidences (cDNAs, HMM domain searches, RNASeq, similarity with other species), and human analysis are used by Apollo to manually curate an annotation](../../images/apollo/apollo_workflow.png)]]
 
-.pull-right[.image-40[![Apollo screenshot showing how RNASeq reads align mostly within some exons limits, but not perfectly](../../images/apollo/rnaseq_cov.png)]]
+.pull-right[.image-25[![Apollo screenshot showing how RNASeq reads align mostly within some exons limits, but not perfectly](../../images/apollo/rnaseq_cov.png)]]
 
 ???
 


### PR DESCRIPTION
Fixing the display of this slide: https://training.galaxyproject.org/training-material/topics/genome-annotation/tutorials/apollo/slides.html#7