### PR TITLE
Fix for tutorial nav back button

### DIFF
--- a/assets/css/slides.scss
+++ b/assets/css/slides.scss
@@ -184,7 +184,7 @@ body.remark-container {
 		font-size: 10pt;
 		position: absolute;
 		left: 15px;
-		bottom: 2px;
+		display: flex;
 	}
 
 	.remark-slide-number {


### PR DESCRIPTION
- Quick fix for overlapping icons on GTN.
- Related to [this issue](https://github.com/galaxyproject/galaxy/issues/16634) on the main Galaxy repo.
- Putting PR in "draft" until @shiltemann has time to preview.
- Preview of suggested change below:

![screenshot_Before_After](https://github.com/galaxyproject/training-material/assets/3672779/2e615502-9c50-431d-8ac5-20eab53f6248)

