### PR TITLE
Update PyEGA to version 5 and remove EGA track if Zenodo track is chosen.

### DIFF
--- a/topics/variant-analysis/tutorials/trio-analysis/tutorial.md
+++ b/topics/variant-analysis/tutorials/trio-analysis/tutorial.md
@@ -58,32 +58,6 @@ We offer two ways to download the files. Firstly, you can download the files dir
 {% include _includes/cyoa-choices.html option1="EGA-Archive" option2="Zenodo" default="EGA-Archive"
        text="Here you can choose to either follow the data preperation for the data from the EGA-archive or Zenodo." %}
 
-<div class="Zenodo" markdown="1">
-I see, you can't wait to get DAC access. To download the data from zenodo for this tutorial you can follow the step below.
-
-> <hands-on-title>Retrieve data from zenodo</hands-on-title>
->
-> 1. Import the 3 VCFs from [Zenodo](https://zenodo.org/record/6483454) to Galaxy **as a collection**.
->    ```
->    https://zenodo.org/record/6483454/files/Case5_F.17.g.vcf.gz
->    https://zenodo.org/record/6483454/files/Case5_IC.17.g.vcf.gz
->    https://zenodo.org/record/6483454/files/Case5_M.17.g.vcf.gz
->    ```
->
->    {% snippet faqs/galaxy/datasets_import_via_link.md collection=true %}
->
-> 2. Set the datatype to **vcf**.
->
-> 3. Click on **Start**
->
-> 4. If you forgot to select the *"Collections"* tab during upload, please put the file in a collection now.
->
->    {% snippet faqs/galaxy/collections_build_list.md %}
->
-{: .hands_on}
-
-</div>
-
 <div class="EGA-Archive" markdown="1">
 
 ## Getting DAC access
@@ -169,6 +143,32 @@ Finally, we need to decompress our bgzipped VCFs, since we will use a text manip
 > After transforming all the VCFs you need to combine the converted VCFs into a colllection again.
 >
 > {% snippet faqs/galaxy/collections_build_list.md datasets_description="the 3 vcf files" n="3" %}
+>
+{: .hands_on}
+
+</div>
+
+<div class="Zenodo" markdown="1">
+I see, you can't wait to get DAC access. To download the data from zenodo for this tutorial you can follow the step below.
+
+> <hands-on-title>Retrieve data from zenodo</hands-on-title>
+>
+> 1. Import the 3 VCFs from [Zenodo](https://zenodo.org/record/6483454) to Galaxy **as a collection**.
+>    ```
+>    https://zenodo.org/record/6483454/files/Case5_F.17.g.vcf.gz
+>    https://zenodo.org/record/6483454/files/Case5_IC.17.g.vcf.gz
+>    https://zenodo.org/record/6483454/files/Case5_M.17.g.vcf.gz
+>    ```
+>
+>    {% snippet faqs/galaxy/datasets_import_via_link.md collection=true %}
+>
+> 2. Set the datatype to **vcf**.
+>
+> 3. Click on **Start**
+>
+> 4. If you forgot to select the *"Collections"* tab during upload, please put the file in a collection now.
+>
+>    {% snippet faqs/galaxy/collections_build_list.md %}
 >
 {: .hands_on}
 

--- a/topics/variant-analysis/tutorials/trio-analysis/tutorial.md
+++ b/topics/variant-analysis/tutorials/trio-analysis/tutorial.md
@@ -36,7 +36,7 @@ To discover causal mutations of inherited diseases it’s common practice to do 
 
 To discover these mutations either whole exome sequencing (WES) or whole genome sequencing (WGS) can be used. With these technologies it is possible to uncover the DNA of the parents and offspring to find (shared) mutations in the DNA. These mutations can include insertions/deletions (indels), loss of heterozygosity (LOH), single nucleotide variants (SNVs), copy number variations (CNVs), and fusion genes.
 
-In this tutorial we will also make use of the HTSGET protocol, which is a program to download our data securely and savely. This protocol has been implemented in the {% tool [EGA Download Client](toolshed.g2.bx.psu.edu/repos/iuc/ega_download_client/pyega3/4.0.0+galaxy0) %} tool, so we don't have to leave Galaxy to retrieve our data.
+In this tutorial we will also make use of the HTSGET protocol, which is a program to download our data securely and savely. This protocol has been implemented in the {% tool [EGA Download Client](toolshed.g2.bx.psu.edu/repos/iuc/ega_download_client/pyega3/5.0.2+galaxy0) %} tool, so we don't have to leave Galaxy to retrieve our data.
 
 We will not start our analysis from scratch, since the main goal of this tutorial is to use the HTSGET protocol to download variant information from an online archive and to find the causative variant from those variants. If you want to learn how to do the analysis from scratch, using the raw reads, you can have a look at the [Exome sequencing data analysis for diagnosing a genetic disease]({% link topics/variant-analysis/tutorials/exome-seq/tutorial.md %}) tutorial.
 
@@ -91,7 +91,7 @@ Our test data is stored in EGA, which can be easily accessed using the EGA Downl
 
 > <hands-on-title>Check log-in and authorized datasets</hands-on-title>
 >
-> 1. {% tool [EGA Download Client](toolshed.g2.bx.psu.edu/repos/iuc/ega_download_client/pyega3/4.0.0+galaxy0) %} with the following parameters:
+> 1. {% tool [EGA Download Client](toolshed.g2.bx.psu.edu/repos/iuc/ega_download_client/pyega3/5.0.2+galaxy0) %} with the following parameters:
 >    - *"What would you like to do?"*: `List my authorized datasets`
 >
 > > <comment-title>Check if the dataset is listed.</comment-title>
@@ -102,11 +102,11 @@ Our test data is stored in EGA, which can be easily accessed using the EGA Downl
 {: .hands_on}
 
 ## Download list of files
-When you have access to the EGA dataset, you can download all the needed files. However, the EGA dataset contains many different filetypes and cases, but we are only interested in the VCFs from case 5 and, to reduce execution time, the variants on chromosome 17. To be able to donwload these files we first need to request the list of files from which we can download. Make sure to use **version 4+** of the {% tool [EGA Download Client](toolshed.g2.bx.psu.edu/repos/iuc/ega_download_client/pyega3/4.0.0+galaxy0) %}.
+When you have access to the EGA dataset, you can download all the needed files. However, the EGA dataset contains many different filetypes and cases, but we are only interested in the VCFs from case 5 and, to reduce execution time, the variants on chromosome 17. To be able to donwload these files we first need to request the list of files from which we can download. Make sure to use **version 4+** of the {% tool [EGA Download Client](toolshed.g2.bx.psu.edu/repos/iuc/ega_download_client/pyega3/5.0.2+galaxy0) %}.
 
 > <hands-on-title>Request list of files in the dataset</hands-on-title>
 >
-> 1. {% tool [EGA Download Client](toolshed.g2.bx.psu.edu/repos/iuc/ega_download_client/pyega3/4.0.0+galaxy0) %} **version 4+** with the following parameters:
+> 1. {% tool [EGA Download Client](toolshed.g2.bx.psu.edu/repos/iuc/ega_download_client/pyega3/5.0.2+galaxy0) %} **version 4+** with the following parameters:
 >    - *"What would you like to do?"*: `List files in a datasets`
 >    - *"EGA Dataset Accession ID?"*: `EGAD00001008392`
 >
@@ -139,7 +139,7 @@ EGAF00005573882	1	42856357	14b53924d1492e28ad6078ceb8cfdbc7	Case5_F.17.g.vcf.gz
 
 > <hands-on-title>Download listed VCFs</hands-on-title>
 >
-> 1. {% tool [EGA Download Client](toolshed.g2.bx.psu.edu/repos/iuc/ega_download_client/pyega3/4.0.0+galaxy0) %} with the following parameters:
+> 1. {% tool [EGA Download Client](toolshed.g2.bx.psu.edu/repos/iuc/ega_download_client/pyega3/5.0.2+galaxy0) %} with the following parameters:
 >    - *"What would you like to do?"*: `Download multiple files (based on a file with IDs)`
 >        - {% icon param-file %} *"Table with IDs to download"*: `Filtered list of files` (output of **Search in textfiles** {% icon tool %})
 >        - *"Column containing the file IDs"*: `Column: 1`

--- a/topics/variant-analysis/tutorials/trio-analysis/workflows/main_workflow.ga
+++ b/topics/variant-analysis/tutorials/trio-analysis/workflows/main_workflow.ga
@@ -28,8 +28,8 @@
                 }
             ],
             "position": {
-                "left": 8.12502877352,
-                "top": 12.187493151613012
+                "left": 9.124978066530579,
+                "top": 12.171892668878
             },
             "post_job_actions": {},
             "tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/ega_download_client/pyega3/5.0.2+galaxy0",
