### PR TITLE
Add tool version to tool buttons

### DIFF
--- a/_plugins/jekyll-tool-tag.rb
+++ b/_plugins/jekyll-tool-tag.rb
@@ -22,11 +22,23 @@ module Jekyll
       if m
         # check if a variable was provided for the tool id
         tool = context[m[2].tr('{}', '')] || m[2]
+        version = tool.split('/').last
 
-        "<span class=\"tool\" data-tool=\"#{tool}\" title=\"#{m[1]} tool\" aria-role=\"link\">" \
-          "<strong>#{m[1]}</strong> " \
-          '<i class="fas fa-wrench" aria-hidden="true"></i><i aria-hidden="true" class="fas fa-cog"></i>' \
-          "<span class=\"visually-hidden\">Tool: #{tool}</span></span>"
+        if tool.count('/') == 0
+          "<span class=\"tool\" data-tool=\"#{tool}\" title=\"#{m[1]} tool\" aria-role=\"button\">" \
+            '<i class="fas fa-wrench" aria-hidden="true"></i> ' \
+            "<strong>#{m[1]}</strong>" \
+          '</span>'
+        else
+          "<span class=\"tool\" data-tool=\"#{tool}\" title=\"#{m[1]} tool\" aria-role=\"button\">" \
+            '<i class="fas fa-wrench" aria-hidden="true"></i> ' \
+            "<strong>#{m[1]}</strong> " \
+            '(' \
+            '<i class="fas fa-cubes" aria-hidden="true"></i> ' \
+            "Galaxy version #{version}" \
+            ')' \
+          '</span>'
+        end
       else
         %(<span><strong>#{@text}</strong> <i class="fas fa-wrench" aria-hidden="true"></i></span>)
       end

--- a/assets/css/main.scss
+++ b/assets/css/main.scss
@@ -1584,6 +1584,11 @@ a[target="_blank"]::after {
   height: 1em;
 }
 
+/* Not for figures where it's duplicated */
+figure > a[target="_blank"]::after {
+	content: unset;
+}
+
 .tutorials-list {
 /* Big */
 @media (min-width:768px) {


### PR DESCRIPTION
cc @nomadscientist @lldelisle  we've discussed this in the past but it continues to be an issue so time to finally do it. It's a bit more verbose, but tutorials are already verbose, and reproducibility of using the correct tool version is more important.

![image](https://github.com/galaxyproject/training-material/assets/458683/48e25fd8-ba92-432e-8de8-92a8763beb9b)
