### PR TITLE
Add internal linking section

### DIFF
--- a/topics/contributing/tutorials/create-new-tutorial-content/tutorial.md
+++ b/topics/contributing/tutorials/create-new-tutorial-content/tutorial.md
@@ -397,7 +397,7 @@ If you want to link to other training material within your text, please use the 
 ```
 {%endraw%}
 
-(Note the `.md` extension, and not `.html`)
+(Note the `.md` extension, and not `.html`, always provide the file name here, it will automatically be converted to the correct link)
 
 If you want to link to a specific section in a tutorial using an anchor (e.g. `#getting-started`), place it outside of the {%raw%}`{% link %}`{%endraw%} tag:
 

--- a/topics/contributing/tutorials/create-new-tutorial-content/tutorial.md
+++ b/topics/contributing/tutorials/create-new-tutorial-content/tutorial.md
@@ -389,11 +389,24 @@ The rendered table is then given as a minimum-width and centred matrix:
 
 ## Internally linking to other training material
 
-If you want to link to other training material within your text, you can use the following, but inputting the correct file location:
+If you want to link to other training material within your text, please use the {%raw%}`{% link path/to/file.ext %}`{%endraw%} tag:
 
+{%raw%}
 ```markdown
-{% link topics/single-cell/tutorials/scrna-case_monocle3-trajectories/tutorial.md %}
+[link text]( {% link topics/single-cell/tutorials/scrna-case_monocle3-trajectories/tutorial.md %} )
 ```
+{%endraw%}
+
+(Note the `.md` extension, and not `.html`)
+
+If you want to link to a specific section in a tutorial using an anchor (e.g. `#getting-started`), place it outside of the {%raw%}`{% link %}`{%endraw%} tag:
+
+{%raw%}
+```markdown
+[link text]({% link topics/single-cell/tutorials/scrna-case_monocle3-trajectories/tutorial.md %}#section-name)
+```
+{%endraw%}
+
 
 # Improving the learning experience with Boxes
 

--- a/topics/contributing/tutorials/create-new-tutorial-content/tutorial.md
+++ b/topics/contributing/tutorials/create-new-tutorial-content/tutorial.md
@@ -387,6 +387,14 @@ The rendered table is then given as a minimum-width and centred matrix:
 > | Feat3 | 2    | 3    | 4    |
 {: .matrix}
 
+## Internally linking to other training material
+
+If you want to link to other training material within your text, you can use the following, but inputting the correct file location:
+
+```markdown
+{% link topics/single-cell/tutorials/scrna-case_monocle3-trajectories/tutorial.md %}
+```
+
 # Improving the learning experience with Boxes
 
 To improve the learning experience in our tutorial, we define some boxes to highlight content.


### PR DESCRIPTION
This is super minor, but useful for tutorial creators to remember how to internally link to other tutorials without just copying the actual link.