@@ -44,7 +44,13 @@
             "type": "tool",
             "uuid": "5f03b99a-3f46-47d8-a5b1-31b6d3ae39ee",
             "when": null,
-            "workflow_outputs": []
+            "workflow_outputs": [
+                {
+                    "label": "EGA Download Client: authorized datasets",
+                    "output_name": "authorized_datasets",
+                    "uuid": "85672f3a-1556-49b6-be09-2e6c81721fb3"
+                }
+            ]
         },
         "1": {
             "annotation": "",
@@ -481,14 +487,14 @@
             "when": null,
             "workflow_outputs": [
                 {
-                    "label": null,
-                    "output_name": "statsFile",
-                    "uuid": "bb59ec32-10c8-4923-8f41-62e3ed1adf11"
-                },
-                {
                     "label": "Case 5 SnpEff Annotated VCF",
                     "output_name": "snpeff_output",
                     "uuid": "1b9750cc-e0ab-4361-906e-306e97b243ad"
+                },
+                {
+                    "label": null,
+                    "output_name": "statsFile",
+                    "uuid": "bb59ec32-10c8-4923-8f41-62e3ed1adf11"
                 }
             ]
         },
@@ -590,6 +596,6 @@
     "tags": [
         "variant-analysis"
     ],
-    "uuid": "45d8923d-3a0d-46c4-b250-d49efb91de0a",
-    "version": 67
+    "uuid": "1a9a123d-8308-4ee4-93c3-9f54cbebd827",
+    "version": 68
 }

