### PR TITLE
add a Webfinger endpoint, allowing mentioning fedi users by GTN handle

### DIFF
--- a/CONTRIBUTORS.yaml
+++ b/CONTRIBUTORS.yaml
@@ -44,6 +44,7 @@ abretaud:
       lat: 48.11
       lon: -1.64
     fediverse: https://genomic.social/@abretaud
+    fediverse_flavor: mastodon
 
 abdulrahmanazab:
     name: Abdulrahman Azab
@@ -205,6 +206,7 @@ bebatut:
       lat: 45.77
       lon: 3.08
     fediverse: https://piaille.fr/@bebatut
+    fediverse_flavor: mastodon
 
 bedroesb:
     name: Bert Droesbeke
@@ -623,6 +625,7 @@ hexylena:
     joined: 2017-09
     elixir_node: nl
     fediverse: https://galaxians.garden/hexylena
+    fediverse_flavor: akkoma
     contact_for_training: false
     location:
       country: NL
@@ -973,6 +976,7 @@ martenson:
       lat: 37.0
       lon: -122.0
     fediverse: https://mastodon.world/@martenson
+    fediverse_flavor: mastodon
     joined: 2017-09
 
 MarenStillger:
@@ -1437,6 +1441,7 @@ stain:
         lat: 53.46724379071192 
         lon: -2.233631283105614
     fediverse: https://scholar.social/@soilandreyes
+    fediverse_flavor: mastodon
 
 stephanierobin:
     name: Stéphanie Robin

--- a/_plugins/jekyll-webfinger.rb
+++ b/_plugins/jekyll-webfinger.rb
@@ -1,0 +1,48 @@
+Jekyll::Hooks.register :site, :post_write do |site|
+  # Make the directory
+  Jekyll.logger.info "Generating webfinger files"
+  FileUtils.mkdir_p "#{site.dest}/api/fedi"
+
+  site.data['contributors']
+    .select { |k, v| v['fediverse'] }
+    .each do |k, v|
+      # saving the outputs to
+      # training-material/api/fedi/resource=acct%3Ahexylena%40galaxy.training.json
+      path = "#{site.dest}/api/fedi/resource=acct:#{k}@training.galaxyproject.org.json"
+
+      subscribe_url = if v['fediverse_flavor'] == 'mastodon'
+                        "https://#{v['fediverse'].split('@')[1]}/users/#{k}/outbox"
+                        v['fediverse'].gsub(/\/@[a-z]*$/, '') + "/authorize_interaction?uri={uri}"
+                      else
+                        v['fediverse'].gsub(/\/[a-z]*$/, '') + "/ostatus_subscribe?acct={uri}"
+                      end
+      profile = {
+        "subject": "acct:#{k}@training.galaxyproject.org",
+        "aliases": [
+          v['fediverse'],
+        ],
+        "links": [
+          {
+            "rel": "http://webfinger.net/rel/profile-page",
+            "type": "text/html",
+            "href": v['fediverse']
+          },
+          {
+            "rel": "self",
+            "type": "application/activity+json",
+            "href": v['fediverse'] #ehhh
+          },
+          {
+            "rel": "self",
+            "type": "application/ld+json; profile=\"https://www.w3.org/ns/activitystreams\"",
+            "href": v['fediverse']
+          },
+          {
+            "rel": "http://ostatus.org/schema/1.0/subscribe",
+            "template": subscribe_url
+          }
+        ]
+      }
+      File.write(path, profile.to_json)
+  end
+end

--- a/bin/schema-contributors.yaml
+++ b/bin/schema-contributors.yaml
@@ -41,6 +41,12 @@ mapping:
                 description: The URL to your fediverse profile
                 examples:
                   - http://genomic.social/@abretaud
+            fediverse_flavor:
+                type: str
+                enum:
+                  - mastodon
+                  - akkoma
+                description: The flavor of the fediverse server (used in our webfinger endpoint.)
             bio:
                 type: str
                 description: |


### PR DESCRIPTION
This can make it easier to announce news on the fedi, as we can write things like "Thanks @abretaud@training.galaxyproject.org" and it'll mention @abretaud's account :)

requires https://github.com/galaxyproject/infrastructure-playbook/pull/44