### PR TITLE
TB Variant Analysis: Update tb_variant_filter to v. 0.4.0

### DIFF
--- a/topics/variant-analysis/tutorials/tb-variant-analysis/tutorial.md
+++ b/topics/variant-analysis/tutorials/tb-variant-analysis/tutorial.md
@@ -247,7 +247,7 @@ gene annotation from the [H37Rv strain](https://www.ncbi.nlm.nih.gov/nuccore/NC_
 We still cannot entirely trust the proposed variants. In particular, there are regions of the *M. tuberculosis* genome that are difficult to effectively map reads to. These include the PE/PPE/PGRS genes, which are highly repetitive, and the IS (insertion sequence sites). Secondly, when an insertion or deletion (indel) occurs in our sample relative to the reference it can cause apparent, but false, single nucleotide variants to appear near the indel. Finally where few reads map to a region of the reference genome, either because of a sequence deletion or because of a high GC content in the genomic region, we cannot be confident about the quality of variant calling in the region. The `TB Variant Filter` can help filter out variants based on a variety of criteria, including those listed above.
 
 > <hands-on-title>Run Snippy</hands-on-title>
-> 1. {% tool [TB Variant Filter](toolshed.g2.bx.psu.edu/repos/iuc/tb_variant_filter/tb_variant_filter/0.3.6+galaxy0) %} with the following parameters
+> 1. {% tool [TB Variant Filter](toolshed.g2.bx.psu.edu/repos/iuc/tb_variant_filter/tb_variant_filter/0.4.0+galaxy0) %} with the following parameters
 >   - *"VCF file to be filter"*: `snippy on data XX, data XX, and data XX mapped reads vcf file`
 >   - *"Filters to apply"*: Select `Filter variants by region` and `Filter sites by read alignment depth`.
 >

--- a/topics/variant-analysis/tutorials/tb-variant-analysis/workflows/tb-variant-analysis.ga
+++ b/topics/variant-analysis/tutorials/tb-variant-analysis/workflows/tb-variant-analysis.ga
@@ -580,7 +580,7 @@
         },
         "11": {
             "annotation": "",
-            "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/tb_variant_filter/tb_variant_filter/0.3.6+galaxy0",
+            "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/tb_variant_filter/tb_variant_filter/0.4.0+galaxy0",
             "errors": null,
             "id": 11,
             "input_connections": {
@@ -617,13 +617,13 @@
             },
             "tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/tb_variant_filter/tb_variant_filter/0.3.6+galaxy0",
             "tool_shed_repository": {
-                "changeset_revision": "ee4a90760848",
+                "changeset_revision": "32f14a2723ec",
                 "name": "tb_variant_filter",
                 "owner": "iuc",
                 "tool_shed": "toolshed.g2.bx.psu.edu"
             },
             "tool_state": "{\"filter_options\": {\"show_filter_options\": \"no\", \"__current_case__\": 1}, \"filters\": [\"region_filter\", \"close_to_indel_filter\", \"min_depth_filter\"], \"input1\": {\"__class__\": \"ConnectedValue\"}, \"__page__\": null, \"__rerun_remap_job_id__\": null}",
-            "tool_version": "0.3.6+galaxy0",
+            "tool_version": "0.4.0+galaxy0",
             "type": "tool",
             "uuid": "c50ba675-3d30-4ea3-9d96-71285287e3a2",
             "workflow_outputs": []


### PR DESCRIPTION
Minor update to TB Variant Analysis tutorial that updates tb_variant_filter version to 0.4.0. (The changes in the updated tool are not needed for this tutorial because it uses Snippy / FreeBayes VCF, but the update is made just to ensure we track the upstream tool version)