### PR TITLE
fixes Makefile, prefers mamba over conda if available

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,9 +27,12 @@ else
 	ENV_FILE=environment.yml
 endif
 
-CONDA=$(shell which conda)
+CONDA=$(shell which mamba)
 ifeq ($(CONDA),)
-	CONDA=${HOME}/miniconda3/bin/conda
+    CONDA=$(shell which conda)
+    ifeq ($(CONDA),)
+    	CONDA=${HOME}/miniconda3/bin/mamba
+    endif
 endif
 
 default: help


### PR DESCRIPTION
The [GTN tutorial on viewing the site locally](https://training.galaxyproject.org/training-material/topics/contributing/tutorials/running-jekyll/tutorial.html) basically says that one should run
1. `make create-env`
2. `make install`

after installing Conda. I have a fresh local clone of the repository. Both steps yield an out of memory error on my system (see #4313). When using mamba instead of conda, everything works.

This PR proposes to use mamba in Makefile if it is available, and conda otherwise.