### PR TITLE
avoid double-fonts in RO-Crate SVG

### DIFF
--- a/topics/fair/images/ro-crate-intro/crate1-folders.svg
+++ b/topics/fair/images/ro-crate-intro/crate1-folders.svg
@@ -7,8 +7,8 @@
    viewBox="0 0 168.80416 66.939585"
    version="1.1"
    id="svg5"
-   inkscape:version="1.1.2 (0a00cf5339, 2022-02-04)"
-   sodipodi:docname="ro-crate-root.svg"
+   inkscape:version="1.2.2 (732a01da63, 2022-12-09)"
+   sodipodi:docname="crate1-folders.svg"
    xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
    xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
    xmlns="http://www.w3.org/2000/svg"
@@ -33,14 +33,16 @@
      height="200px"
      scale-x="1.1"
      inkscape:zoom="1"
-     inkscape:cx="330.5"
-     inkscape:cy="201.5"
-     inkscape:window-width="1846"
-     inkscape:window-height="1136"
-     inkscape:window-x="0"
-     inkscape:window-y="0"
+     inkscape:cx="118"
+     inkscape:cy="201"
+     inkscape:window-width="2560"
+     inkscape:window-height="1369"
+     inkscape:window-x="-8"
+     inkscape:window-y="-8"
      inkscape:window-maximized="1"
-     inkscape:current-layer="layer1" />
+     inkscape:current-layer="g95234"
+     inkscape:showpageshadow="2"
+     inkscape:deskcolor="#d1d1d1" />
   <defs
      id="defs2" />
   <g
@@ -73,9 +75,7 @@
            d="m 102.15171,208.79138 v 0.26459 0.26458 h 0.91054 0.91054 l 0.16329,-0.26458 0.1633,-0.26459 h -1.07384 z m 2.61483,0 0.16329,0.26459 0.1633,0.26458 h 0.91054 0.91054 v -0.26458 -0.26459 h -1.07384 z m -2.61483,1.05834 v 0.26458 0.26458 h 1.05833 1.05834 v -0.26458 -0.26458 h -1.05834 z m 2.64583,0 v 0.26458 0.26458 h 1.05834 1.05833 v -0.26458 -0.26458 h -1.05833 z m -2.64583,1.32291 v 0.26459 0.26458 h 1.05833 1.05834 v -0.26458 -0.26459 h -1.05834 z m 2.64583,0 v 0.26459 0.26458 h 1.05834 1.05833 v -0.26458 -0.26459 h -1.05833 z m -2.64583,1.05834 v 0.26458 0.26458 h 1.07383 1.07384 l -0.1633,-0.26458 -0.16329,-0.26458 h -0.91054 z m 2.94142,0 -0.1633,0.26458 -0.16329,0.26458 h 1.07383 1.07384 v -0.26458 -0.26458 h -0.91054 z" />
       </g>
       <g
-         aria-label="crate1/
-    data.csv
-    ro-crate-metadata.json"
+         aria-label="crate1/     data.csv     ro-crate-metadata.json"
          id="text5966"
          style="font-size:10.5833px;line-height:1.45;font-family:'DejaVu Sans';-inkscape-font-specification:'DejaVu Sans, Normal';letter-spacing:0px;word-spacing:0px;fill:#c6cbcc;stroke-width:0.264583">
         <path
@@ -192,22 +192,22 @@
       </g>
       <text
          xml:space="preserve"
-         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:10.5833px;line-height:1.45;font-family:'DejaVu Sans';-inkscape-font-specification:'DejaVu Sans, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;letter-spacing:0px;word-spacing:0px;fill:#c6cbcc;fill-opacity:1;stroke:none;stroke-width:0.264583"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:10.5833px;line-height:1.45;font-family:'DejaVu Sans';-inkscape-font-specification:'DejaVu Sans, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;letter-spacing:0px;word-spacing:0px;fill:#c6cbcc;fill-opacity:0;stroke:none;stroke-width:0.264583;opacity:1"
          x="31.107971"
          y="62.017189"
          id="text5966-4"><tspan
            sodipodi:role="line"
            id="tspan5964-8"
-           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:10.5833px;font-family:'DejaVu Sans';-inkscape-font-specification:'DejaVu Sans, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;fill:#c6cbcc;fill-opacity:1;stroke-width:0.264583"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:10.5833px;font-family:'DejaVu Sans';-inkscape-font-specification:'DejaVu Sans, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;fill:#c6cbcc;fill-opacity:0;stroke-width:0.264583"
            x="31.107971"
            y="62.017189">crate1/</tspan><tspan
            sodipodi:role="line"
-           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:10.5833px;font-family:'DejaVu Sans';-inkscape-font-specification:'DejaVu Sans, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;fill:#c6cbcc;fill-opacity:1;stroke-width:0.264583"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:10.5833px;font-family:'DejaVu Sans';-inkscape-font-specification:'DejaVu Sans, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;fill:#c6cbcc;fill-opacity:0;stroke-width:0.264583"
            x="31.107971"
            y="77.362976"
            id="tspan5968-1">    data.csv</tspan><tspan
            sodipodi:role="line"
-           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:10.5833px;font-family:'DejaVu Sans';-inkscape-font-specification:'DejaVu Sans, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;fill:#c6cbcc;fill-opacity:1;stroke-width:0.264583"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:10.5833px;font-family:'DejaVu Sans';-inkscape-font-specification:'DejaVu Sans, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;fill:#c6cbcc;fill-opacity:0;stroke-width:0.264583"
            x="31.107971"
            y="92.708755"
            id="tspan5970-2">    ro-crate-metadata.json</tspan></text>


### PR DESCRIPTION
There was a bug in the previous SVG as the selectable-text layer was visible, as well as the rendered-text layer.

![image](https://github.com/galaxyproject/training-material/assets/253413/6a1ea290-aeaa-4257-be66-51da95da7a3a)

![image](https://github.com/galaxyproject/training-material/assets/253413/c80dbd5b-565e-4049-bca7-b56114ca0972)
