### PR TITLE
Small update to cron job for cleanup

### DIFF
--- a/topics/admin/tutorials/backup-cleanup/tutorial.md
+++ b/topics/admin/tutorials/backup-cleanup/tutorial.md
@@ -129,7 +129,7 @@ tutorial]({% link topics/admin/tutorials/gxadmin/tutorial.md %}).
 >    +        user: galaxy # Run as the Galaxy user
 >    +        minute: "0"
 >    +        hour: "0"
->    +        job: "GALAXY_LOG_DIR=/tmp/gxadmin/ GALAXY_ROOT={{ galaxy_root }}/server /usr/local/bin/gxadmin galaxy cleanup 60"
+>    +        job: "SHELL=/bin/bash source {{ galaxy_venv_dir }}/bin/activate &&  GALAXY_LOG_DIR=/tmp/gxadmin/ GALAXY_ROOT={{ galaxy_root }}/server GALAXY_CONFIG_FILE={{ galaxy_config_file }} /usr/local/bin/gxadmin galaxy cleanup 60"
 >    {% endraw %}
 >    ```
 >    {: data-commit="Configure gxadmin to cleanup data"}


### PR DESCRIPTION
`gxadmin galaxy cleanup` requires some python scripts which require dependencies installed in the virtual env unless these are all covered by pre-task? If the latter is the case please ignore and close. If not, then it's possible better to move this to one of the `galaxyproject.galaxy` tasks?
