### PR TITLE
Adding banner to show that FTP is no longer supported on UseGalaxy.org

### DIFF
--- a/faqs/galaxy/datasets_upload_ftp.md
+++ b/faqs/galaxy/datasets_upload_ftp.md
@@ -3,27 +3,31 @@ title: Upload many files (>10) via FTP
 area: data upload
 box_type: tip
 layout: faq
-contributors: [bebatut]
+contributors: [bebatut, shiltemann]
 ---
 
-<div class="alert alert-success trim-p" role="alert">
-UPDATE: FTP upload is no longer supported on UseGalaxy.org. For more information and to learn about alternative options, please see https://help.galaxyproject.org/t/the-usegalaxy-org-ftp-service-will-be-decommissioned-on-august-12-2022/8318.
-</div>
+Some Galaxies offer FTP upload for very large datasets.
 
-1. Make sure to have an FTP client installed
+1. Check that your Galaxy supports FTP upload and look up the FTP settings.
+   - **Galaxy EU** (usegalaxy.eu): [FTP settings](https://usegalaxy-eu.github.io/ftp/)
+   - **Galaxy Australia** (usegalaxy.org.au): [FTP settings](https://usegalaxy-au.github.io/posts/2019/03/18/new-ftp-upload-url/plain.html)
+   - **Galaxy Main** (usegalaxy.org): [FTP no longer supported, command-line upload available](https://help.galaxyproject.org/t/the-usegalaxy-org-ftp-service-will-be-decommissioned-on-august-12-2022/8318)
+   - **Other Galaxies**: check the homepage of your Galaxy or contact one of the Galaxy administrators.
+
+2. Make sure to have an FTP client installed
 
     There are many options. We can recommend [FileZilla](https://filezilla-project.org/), a free FTP client that is available on Windows, MacOS, and Linux.
 
-2. Establish FTP connection to the Galaxy server
-    1. Provide the Galaxy server's FTP server name (e.g. `usegalaxy.org`, `ftp.usegalaxy.eu`)
+3. Establish FTP connection to the Galaxy server
+    1. Provide the Galaxy server's FTP server name (e.g. `ftp.usegalaxy.eu`)
     2. Provide the **username** (usually the email address) and the **password** on the Galaxy server
     3. Connect
 
-3. Add the files to the FTP server by dragging/dropping them or right clicking on them and uploading them
+4. Add the files to the FTP server by dragging/dropping them or right clicking on them and uploading them
 
     The FTP transfer will start. We need to wait until they are done.
 
-4. Open the Upload menu on the Galaxy server
-5. Click on **Choose FTP file** on the bottom
-6. Select files to import into the history
-7. Click on **Start**
+5. Open the Upload menu on the Galaxy server
+6. Click on **Choose FTP file** on the bottom
+7. Select files to import into the history
+8. Click on **Start**

--- a/faqs/galaxy/datasets_upload_ftp.md
+++ b/faqs/galaxy/datasets_upload_ftp.md
@@ -8,12 +8,12 @@ contributors: [bebatut, shiltemann]
 
 Some Galaxies offer FTP upload for very large datasets.
 
-Note that the *"Big Three"* Galaxies (Galaxy Main, Galaxy EU, and Galaxy Australia) no longer support FTP upload, due to the recent improvements
-of the standard web upload, which should now support large file uploads and almost all use cases.
+**Note:** the *"Big Three"* Galaxies (Galaxy Main, Galaxy EU, and Galaxy Australia) no longer support FTP upload, due to the recent improvements
+of the default web upload, which should now support large file uploads and almost all use cases. For situations where uploading via the web
+interface is too tedious, the
+[galaxy-upload commandline utility](https://github.com/galaxyproject/galaxy-upload) is also available as an alternative to FTP.
 
-As an alternative to FTP upload for when uploading via the web interface is too tedious, the
-[galaxy-upload commandline utility](https://github.com/galaxyproject/galaxy-upload) is also available.
-
+To upload files via FTP, please
 
 1. Check that your Galaxy supports FTP upload and look up the FTP settings.
 

--- a/faqs/galaxy/datasets_upload_ftp.md
+++ b/faqs/galaxy/datasets_upload_ftp.md
@@ -8,19 +8,22 @@ contributors: [bebatut, shiltemann]
 
 Some Galaxies offer FTP upload for very large datasets.
 
+Note that the *"Big Three"* Galaxies (Galaxy Main, Galaxy EU, and Galaxy Australia) no longer support FTP upload, due to the recent improvements
+of the standard web upload, which should now support large file uploads and almost all use cases.
+
+As an alternative to FTP upload for when uploading via the web interface is too tedious, the
+[galaxy-upload commandline utility](https://github.com/galaxyproject/galaxy-upload) is also available.
+
+
 1. Check that your Galaxy supports FTP upload and look up the FTP settings.
-   - **Galaxy EU** (usegalaxy.eu): [FTP settings](https://usegalaxy-eu.github.io/ftp/)
-   - **Galaxy Australia** (usegalaxy.org.au): [FTP settings](https://usegalaxy-au.github.io/posts/2019/03/18/new-ftp-upload-url/plain.html)
-   - **Galaxy Main** (usegalaxy.org): [FTP no longer supported, command-line upload available](https://help.galaxyproject.org/t/the-usegalaxy-org-ftp-service-will-be-decommissioned-on-august-12-2022/8318)
-   - **Other Galaxies**: check the homepage of your Galaxy or contact one of the Galaxy administrators.
 
 2. Make sure to have an FTP client installed
 
     There are many options. We can recommend [FileZilla](https://filezilla-project.org/), a free FTP client that is available on Windows, MacOS, and Linux.
 
 3. Establish FTP connection to the Galaxy server
-    1. Provide the Galaxy server's FTP server name (e.g. `ftp.usegalaxy.eu`)
-    2. Provide the **username** (usually the email address) and the **password** on the Galaxy server
+    1. Provide the Galaxy server's FTP server name (e.g. `ftp.mygalaxy.com`)
+    2. Provide the **username** (usually the e-mail address) and the **password** on the Galaxy server
     3. Connect
 
 4. Add the files to the FTP server by dragging/dropping them or right clicking on them and uploading them

--- a/faqs/galaxy/datasets_upload_ftp.md
+++ b/faqs/galaxy/datasets_upload_ftp.md
@@ -6,6 +6,10 @@ layout: faq
 contributors: [bebatut]
 ---
 
+<div class="alert alert-success trim-p" role="alert">
+UPDATE: FTP upload is no longer supported on UseGalaxy.org. For more information and to learn about alternative options, please see https://help.galaxyproject.org/t/the-usegalaxy-org-ftp-service-will-be-decommissioned-on-august-12-2022/8318.
+</div>
+
 1. Make sure to have an FTP client installed
 
     There are many options. We can recommend [FileZilla](https://filezilla-project.org/), a free FTP client that is available on Windows, MacOS, and Linux.


### PR DESCRIPTION
Since FTP is no longer supported on UseGalaxy.org, we are adding banners to let users know and direct them to alternatives.
