### PR TITLE
Export ro-crate-metadata.json for building RO Crates of the Workflows

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -24,3 +24,6 @@ gem 'fastimage'
 
 # For our CLI tools
 gem 'commander'
+
+# RO-Crates
+gem 'rubyzip', '~> 2.3.0'

--- a/Gemfile
+++ b/Gemfile
@@ -5,7 +5,7 @@
 source 'https://rubygems.org'
 gem 'addressable'
 gem 'awesome_bot'
-gem 'html-proofer'
+gem 'html-proofer', '< 5.0.0' # No specific need, it adds a lot of extra deps that we don't really need.
 gem 'jekyll'
 gem 'jekyll-feed'
 gem 'jekyll-redirect-from'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -89,16 +89,15 @@ GEM
     public_suffix (5.0.3)
     racc (1.7.1)
     rainbow (3.1.1)
-    rake (13.0.6)
     rb-fsevent (0.11.2)
     rb-inotify (0.10.1)
       ffi (~> 1.0)
     rexml (3.2.6)
     rouge (4.1.3)
+    rubyzip (2.3.2)
     safe_yaml (1.0.5)
-    sass-embedded (1.68.0)
+    sass-embedded (1.68.0-x86_64-linux-gnu)
       google-protobuf (~> 3.23)
-      rake (>= 13.0.0)
     terminal-table (3.0.2)
       unicode-display_width (>= 1.1.1, < 3)
     typhoeus (1.4.0)
@@ -119,13 +118,14 @@ DEPENDENCIES
   commander
   csl-styles
   fastimage
-  html-proofer
+  html-proofer (< 5.0.0)
   jekyll
   jekyll-feed
   jekyll-redirect-from
   kwalify
   nokogiri (>= 1.10.4)
   pkg-config
+  rubyzip (~> 2.3.0)
   webrick
 
 BUNDLED WITH

--- a/Makefile
+++ b/Makefile
@@ -53,7 +53,7 @@ COND_ENV_DIR=$(shell dirname $(dir $(CONDA)))
 install: clean create-env ## install dependencies
 	$(ACTIVATE_ENV) && \
 		gem update --no-document --system && \
-		ICONV_LIBS="-L${CONDA_PREFIX}/lib/ -liconv" gem install --no-document addressable:'2.5.2' jekyll jekyll-feed jekyll-redirect-from csl-styles awesome_bot html-proofer pkg-config kwalify bibtex-ruby citeproc-ruby fastimage && \
+		ICONV_LIBS="-L${CONDA_PREFIX}/lib/ -liconv" gem install --no-document addressable:'2.5.2' jekyll jekyll-feed jekyll-redirect-from csl-styles awesome_bot html-proofer pkg-config kwalify bibtex-ruby citeproc-ruby fastimage rubyzip && \
 		pushd ${COND_ENV_DIR}/envs/${CONDA_ENV}/share/rubygems/bin && \
 		ln -sf ../../../bin/ruby ruby
 .PHONY: install

--- a/_plugins/api.rb
+++ b/_plugins/api.rb
@@ -379,52 +379,52 @@ Jekyll::Hooks.register :site, :post_write do |site|
 
       Jekyll.logger.debug "[GTN/API/WFRun] Writing #{path}"
 
