### PR TITLE
remove single cell tag from tutorials

### DIFF
--- a/_plugins/jekyll-jsonld.rb
+++ b/_plugins/jekyll-jsonld.rb
@@ -185,7 +185,7 @@ module Jekyll
         url: "#{site['url']}#{site['baseurl']}#{page['url']}",
         name: page['title'],
         headline: page.excerpt[0..100].gsub(/\n/, ' '), # TODO: remove html tags.
-        keywords: page.fetch('tags', []),
+        keywords: page['tags'] || [],
         description: page.excerpt[0..100].gsub(/\n/, ' '), # TODO: remove html tags
         articleBody: page.content, # TODO: remove html tags
         datePublished: page.date,
@@ -395,7 +395,7 @@ module Jekyll
         end
 
         # Keywords
-        data['keywords'] = [topic['name']] + material.fetch('tags', [])
+        data['keywords'] = [topic['name']] + (material['tags'] || [])
         data['keywords'] = data['keywords'].join(', ')
         # Zenodo links
         if material.key?('zenodo_link')
@@ -532,7 +532,7 @@ module Jekyll
       data['about'] = about
 
       data['educationalLevel'] = material.key?('level') ? eduLevel[material['level']] : 'Introductory'
-      data['mentions'] = material.fetch('tags', []).map { |x| { '@type': 'Thing', name: x } }
+      data['mentions'] = (material['tags'] || []).map { |x| { '@type': 'Thing', name: x } }
       data['abstract'] = material['content'].split("\n").first
 
       JSON.pretty_generate(data)

--- a/_plugins/jekyll-topic-filter.rb
+++ b/_plugins/jekyll-topic-filter.rb
@@ -610,7 +610,7 @@ module TopicFilter
   #
   def self.list_all_tags(site)
     materials = process_pages(site, site.pages)
-    materials.map { |x| x.fetch('tags', []) }.flatten.sort.uniq
+    materials.map { |x| (x['tags'] || []) }.flatten.sort.uniq
   end
 
   def self.filter_by_topic(site, topic_name)
@@ -622,7 +622,7 @@ module TopicFilter
     resource_pages = materials.select { |x| x['topic_name'] == topic_name }
 
     # If there is nothing with that topic name, try generating it by tags.
-    resource_pages = materials.select { |x| x.fetch('tags', []).include?(topic_name) } if resource_pages.empty?
+    resource_pages = materials.select { |x| (x['tags'] || []).include?(topic_name) } if resource_pages.empty?
 
     # The complete resources we'll return is the introduction slides first
     # (EDIT: not anymore, we rely on prioritisation!)
@@ -640,7 +640,7 @@ module TopicFilter
     materials = process_pages(site, site.pages)
 
     # If there is nothing with that topic name, try generating it by tags.
-    resource_pages = materials.select { |x| x.fetch('tags', []).include?(topic_name) }
+    resource_pages = materials.select { |x| (x['tags'] || []).include?(topic_name) }
 
     # The complete resources we'll return is the introduction slides first
     # (EDIT: not anymore, we rely on prioritisation!)

--- a/_plugins/notebook-jupyter.rb
+++ b/_plugins/notebook-jupyter.rb
@@ -48,7 +48,7 @@ def jupyter_pre_render(site)
     notebook_language = page.data['notebook'].fetch('language', 'python')
 
     # Tag our source page
-    page.data['tags'] = [] unless page.data.key? 'tags'
+    page.data['tags'] = page.data['tags'] || []
     page.data['tags'].push('jupyter-notebook')
 
     puts "[GTN/Notebooks] Rendering #{notebook_language} #{fn}"

--- a/_plugins/notebook-rmarkdown.rb
+++ b/_plugins/notebook-rmarkdown.rb
@@ -17,7 +17,7 @@ module Jekyll
         fn = File.join('.', page.url).sub(/html$/, 'Rmd')
 
         # Tag our source page
