### PR TITLE
add gsc verificaiton

### DIFF
--- a/_includes/analytics.html
+++ b/_includes/analytics.html
@@ -1,3 +1,5 @@
+<meta name="google-site-verification" content="9mOXn2JL833-i7-aioCCEuIdG4_tb6qjwUozB5GJnPQ" />
+
 <!-- JavaScript Error Monitoring, and performance tracking. -->
 <script
   src="https://browser.sentry-cdn.com/7.52.1/bundle.tracing.min.js"


### PR DESCRIPTION
might give us some useful data in plausible/google search console on how folks are finding the GTN and what phrases they're using.