-      uuids = workflow['creators'].map { |c|
-        if c.has_key?('identifier')
-          'https://orcid.org/' + c['identifier']
+      uuids = workflow['creators'].map do |c|
+        if c.key?('identifier')
+          "https://orcid.org/#{c['identifier']}"
         else
-          '#' + SecureRandom.uuid
+          "##{SecureRandom.uuid}"
         end
-      }
-      author_uuids = uuids.map{|u| { '@id' => "#{u}" } }
-      author_linked = workflow['creators'].map.with_index { |c, i| 
+      end
+      author_uuids = uuids.map { |u| { '@id' => u.to_s } }
+      author_linked = workflow['creators'].map.with_index do |c, i|
         {
-          '@id' => "#{uuids[i]}",
+          '@id' => (uuids[i]).to_s,
           '@type' => c['class'],
           'name' => c['name'],
         }
-      }
+      end
 
       crate = {
         '@context' => 'https://w3id.org/ro/crate/1.1/context',
         '@graph' => [
           {
-              "@id": "./",
-              "@type": "Dataset",
-              "datePublished": workflow['modified'],
+            '@id': './',
+            '@type': 'Dataset',
+            datePublished: workflow['modified'],
           },
           {
-              "@id": "ro-crate-metadata.json",
-              "@type": "CreativeWork",
-              "about": {
-                  "@id": "./"
-              },
-              "conformsTo": {
-                  "@id": "https://w3id.org/ro/crate/1.1"
-              }
+            '@id': 'ro-crate-metadata.json',
+            '@type': 'CreativeWork',
+            about: {
+              '@id': './'
+            },
+            conformsTo: {
+              '@id': 'https://w3id.org/ro/crate/1.1'
+            }
           },
           {
-              "@id": "#assembly-assembly-quality-control",
-              "@type": [
-                  "File",
-                  "SoftwareSourceCode",
-                  "ComputationalWorkflow"
-              ],
-              "author": author_uuids,
-              "license": workflow['license'] ? "https://spdx.org/licenses/#{workflow['license']}" : "https://spdx.org/licenses/CC-BY-4.0",
-              "name": workflow['name'],
-              "version": 0 # TODO
-          },
+            '@id': '#assembly-assembly-quality-control',
+            '@type': %w[
+              File
+              SoftwareSourceCode
+              ComputationalWorkflow
+            ],
+            author: author_uuids,
+            license: workflow['license'] ? "https://spdx.org/licenses/#{workflow['license']}" : 'https://spdx.org/licenses/CC-BY-4.0',
+            name: workflow['name'],
+            version: 0 # TODO
+          }
         ]
       }
       crate['@graph'] += author_linked

--- a/_plugins/api.rb
+++ b/_plugins/api.rb
@@ -421,7 +421,7 @@ Jekyll::Hooks.register :site, :post_write do |site|
                   "ComputationalWorkflow"
               ],
               "author": author_uuids,
-              "license": workflow['license'],
+              "license": workflow['license'] ? "https://spdx.org/licenses/#{workflow['license']}" : "https://spdx.org/licenses/CC-BY-4.0",
               "name": workflow['name'],
               "version": 0 # TODO
           },

--- a/_plugins/api.rb
+++ b/_plugins/api.rb
@@ -380,7 +380,7 @@ Jekyll::Hooks.register :site, :post_write do |site|
       Jekyll.logger.debug "[GTN/API/WFRun] Writing #{path}"
 
       uuids = workflow['creators'].map do |c|
-        if c.key?('identifier')
+        if c.key?('identifier') && !c['identifier'].empty?
           "https://orcid.org/#{c['identifier']}"
         else
           "##{SecureRandom.uuid}"
@@ -423,7 +423,7 @@ Jekyll::Hooks.register :site, :post_write do |site|
             author: author_uuids,
             license: workflow['license'] ? "https://spdx.org/licenses/#{workflow['license']}" : 'https://spdx.org/licenses/CC-BY-4.0',
             name: workflow['name'],
-            version: 0 # TODO
+            version: Gtn::ModificationTimes.obtain_modification_count(workflow['path'])
           }
         ]
       }

--- a/_plugins/api.rb
+++ b/_plugins/api.rb
@@ -377,19 +377,18 @@ Jekyll::Hooks.register :site, :post_write do |site|
       # {"workflow"=>"galaxy-workflow-mouse_novel_peptide_analysis.ga",
       # "tests"=>false,
       # "url"=>
-      # "http://0.0.0.0:4002/training-material/topics/proteomics/tutorials/proteogenomics-novel-peptide-analysis/workflows/galaxy-workflow-mouse_novel_peptide_analysis.ga",
+      # "http://0.0.0.0:4002/training-material/topics/.../workflows/galaxy-workflow-mouse_novel_peptide_analysis.ga",
       # "path"=>
-      # "topics/proteomics/tutorials/proteogenomics-novel-peptide-analysis/workflows/galaxy-workflow-mouse_novel_peptide_analysis.ga",
+      # "topics/proteomics/tutorials/.../galaxy-workflow-mouse_novel_peptide_analysis.ga",
       # "wfid"=>"proteomics-proteogenomics-novel-peptide-analysis",
       # "wfname"=>"galaxy-workflow-mouse_novel_peptide_analysis",
       # "trs_endpoint"=>
-      # "http://0.0.0.0:4002/training-material/api/ga4gh/trs/v2/tools/proteomics-proteogenomics-novel-peptide-analysis/versions/galaxy-workflow-mouse_novel_peptide_analysis",
+      # "http://0.0.0.0:4002/training-material/api/.../versions/galaxy-workflow-mouse_novel_peptide_analysis",
       # "license"=>nil,
       # "creators"=>[],
       # "name"=>"GTN Proteogemics3 Novel Peptide Analysis",
       # "test_results"=>nil,
       # "modified"=>2023-06-07 12:09:36.12 +0200}