-        page.data['tags'] = [] unless page.data.key? 'tags'
+        page.data['tags'] = page.data['tags'] || []
         page.data['tags'].push('rmarkdown-notebook')
 
         puts "[GTN/Notebooks/R] Rendering RMarkdown #{fn}"

--- a/_plugins/search.rb
+++ b/_plugins/search.rb
@@ -14,9 +14,7 @@ module Jekyll
     end
 
     def getlist(tutorial, attr)
-      [] if tutorial[attr].nil?
-
-      tutorial.fetch(attr, [])
+      tutorial[attr] || []
     end
 
     def render(context)

--- a/topics/single-cell/tutorials/bulk-music-2-preparescref/tutorial.md
+++ b/topics/single-cell/tutorials/bulk-music-2-preparescref/tutorial.md
@@ -37,7 +37,6 @@ follow_up_training:
         - bulk-music-3-preparebulk
 
 tags:
-  - single-cell
   - transcriptomics
   - data management
 ---

--- a/topics/single-cell/tutorials/bulk-music-3-preparebulk/tutorial.md
+++ b/topics/single-cell/tutorials/bulk-music-3-preparebulk/tutorial.md
@@ -25,7 +25,6 @@ contributions:
     - MarisaJL
 
 tags:
-  - single-cell
   - transcriptomics
   - data management
 

--- a/topics/single-cell/tutorials/bulk-music-4-compare/tutorial.md
+++ b/topics/single-cell/tutorials/bulk-music-4-compare/tutorial.md
@@ -5,7 +5,6 @@ priority: 4
 title: Comparing inferred cell compositions using MuSiC deconvolution
 zenodo_link: https://zenodo.org/record/7319925
 tags:
-  - single-cell
   - transcriptomics
 questions:
 - How do the cell type distributions vary in bulk RNA samples across my variable of interest?

--- a/topics/single-cell/tutorials/bulk-music/tutorial.md
+++ b/topics/single-cell/tutorials/bulk-music/tutorial.md
@@ -7,7 +7,6 @@ redirect_from:
 priority: 1
 zenodo_link: https://zenodo.org/record/5719228
 tags:
-  - single-cell
   - transcriptomics
 questions:
 - How do we infer cell type proportions from bulk RNA-seq data?

--- a/topics/single-cell/tutorials/scanpy_parameter_iterator/tutorial.md
+++ b/topics/single-cell/tutorials/scanpy_parameter_iterator/tutorial.md
@@ -34,7 +34,6 @@ key_points:
 
 
 tags:
-- single-cell
 
 contributions:
   authorship:

--- a/topics/single-cell/tutorials/scatac-preprocessing-tenx/tutorial.md
+++ b/topics/single-cell/tutorials/scatac-preprocessing-tenx/tutorial.md
@@ -8,7 +8,6 @@ redirect_from:
   - /topics/transcriptomics/tutorials/satac-preprocessing-tenx/tutorial
 zenodo_link: "https://zenodo.org/record/7855968"
 tags:
-  - single-cell
   - 10x
   - epigenetics
 questions:

--- a/topics/single-cell/tutorials/scrna-case-cell-annotation/slides.html
+++ b/topics/single-cell/tutorials/scrna-case-cell-annotation/slides.html
@@ -18,7 +18,6 @@ subtopic: scintroduction
 priority: 4
 
 tags:
-  - single-cell
 
 key_points:
   - "Automated cell annotation is a useful tool for automatically assigning cell type labels to cell data."

--- a/topics/single-cell/tutorials/scrna-case-jupyter_basic-pipeline/tutorial.md
+++ b/topics/single-cell/tutorials/scrna-case-jupyter_basic-pipeline/tutorial.md
@@ -29,7 +29,6 @@ requirements:
         - scrna-case_alevin
         - scrna-case_alevin-combine-datasets
 tags:
-- single-cell
 - 10x
 - paper-replication
 

--- a/topics/single-cell/tutorials/scrna-case_FilterPlotandExploreRStudio/tutorial.md
+++ b/topics/single-cell/tutorials/scrna-case_FilterPlotandExploreRStudio/tutorial.md
@@ -35,7 +35,6 @@ requirements:
 
 
 tags:
