### PR TITLE
use igraph instead of python-igraph, as the latter name is deprecated for "pip install"

### DIFF
--- a/topics/single-cell/tutorials/scrna-case_JUPYTER-trajectories/tutorial.md
+++ b/topics/single-cell/tutorials/scrna-case_JUPYTER-trajectories/tutorial.md
@@ -65,7 +65,7 @@ pip install scanpy
 pip install fa2
 ```
 ```python
-pip install python-igraph
+pip install igraph
 ```
 ```python
 pip install louvain


### PR DESCRIPTION
Please see https://github.com/igraph/python-igraph/issues/699 for why this is necessary.