-
 
       wfdir = File.join(dir, wfid, wfname)
       FileUtils.mkdir_p(wfdir)
@@ -429,11 +428,11 @@ Jekyll::Hooks.register :site, :post_write do |site|
             },
             conformsTo: [
               {
-              '@id': 'https://w3id.org/ro/crate/1.1'
-            },
-            {
-              "@id": "https://about.workflowhub.eu/Workflow-RO-Crate/"
-            }
+                '@id': 'https://w3id.org/ro/crate/1.1'
+              },
+              {
+                '@id': 'https://about.workflowhub.eu/Workflow-RO-Crate/'
+              }
             ]
           },
           {
@@ -458,12 +457,12 @@ Jekyll::Hooks.register :site, :post_write do |site|
             ],
             author: author_uuids,
             license: {
-              "@id": license,
+              '@id': license,
             },
             name: workflow['name'],
             version: Gtn::ModificationTimes.obtain_modification_count(workflow['path']),
             programmingLanguage: {
-                "@id": "https://w3id.org/workflowhub/workflow-ro-crate#galaxy"
+              '@id': 'https://w3id.org/workflowhub/workflow-ro-crate#galaxy'
             }
           },
           {
@@ -472,26 +471,26 @@ Jekyll::Hooks.register :site, :post_write do |site|
             name: workflow['license'],
           },
           {
-              "@id": "https://w3id.org/workflowhub/workflow-ro-crate#galaxy",
-              "@type": "ComputerLanguage",
-              "identifier": {
-                  "@id": "https://galaxyproject.org/"
-              },
-              "name": "Galaxy",
-              "url": {
-                  "@id": "https://galaxyproject.org/"
-              },
-              "version": "23.1"
+            '@id': 'https://w3id.org/workflowhub/workflow-ro-crate#galaxy',
+            '@type': 'ComputerLanguage',
+            identifier: {
+              '@id': 'https://galaxyproject.org/'
+            },
+            name: 'Galaxy',
+            url: {
+              '@id': 'https://galaxyproject.org/'
+            },
+            version: '23.1'
           }
         ]
       }
       crate['@graph'] += author_linked
       File.write(path, JSON.pretty_generate(crate))
 
-      zip_path = File.join(wfdir, "rocrate.zip")
+      zip_path = File.join(wfdir, 'rocrate.zip')
       Zip::File.open(zip_path, create: true) do |zipfile|
-          # - The name of the file as it will appear in the archive
-          # - The original file, including the path to find it
+        # - The name of the file as it will appear in the archive
+        # - The original file, including the path to find it
         zipfile.add('ro-crate-metadata.json', path)
         zipfile.add("#{wfname}.ga", workflow['path'])
       end