-- single-cell
 - 10x
 - paper-replication
 

--- a/topics/single-cell/tutorials/scrna-case_JUPYTER-trajectories/tutorial.md
+++ b/topics/single-cell/tutorials/scrna-case_JUPYTER-trajectories/tutorial.md
@@ -31,7 +31,6 @@ requirements:
     tutorials:
         - galaxy-intro-jupyter
 tags:
-- single-cell
 - 10x
 - paper-replication
 

--- a/topics/single-cell/tutorials/scrna-case_alevin-combine-datasets/tutorial.md
+++ b/topics/single-cell/tutorials/scrna-case_alevin-combine-datasets/tutorial.md
@@ -24,7 +24,6 @@ key_points:
   - Retreive partially analysed data from a public repository
 
 tags:
-  - single-cell
   - 10x
   - paper-replication
 

--- a/topics/single-cell/tutorials/scrna-case_alevin/tutorial.md
+++ b/topics/single-cell/tutorials/scrna-case_alevin/tutorial.md
@@ -25,7 +25,6 @@ key_points:
   - Create a scanpy-accessible AnnData object from FASTQ files, including relevant gene metadata
 
 tags:
-  - single-cell
   - 10x
   - paper-replication
 

--- a/topics/single-cell/tutorials/scrna-case_basic-pipeline/tutorial.md
+++ b/topics/single-cell/tutorials/scrna-case_basic-pipeline/tutorial.md
@@ -32,7 +32,6 @@ requirements:
         - scrna-case_alevin
         - scrna-case_alevin-combine-datasets
 tags:
-- single-cell
 - 10x
 - paper-replication
 

--- a/topics/single-cell/tutorials/scrna-case_cell-cycle/tutorial.md
+++ b/topics/single-cell/tutorials/scrna-case_cell-cycle/tutorial.md
@@ -24,7 +24,6 @@ key_points:
 - Cell cycle genes can conceal what is happening in your data if cells are grouping together according to their stage in the cycle
 - Identifying the cell cycle genes and using them to regress out the effects of the cell cycle can reveal underlying patterns in the data
 tags:
-- single-cell
 - 10x
 
 contributions:

--- a/topics/single-cell/tutorials/scrna-case_monocle3-rstudio/tutorial.md
+++ b/topics/single-cell/tutorials/scrna-case_monocle3-rstudio/tutorial.md
@@ -38,7 +38,6 @@ requirements:
 
 
 tags:
-- single-cell
 - 10x
 - paper-replication
 

--- a/topics/single-cell/tutorials/scrna-case_monocle3-trajectories/tutorial.md
+++ b/topics/single-cell/tutorials/scrna-case_monocle3-trajectories/tutorial.md
@@ -36,7 +36,6 @@ requirements:
         - scrna-case_basic-pipeline
         - scrna-case_JUPYTER-trajectories
 tags:
-- single-cell
 - 10x
 - paper-replication
 

--- a/topics/single-cell/tutorials/scrna-intro/slides.html
+++ b/topics/single-cell/tutorials/scrna-intro/slides.html
@@ -11,7 +11,6 @@ zenodo_link: ""
 redirect_from:
 - /topics/transcriptomics/tutorials/scrna-intro/slides
 tags:
-  - single-cell
 
 questions:
   - How are samples compared?

--- a/topics/single-cell/tutorials/scrna-plant/tutorial.md
+++ b/topics/single-cell/tutorials/scrna-plant/tutorial.md
@@ -7,7 +7,6 @@ redirect_from:
   - /topics/transcriptomics/tutorials/scrna-plant/tutorial
 zenodo_link: 'https://zenodo.org/record/4597857'
 tags:
-  - single-cell
   - plants
   - paper-replication
 questions:

