### PR TITLE
Add single cell community site to the training page

### DIFF
--- a/topics/single-cell/metadata.yaml
+++ b/topics/single-cell/metadata.yaml
@@ -3,6 +3,7 @@ name: single-cell
 type: use
 title: Single Cell
 summary: Training material and practicals for all kinds of single cell analysis (particularly scRNA-seq!). When you generate your lovely gene lists for your cells, consider checking out our Transcriptomics tutorials for further network analysis!
+What else do you want to see? You can submit tool and/or tutorial requests, as well as up-vote requests from others at our [Single Cell Community Planning site](https://github.com/orgs/galaxyproject/projects/31/views/1).
 #docker_image: "quay.io/galaxy/transcriptomics-training"
 
 requirements:


### PR DESCRIPTION
I'm adding a GitHub project link to the training page for people to submit user requests more easily. It would be nice if this could become a wee box