### PR TITLE
Updates to both ToolFactory topics to fix broken installation instructions

### DIFF
--- a/topics/dev/tutorials/tool-generators-advanced/tutorial.md
+++ b/topics/dev/tutorials/tool-generators-advanced/tutorial.md
@@ -3,8 +3,8 @@
 layout: tutorial_hands_on
 title: "ToolFactory: Generating Tools From More Complex Scripts"
 key_points:
-  - The ToolFactory Appliance includes an automated form driven tool generator available as a pop-up Docker appliance.
-  - It runs in a flavour of docker-galaxy-stable and produces new tools as Toolshed ready archives
+  - The ToolFactory Appliance includes an automated form driven tool generator.
+  - It produces new tools as Toolshed ready archives
   - It was designed for scientists and developers who routinely write scripts for their analyses.
   - It can quickly turn a working command line script into a working Galaxy tool.
   - It generates tools from information entered on a Galaxy form in the familiar UI.
@@ -49,7 +49,7 @@ contributors:
 
 ---
 
-# Welcome, background and a user's guide to this training material
+# Background and a user's guide to this training material
 
 Galaxy users who write and share scripts useful for scientific analyses are likely to be reading this material, perhaps after seeing the "Hello Galaxy"
 demonstration. It was written to help you find out about the capabilities and limits of the ToolFactory by experimenting with it yourself.
@@ -66,7 +66,7 @@ The result of editing and regenerating a tool is immediately available in the To
 Developers are free to explore their own specific requirements.
 
 Simple demonstration tools are provided. The are both the functional documentation, and useful models to adjust and explore.
-They each address a specific feature (such as the `plotter` illustrating collections),
+They each address a specific feature (such as the `plotter` illustrating R parameter passing and collectionscollections),
 and they illustrate some of the styles of tool building supported by the ToolFactory. The `sed` example does not use a script. All the others do.
 The ToolFactory is likely to be more useful for scripts than directly driving Conda packages. Many Conda package interfaces have requirements that the ToolFactory cannot
 currently address. Those will probably always require a skilled tool document developer. Conda dependencies requiring minimal conditional parameter
@@ -77,11 +77,9 @@ The introductory tutorial walked through some simple tools. This advanced tutori
 exploration of the sample tools to see how they might be used in your work.
 
 
-## The ToolFactory Appliance for scientists and developers who write command line scripts in their work.
+## The ToolFactory is for scientists and developers who write command line scripts in their work.
 
-The ToolFactory is distributed as a Docker appliance, created as a "flavour" of the widely used `docker-galaxy-stable` infrastructure, so it includes a fully functional
-Galaxy server. New tools can be generated locally or they can be added from any Toolshed. This is intended to make it easy to create
-tailored private development Galaxy servers, so new tools, analyses and workflows can be developed to help speed uptake in areas of data-intensive science where
+The ToolFactory is distributed as a docker image or as a self-configuring clone of the Galaxy server code. This is intended to make it easy to create new tools, analyses and workflows can be developed to help speed uptake in areas of data-intensive science where
 few Galaxy tools are currently available.
 
 The ToolFactory automates much of the work needed to prepare a new Galaxy tool using information provided by the script writer
@@ -94,36 +92,29 @@ development environment for simple scripts. Jobs that generate tools can always 
 when the tool was generated. Data and user configurable parameters can be added or removed. Text that appears when the tool is run, such as user parameter or data input
 labels and help, can be updated by editing the form. When the updated tool is generated, installed and run as a tool, the tool form will include all the changes, ready to run.
 
-Tools can be tested and prepared for export as toolshed ready archives when the developer is ready using a companion `planemo_test` tool in the ToolFactory tool section.
 
-
-The Appliance is a pop-up platform for a data intensive scientist to quickly learn how Galaxy tools work, in preparation for the more flexible and efficient
+The development server is a self-configuring, disposable platform for a data intensive scientist to learn how Galaxy tools work, in preparation for the more flexible and efficient
 Galaxy project supported manual tool building infrastructure. At the same time, they can wrap and refine new tools from existing scripts
-on their own workstations, preparing them for sharing and deployment to production servers. It also may be useful as a private sandbox for learning about tools and Galaxy administration or experimenting with code development. In the worst possible scenario where the
-system is damaged, the Appliance can be rebuilt from scratch in a few minutes.
+on their own workstations, preparing them for sharing and deployment to production servers. It also may be useful as a private sandbox for learning about tools and
+Galaxy administration or experimenting with code development.
 
 
 > <tip-title>Under the hood:</tip-title>