--- a/topics/single-cell/tutorials/scrna-plates-batches-barcodes/slides.html
+++ b/topics/single-cell/tutorials/scrna-plates-batches-barcodes/slides.html
@@ -12,7 +12,6 @@ redirect_from:
 video: yes
 zenodo_link: ""
 tags:
-  - single-cell
 questions:
   - "What is a batch when it comes to single cells?"
   - "What’s the difference between a barcode and an index?"

--- a/topics/single-cell/tutorials/scrna-preprocessing-tenx/tutorial.md
+++ b/topics/single-cell/tutorials/scrna-preprocessing-tenx/tutorial.md
@@ -8,7 +8,6 @@ redirect_from:
   - /topics/transcriptomics/tutorials/scrna-preprocessing-tenx/tutorial
 zenodo_link: "https://zenodo.org/record/3457880"
 tags:
-  - single-cell
   - 10x
 questions:
   - What is 10X?

--- a/topics/single-cell/tutorials/scrna-preprocessing/slides.html
+++ b/topics/single-cell/tutorials/scrna-preprocessing/slides.html
@@ -4,7 +4,6 @@ logo: "GTN"
 title: "Dealing with Cross-Contamination in Fixed Barcode Protocols"
 zenodo_link: ""
 tags:
-  - single-cell
 questions:
   - "What is cross-contamination?"
   - "What are fixed barcodes?"

--- a/topics/single-cell/tutorials/scrna-preprocessing/tutorial.md
+++ b/topics/single-cell/tutorials/scrna-preprocessing/tutorial.md
@@ -55,7 +55,7 @@ gitter: Galaxy-Training-Network/galaxy-single-cell
 
 
 
-#### Why do Single Cell sequencing?
+## Why do Single Cell sequencing?
 
 
 Single-cell RNA (scRNA) sequencing is the technological successor to classical "bulk" RNA-seq, where samples are no longer defined at the tissue level but at the individual cell level. The bulk RNA-seq methods seen in [previous hands-on material]({% link topics/transcriptomics/tutorials/ref-based/tutorial.md %}) would give the average expression of genes in a sample, whilst overlooking the distinct expression profiles given by the cell sub-populations due to their heterogeneity.
@@ -115,7 +115,7 @@ The second part of this tutorial will deal with merging several output count mat
 
 # Single-Batch Processing
 
-### Data upload and organization
+## Data upload and organization
 
 In this tutorial we will be analysing scRNA-seq data of bone marrow cells taken from a single C57 mouse by *Herman et al.* ({% cite Herman2018 %}) and producing a count matrix that we can use for later analysis.
 
@@ -267,7 +267,7 @@ Before continuing let us first look back on some of the previous stages:
 >
 {: .comment}
 
-#### Confirming Reads in the BAM file
+### Confirming Reads in the BAM file
 
 We now have a BAM file of our aligned reads, with cell and UMI barcodes embedded in the read headers. We also have the chromosome and base-pair positions of where these reads are aligned. The can be confirmed by peeking into the BAM file:
 
