### PR TITLE
FAIR intro: fix typos

### DIFF
--- a/_includes/extras.html
+++ b/_includes/extras.html
@@ -4,7 +4,7 @@
     </a>
     <div class="dropdown-menu dropdown-menu-right">
 
-        <a class="dropdown-item" href="{{ site.github_repository }}/edit/{{ site.github_repository_branch }}{{ page.path }}" title="Edit on GitHub">
+        <a class="dropdown-item" href="{{ site.github_repository }}/edit/{{ site.github_repository_branch }}/{{ page.path }}" title="Edit on GitHub">
           {% icon github %} Edit on GitHub
         </a>
 

--- a/topics/fair/tutorials/fair-intro/tutorial.md
+++ b/topics/fair/tutorials/fair-intro/tutorial.md
@@ -67,7 +67,7 @@ The level of accessibility and usability criteria distinguish open from FAIR dat
 
 ![](../../images/fair_open.png)
 
-Open data can be modify, and distribute for any reason. Although extensively used and accessible, FAIR data additionally includes the following usability standards that go beyond permission alone: 
+Open data can be modified, and distributed for any reason. Although extensively used and accessible, FAIR data additionally includes the following usability standards that go beyond permission alone: 
 
 - In order to be found and cited, FAIR data must be identified and deposited into online public records. 
 

--- a/topics/fair/tutorials/fair-intro/tutorial.md
+++ b/topics/fair/tutorials/fair-intro/tutorial.md
@@ -65,7 +65,7 @@ A report from the European Commission Expert Group on [FAIR data](https://zenodo
 ## Open data and FAIR
 The level of accessibility and usability criteria distinguish open from FAIR data. Open data is accessible without limitations, whereas FAIR data specifies certain requirements for access and use.
 
-![](../../images/fair_open.png)
+![text reading fair does not equal open](../../images/fair_open.png)
 
 Open data can be modified, and distributed for any reason. Although extensively used and accessible, FAIR data additionally includes the following usability standards that go beyond permission alone: 
 


### PR DESCRIPTION
Fixed two minor typos.

I also noticed that the "edit on github" link is broken on https://training.galaxyproject.org/training-material/topics/fair/tutorials/fair-intro/tutorial.html, there's a `/` missing