->
 >  - It uses [galaxyml](https://github.com/hexylena/galaxyxml) to generate the tool XML from ToolFactory form settings.
->  - It uses [Planemo](https://github.com/galaxyproject/planemo) to generate the test outputs and then again to test newly generated code
->  - The Appliance is a flavour added to the base [docker-galaxy-stable](https://github.com/bgruening/docker-galaxy-stable/compose) infrastructure
 {: .tip}
 
 ---
 
 ## Limits and scope
 
-- The Appliance can generate, install and run new tools from scripts on your desktop.
+- The ToolFactory can generate, install and run new tools from scripts on your desktop.
     - It is a fully functional development Galaxy instance, so it can import any existing tool from a toolshed and can handle as much data as your desktop disks will fit.
-    - It [can connect to a cluster for real work](https://github.com/bgruening/docker-galaxy-stable/compose) so potentially useful for development at scale.
-    - It takes only a few minutes to install and can be completely removed even more quickly when no longer useful.
-    - It lacks the data backup and security provided by an institutional Galaxy service.
-    - The user is entirely responsible for securing and backing up all their work.
-    - It is not recommended for production and is not supported by the Galaxy developers.
+    - It takes 30 minutes to install locally or a few minutes as a docker image, and can be completely removed when no longer useful.
+    - The user is entirely responsible for securing and backing up all their work in the docker version. The desktop version is a normal persistent Galaxy development server.
+    - It is not recommended for production and is *not supported by the Galaxy team*.
     - A well endowed modern workstation or laptop with plenty of cores, disk and RAM is needed. Older commodity hardware may struggle.
 - The ToolFactory works best wrapping simple R/Bash/Python and other interpreted scripts, with a few user supplied parameters and a few I/O history files.
-- XML macros, output filters and many other advanced features that are available when writing wrappers manually are not currently supported.
+- Conditional parameters, XML macros, output filters and many other advanced features are not currently supported. Manual coding will be needed.
 - Scripts are easier than some Conda packages
     - This is because the tool builder can modify the code to respond to default empty parameters as if they had not been passed.
     - This may not sound like much, but as a result, advanced tool building elements such as conditionals and related tricks requiring manual coding, can sometimes be avoided.
@@ -144,152 +135,75 @@ automated code generator in a tailored, readily deployed appliance.
 
 ---
 
-# Getting your hands on a ToolFactory Appliance for some hands-on training.
-
-
-## Installation
+# Installation (Copied from the introductory tutorial)
 
 > <warning-title>Security advisory!</warning-title>
 >- *Please do not install the ToolFactory on any public server*
->- Although it will only run for administrative users, it allows unlimited scripting and that exposes unwise security weakness for any public facing machine.
->- In fact, Galaxy is very good at isolating tools to stop them doing mischief. But that's no reason to chance your arm. They keep inventing better mice.
->- Please install it locally as described below.
+>- Configured as a default server, it has none of the usual additional security layers required for a safe public Galaxy server.
+>- Although it will only run for administrative users, it allows unlimited scripting and exposes unacceptable risks.
+>- Please install it locally.
 >- For this reason, the training materials can't make use of existing public Galaxy infrastructure like most of the GTN material.
 {: .warning}
 
 
-> <hands-on-title>Launching the Appliance</hands-on-title>
+> <hands-on-title>Installing and managing a Galaxy ToolFactory development server</hands-on-title>
+> # Logging in as an administrator
+> 
+> Once you have a working installation running as described below, the server should be ready in 20-30 seconds or so, at [http://localhost:8080](http://localhost:8080).
+> *The ToolFactory will only execute for administrative users as a minimal security barrier.* 
+> When the webserver starts, immediately login using the administrative user email *toolfactory@galaxy.org* with the password *ChangeMe!* which of course you should change.
+>   
+> # Docker
+> Note: *Nothing is persistent in the image*. Useful work must be manually exported and saved.
+> For following the GTN tutorial and for test driving the ToolFactory for the first time, the docker version is recommended.
+> Non-persistent means it does not remember anything after you stop the container. The next time it starts it will be a fresh installation.
+> You can save your work by exporting the histories and tool tarballs you want to keep. You need the history to rerun the job that generated a tarball, so the history is the most important thing to preserve if you make a useful tool.
+> The image must be pulled first, then run with port 8080 open for the Galaxy server.
+> 
+> ```
+> docker pull quay.io/fubar2/galaxy_toolfactory:latest
+> docker run -d -p 8080:8080 quay.io/fubar2/galaxy_toolfactory:latest
+> ```
+> Check the docker logs until gunicorn is ready to serve or wait 
+> about 20-30 seconds, then browse to [http://localhost:8080](http://localhost:8080)
+> If a Galaxy server appears, proceed with the login instructions above and you should see a history containing all the example tools. There is also a workflow that can reproduce that history if you set all the inputs to the right input datasets in that history.
+>  
+> # Local workstation development Galaxy server installation
+> 
+> A persistent desktop development ToolFactory server can be built by cloning the [bootstrap github repository](https://github.com/fubar2/galaxy_tf_overlay), and using the included *localtf.sh* script, to build a complete, new development server with the ToolFactory installed and ready to run.
 >
-> > <warning-title>`Pull` the images first as shown below to save time.</warning-title>
-> >
-> > If they are not found locally the first time you run `docker-compose up`, docker will build them, taking half an hour or more instead of a couple of minutes.
-> >
-> {: .warning}
+> From a convenient directory, download the overlay configuration code repository, then
+> run the *localtf.sh* setup script from that cloned repository root directory:
 >
-> 1. [Install Docker](https://docs.docker.com/engine/install/) following the appropriate instructions for your platform.
+> ```
+> git clone https://github.com/fubar2/galaxy_tf_overlay.git
+> cd galaxy_tf_overlay
+> sh ./localtf.sh
+> ```
+> Running *localtf.sh* will create a new directory, *galaxytf*, in the parent directory of the *galaxy_tf_overlay* clone.
+> The script will configure a fresh Galaxy 23.0 server, with the ToolFactory installed, in that new directory.
+> This takes 20 minutes or more to complete since the client must be built once.
 >
-> 2. Then, `pip3 install docker-compose`
+> The resulting development server directory will occupy ~9GB of disk space, so be sure your machine has plenty of room.
+> It will be based in a single directory, *galaxytf* in the same directory as the galaxy_tf_overlay repository was cloned into.
+> That is where the script should be run as shown above.
 >
-> 3. Clone/Download, Change to the compose directory, and launch it:
+> Rerunning the *localtf.sh* script will *destroy the entire galaxytf directory* - all ~9GB, and create a clean new installation.
+> It should only need to be run once in the life of the development server.
 >
->    > <tip-title>Installing the docker files, pulling and launching the Appliance</tip-title>
->    > ```bash
->    > git clone https://github.com/fubar2/toolfactory-galaxy-server
->    > cd toolfactory-galaxy-server/compose
->    > mkdir export
->    > docker-compose pull
->    > docker-compose up
->    > ```
->    {: .tip}
+> Remove the *galaxytf* directory to remove the entire development server when it is no longer needed. Save all your tools and histories,
+> because the jobs in a history can be used to update a tool easily, and a history can be imported into a fresh development instance
+> when needed.
 >
->    > <tip-title>Appliance tips</tip-title>
->    >
->    >  - `docker-compose pull` and making the local export directory *are only needed the first time*.
->    >  - Add `-d` at the end of the `docker-compose up` command to detach the terminal so you can keep working - but only after watching the process the first time.
->    >      - It is important to wait until the server stops sending log messages before you first log in. That means everything is ready. The first startup is very complex and takes time.
->    >  - For the first time start, watching the startup process logs reveals a lot of interesting activity.
->    >      - You will learn a lot about how a Galaxy server works and see when the Appliance is ready to use.
->    >  - Expect a few minutes for the pull to complete.
->    >  - Expect another 5 to 10 minutes to complete the first startup. Subsequent starts are much faster but a lot has to be done the first time.
->    >  - The docker containers may not fit or run well on an underpowered machine. Multiple CPU cores, 8+GB of RAM and fast disk are needed for an enjoyable appliance.
->    >  - The demonstration history will only be available after logging in with the administrator credentials - `admin@galaxy.org` and password `password`. Check your histories if the smaller data-only history appears when you log in.
->    >  - Change your admin password.
->    >  - It is important that your appliance is not accessible to any potential miscreants on the local or public internet.
->    >  - It is recommended for use only as a private disposable desktop development environment.
->    >    - The Appliance keeps no backup of any work.
->    >    - The user can backup the export directory if desired.
->    >    - An institutional server is a safer bet for preserving real research.
->    >
->    {: .tip}
 >
-> 5. Your appliance should be running with a local Galaxy on [port 8080 of your workstation](http://localhost:8080) after a fair bit of activity.
+> Once installation is complete:
+>  * start the server from the *galaxytf* directory with *sh run.sh*. The logs will be displayed.
+>  * ^c (control+c) will stop it from the console.
+>  * In 23.0 that is equivalent to *.venv/bin/galaxyctl start* and *.venv/bin/galaxyctl stop*.
 >
->    -  Out of the box login is 'admin@galaxy.org' and the password is 'password'
->      - This is obviously insecure but convenient and easily changed at first login.
->      - Or more permanently in the docker-compose.yml if you prefer.
->    - The container `/export` directory is mounted locally at `compose/export` so you can find your generated and tested tools for sharing.
->
->    > <tip-title>Demonstration tools are the functional documentation</tip-title>
->    >
->    > - At first login you will find the demonstration history ready to explore if you waited for all the first run installation activity to die down
->    > - First run startup takes about 5 minutes. Subsequent starts take less than a minute.
->    > - First planemo_test run takes about 5 minutes - subsequently more like 1 minute depending on Conda dependency install time
->    > - To explore an example, open the toolshed XML history item by clicking on the name, and select the {% icon galaxy-refresh %} `rerun` button from the expanded view
->    >    - The form that generated that tool will appear for you to examine
->    >    - Edit the form - add parameters and change the script to suit - and rerun to create an *updated* tool. The history has previous versions.
->    >    - Change the tool ID to change the tool name and generate a different tool. *Generating a same-name tool will overwrite the old version*.
->    {: .tip}
->
->    > <tip-title>Patience!</tip-title>
->    > When you run the ToolFactory for the first time inside the container and whenever you run a new tool with new dependencies, it will require some time to build the conda environment.
->    > Check for Conda or other processes if things seem stuck.
->    {: .tip}
->
-> 6. Later, after you've finished:
->
->    To safely shut the appliance down
->    - If the console was not detached using the --detach/-d flag:
->         - `<ctrl><c>` in the console will gracefully shut the server down - takes time but your work will be preserved.
->    - If the -d flag was used:
->       - `docker-compose down` from the same directory it was started `.../compose`, should shut it down nicely
 >
 {: .hands_on}
 
-> <hands-on-title>Brief Guide to ToolFactory Appliance Operation</hands-on-title>
->
-> ## Generating new tools - what happens when you press `execute` on a completed ToolFactory form?
->
-> - The form is processed and a new tool XML is generated, appearing in the history.
-> - The generated tool is installed in the Appliance. It will appear in the `ToolFactory Generated Tools` tool menu.
->    - The tool generation process takes a few seconds.
->    - The `Home` or `Analysis` tab should be selected so the screen is refreshed after building.
->         - Otherwise the new tool menu will not be loaded so the newly generated tool will not be there
-> - Choose tool names thoughtfully and be warned: *there are no checks on tool name duplicates*
-> - Any existing installed tool XML with the same name will be overwritten permanently.
-> - The history will retain all the generating jobs if you accidentally overwrite a tool.
-> - Rerun the job and adjust the form. Rinse and repeat until ready.
->
-> - Note that the generated tool has no test outputs yet so the test is broken until the tool is "finalised" with the companion tool tester.
->
-> - To generate a "proper" tested toolshed archive, execute the `planemo_test` tool from the ToolFactory tool submenu after selecting the relevant tool XML from the history.
-> - The appliance will run `planemo lint`, then `planemo test` to generate sample outputs, then again for final "real" test.
->     - A finalised archive will be available in the history after a while - testing takes time - with a collection containing the test run log, planemo lint and test reports.
->     - The archive can be downloaded and shared in the usual ways. It is a normal Galaxy tool that wraps the supplied script and contains a test to validate it.
->     - It will also be found in the `..compose/export/galaxy/testedTFtools/[tool name]` on your workstation, mounted as a volume in the container.
-{: .hands_on}
-
----
-
-# ToolFactory functional documentation - the demonstration tools.
-
-> {% icon congratulations %}
-> Congratulations on acquiring a local instance of the ToolFactory Appliance
-> - There is a sample history built in that shows some sample tools.
-> - If there is an empty history when you first log in, check the histories after a minute - if still not there, follow the Welcome page instructions to install it manually.
-> - They can be examined to learn how the ToolFactory form was configured to generate the tool.
-{:.congratulations}
-
-# Hands-on: Learning to use the ToolFactory
-
-> <tip-title>Using an Appliance involves dependency installation that may cause long pauses...</tip-title>
-> There will be delays as any new dependencies are installed for the first time
-> - the first ToolFactory run after first starting a new Appliance will involve Conda installing the ToolFactory dependencies before running the job.
-> - the first time any new tool with a new dependency is run, Conda must install it locally taking a variable amount of time depending on complexity.
-> - the first time the planemo_test tool is run, there will be a 10+ minute delay as Conda grinds away.
-> - Check for Conda and other running processes before assuming it has frozen.
-{: .tip}
-
-
-> <hands-on-title>Exploring the sample tools by regenerating their original ToolFactory forms</hands-on-title>
->
-> * With the ToolFactory working and the sample history active as described above
-> * Select any of the generated toolshed archive history items.
-> * This should open the item details up, so you can see the circular "redo" button
-> * Click that button - the ToolFactory form that generated that tool will appear.
-> * Examine the form settings used to generate the tool.
-> * Try changing names or prompts. Add new parameters or inputs/outputs; press `execute`; check the new version of the tool
-> * For example, change the default for the Hello example to `Galaxy Training Network` and generate an updated version.
-{: .hands_on}
 
 The trivial `Hello World!` tool example is readily extended to suit many situations where a tool is needed quickly for a workflow. Try adding another parameter.
 For example, the planemo `lint` tool example (described below) can be derived by adding a history toolshed archive as input, plus a few more lines of bash script.
@@ -343,7 +257,7 @@ line will echo all the repeated parameters is shown in the example shown in the 
 >
 > ```xml
 > <tool name="repeats_demo" id="repeats_demo" version="2.00">
->   <!--Source in git at: https://github.com/fubar2/toolfactory-->
+>   <!--Source in git at: https://github.com/fubar2/galaxy_tf_overlay-->
 >   <!--Created by admin@galaxy.org at 29/05/2021 07:46:08 using the Galaxy Tool Factory.-->
 >   <description>Repeated parameter demonstration</description>
 >   <requirements/>
@@ -461,9 +375,8 @@ line will echo all the repeated parameters is shown in the example shown in the 
 >    - Example code is shown on the sample tool's form and in the original example code below - removed from the current sample.
 >    - For a real test, one or more expected <element.../> tags must be provided so the test really does test something.
 >    - Add your own file names to the sample to make a real test for your own collections.
->    - Otherwise, the generated test will be empty, because that is what the code generator knows about what's in the collection when the `<test>` code is generated. Nothing.
+>    - Otherwise, the generated test will be empty, because the code generator knows nothing about what's going to appear in the collection at the time the `<test>` code is generated.
 >    - Introspecting arbitrary scripts to reliably populate the test with actual file names?. Not likely any time soon.
->    - Introspecting the Planemo test result to write the test and then retest might be possible but is not planned.
 >
 {: .warning}
 
@@ -478,7 +391,7 @@ line will echo all the repeated parameters is shown in the example shown in the 
 >
 > ```xml
 > <tool name="plotter" id="plotter" version="0.01">
->   <!--Source in git at: https://github.com/fubar2/toolfactory-->
+>   <!--Source in git at: https://github.com/fubar2/tgalaxy_tf_overlay-->
 >   <!--Created by admin@galaxy.org at 24/01/2021 05:02:33 using the Galaxy Tool Factory.-->
 >   <description>ToolFactory collection demonstration - random plots</description>
 >   <requirements>
@@ -608,7 +521,7 @@ line will echo all the repeated parameters is shown in the example shown in the 
 >
 > ```xml
 > <tool name="select_test" id="select_test" version="0.01">
->   <!--Source in git at: https://github.com/fubar2/toolfactory-->
+>   <!--Source in git at: https://github.com/fubar2/galaxy_tf_overlay-->
 >   <!--Created by admin@galaxy.org at 24/01/2021 05:03:21 using the Galaxy Tool Factory.-->
 >   <description>ToolFactory select demonstration</description>
 >   <stdio>
@@ -671,14 +584,6 @@ line will echo all the repeated parameters is shown in the example shown in the 
 
 #### The ToolFactory can wrap some Conda packages correctly using a simple wrapper script to work around limitations.
 
-- There are two tools that use Planemo as a Conda dependency
-- One runs `planemo test...` and the other `planemo lint....` on toolshed archives in a history
-- The linter XML is available below. It is a small python script that parses out the tool name from the XML input file and
-runs planemo lint on the inferred tool path. STDOUT is captured with the linter output.
-
-- The ToolFactory exposes the Planemo function as Galaxy tool that works on ToolFactory generated XML files.
-  - Planemo test will not work as it involves planemo within planemo in a tool and this, unsurprisingly, does not seem to work.
-  - Some other tractable Conda dependencies are also potential candidates for being wrapped as tools
 - Many complex tools require manual coding to make them useable.
   - Often complex tools hide data being moved between multiple dependencies such as samtools in the bwa tool.
   - These are often not suitable for the simple automated tool generator in the ToolFactory.
@@ -691,7 +596,7 @@ runs planemo lint on the inferred tool path. STDOUT is captured with the linter 
 >
 > ```xml
 > <tool name="planemo_lint" id="planemo_lint" version="0.01">
->   <!--Source in git at: https://github.com/fubar2/toolfactory-->
+>   <!--Source in git at: https://github.com/fubar2/galaxy_tf_overlay->
 >   <!--Created by admin@galaxy.org at 18/05/2021 01:16:17 using the Galaxy Tool Factory.-->
 >   <description>Runs Planemo lint on any ToolFactory xml history file</description>
 >   <requirements>
@@ -710,12 +615,12 @@ runs planemo lint on the inferred tool path. STDOUT is captured with the linter 
 > $lint_output]]></command>
 >   <configfiles>
 >     <configfile name="runme"><![CDATA[#raw
-> 
+>
 > import lxml.etree as ET
 > import os
 > import subprocess
 > import sys
-> 
+>
 > def main():
 >     assert len(sys.argv) >= 2, 'Must have input xml on command line'
 >     xmlin = sys.argv[1]
@@ -731,8 +636,8 @@ runs planemo lint on the inferred tool path. STDOUT is captured with the linter 
 >     else:
 >          print('Lint report ends')
 > main()
-> 
-> 
+>
+>
 > #end raw]]></configfile>
 >   </configfiles>
 >   <inputs>
@@ -748,18 +653,18 @@ runs planemo lint on the inferred tool path. STDOUT is captured with the linter 
 >     </test>
 >   </tests>
 >   <help><![CDATA[
-> 
+>
 > **What it Does**
-> 
+>
 > ToolFactory demonstration script using bash to run planemo lint from a history XML representing a tool.
-> 
-> 
-> 
+>
+>
+>
 > ------
-> 
-> 
+>
+>
 > Script::
-> 
+>
 >     import lxml.etree as ET
 >     import os
 >     import subprocess
@@ -785,9 +690,9 @@ runs planemo lint on the inferred tool path. STDOUT is captured with the linter 
 >     <citation type="doi">10.1093/bioinformatics/bts573</citation>
 >   </citations>
 > </tool>
-> 
-> 
-> 
+>
+>
+>
 > ```
 {: .details}
 
@@ -803,7 +708,7 @@ runs planemo lint on the inferred tool path. STDOUT is captured with the linter 
 > <details-title>`Prolog` and `Lisp` demonstration tools</details-title>
 > ```xml
 > <tool name="prolog_demo" id="prolog_demo" version="0.01">
->   <!--Source in git at: https://github.com/fubar2/toolfactory-->
+>   <!--Source in git at: https://github.com/fubar2/galaxy_tf_overlay-->
 >   <!--Created by admin@galaxy.org at 04/04/2021 17:21:32 using the Galaxy Tool Factory.-->
 >   <description>Runs a prolog script</description>
 >   <requirements>
@@ -818,7 +723,7 @@ runs planemo lint on the inferred tool path. STDOUT is captured with the linter 
 > -g
 > main
 > -s
-> 
+>
 > $runme
 > >
 > $prolog_out]]></command>
@@ -830,7 +735,7 @@ runs planemo lint on the inferred tool path. STDOUT is captured with the linter 
 > parent(bob,ann).
 > parent(bob,pat).
 > parent(pat,jim).
-> 
+>
 > main :-
 >     parent(X,jim),
 >     format('~a is the parent of jim~n', [X]),
@@ -847,20 +752,20 @@ runs planemo lint on the inferred tool path. STDOUT is captured with the linter 
 >     </test>
 >   </tests>
 >   <help><![CDATA[
-> 
+>
 > **What it Does**
-> 
-> 
-> 
+>
+>
+>
 > Prolog demonstration in the ToolFactory
-> 
-> 
-> 
+>
+>
+>
 > ------
-> 
-> 
+>
+>
 > Script::
-> 
+>
 >     parent(pam,bob).
 >     parent(tom,bob).
 >     parent(tom,liz).
@@ -871,23 +776,23 @@ runs planemo lint on the inferred tool path. STDOUT is captured with the linter 
 >         parent(X,jim),
 >         format('~a is the parent of jim~n', [X]),
 >         halt.
-> 
+>
 > ]]></help>
 >   <citations>
 >     <citation type="doi">10.1093/bioinformatics/bts573</citation>
 >   </citations>
 > </tool>
 > ```
-> 
+>
 >  Lisp too!
 >  In this case, the tool takes a lisp script as input
-> 
+>
 >  A lisp expression was typed into the upload tool text box and saved as hello_lisp.txt ```(write-line "Hello, ToolFactory does Lisp!")```.
 >  It or any other lisp script can be used as input to the SBCL Conda dependency.
-> 
+>
 > ```xml
 > <tool name="lisp_demo" id="lisp_demo" version="0.01">
->   <!--Source in git at: https://github.com/fubar2/toolfactory-->
+>   <!--Source in git at: https://github.com/fubar2/galaxy_tf_overlay-->
 >   <!--Created by admin@galaxy.org at 04/04/2021 16:38:47 using the Galaxy Tool Factory.-->
 >   <description>Runs SBCL hello world demonstration</description>
 >   <requirements>
@@ -915,11 +820,11 @@ runs planemo lint on the inferred tool path. STDOUT is captured with the linter 
 >     </test>
 >   </tests>
 >   <help><![CDATA[
-> 
+>
 > **What it Does**
-> 
+>
 > Lisp in the ToolFactory
-> 
+>
 >  ]]></help>
 >   <citations>
 >     <citation type="doi">10.1093/bioinformatics/bts573</citation>
@@ -943,7 +848,7 @@ runs planemo lint on the inferred tool path. STDOUT is captured with the linter 
 
 > <details-title>`bwa_test_command_override` sample - the command override</details-title>
 >  ToolFactory command over-ride section adapted from the Planemo BWA example.
-> 
+>
 > ```
 >  ## Build reference
 > #set $reference_fasta_filename = "localref.fa"
@@ -965,7 +870,7 @@ runs planemo lint on the inferred tool path. STDOUT is captured with the linter 
 
 > <details-title>`bwa_test_toolfactory_positional_bash` sample alternative.</details-title>
 > ToolFactory form bash script to replace above command over-ride section:
-> 
+>
 > ```
 > REFFILE=$1
 > FASTQ=$2
@@ -1003,16 +908,6 @@ runs planemo lint on the inferred tool path. STDOUT is captured with the linter 
 
 # Notes on common issues
 
-#### First job I submitted remains grey or running for a long time - is it broken?
-
-- Check with `top` or your system monitor - if Conda is running, things are working but it's slow the first time a dependency is installed.
-- The first run generally takes a while to install all the needed dependencies.
-- Subsequent runs should start immediately with all dependencies already in place.
-- Installing new Conda dependencies just takes time so tools that have new Conda packages will take longer to run the first time if they must be installed.
-- In general, a `planemo_test` job usually takes around a minute - planemo has to build and tear down a new Galaxy for generating test results and then
-again for testing properly. Longer if the tool has Conda dependencies.
-- The very first test in a fresh appliance may take 5 minutes so be patient.
-
 #### My Rscript generates a strange R error on STDOUT about an invalid operation on a closure called 'args' ?
 
 - Did your code declare the `args vector` with something like `args = commandArgs(trailingOnly=TRUE)` before it tried to access args[1] ?
@@ -1028,40 +923,21 @@ again for testing properly. Longer if the tool has Conda dependencies.
 - It is recommended that you modify the test over-ride that appears in that sample form. Substitute one
 or more of the file names you expect to see after the collection is filled by your new tool for the `<element.../>` used in the plotter sample's tool test.
 
-#### `docker-compose up` fails and the last log message before the galaxy-server_1 exits is `/usr/bin/start.sh: line 133: /galaxy/.venv/bin/uwsgi: No such file or directory`
+#### Only one ToolFactory job runs at a time. Why doesn't the server allow more than one at once?
 
-- This is why it's useful to watch the boot process without detaching
-- This can happen if a container has become corrupt on disk after being interrupted
-    - cured by a complete cleanup.
-        - make sure no docker galaxy-server related processes are running - use docker ps to check and stop them manually
-        - delete the `..compose/export` directory with `sudo rm -rf export/*` to clean out any corrupted files
-        - enter "y" when you run `docker system prune` to clear out any old corrupted containers, images or networks.
-        - run `docker-compose pull` again to ensure the images are correct
-        - run `docker-compose up` to completely rebuild the appliance from scratch. Please be patient.
-
-#### Only one Planemo test runs at a time. Why doesn't the server allow more than one at once?
-
-- When a new dependency is being installed in the Planemo Conda repository, there is no locking to prevent a second process from overwriting or otherwise
+- When a new dependency is being installed in the Conda repository, there is no locking to prevent a second process from overwriting or otherwise
 interfering with it's own independent repository update. The result is not pretty.
-- Allowing two tests to run at once has proven to be unstable so the Appliance is currently limited to one.
+- Allowing two tests to run at once has proven to be unstable so the job queue is currently limited to one.
 
-#### pip hangs inside the Docker container when I have my VPN turned on
+#### The tool I just generated is not in the tool menu?
 
-- This affects Ross with a Private Internet Access client running. Other VPNs may be similarly affected. If the VPN is running, docker containers will
-fail to download dependencies with timeouts on the pip web site. No idea why - some strange DNS problem - but I turn mine off and that solves the problem for me.
-Toolfactory timeouts, particularly on the first test may be related or at least, was for me. Check your logs carefully or just try turning your VPN off since there are
-situations where nothing is logged - pip will be seen running but with no obvious network activity.
-Your mileage may vary...
-
-
-#### The is the tool I just generated not in the tool menu?
 - Did you refresh your browser's Galaxy page? Click on the "Analyse data" or "home" or the left side of the masthead to do that, then open the "ToolFactory Generated Tools" submenu.
 It should be there if the XML for the new tool appeared without complaint. Please export and send me a copy of the history so I can see what's going on?
 
 
 # Appendices - material of potential interest for those interested in details
 
-## Appliance and ToolFactory functional test workflows
+## ToolFactory functional test workflows
 
 - There are two workflows supplied in the Appliance.
 - One will make and install all the test tools and runs pretty fast.
@@ -1093,11 +969,6 @@ It should be there if the XML for the new tool appeared without complaint. Pleas
 >     - Multiple dependencies. Conda is currently supported.
 >     - Interpreters such as python, r-base and perl are typically used for ToolFactory tools.
 >     - System utilities such as bash and sed can be used.
->     - The Appliance server always exposes them to tools, but this may/should not happen on production servers.
->         - It is recommended that they be added as dependencies after testing locally before testing and export of production ready toolshed archives.
->         - They can be added to the tool form like other Conda dependencies
->         - This will ensure that they are available when the script runs. Bash, sed and so on are all available in Conda.
->         - Versions may not matter as much as other packages. Latest will be selected by default but a version can be specified.
 >     - Argparse (named) or positional (ordered) style parameter passing at tool execution time depending on the script requirements. Positional works well for bash scripts with only a handful of parameters. Argparse is preferred for clarity.
 >     - Unlimited individual input data files to be selected from the user's history.
 >     - Unlimited individual output files to be written to the user's history, paths determined at tool execution.
@@ -1125,14 +996,14 @@ It should be there if the XML for the new tool appeared without complaint. Pleas
 {: .details}
 
 
-## Food for thought and beer.
+## Motivation
 
 - Uptake of Galaxy in new quantitative scientific fields requiring complex computing for analyses is arguably rate-limited early on by the availability of domain specific tools.
    - many scientists routinely write their own analysis code in quantitative disciplines - probably more commonly than in biological domains where Galaxy started.
    - lowering the barriers to those scientists generating their own new tools may speed up adoption of Galaxy in their domains.
 - Galaxy tool wrapping has a well established and growing range of project supported infrastructure.
 - Much complex Galaxy tool logic is embedded in the tool document namespace.
-  - Some document logic cannot be replaced by code in a script. These include output filters and other constructs and are hard to generate automatically.
+  - Some document logic cannot be easily automated. This includes output filters and other constructs that are hard to generate automatically.
   - Being in the namespace saves substantial effort compared to the alternative of writing the command  section logic in a script, as provided by the ToolFactory.
   - That extra effort is needed to pass those parameters on the command line and then to parse them in the script so the logic can be implemented.
 - Manual templating is far more efficient of developer time and effort, particularly as conditional parameter and tool complexities grow.
@@ -1155,16 +1026,6 @@ It should be there if the XML for the new tool appeared without complaint. Pleas
 - Developers can choose the method that suits them best for each new task.
   - For simple tools, the ToolFactory provides a convenient, pop-up, persistent but easily disposable integrated development environment.
 
-## Learning more about security issues and the methods implemented in the Appliance.
-
-For private desktop applications like the ToolFactory, it is sometimes convenient to be able to do things that normal Galaxy security does not permit, such
-as allowing a tool to update a configuration file to install a new tool. The Appliance uses a readily adaptable model for private desktop applications that
-allow tools to call exposed `rpyc` python functions in a companion container. These could, for example, offload calculation to GPU or other hardware and services.
-Please see the documentation on the [Appliance's embedded `rpyc` server](https://github.com/fubar2/toolfactory-galaxy-server/tree/main/compose#readme). The
-model is powerful and requires explicit security bypasses. These may be manageable and acceptable in a private development, but mitigate
-strongly against deployment exposed to the public internet. Aside from that, allowing potentially hostile users to run the ToolFactory and thus unrestricted code as tools on your
-production server seems like a bad idea to me.
-
 ---
 
 # Your turn! Please help improve this community resource!
@@ -1173,12 +1034,12 @@ production server seems like a bad idea to me.
 - Please use the fork at [fubar2/training-material](https://github.com/fubar2/training-material) for issues and pull requests for the nonce.
 - The ToolFactory has had little testing in the present form so expect many bugs
 - If the ToolFactory works well for you, please tell your friends.
-- If you find bugs, please tell me by raising an issue at [fubar2/toolfactory](https://github.com/fubar2/toolfactory), or better, a pull request with the fix :)
+- If you find bugs, please tell me by raising an issue at [fubar2/galaxy_tf_overlay](https://github.com/fubar2/galaxy_tf_overlay), or better, a pull request with the fix :)
 
 
 # Acknowledgements
 
-This tutorial is based on the work of thousands of individual contributers to the Galaxy project over the last 15 years or so.
+This tutorial is based on the work of thousands of individual contributers to the Galaxy project over the last 18 years or so.
 Thanks all! It has been a lot of fun.
 
 Special thanks to:
@@ -1187,5 +1048,4 @@ Special thanks to:
     - review and contribution to the tutorial and associated code.
     - the vision of instant installation of generated tools for developer feedback.
     - elegantly generated lint-free XML provided by [galaxyml code](https://github.com/hexylena/galaxyxml)
-- {% include _includes/contributor-badge.html id="bgruening" %} for making it easy to pop-up and flavour [docker-galaxy-stable](https://github.com/bgruening/docker-galaxy-stable)
- {% include _includes/contributor-badge.html id="mvdbeek" %} for thoughtful comments on the role of the ToolFactory that helped motivate the tutorial.
+- {% include _includes/contributor-badge.html id="mvdbeek" %} for thoughtful comments on the role of the ToolFactory that helped motivate the tutorial.

--- a/topics/dev/tutorials/tool-generators-advanced/tutorial.md
+++ b/topics/dev/tutorials/tool-generators-advanced/tutorial.md
@@ -204,12 +204,6 @@ automated code generator in a tailored, readily deployed appliance.
 >
 {: .hands_on}
 
-
-The trivial `Hello World!` tool example is readily extended to suit many situations where a tool is needed quickly for a workflow. Try adding another parameter.
-For example, the planemo `lint` tool example (described below) can be derived by adding a history toolshed archive as input, plus a few more lines of bash script.
-In practice, it's a flexible basis for generating many simple tools.
-
-
 ## ToolFactory tips and tricks illustrated by some of the examples.
 
 #### Before you begin a new tool

--- a/topics/dev/tutorials/tool-generators/tutorial.md
+++ b/topics/dev/tutorials/tool-generators/tutorial.md
@@ -3,15 +3,15 @@
 layout: tutorial_hands_on
 title: "ToolFactory: Generating Tools From Simple Scripts"
 key_points:
-  - The ToolFactory is a fully automated Galaxy tool generator for scientists and developers who routinely write command line scripts.
+  - The ToolFactory is an automated Galaxy tool generator for scientists and developers who routinely write command line scripts.
   - It can turn a working command line script into a proper Galaxy tool with a test in a few minutes.
   - It automatically generates simple, complete Galaxy tools from information provided by filling in a normal Galaxy form in the familiar UI.
-  - It is installed as a docker-galaxy-stable flavour - the ToolFactory Appliance.
-  - The Appliance is a Galaxy server running in Docker, suited to any modern Linux workstation or high-end laptop.
+  - It is installed as a self-configuring development code clone.
+  - The Galaxy server is suited any modern Linux workstation or high-end laptop.
   - Useful for learning about system administration or framework code, and for developing tools - all on your own private pop-up server.
 
 objectives:
- - Learn why you might want to use the ToolFactory Appliance
+ - Learn why you might want to use the ToolFactory development server
  - Watch a video demonstration and explore the generated code - Hello Galaxy Training Network!
  - Run it locally in Docker.
  - Install and explore the simple examples provided.
@@ -21,7 +21,6 @@ objectives:
 questions:
  - What options exist for new-to-Galaxy developers to convert functioning command line scripts into Galaxy tools?
  - Can any command line script I've written be wrapped as a Galaxy tool?
- - Can I make a tool from a script developed in a Galaxy Interactive Environment notebook?
  - How can I get the ToolFactory working locally, since you tell me it should never be exposed on a public server?
  - What is the difference between a hand-crafted tool and a ToolFactory generated one?
 
@@ -55,8 +54,8 @@ The Toolfactory and these tutorials are for developers and researchers learning 
 bash, Python, Perl, Rscript or other common scientific scripting languages. The tutorials show a convenient way to bridge the gap between a
 working command line script and a new tool that "wraps" that script so users can use it like any other tool in Galaxy.
 
-The ToolFactory is a Galaxy tool. Tools are constructed through the normal Galaxy interface when it is run. It is distributed as the ToolFactory Appliance,
-ready to run on a developer linux workstation using Docker. Generated tools are *immediately installed* and ready to run so you can see
+The ToolFactory is a Galaxy tool. Tools are constructed through the normal Galaxy interface when it is run. It is distributed as a self-installing
+configuration on a freshly cloned copy of the Galaxy source code. Generated tools are *immediately installed* and ready to run so you can see
 what the end user will see. Jobs can be re-run to edit and update generated tools, so Galaxy becomes an integrated development environment for Galaxy tools.
 
 A [`Hello Galaxy!` demonstration](https://youtu.be//DK1eKz5TRs4) using the ToolFactory is available if you'd like to see a walk-through of some of
@@ -116,47 +115,48 @@ The Galaxy developers support extensive software infrastructure for manually cre
 These are complex and powerful with substantial
 learning curves but can be used to turn almost any software package into a tool.
 
-For those new to Galaxy, in many simple cases, it may be possible to generate a new tool "wrapping" a script in a few minutes, using a
-specialised Galaxy tool for developers that generates tools.
-
-This tutorial introduces that unusual tool.
+For those new to Galaxy, in many simple cases, it may be possible to generate a new tool "wrapping" a script in a few minutes, using an XML code generator for tool wrappers
+in a specialised Galaxy tool for developers.
 
 ---
 
-# The ToolFactory Appliance
+# The ToolFactory development server
 
-The ToolFactory implements an automated, form driven wrapper code generator, and an installer for newly generated tools so you can try them straight away
-in Galaxy. The ToolFactory is distributed as a Docker appliance and can be "popped up" and ready to run in a few minutes - well, 5 or 10 perhaps.
+The ToolFactory implements an automated, form driven XML document generator, and an installer for newly generated tools so you can try them straight away
+in Galaxy. The ToolFactory can be "popped up" as a docker container conveniently but all work must be exported and saved before shutting down because no changes are persisted in the docker image. It can be installed locally by cloning and running the setup script from the git repository - ready to run in about 20 minutes as a fully functional, local, throw-away Galaxy development server.
 
-> <tip-title>The ToolFactory appliance provides a fully featured Galaxy server.</tip-title>
-> - It is a private local desktop Galaxy server, ideal for tinkering and experimentation, learning how the Galaxy server works and for developing new tools for new kinds of scientists using Galaxy.
+> <tip-title>The ToolFactory installs and configures a fresh development server clone.</tip-title>
+> - Private local desktop Galaxy server or docker image
+>     - ideal for tinkering and experimentation
+>     - learning how the Galaxy server works and
+>     - developing new tools for new kinds of scientists.
 > - Any Galaxy tool from the toolshed can be installed and used.
-> - Any simple script can have a tool wrapper generated and installed as a new tool in the Appliance.
+> - Simple scripts can have tool wrapper XML generated, and installed for testing.
+> - They appear as a shareable Toolshed ready archive in the history.
 > - Newly generated tools appear in the tool menu after a refresh, and can be viewed and used as the user will see them.
 > - Tool generation jobs can be rerun using the {% icon galaxy-refresh %} button on the history item after editing the form to make changes to the tool the user will see in Galaxy.
-> - The Appliance is a Toolfactory flavour of the [docker-galaxy-stable resource](https://github.com/bgruening/docker-galaxy-stable/tree/master/compose).
->    - Documentation on connecting the appliance to a cluster for getting real work done with newly generated tools can be found at that repository.
+> - The development server is a self-installing clone of the Galaxy code, configured with the ToolFactory and sample tools to explore.
 >    - It can be backed up and persisted for as long as required, or it can be treated as a throw-away instance and deleted when no longer needed.
->    - There is almost zero technical friction if Docker and docker-compose are already installed. Only time is required.
->    - Usefulness will depend on sufficient hardware. Plenty of cores, RAM and disk storage are needed.
+>    - There is almost zero technical friction. Only time is required to initialise the server.
 >    - On a modern workstation or well-endowed laptop, it will perform well out of the box.
->    - It will struggle on older consumer hardware with limited RAM and CPU capacity.
 >    - It is suitable only for development in a private deployment.
->    - Production is best done on a professionally maintained service, but please, not a public one.
+>    - Please, never expose as a public server.
 {: .tip }
 
-The Appliance was developed for programmers who need scripts they write turned in to new Galaxy tools for their own use and if sufficiently useful,
+The server was developed for programmers who need scripts they write turned in to new Galaxy tools for their own use and if sufficiently useful,
 for others to share. Any user comfortable with scientific or general scripting languages on a Linux command
 line may find it useful if they ever need a Galaxy tool that wraps a working script. Linux command line utilities and scripting language interpreters supported by Conda can be used.
 Some Conda packages can also be used without a script, but the focus is on scripts.
 
-Generated tools pass Planemo lint (if they take an input - some of the test tools do not!), and are functionally indistinguishable from equivalent
-manually written tools. A second tool can be used to finalise ToolFactory untested archives. It uses Planemo.
-The tested toolshed archives contain a test based on the test data provided at tool generation.
+Generated tools pass Planemo lint and are functionally indistinguishable from equivalent
+manually written tools. The tested toolshed archives contain a test based on the test data provided at tool generation.
 
-Working generated examples using bash, Python, Rscript, Lisp, Prolog, Perl and sed are provided and described below. Many demonstrate ToolFactory features.
-All can be updated and changed easily, supporting learning by experimenting. More useful tools can be developed and tested using more complex scripts and as many inputs, outputs
-and user supplied parameters as needed by that script.
+Working demonstration scripts are provided that use bash, Python, Rscript, Lisp, Prolog, Perl, sed, BWA and samtools, as described below.
+Many demonstrate ToolFactory features and all can be updated and changed easily, supporting learning by experimenting.
+More useful tools can be developed using more complex scripts and as many inputs, outputs
+and user supplied parameters as needed by that script. Note that many tool complexities are not easily automated, so the
+XML generator provides only limited features. Tools using those limited features may still be useful in many situations but a specialised
+tool developer will be needed for many requirements.
 
 If you are a scientist/programmer or software developer new to Galaxy and new to the dark arts of Galaxy tool building, this tutorial may be of help.
 It introduces an automated way to convert any useful script into a toolshed ready tool, quickly *inside* Galaxy.
@@ -167,17 +167,18 @@ It introduces an automated way to convert any useful script into a toolshed read
 >   - Undergoing rapid development.
 >   - Specialised semi-automated tool building environment with VCS bindings.
 > - Planemo can manually [generate and serve tool XML](https://planemo.readthedocs.io/en/latest/writing_standalone.html) with an optional test.
->    - Planemo is recommended for developers who will focus on Galaxy tools on the command line. Outstanding documentation.
+>    - Recommended for developers who will focus on building Galaxy tools on the command line.
+>    - Outstanding documentation.
 >    - Widely used. Requires relatively little time to figure out - Galaxy tool syntax takes longer.
->    - No GUI. Command line only. Can create archives with additional steps.
+>    - No GUI, although can serve tools on a web port.
+>    - Command line only. Can create archives with additional steps.
 >    - Need to pass all i/o and parameter details at once on the command line.
 >    - Takes longer to learn to use and less accessible to many users than a form driven GUI might be.
 >    - Manual XML editing required for selects and collections.
 >    - See the recommended next steps at the end of this tutorial for Planemo related training.
->    - The ToolFactory uses planemo to generate test data and to run the test in the companion `planemo_test` tool.
 > - Many Unix utilities (sed, awk...) are already available as IUC tools.
 >    - They are `generic` in the sense that a script is supplied at **run time** by the tool user.
->    - The Lisp demonstration uses that model, but it may be desirable that one very specific script is "wrapped" as a reproducible tool.
+>    - This is possible with the ToolFactory, but for reproducible workflows, a specific script can be permanently built-in to make a reproducible tool.
 >        - The user supplies only those I/O and parameter values specified on the ToolFactory form.
 >        - Nothing else can be changed - just like with most Galaxy tools.
 > - Choose whichever one fits best for the task at hand.
@@ -185,13 +186,13 @@ It introduces an automated way to convert any useful script into a toolshed read
 
 ---
 
-# `Hello World!` with the ToolFactory Appliance
+# `Hello World!` with the ToolFactory.
 
-A `Hello World!` Galaxy tool is a good place to start, just like any other new programming environment. It requires planning
-and preparation. The ToolFactory can automate the generation of a wrapper, but the developer must supply a working script and
+A `Hello World!` Galaxy tool is a good place to start, just like any other new programming environment.
+It requires planning and preparation. The ToolFactory can automate the generation of a wrapper, but the developer must supply a working script and
 configure the inputs, outputs, user supplied parameters and metadata for the tool to be useful.
 
-### Planning the new tool
+## Planning the new tool
 
 A very simple bash script can be used to say "hello" but we make it a little more like a real
 Galaxy tool by adding a text box so the user may designate whatever they want to add after that
@@ -213,6 +214,7 @@ Test it on the command line by running:
 In this case, `ToolFactory` is the first command line parameter. `Hello ToolFactory!` should appear as the output.
 
 Once the script works and produces the expected outputs, the next step is to plan how the generated tool form should look to the user when run as a Galaxy tool.
+In this case, a single text string is needed from the user.
 
 Tool definition involves configuring the major sections of the ToolFactory form for the new tool.
 
@@ -224,7 +226,9 @@ The following information about a script is needed:
 - User controlled parameters
 
 For the `hello` tool case:
-- There are no dependencies. Bash is always available and version is not important usually.
+
+- There are no dependencies usually because bash is available and version is not important.
+- For completeness, it could be included as a Conda package. It's your tool.
 - This tool requires no history input files.
 - It produces one text output file.
 - The tool form should show a single input text field for the user to supply.
@@ -232,18 +236,20 @@ For the `hello` tool case:
 
 At this point, the plan for this new tool is:
 
-- The user should see a helpfully labelled text input field on the tool form, and the usual tool `execute` button.
+- The Galaxy user should see a helpfully labelled text input field on the tool form, and the usual tool `execute` button.
 - When the tool executes, that text should be passed to the script running under bash, as the first positional parameter.
 - The script output should appear as a new output file in the history.
 - It should contain the expected decorated input text.
 - Galaxy tools need a test.
    - A simple test would be to supply a default value for the text string, run the tool and check that the output is correct.
 
-Trivial, but an excellent model worth studying in detail because it is easily extended to do
-more useful tasks. This is the simplest case of a very useful generic model for Galaxy tools. More useful tools will require input files and parameters, as discussed below.
-Bash is used here but any scripting language available in Conda could probably be used.
+This is a trivial example, but it demonstrates a flexible model worth studying in detail, because it is easily extended to do
+more useful things.
 
-### Putting the plan into action using the ToolFactory
+This is the simplest case of a very useful generic model for Galaxy tools. More useful tools will require one or more input files and more parameters, as discussed below.
+Bash is used here but any scripting language but any other package available in Conda can be made available for tool execution.
+
+## Putting the plan into action using the ToolFactory
 
 The form collects all the information needed for a new Galaxy tool. It is long and complex as a result, particularly with many repeated form elements for more complex tools.
 Much of what is collected is used to construct a command line for the script when the generated tool runs.
@@ -260,7 +266,7 @@ sections of the generated XML file in the toolshed archive. The ToolFactory form
 {: .details }
 
 
-The generated tool XML appears in the history after the ToolFactory is executed and the tool itself is installed in the `ToolFactory Generated Tools` submenu.
+The generated tool XML appears in the history after the ToolFactory is executed and the tool itself is installed in the `Local Tools` submenu.
 Text on the form is specified in the XML and it all comes from the ToolFactory form.
 
 > <details-title>Detail to explore: Generated XML and tool form</details-title>
@@ -271,7 +277,7 @@ Text on the form is specified in the XML and it all comes from the ToolFactory f
 >
 > ```xml
 > <tool name="hello_toolshed" id="hello_toolshed" version="0.01">
->   <!--Source in git at: https://github.com/fubar2/toolfactory-->
+>   <!--Source in git at: https://github.com/fubar2/galaxy_tf_overlay-->
 >   <!--Created by planemo@galaxyproject.org at 22/01/2021 13:48:27 using the Galaxy Tool Factory.-->
 >   <description>Says hello</description>
 >   <stdio>
@@ -345,111 +351,97 @@ Text on the form is specified in the XML and it all comes from the ToolFactory f
 > - It works best wrapping simple R/Bash/Python and other interpreted scripts, with few user supplied parameters and a few input and output files.
 > - Scripts are easier than some Conda packages
 >   - They can easily be modified to respond to default empty parameters as if they had not been passed.
->   - As a result, advanced tool building elements such as conditionals and related tricks requiring manual coding, can often be avoided.
+>   - As a result, advanced tool building elements such as conditionals and related tricks requiring manual coding, can sometimes be avoided.
+>         - where they are needed, a skilled developer will be required.
 > - On the other hand, many Conda dependencies will require XML conditionals or other tool XML constructs that are not easy to generate automatically.
 > - While some simple requirements may be manageable, complex ones will not be suitable for the ToolFactory.
 > - Compared to the more usual shell and a text editor, The ToolFactory in Galaxy is a slow and clumsy way to debugging scripts.
-> - **Starting a new ToolFactory tool with a know good command line and data** is strongly recommended. You will know exactly what to expect from the tool test for a first sanity check.
+> - **Starting a new ToolFactory tool with a know good command line and data** is strongly recommended.
+>      - You will know exactly what to expect from the tool test for a first sanity check.
 > - Corrolary: Unless there is a working script that needs to be wrapped into a toolshed-ready Galaxy tool, the ToolFactory is of little use.
-> - Generated tools are untested and not recommended for sharing.
->   - Testing is easy - use the Planemo test tool. It may take a while to run depending on Conda dependency installation. It will return the tested tool to your history and a report collection.
->   - The planemo_test tool creates a new tested toolshed archive ready for sharing, and a collection with reports.
->       - The Planemo test report is in the collection with a lint report and a log of the entire run.
->       - *Please check the html report to make sure it passed* before sharing your new tool.
 {: .comment}
 
 ---
 
-# Installation
+# Installation Options
 
-> <hands-on-title>Launching the Appliance</hands-on-title>
+
+> <warning-title>Security advisory!</warning-title>
+>- *Please do not install the ToolFactory on any public server*
+>- Configured as a default server, it has none of the usual additional security layers required for a safe public Galaxy server.
+>- Although it will only run for administrative users, it allows unlimited scripting and exposes unacceptable risks.
+>- Please install it locally.
+>- For this reason, the training materials can't make use of existing public Galaxy infrastructure like most of the GTN material.
+{: .warning}
+
+
+> <hands-on-title>Installing and managing a Galaxy ToolFactory development server</hands-on-title>
+> # Logging in as an administrator
+> 
+> Once you have a working installation running as described below, the server should be ready in 20-30 seconds or so, at [http://localhost:8080](http://localhost:8080).
+> *The ToolFactory will only execute for administrative users as a minimal security barrier.* 
+> When the webserver starts, immediately login using the administrative user email *toolfactory@galaxy.org* with the password *ChangeMe!* which of course you should change.
+>   
+> # Docker
+> Note: *Nothing is persistent in the image*. Useful work must be manually exported and saved.
+> For following the GTN tutorial and for test driving the ToolFactory for the first time, the docker version is recommended.
+> Non-persistent means it does not remember anything after you stop the container. The next time it starts it will be a fresh installation.
+> You can save your work by exporting the histories and tool tarballs you want to keep. You need the history to rerun the job that generated a tarball, so the history is the most important thing to preserve if you make a useful tool.
+> The image must be pulled first, then run with port 8080 open for the Galaxy server.
+> 
+> ```
+> docker pull quay.io/fubar2/galaxy_toolfactory:latest
+> docker run -d -p 8080:8080 quay.io/fubar2/galaxy_toolfactory:latest
+> ```
+> Check the docker logs until gunicorn is ready to serve or wait 
+> about 20-30 seconds, then browse to [http://localhost:8080](http://localhost:8080)
+> If a Galaxy server appears, proceed with the login instructions above and you should see a history containing all the example tools. There is also a workflow that can reproduce that history if you set all the inputs to the right input datasets in that history.
+>  
+> # Local workstation development Galaxy server installation
+> 
+> A persistent desktop development ToolFactory server can be built by cloning the [bootstrap github repository](https://github.com/fubar2/galaxy_tf_overlay), and using the included *localtf.sh* script, to build a complete, new development server with the ToolFactory installed and ready to run.
 >
-> 1. [Install Docker](https://docs.docker.com/engine/install/) following the appropriate instructions for your platform.
+> From a convenient directory, download the overlay configuration code repository, then
+> run the *localtf.sh* setup script from that cloned repository root directory:
 >
-> 2. Then, `pip3 install docker-compose`
+> ```
+> git clone https://github.com/fubar2/galaxy_tf_overlay.git
+> cd galaxy_tf_overlay
+> sh ./localtf.sh
+> ```
+> Running *localtf.sh* will create a new directory, *galaxytf*, in the parent directory of the *galaxy_tf_overlay* clone.
+> The script will configure a fresh Galaxy 23.0 server, with the ToolFactory installed, in that new directory.
+> This takes 20 minutes or more to complete since the client must be built once.
 >
-> 2. Go to [the ToolFactory appliance github repository](https://github.com/fubar2/toolfactory-galaxy-server)
+> The resulting development server directory will occupy ~9GB of disk space, so be sure your machine has plenty of room.
+> It will be based in a single directory, *galaxytf* in the same directory as the galaxy_tf_overlay repository was cloned into.
+> That is where the script should be run as shown above.
 >
-> 3. Clone it or download the zip and unzip it somewhere handy - such as `~/toolfactory-galaxy-server-main`
+> Rerunning the *localtf.sh* script will *destroy the entire galaxytf directory* - all ~9GB, and create a clean new installation.
+> It should only need to be run once in the life of the development server.
 >
-> 4. Change to the compose directory, pull the images from quay.io and launch it
->
-> > <warning-title>`Pull` the images first as shown below to save time.</warning-title>
-> >
-> > If they are not found locally (`docker images`), the first time you run `docker-compose up`, docker will build them, taking much, much, much longer.
-> >
-> {: .warning}
->
->    > <code-in-title>Bash: Installing the docker files, pulling and launching the Appliance</code-in-title>
->    > ```bash
->    > git clone https://github.com/fubar2/toolfactory-galaxy-server
->    > cd toolfactory-galaxy-server/compose
->    > mkdir export
->    > docker-compose pull
->    > docker-compose up
->    > ```
->    {: .code-in}
->
->    > <tip-title>Appliance tips</tip-title>
->    >
->    >  - First time start takes 5-10 minutes after the pull completes.
->    >      - Watching the first startup process activity log is highly recommended.
->    >      - Subsequent starts will be much faster.
->    >  - The docker containers may not fit or run well on an underpowered machine.
->    >      - Multiple CPU cores, 8GB of RAM and fast disk are needed for an enjoyable appliance.
->    >  - This Appliance is recommended for use *only as a private disposable desktop development environment*.
->    >    - The Appliance keeps no backup of any work.
->    >    - The `export` directory has most of the changeable parts of the Appliance.
->    >    - The user can backup the export directory if desired.
->    >    - A professionally managed Galaxy server is a much safer bet for preserving real research.
->    >    - The Appliance is disposable if development goes awry.
->    >  - Even then, secure your Appliance against potential miscreants on the local or public internet.
->    >     - Change your admin password
->   {: .tip}
->
->    > <tip-title>Appliance disposal to free up desktop resources when no longer needed</tip-title>
->    > - Save any useful generated material from the `export` directory or from the running Appliance.
->    > - Delete the `...compose/export` directory - you will need `sudo rm -rf export/*` and perhaps `sudo rm -rf export/.d*`
->    >   - Then you can delete the parent `toolfactory-galaxy-server` directory
->    > - Use `docker system prune` and respond `y` to the prompt to clean up any damaged or dangling images and containers.
->    > - Use `docker volume prune` and respond `y` to the prompt to remove the shared galaxy-central and /etc/galaxy volumes.
->    > - Remove the 2 pulled `quay.io/fubar2/toolfactory*` docker images in the usual way.
->   {: .tip}
+> Remove the *galaxytf* directory to remove the entire development server when it is no longer needed. Save all your tools and histories,
+> because the jobs in a history can be used to update a tool easily, and a history can be imported into a fresh development instance
+> when needed.
 >
 >
-> 5. Your appliance should run a local Galaxy on [port 8080 of your workstation](http://localhost:8080) after about 5 minutes of activity on the logs.
->
->    - Login with the username `admin@galaxy.org` and the password `password`
->    - This is obviously insecure but convenient and easily changed at first login.
->    - The container `/export` directory is mounted locally at `compose/export` so you can find your generated and tested tools for sharing.
->
->    > <tip-title>Demonstration tools are the best functional documentation.</tip-title>
->    >
->    > - At first login you will find the demonstration history ready to explore if you waited for all the Conda activity to die down
->    > - It takes a minute or two to import because the dependencies for the ToolFactory must first be installed.
->    > - If it's not there, you can import it manually from Zenodo as described in the Welcome page text.
->    > - To explore an example, open the toolshed XML history item by clicking on the name, and select the {% icon galaxy-refresh %} `rerun` button from the expanded view
->    >    - The form that generated that tool will appear for you to examine
->    >    - Edit the form - add parameters and change the script to suit - and rerun to create an *updated* tool. The history has previous versions.
->    >    - Change the tool ID to change the tool name and generate a different tool. *Generating a same-name tool will overwrite the old version*.
->    {: .tip}
->
->    > <tip-title>Patience!</tip-title>
->    > When you run the ToolFactory for the first time inside the container and whenever you run a new tool with new dependencies, it will require some time to build the conda environment.
->    > Check for Conda or other processes if things seem stuck.
->    {: .tip}
+> Once installation is complete:
+>  * start the server from the *galaxytf* directory with *sh run.sh*. The logs will be displayed.
+>  * ^c (control+c) will stop it from the console.
+>  * In 23.0 that is equivalent to *.venv/bin/galaxyctl start* and *.venv/bin/galaxyctl stop*.
 >
 >
 {: .hands_on}
 
-## Exploring the ToolFactory in the running Appliance.
 
-- The best way to explore the kinds of tasks that can be achieved with simple scripts is to take a look at each sample tool.
+## Exploring the ToolFactory
+
+- The best way to explore what can be done is to take a look at the sample tools in the default administrator initial history.
 - Note how the various options have been configured and what kinds of scripts this could be used for in your work.
 - The example script can be swapped out for another one known to work and additional new parameters added to suit, to extend the toy examples and create tools of use to your users.
 - Change the tool name when you do this on the newly edited form, then press `execute`
   - The new wrapper XML will appear
-  - The new tool will be installed in the `ToolFactory Generated Tools` submenu.
+  - The new tool will be installed in the `Local Tools` submenu.
 - If the tool name is not changed before re-generating a tool, the original installed tool will be updated with the new configuration.
 
 ---
@@ -475,50 +467,40 @@ Text on the form is specified in the XML and it all comes from the ToolFactory f
 >          - *"Enter this parameter's label for the form"*: `Say hello to`
 >          - *"Positional ordinal \| argparse argument name"*: `1`
 >
->    > <comment-title>First time use involves a long pause in some installations</comment-title>
->    > The first job takes longer in some installation scenarios because the ToolFactory dependencies are installed before the tool can run.
->    {: .comment}
->
 > 2. Execute
 >
-> 2. Explore the outputs - do they match what you expected?
+> 3. Explore the outputs - do they match what you expected?
 >
-> 3. Refresh the page - click the home icon (or the "Analysis" tab) - to see the new tool in the `ToolFactory Generated Tools` section of the tools menu.
+> 4. Refresh the page - click the home icon (or the "Analysis" tab) - to see the new tool in the `Local Tools` section of the tools menu.
 >
-> 4. Run the tool that has been added - Select the new tool and examine the form. Check that all the changes are as they should be.
->
-> 5. Test the tool using the `planemo_test` tool from the `ToolFactory` tool section. This may take 5 or 10 minutes if this is the first test on a new appliance. Subsequent startup will be quicker.
->     - Check the lint report
->     - View the planemo test report - is it ok? See if you can open up the details hidden when you first view the page.
->     - Take a look at what Planemo did in the report log. It is very, very long and usually involves popping up and tearing down a Galaxy server twice.
->     - This can take time, particularly if Conda dependencies are required as they can take a long time to initialise.
+> 5. Run the tool that has been added - Select the new tool and examine the form. Check that all the changes are as they should be.
 >
 {: .hands_on}
 
 ## The Development Cycle
 
-1. Test your script on the command line and confirm it works.
-1. In the appliance, start a new history and upload all the input samples used on the command line.
+1. Test on the command line and confirm it produces correct output with defaults and test data.
+1. In the development server, start a new history
+1. Upload all input samples used on the command line if any, for use in the tool test.
 1. Open the ToolFactory tool form.
-1. Define the tool metadata, dependencies, interpreter and paste the script.
-1. Add the required history inputs using the small samples as examples.
-1. Specify all the output files to be created in the user's history.
-1. Add any user adjustable command line parameters such as text fields. Look at the samples to see how the ToolFactory form can be used.
+    1. Define the tool metadata, dependencies, interpreter and optionally, paste the script.
+    1. Add the required history inputs using the small samples as examples.
+    1. Specify all the output files to be created in the user's history.
+    1. Add any user adjustable command line parameters such as text fields.
+    1. Look at the samples to see how the ToolFactory form can be used.
 1. Execute the tool when the form is completed.
-1. When the job is complete, refresh the page (Home icon or Analysis tab). The new tool will be found in the `ToolFactory Generated Tools` section, ready to run.
+1. When the job is complete, refresh the page (Home icon or Analysis tab). The new tool will be found in the `Local Tools` section, ready to run.
 1. Run the new tool and check that it does what you expect, or re-generate after adjusting the form settings as needed.
 1. If it needs any changes, open the XML history item created when the tool was generated and use the {% icon galaxy-refresh %} rerun button to
 recreate the ToolFactory form as it was when you last ran it. Adjust as needed and use the tool form`Execute` button to run the ToolFactory again with updated settings.
-1. Rinse, repeat.
-1. When everything is to your satisfaction, start the `planemo_test` tool in the ToolFactory menu and select the tool XML to finalise.
-    1. A Planemo test will be run
-    1. Time will depend on Conda dependencies. If none a minute or so.
-    1. A new tested archive, Planemo test report, Planemo lint output and a log of the test run will be in a new collection in the history when the job finishes.
-    1. The tested toolshed archive can be downloaded from the history or found in `...compose/export/galaxy/tested_TF_archives/[tool name]`
-1. Warning: generating a tool with the tool id `mytool` will overwrite the installed version of any previously generated ToolFactory tool with the same id.
-    1. Persisted jobs in user histories allow previous versions to be recreated if this is not wanted.
+    1. Rinse, repeat.
+1. Warning: generating a tool with an existing tool id such as `mytool` will overwrite the installed version of any previously generated tool with id "mytool".
+    1. Persisted jobs in user histories allow previous versions to be recreated to restore older versions.
 
-Galaxy can be used as an Integrated Development Environment for tools - clunky but oddly satisfying. Note this is distinct from debugging the script - that is not at all satisfying in Galaxy unless you like waiting for jobs to finish. A shell is much better for that.
+Galaxy can be used as an Integrated Development Environment for tools - clunky but oddly satisfying.
+Note this is distinct from debugging the script - that is not at all satisfying in Galaxy unless you like waiting for jobs to finish.
+
+A shell is much better for that.
 
 ![Galaxy as an IDE for tools with the ToolFactory](../../images/ToolFactory_big_picture.png "Galaxy can be used as a tool development environment for users who can write their own scripts as shown in this process overview slide.")
 
@@ -595,11 +577,9 @@ that a user might want to be able to easily view if they want without cluttering
 
 ## Done!
 
-> <hands-on-title>To safely shut the appliance down</hands-on-title>
+> <hands-on-title>To safely shut the server down</hands-on-title>
 >
-> 1. Type <kbd>Ctrl-C</kbd> in the terminal where you ran `docker-compose`. Most things will still be there next time you start it.
->
-> 2. Explore the `export/galaxy/tools/TFtools` directory. There you should find directories with the tools you created during this tutorial, as well as some others that are pre-loaded.
+> 1. Type <kbd>Ctrl-C</kbd> in the terminal where you ran `sh run.sh`.
 >
 {: .hands_on}
 
@@ -632,5 +612,4 @@ Special thanks to:
     - review and contribution to the tutorial and associated code.
     - the vision of instant installation of generated tools for developer feedback.
     - elegantly generated lint-free XML provided by [galaxyml code](https://github.com/hexylena/galaxyxml)
-- {% include _includes/contributor-badge.html id="bgruening" %} for making it easy to pop-up and flavour [docker-galaxy-stable](https://github.com/bgruening/docker-galaxy-stable)
 - {% include _includes/contributor-badge.html id="mvdbeek" %} for thoughtful comments on the role of the ToolFactory that helped motivate the tutorial.


### PR DESCRIPTION
TF has been simplified by removing planemo from the testing part. Now uses galaxy-tool-test so is much faster and more stable as a result. Works well with sqlite so that's the default.

A non-persistent docker image has been created using a simple overlay to a standard 23.0 git checkout.
Instructions for building a local desktop version take longer but give a normal persistent dev server.
