### PR TITLE
fix figcaption complaints

### DIFF
--- a/_plugins/jekyll-figurify.rb
+++ b/_plugins/jekyll-figurify.rb
@@ -45,7 +45,6 @@ module Jekyll
             #{alt}
           </object>
           </div>
-          <small><a target="_blank" href="#{url}">Open image in new tab</a></small>
         )
       else
         %(
@@ -81,9 +80,8 @@ module Jekyll
 
           %(
             <figure id="figure-#{num_figure}" style="max-width: 90%; margin:auto;">
-              <a href="#{url}" rel="noopener noreferrer">
               #{image}
-              </a>
+              <a target="_blank" href="#{url}" rel="noopener noreferrer"><small>Open image in new tab</small></a>
               <figcaption>
                 <span class="figcaption-prefix"><strong>#{prefix}#{num_figure}</strong>:</span> #{title}
               </figcaption>

--- a/_plugins/jekyll-figurify.rb
+++ b/_plugins/jekyll-figurify.rb
@@ -80,14 +80,14 @@ module Jekyll
           image = insert_image(url, alt, style, dimensions, actual_path)
 
           %(
-          <a href="#{url}" rel="noopener noreferrer">
             <figure id="figure-#{num_figure}" style="max-width: 90%; margin:auto;">
+              <a href="#{url}" rel="noopener noreferrer">
               #{image}
+              </a>
               <figcaption>
                 <span class="figcaption-prefix"><strong>#{prefix}#{num_figure}</strong>:</span> #{title}
               </figcaption>
             </figure>
-          </a>
           ).split("\n").map(&:strip).join
         end
       end


### PR DESCRIPTION
yeah this was wrong semantically. we should have something in the pipeline to check the validity of our html at some point eh, we have a number of complaints on [w3's validator](https://validator.w3.org/nu/?doc=https%3A%2F%2Ftraining.galaxyproject.org%2Ftraining-material%2Ftopics%2Fintroduction%2Ftutorials%2Fgalaxy-intro-short%2Ftutorial.html). At least half will be fixed by this PR.

We have an "html-validator" ruby library as part of the GTN but that's actually quite misleading, it doesn't validate the whole HTML, just parts of it :/