@@ -306,7 +306,7 @@ The fields of the BAM file can be better explained at section 1.4 of [the SAM sp
 * `nM`: The number of base mismatches in the alignment of this read to the reference (here `1`).
 
 
-#### Filtering the BAM File
+### Filtering the BAM File
 
 If we perform counting on the current BAM file we will be counting all reads, even the undesirable ones such as those that did not align so optimally.
 
@@ -529,7 +529,7 @@ Handling more than one batch of sequencing data is rather trivial when we take i
 The first step merely requires us to run the same workflow on each of our batches, using the exact same inputs except for the FASTQ paired data. The second step requires a minimal level of interaction from us; namely using a merge tool and selecting our matrices.
 
 
-### Data upload and organisation
+## Data upload and organisation
 
 The count matrix we have generated in the previous section is too sparse to perform any reasonable analysis upon, and constitutes data only of a single batch. Here we will use more populated count matrices from multiple batches, under the assumption that we now know how to generate each individual one of them using the steps provided in the previous section. This data is available at [`Zenodo`](https://zenodo.org/record/3253142).
 
@@ -729,7 +729,7 @@ Let us now apply this protocol to our count matrix, and look for any cross-conta
 
 The plot that follows tells us everything we need to know about each of our batches. Each batch is essentially tested against the full set of barcodes in order to assert that only the desired or 'Real' barcodes have been sequenced.
 
-#### Cross-contamination Plot
+### Cross-contamination Plot
 
 ![Contamination Plots]({% link topics/single-cell/images/scrna-pre-processing/scrna_crosscontamination.png %} "The Pre-filter and Post-filter plots")
 

--- a/topics/single-cell/tutorials/scrna-preprocessing/tutorial.md
+++ b/topics/single-cell/tutorials/scrna-preprocessing/tutorial.md
@@ -9,7 +9,6 @@ priority: 1
 
 zenodo_link: "https://zenodo.org/record/3253142"
 tags:
-  - single-cell
 questions:
   - "What is single-cell?"
   - "How do we process a batch?"

--- a/topics/single-cell/tutorials/scrna-raceid/tutorial.md
+++ b/topics/single-cell/tutorials/scrna-raceid/tutorial.md
@@ -7,7 +7,6 @@ redirect_from:
   - /topics/transcriptomics/tutorials/scrna-raceid/tutorial
 zenodo_link: 'https://zenodo.org/record/1511582'
 tags:
-  - single-cell
 questions:
   - What is normalisation and why is it necessary?
   - How many types of unwanted variation are there?

--- a/topics/single-cell/tutorials/scrna-scanpy-pbmc3k/tutorial.md
+++ b/topics/single-cell/tutorials/scrna-scanpy-pbmc3k/tutorial.md
@@ -33,7 +33,6 @@ requirements:
         - scrna-preprocessing
         - scrna-preprocessing-tenx
 tags:
-- single-cell
 - 10x
 contributors:
 - bebatut

--- a/topics/single-cell/tutorials/scrna-scater-qc/tutorial.md
+++ b/topics/single-cell/tutorials/scrna-scater-qc/tutorial.md
@@ -8,7 +8,6 @@ redirect_from:
   - /topics/transcriptomics/tutorials/scrna-scater-qc/tutorial
 zenodo_link: 'https://zenodo.org/record/3386291'
 tags:
-  - single-cell
 questions:
 - How to ensure the quality of single-cell RNA-seq data?
 - What are the confounding factors that may affect the interpretation of downstream analyses?

--- a/topics/single-cell/tutorials/scrna-trajectories/slides.html
+++ b/topics/single-cell/tutorials/scrna-trajectories/slides.html
@@ -18,7 +18,6 @@ redirect_from:
   - /topics/transcriptomics/tutorials/scrna-case_monocle3-trajectories/slides
 
 tags:
-  - single-cell
 
 subtopic: scintroduction
 priority: 5

--- a/topics/single-cell/tutorials/scrna-umis/tutorial.md
+++ b/topics/single-cell/tutorials/scrna-umis/tutorial.md
@@ -41,7 +41,7 @@ When the sequence is mapped against a reference genome, we can then see which ge
 
 Barcodes come in a variety of formats, and in this tutorial we will be looking at the CEL-Seq2 protocol {% cite Hashimshony2016 %} used in droplet-based single-cell RNA-seq.
 
-### The CEL-Seq2 Protocol
+## The CEL-Seq2 Protocol
 
 <small>[Back to previous](javascript:window.history.back())</small>
 

--- a/topics/single-cell/tutorials/scrna-umis/tutorial.md
+++ b/topics/single-cell/tutorials/scrna-umis/tutorial.md
@@ -8,7 +8,6 @@ redirect_from:
 
 zenodo_link: "https://zenodo.org/record/2573177"
 tags:
-  - single-cell
 questions:
   - "What are barcodes?"
   - "What is their purpose?"


### PR DESCRIPTION
I've learned it's bad practice to label a tag the same as the actual page, so let's remove it! Woo!