### PR TITLE
Update container_resolvers_config_file option

### DIFF
--- a/topics/admin/tutorials/apptainer/tutorial.md
+++ b/topics/admin/tutorials/apptainer/tutorial.md
@@ -185,7 +185,7 @@ Now, we will configure Galaxy to run tools using Apptainer containers, which wil
 >         tool_data_table_config_path: /cvmfs/data.galaxyproject.org/byhand/location/tool_data_table_conf.xml,/cvmfs/data.galaxyproject.org/managed/location/tool_data_table_conf.xml
 >    +    # Tool Dependencies
 >    +    dependency_resolvers_config_file: "{{ galaxy_config_dir }}/dependency_resolvers_conf.xml"
->    +    containers_resolvers_config_file: "{{ galaxy_config_dir }}/container_resolvers_conf.yml"
+>    +    container_resolvers_config_file: "{{ galaxy_config_dir }}/container_resolvers_conf.yml"
 >       gravity:
 >         process_manager: systemd
 >         galaxy_root: "{{ galaxy_root }}/server"
@@ -195,7 +195,7 @@ Now, we will configure Galaxy to run tools using Apptainer containers, which wil
 >     
 >    +galaxy_config_templates:
 >    +  - src: templates/galaxy/config/container_resolvers_conf.yml.j2
->    +    dest: "{{ galaxy_config.galaxy.containers_resolvers_config_file }}"
+>    +    dest: "{{ galaxy_config.galaxy.container_resolvers_config_file }}"
 >    +  - src: templates/galaxy/config/dependency_resolvers_conf.xml
 >    +    dest: "{{ galaxy_config.galaxy.dependency_resolvers_config_file }}"
 >    +
@@ -393,14 +393,14 @@ After finishing the CVMFS tutorial, come back, and do this hands-on.
 
 > <hands-on-title>Optional: Configure Galaxy to use Apptainer containers from CVMFS</hands-on-title>
 >
-> 1. Edit the `group_vars/galaxyservers.yml` file and add `containers_resolvers_config_file` and `galaxy_singularity_images_cvmfs_path`:
+> 1. Edit the `group_vars/galaxyservers.yml` file and add `container_resolvers_config_file` and `galaxy_singularity_images_cvmfs_path`:
 >    {% raw %}
 >    ```yaml
 >    galaxy_singularity_images_cvmfs_path: "/cvmfs/singularity.galaxyproject.org/all/"
 >    galaxy_config:
 >      galaxy:
 >        ...
->        containers_resolvers_config_file: "{{ galaxy_config_dir }}/container_resolvers_conf.yml"
+>        container_resolvers_config_file: "{{ galaxy_config_dir }}/container_resolvers_conf.yml"
 >    ```
 >    {% endraw %}
 >


### PR DESCRIPTION
It seems that this config option should be renamed from `containers_resolvers_config_file` to `container_resolvers_config_file` as indicated here: https://github.com/galaxyproject/galaxy/blob/b54e7a773fbb8476c24071798f648d7305051d2c/lib/galaxy/config/sample/galaxy.yml.sample#L714

# Thank you for contributing to the GTN! :yellow_heart:

## Please check that:

- [ x ] Your pull request has a **good title**, e.g.
    - "Fix typo in ansible-galaxy tutorial"
    - "Add new transcriptomics tutorial covering a new sequencing technology"
- [ ] Please **replace this entire pull request message** with a *description of your changes*, it will help us review your pull request faster
- [ ] Check that your images are allowed to be re-hosted by the GTN

Once these are done, you're ready to go!

<details>
    <summary>Consider sustainable computing with Draft Mode :green_heart:</summary>

Is your pull request finished? 100% ready to be merged? Or do you want some time to work on it first (which we encourage! It's great to have visibility)

If not, then please consider creating this pull request as a draft.

Regular pull requests will trigger automated test runs when they are created
and every time you update them.

As a small contribution to sustainable computing, we skip the most energy intensive of these tests for pull requests marked as drafts. Once your pull request is ready to go, then you can click a button saying "Ready for Review" and the tests will be run!
</details>