--- a/_plugins/api.rb
+++ b/_plugins/api.rb
@@ -398,23 +398,41 @@ Jekyll::Hooks.register :site, :post_write do |site|
       crate = {
         '@context' => 'https://w3id.org/ro/crate/1.1/context',
         '@graph' => [
-          {
-            '@id': './',
-            '@type': 'Dataset',
-            datePublished: workflow['modified'],
-          },
+          # {
+          #   '@id': './',
+          #   '@type': 'Dataset',
+          #   datePublished: workflow['modified'],
+          # },
           {
             '@id': 'ro-crate-metadata.json',
             '@type': 'CreativeWork',
             about: {
               '@id': './'
             },
-            conformsTo: {
+            conformsTo: [
+              {
               '@id': 'https://w3id.org/ro/crate/1.1'
+            },
+            {
+              "@id": "https://about.workflowhub.eu/Workflow-RO-Crate/"
+            }
+            ]
+          },
+          {
+            '@id': './',
+            '@type': 'Dataset',
+            datePublished: workflow['modified'].strftime('%Y-%m-%dT%H:%M:%S.%L%:z'),
+            # hasPart: [
+            #   {
+            #     '@id': '#assembly-assembly-quality-control'
+            #   }
+            # ],
+            mainEntity: {
+              '@id': '#' + wfid
             }
           },
           {
-            '@id': '#assembly-assembly-quality-control',
+            '@id': '#' + wfid,
             '@type': %w[
               File
               SoftwareSourceCode
@@ -423,7 +441,22 @@ Jekyll::Hooks.register :site, :post_write do |site|
             author: author_uuids,
             license: workflow['license'] ? "https://spdx.org/licenses/#{workflow['license']}" : 'https://spdx.org/licenses/CC-BY-4.0',
             name: workflow['name'],
-            version: Gtn::ModificationTimes.obtain_modification_count(workflow['path'])
+            version: Gtn::ModificationTimes.obtain_modification_count(workflow['path']),
+            programmingLanguage: {
+                "@id": "https://w3id.org/workflowhub/workflow-ro-crate#galaxy"
+            }
+          },
+          {
+              "@id": "https://w3id.org/workflowhub/workflow-ro-crate#galaxy",
+              "@type": "ComputerLanguage",
+              "identifier": {
+                  "@id": "https://galaxyproject.org/"
+              },
+              "name": "Galaxy",
+              "url": {
+                  "@id": "https://galaxyproject.org/"
+              },
+              "version": "23.1"
           }
         ]
       }

--- a/_plugins/gtn.rb
+++ b/_plugins/gtn.rb
@@ -274,9 +274,7 @@ module Jekyll
 
     def convert_to_material_list(site, materials)
       # [{"name"=>"introduction", "topic"=>"admin"}]
-      if materials.nil?
-        return []
-      end
+      return [] if materials.nil?
 
       materials.map do |m|
         if m.key?('name') && m.key?('topic')

--- a/_plugins/gtn/mod.rb
+++ b/_plugins/gtn/mod.rb
@@ -16,7 +16,7 @@ module Gtn
       puts '[GTN/MOD] Filling Time Cache'
       `git log --name-only --pretty='GTN_GTN:%ct'`
         .split('GTN_GTN:')
-        .map { |x| x.split(/\n\n/) }
+        .map { |x| x.split("\n\n") }
         .select { |x| x.length > 1 }
         .each do |date, files|
         files.split(/\n/).each do |f|

--- a/_plugins/jekyll-topic-filter.rb
+++ b/_plugins/jekyll-topic-filter.rb
@@ -480,7 +480,9 @@ module TopicFilter
           'trs_endpoint' => "#{domain}/#{trs}",
           'license' => license,
           'creators' => creators,
+          'name' => wf_json['name'],
           'test_results' => workflow_test_outputs,
+          'modified' => File.mtime(wf_path),
         }
       end
     end

--- a/_plugins/jekyll-topic-filter.rb
+++ b/_plugins/jekyll-topic-filter.rb
@@ -506,11 +506,11 @@ module TopicFilter
     page_obj['tools'] = page_obj['tools'].flatten.sort.uniq
 
     topic = site.data[page_obj['topic_name']]
-    if topic['type'] == 'use' || topic['type'] == 'basics'
-      page_obj['supported_servers'] = Gtn::Supported.calculate(site.data['public-server-tools'], page_obj['tools'])
-    else
-      page_obj['supported_servers'] = []
-    end
+    page_obj['supported_servers'] = if topic['type'] == 'use' || topic['type'] == 'basics'
+                                      Gtn::Supported.calculate(site.data['public-server-tools'], page_obj['tools'])
+                                    else
+                                      []
+                                    end
 
     topic_name_human = site.data[page_obj['topic_name']]['title']
     page_obj['topic_name_human'] = topic_name_human # TODO: rename 'topic_name' and 'topic_name' to 'topic_id'

--- a/_plugins/notebook.rb
+++ b/_plugins/notebook.rb
@@ -526,7 +526,7 @@ module GTNNotebooks
           cell['source'].gsub!(/<img src="(\.\.[^"]*)/) do |img|
             path = img[10..]
             image_path = File.join(dir, path)
-        
+
             if img[-3..].downcase == 'png'
               # puts "[GTN/Notebook/Images] Embedding png: #{img}"
               data = Base64.encode64(File.binread(image_path))


### PR DESCRIPTION
Based on the example by @supernord, fyi @uwwint

This currently doesn't feel terribly complete, e.g. 

- no workflow is directly mentioned (we can point to a URL? how do we do that?), should that look like the example here? https://www.researchobject.org/ro-crate/1.1/workflows.html#complete-workflow-example
- Should we provide a zip? is that the useful artefact for WFH, or is the json fine (and it will lookup/fetch the galaxy workflow file itself)
- Not sure what we should do about the `version` field, that's... complicated to detect a good linear number over time. We could probably detect # of commits to that file and use that as the version, probably the safest to ensure changes are detected properly.
- and of course, how do we get that into WFH.