--- a/topics/variant-analysis/tutorials/trio-analysis/workflows/main_workflow.ga
+++ b/topics/variant-analysis/tutorials/trio-analysis/workflows/main_workflow.ga
@@ -14,7 +14,7 @@
     "steps": {
         "0": {
             "annotation": "",
-            "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/ega_download_client/pyega3/4.0.5+galaxy2",
+            "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/ega_download_client/pyega3/5.0.2+galaxy0",
             "errors": null,
             "id": 0,
             "input_connections": {},
@@ -32,29 +32,23 @@
                 "top": 12.187493151613012
             },
             "post_job_actions": {},
-            "tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/ega_download_client/pyega3/4.0.5+galaxy2",
+            "tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/ega_download_client/pyega3/5.0.2+galaxy0",
             "tool_shed_repository": {
-                "changeset_revision": "9564758e8638",
+                "changeset_revision": "f9db47f68e5e",
                 "name": "ega_download_client",
                 "owner": "iuc",
                 "tool_shed": "toolshed.g2.bx.psu.edu"
             },
             "tool_state": "{\"action\": {\"action_type\": \"list_datasets\", \"__current_case__\": 1}, \"output_log\": false, \"__page__\": null, \"__rerun_remap_job_id__\": null}",
-            "tool_version": "4.0.5+galaxy2",
+            "tool_version": "5.0.2+galaxy0",
             "type": "tool",
             "uuid": "5f03b99a-3f46-47d8-a5b1-31b6d3ae39ee",
             "when": null,
-            "workflow_outputs": [
-                {
-                    "label": "EGA Download Client: authorized datasets",
-                    "output_name": "authorized_datasets",
-                    "uuid": "7faa2a87-b8c1-413a-bb18-75db2e108a84"
-                }
-            ]
+            "workflow_outputs": []
         },
         "1": {
             "annotation": "",
-            "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/ega_download_client/pyega3/4.0.5+galaxy2",
+            "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/ega_download_client/pyega3/5.0.2+galaxy0",
             "errors": null,
             "id": 1,
             "input_connections": {},
@@ -72,15 +66,15 @@
                 "top": 182.34374816414407
             },
             "post_job_actions": {},
