### PR TITLE
Point tool search users to the GalaxyCat

### DIFF
--- a/galaxy_instances.yaml
+++ b/galaxy_instances.yaml
@@ -1,5 +1,0 @@
-# You can reference these in the metadata of your tutorial
----
-galaxies:
-    - name: usegalaxy
-      url: https://usegalaxy.org/

--- a/news/_posts/2023-06-07-pan-galactic-search.md
+++ b/news/_posts/2023-06-07-pan-galactic-search.md
@@ -12,6 +12,12 @@ tutorial: search-tools.html
 Did you ever want to run a tool, but not know where it might be available?
 The GTN has you covered with the Pan-Galactic Tool Search that is now available.
 
+**Update**: the authors were reminded of
+[GalaxyCat](https://galaxycat.france-bioinformatique.fr/) which does the same
+thing as the GTN but better! Please go use that.
+
+---
+
 We recently received a question online from our colleague [Dr. Scott Cain](https://github.com/scottcain)
 trying to find the *Manta* Structural Variant analysis tool amongst the Galaxies. While
 his complaints about generic names are very apt (and Galaxy existed before the

--- a/search-tools.html
+++ b/search-tools.html
@@ -3,6 +3,12 @@ layout: page
 title: Pan Galactic Tool Search
 ---
 
+
+<blockquote>
+<a href="https://galaxycat.france-bioinformatique.fr/">GalaxyCat</a> does the
+same thing as this search, but better! Please go use that. Their search includes EDAM operation filtering as well as other nice features.
+</blockquote>
+
 This allows you to search the list of tools available on the <a href="https://galaxyproject.org/use/">public Galaxy servers</a>,
 known to the Galaxy Hub. The list of tools is updated daily. These results
 include tools from the {{ site.data['public-server-tools'].servers | size }}


### PR DESCRIPTION
which I completely forgot existed (and is like, halfway impossible to find.) only findable if you know the name https://galaxyproject.org/search/?q=galaxycat#gsc.tab=0&gsc.q=galaxycat but hopefully the GTN can help the SEO here a bit.