### PR TITLE
Update pox-virus-tiled-amplicon-ref-masking.ga

### DIFF
--- a/topics/variant-analysis/tutorials/pox-tiled-amplicon/workflows/pox-virus-tiled-amplicon-ref-masking.ga
+++ b/topics/variant-analysis/tutorials/pox-tiled-amplicon/workflows/pox-virus-tiled-amplicon-ref-masking.ga
@@ -29,7 +29,7 @@
                     "name": "Primer Scheme (BED file with Pool identifiers)"
                 }
             ],
-            "label": "Primer Scheme (BED file with Pool identifiers)",
+            "label": "Primer Scheme",
             "name": "Input dataset",
             "outputs": [],
             "position": {


### PR DESCRIPTION
Make the input label in the WF match the name used in the WF test.
Should fix one of the items in @natefoo's https://gist.github.com/natefoo/2c02814fffc7384e833c5df0e8f28b00#missing-inputs.