-            "tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/ega_download_client/pyega3/4.0.5+galaxy2",
+            "tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/ega_download_client/pyega3/5.0.2+galaxy0",
             "tool_shed_repository": {
-                "changeset_revision": "9564758e8638",
+                "changeset_revision": "f9db47f68e5e",
                 "name": "ega_download_client",
                 "owner": "iuc",
                 "tool_shed": "toolshed.g2.bx.psu.edu"
             },
             "tool_state": "{\"action\": {\"action_type\": \"list_dataset_files\", \"__current_case__\": 0, \"dataset_id\": \"EGAD00001008392\"}, \"output_log\": false, \"__page__\": null, \"__rerun_remap_job_id__\": null}",
-            "tool_version": "4.0.5+galaxy2",
+            "tool_version": "5.0.2+galaxy0",
             "type": "tool",
             "uuid": "265bf049-ac9f-4a59-bba3-311c6c818121",
             "when": null,
@@ -166,7 +160,7 @@
         },
         "4": {
             "annotation": "",
-            "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/ega_download_client/pyega3/4.0.5+galaxy2",
+            "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/ega_download_client/pyega3/5.0.2+galaxy0",
             "errors": null,
             "id": 4,
             "input_connections": {
@@ -185,19 +179,19 @@
                 }
             ],
             "position": {
-                "left": 0.0,
+                "left": 0,
                 "top": 522.1718608604647
             },
             "post_job_actions": {},
-            "tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/ega_download_client/pyega3/4.0.5+galaxy2",
+            "tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/ega_download_client/pyega3/5.0.2+galaxy0",
             "tool_shed_repository": {
-                "changeset_revision": "9564758e8638",
+                "changeset_revision": "f9db47f68e5e",
                 "name": "ega_download_client",
                 "owner": "iuc",
                 "tool_shed": "toolshed.g2.bx.psu.edu"
             },
             "tool_state": "{\"action\": {\"action_type\": \"download_files\", \"__current_case__\": 3, \"id_table\": {\"__class__\": \"ConnectedValue\"}, \"id_column\": \"1\", \"range\": {\"reference_name\": \"\", \"start\": null, \"end\": null}}, \"output_log\": false, \"__page__\": null, \"__rerun_remap_job_id__\": null}",
-            "tool_version": "4.0.5+galaxy2",
+            "tool_version": "5.0.2+galaxy0",
             "type": "tool",
             "uuid": "e9b6ed7b-4275-47a4-99cb-e6779a56ec4e",
             "when": null,
@@ -596,6 +590,6 @@
     "tags": [
         "variant-analysis"
     ],
-    "uuid": "2b5f94f7-dcb8-41ab-a468-83a8732fade2",
-    "version": 64
+    "uuid": "45d8923d-3a0d-46c4-b250-d49efb91de0a",
+    "version": 67
 }


### PR DESCRIPTION
Updated the PyEGA version in the workflow and tutorial.
I want everything in the div box in EGA to be not visible when clicking on Zenodo. But with the previous version it still showed everything. I'm hoping this fixes it.