### PR TITLE
Use latest zenodo data with fixed CIVic.bed

### DIFF
--- a/topics/variant-analysis/tutorials/somatic-variants/tutorial.md
+++ b/topics/variant-analysis/tutorials/somatic-variants/tutorial.md
@@ -685,12 +685,12 @@ license.
 > <hands-on-title>Data upload</hands-on-title>
 >
 > 1. Import the following **variant annotation files** from
->    [Zenodo](https://zenodo.org/record/2581873):
+>    [Zenodo](https://zenodo.org/record/7962928):
 >
 >    ```
->    https://zenodo.org/record/2581873/files/hotspots.bed
->    https://zenodo.org/record/2581873/files/cgi_variant_positions.bed
->    https://zenodo.org/record/2581873/files/01-Feb-2019-CIVic.bed
+>    https://zenodo.org/record/7962928/files/hotspots.bed
+>    https://zenodo.org/record/7962928/files/cgi_variant_positions.bed
+>    https://zenodo.org/record/7962928/files/01-Feb-2019-CIVic.bed
 >    https://zenodo.org/record/2582555/files/dbsnp.b147.chr5_12_17.vcf.gz
 >    ```
 >

--- a/topics/variant-analysis/tutorials/somatic-variants/workflows/somatic_variants_tutorial_workflow-test.yml
+++ b/topics/variant-analysis/tutorials/somatic-variants/workflows/somatic_variants_tutorial_workflow-test.yml
@@ -23,15 +23,15 @@
       filetype: fasta
     hotspots.bed:
       class: File
-      location: https://zenodo.org/record/2581873/files/hotspots.bed
+      location: https://zenodo.org/record/7962928/files/hotspots.bed
       filetype: bed
     cgi_variant_positions.bed:
       class: File
-      location: https://zenodo.org/record/2581873/files/cgi_variant_positions.bed
+      location: https://zenodo.org/record/7962928/files/cgi_variant_positions.bed
       filetype: bed
     01-Feb-2019-CIVic.bed:
       class: File
-      location: https://zenodo.org/record/2581873/files/01-Feb-2019-CIVic.bed
+      location: https://zenodo.org/record/7962928/files/01-Feb-2019-CIVic.bed
       filetype: bed
     Uniprot_Cancer_Genes.13Feb2019.txt:
       class: File


### PR DESCRIPTION
The previous version of the bed file contained two lines with START > STOP, which caused recent version of tabix to refuse indexing the file.
