### PR TITLE
expose version number

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -203,6 +203,7 @@ icon-tag:
   video: fas fa-video
   video-slides: far fa-play-circle
   zenodo_link: far fa-copy
+  version: fas fa-code-commit
 
 # To exclude in _site
 exclude:

--- a/_layouts/tutorial_hands_on.html
+++ b/_layouts/tutorial_hands_on.html
@@ -161,8 +161,11 @@ We should ONLY be using new_material (if at all possible.)
             {% endif %} The GTN Framework is licensed under <a rel="license" href="{{ site.github_repository }}/blob/main/LICENSE.md">MIT</a>
         </div>
         {% if page.short_id %}
-        <div><strong>{% icon purl %}<abbr title="Persistent URL">PURL</abbr>:</strong> <a href="https://gxy.io/GTN:{{ page.short_id }}">https://gxy.io/GTN:{{ page.short_id }}</a> </div>
+        <div><strong>{% icon purl %} <abbr title="Persistent URL">PURL</abbr>:</strong> <a href="https://gxy.io/GTN:{{ page.short_id }}">https://gxy.io/GTN:{{ page.short_id }}</a> </div>
         {% endif %}
+
+	<div><strong>{% icon version %} Revision:</strong> {{ page | get_version_number }} </div>
+
     </blockquote>
     </section>
 

--- a/_plugins/gtn.rb
+++ b/_plugins/gtn.rb
@@ -357,6 +357,10 @@ module Jekyll
       end
     end
 
+    def get_version_number(page)
+      Gtn::ModificationTimes.obtain_modification_count(page['path'])
+    end
+
     def topic_name_from_page(page, site)
       if page.key? 'topic_name'
         site.data[page['topic_name']]['title']


### PR DESCRIPTION
for all tutorials. It can give a teacher a feeling of "is this material being updated over time or just dumped in"

screenshot from galaxy intro for ansible

![image](https://github.com/galaxyproject/training-material/assets/458683/451d3899-b44b-4a6d-85c1-fed7276f00c0)
