### PR TITLE
Implement nicer categories for toolshed install instructions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -235,6 +235,7 @@ annotate: ## annotate the tutorials with usable Galaxy instances
 	wget https://github.com/hexylena/toolshed-version-database/raw/main/guid-rev.json -O metadata/toolshed-revisions.json && \
 	python bin/supported-fetch.py
 	bin/workflows-fetch.rb
+	bin/fetch-categories.rb
 .PHONY: annotate
 
 rebuild-search-index: ## Rebuild search index

--- a/_plugins/api.rb
+++ b/_plugins/api.rb
@@ -143,6 +143,18 @@ module Jekyll
       page2.data['layout'] = nil
       site.pages << page2
 
+      # Tool Categories
+      page2 = PageWithoutAFile.new(site, '', 'api/', 'toolcats.json')
+      page2.content = JSON.generate(site.data['toolcats'])
+      page2.data['layout'] = nil
+      site.pages << page2
+
+      # Tool Categories
+      page2 = PageWithoutAFile.new(site, '', 'api/', 'toolshed-revisions.json')
+      page2.content = JSON.generate(site.data['toolshed-revisions'])
+      page2.data['layout'] = nil
+      site.pages << page2
+
       # Contributors
       puts '[GTN/API] Contributors, Funders, Organisations'
       %w[contributors funders organisations].each do |type|

--- a/_plugins/gtn/toolshed.rb
+++ b/_plugins/gtn/toolshed.rb
@@ -13,7 +13,7 @@ module Gtn
     # +topic+:: The topic to install the tools under
     # Returns:
     # +supported+:: A string of the admin install, ready for ephemeris
-    def self.format_admin_install(data, tool_list, topic)
+    def self.format_admin_install(data, tool_list, topic, tool_cats)
       # p "Calculating supported servers for this tool list"
       return {} if data.nil? || data.empty?
 
@@ -23,7 +23,7 @@ module Gtn
           'name' => tool_info[1],
           'owner' => tool_info[0],
           'revisions' => tool_info[2],
-          'tool_panel_section_label' => topic,
+          'tool_panel_section_label' => tool_cats["#{tool_info[0]}/#{tool_info[1]}"] || topic,
           'tool_shed_url' => 'https://toolshed.g2.bx.psu.edu/',
         }
       end

--- a/_plugins/jekyll-topic-filter.rb
+++ b/_plugins/jekyll-topic-filter.rb
@@ -521,7 +521,7 @@ module TopicFilter
     topic_name_human = site.data[page_obj['topic_name']]['title']
     page_obj['topic_name_human'] = topic_name_human # TODO: rename 'topic_name' and 'topic_name' to 'topic_id'
     admin_install = Gtn::Toolshed.format_admin_install(site.data['toolshed-revisions'], page_obj['tools'],
-                                                       topic_name_human)
+                                                       topic_name_human, site.data['toolcats'])
     page_obj['admin_install'] = admin_install
     page_obj['admin_install_yaml'] = admin_install.to_yaml
 

--- a/bin/fetch-categories.rb
+++ b/bin/fetch-categories.rb
@@ -1,0 +1,61 @@
+#!/usr/bin/env ruby
+require 'json'
+require 'net/http'
+require 'uri'
+require 'yaml'
+
+# Get the list of toolcats
+def fetch_toolcats(server)
+  uri = URI.parse("#{server}")
+  request = Net::HTTP::Get.new(uri)
+  req_options = {
+    use_ssl: uri.scheme == 'https',
+  }
+  response = Net::HTTP.start(uri.hostname, uri.port, req_options) do |http|
+    http.request(request)
+  end
+
+  begin
+    JSON.parse(response.body) do |w|
+      w
+    end
+  rescue StandardError
+    {}
+  end
+end
+
+# Parse the response
+toolcats_eu = fetch_toolcats('https://usegalaxy-eu.github.io/usegalaxy-eu-tools/api/labels.json')
+# toolcats_eu = File.open('/tmp/tmp.ccFYsrbAa5/usegalaxy-eu-tools/api/labels.json') { |f| YAML.safe_load(f) }
+toolcats_org = fetch_toolcats('https://galaxyproject.github.io/usegalaxy-tools/api/labels.json')
+toolcats_aus = fetch_toolcats('https://usegalaxy-au.github.io/usegalaxy-au-tools/api/labels.json')
+# toolcats_aus = File.open('/tmp/tmp.ccFYsrbAa5/usegalaxy-au-tools/api/labels.json') { |f| YAML.safe_load(f) }
+tool_ids = (toolcats_org.keys + toolcats_eu.keys + toolcats_aus.keys).uniq
+# tool_ids = toolcats_org.keys
+tool_ids.sort!
+
+toolcats = {}
+# Cleanup the list
+tool_ids.each do |k|
+  eu = toolcats_eu[k] || nil
+  org = toolcats_org[k] || nil
+  aus = toolcats_aus[k] || nil
+
+  # We get N 'votes' for the categories
+  values = [eu, org, aus].compact
+  # values = [org].compact
+
+
+  # Majority answer wins
+  # set that value to toolcats[k]
+  # If there is no majority, pick one.
+  # print("#{k} - #{values.length} => #{values.uniq.compact.length}\n")
+  if values.length.positive?
+    toolcats[k] = values.max_by { |v| v['count'] }
+  else
+    toolcats[k] = nil
+  end
+end
+
+# Write the list to a file
+File.write('metadata/toolcats.yml', toolcats.to_yaml)


### PR DESCRIPTION
cc @lldelisle
fixes #4513 

depends on:

- [x] https://github.com/usegalaxy-eu/usegalaxy-eu-tools/pull/648
- [x] https://github.com/galaxyproject/usegalaxy-tools/pull/655
- [ ] https://github.com/usegalaxy-au/usegalaxy-au-tools/pull/988

Demo using data from those three PRs, for the atac-seq tutorial:

![image](https://github.com/galaxyproject/training-material/assets/458683/6e27049a-8bd2-44a1-8a95-3681e3d3ec97)

quite a bit nicer than all going to "Epigenetics"