### PR TITLE
Improved workflow listing query language

### DIFF
--- a/_layouts/base.html
+++ b/_layouts/base.html
@@ -31,11 +31,11 @@
         {% if page.title %}
             {% assign og_title = page.title %}
         {% endif %}
-        {% assign og_desc = topic.summary | default: "Collection of tutorials developed and maintained by the worldwide Galaxy community" %}
-        <meta name="description" content="{{ og_desc | strip_html | truncate: 60}}">
+        {% assign og_desc = page.description | default:topic.summary | default: "Collection of tutorials developed and maintained by the worldwide Galaxy community" %}
+        <meta name="description" content="{{ og_desc | strip_html | truncate: 120}}">
         <meta property="og:site_name" content="Galaxy Training Network">
         <meta property="og:title" content="Galaxy Training{% if og_title %}: {{ og_title | truncate: 60}}{% endif %}">
-        <meta property="og:description" content="{{ og_desc | strip_html | truncate: 60}}">
+        <meta property="og:description" content="{{ og_desc | strip_html | truncate: 120}}">
 
         {%- if page.cover %}{% assign coverimage = page.cover %}
         {%- elsif page.tags contains "cofest" %}{% assign coverimage = "/assets/images/cofest.png" %}

--- a/_layouts/base_slides.html
+++ b/_layouts/base_slides.html
@@ -20,6 +20,7 @@
         {{ 'load' | bundle_preloads }}
         <link rel="stylesheet" href="{{ "/assets/css/main.css?v=3" | prepend: site.baseurl }}">
         <script src="https://kit.fontawesome.com/67b3f98409.js" crossorigin="anonymous"></script>
+        <meta name="theme-color" content="#2c3143"/>
 
         {{ page | generate_dublin_core: site }}
 
@@ -28,12 +29,18 @@
         {% if page.title %}
             {% assign og_title = page.title %}
         {% endif %}
-        {% assign og_desc = topic.summary | default: "Collection of tutorials developed and maintained by the worldwide Galaxy community" %}
-        <meta name="description" content="{{ og_desc | strip_html | truncate: 60}}" />
-        <meta property="og:site_name" content="Galaxy Training Network" />
-        <meta property="og:title" content="Galaxy Training{% if og_title %}: {{ og_title | truncate: 60}}{% endif %}" />
-        <meta property="og:description" content="{{ og_desc | strip_html | truncate: 60}}" />
-        {% assign og_image = page.og_image | default: topic.og_image | default: "/assets/images/GTNLogo1000.png" %}
+        {% assign og_desc = page.description | default:topic.summary | default: "Collection of tutorials developed and maintained by the worldwide Galaxy community" %}
+        <meta name="description" content="{{ og_desc | strip_html | truncate: 120}}">
+        <meta property="og:site_name" content="Galaxy Training Network">
+        <meta property="og:title" content="Galaxy Training{% if og_title %}: {{ og_title | truncate: 60}}{% endif %}">
+        <meta property="og:description" content="{{ og_desc | strip_html | truncate: 120}}">
+
+        {%- if page.cover %}{% assign coverimage = page.cover %}
+        {%- elsif page.tags contains "cofest" %}{% assign coverimage = "/assets/images/cofest.png" %}
+        {%- elsif page.tags contains "galaxy" %}{% assign coverimage = "/assets/images/GalaxyNews.png" %}
+        {%- elsif page.tags contains "gat" %}{% assign coverimage = "/assets/images/gat.png" %}
+        {%- else %}{% assign coverimage = "/assets/images/GTNLogo1000.png" %}{% endif %}
+        {% assign og_image = page.og_image | default: coverimage | default: topic.og_image | default: "/assets/images/GTNLogo1000.png" %}
         <meta property="og:image" content="{{ og_image | prepend: site.baseurl }}">
 
         <script type="application/ld+json">

--- a/_layouts/base_slides_ai4life.html
+++ b/_layouts/base_slides_ai4life.html
@@ -32,13 +32,7 @@
         <meta property="og:title" content="Galaxy Training{% if og_title %}: {{ og_title | truncate: 60}}{% endif %}">
         <meta property="og:description" content="{{ og_desc | strip_html | truncate: 120}}">
 
-        {%- if page.cover %}{% assign coverimage = page.cover %}
-        {%- elsif page.tags contains "cofest" %}{% assign coverimage = "/assets/images/cofest.png" %}
-        {%- elsif page.tags contains "galaxy" %}{% assign coverimage = "/assets/images/GalaxyNews.png" %}
-        {%- elsif page.tags contains "gat" %}{% assign coverimage = "/assets/images/gat.png" %}
-        {%- else %}{% assign coverimage = "/assets/images/GTNLogo1000.png" %}{% endif %}
-        {% assign og_image = page.og_image | default: coverimage | default: topic.og_image | default: "/assets/images/GTNLogo1000.png" %}
-        <meta property="og:image" content="{{ og_image | prepend: site.baseurl }}">
+        <meta property="og:image" content="{{ site.baseurl }}/topics/ai4life/images/AI4Life-logo_giraffe-nodes.png">
 
         <script type="application/ld+json">
             {% include _includes/material.jsonld material=page topic=topic site=site %}

--- a/_layouts/base_slides_ai4life.html
+++ b/_layouts/base_slides_ai4life.html
@@ -17,6 +17,7 @@
         {{ 'load' | bundle_preloads }}
         <link rel="stylesheet" href="{{ "/assets/css/main.css?v=3" | prepend: site.baseurl }}">
         <script src="https://kit.fontawesome.com/67b3f98409.js" crossorigin="anonymous"></script>
+        <meta name="theme-color" content="#2c3143"/>
 
         {{ page | generate_dublin_core: site }}
 
@@ -25,12 +26,18 @@
         {% if page.title %}
             {% assign og_title = page.title %}
         {% endif %}
-        {% assign og_desc = topic.summary | default: "Collection of tutorials developed and maintained by the worldwide Galaxy community" %}
-        <meta name="description" content="{{ og_desc | strip_html | truncate: 60}}" />
-        <meta property="og:site_name" content="Galaxy Training Network" />
-        <meta property="og:title" content="Galaxy Training{% if og_title %}: {{ og_title | truncate: 60}}{% endif %}" />
-        <meta property="og:description" content="{{ og_desc | strip_html | truncate: 60}}" />
-        {% assign og_image = page.og_image | default: topic.og_image | default: "/assets/images/GTNLogo1000.png" %}
+        {% assign og_desc = page.description | default:topic.summary | default: "Collection of tutorials developed and maintained by the worldwide Galaxy community" %}
+        <meta name="description" content="{{ og_desc | strip_html | truncate: 120}}">
+        <meta property="og:site_name" content="Galaxy Training Network">
+        <meta property="og:title" content="Galaxy Training{% if og_title %}: {{ og_title | truncate: 60}}{% endif %}">
+        <meta property="og:description" content="{{ og_desc | strip_html | truncate: 120}}">
+
+        {%- if page.cover %}{% assign coverimage = page.cover %}
+        {%- elsif page.tags contains "cofest" %}{% assign coverimage = "/assets/images/cofest.png" %}
+        {%- elsif page.tags contains "galaxy" %}{% assign coverimage = "/assets/images/GalaxyNews.png" %}
+        {%- elsif page.tags contains "gat" %}{% assign coverimage = "/assets/images/gat.png" %}
+        {%- else %}{% assign coverimage = "/assets/images/GTNLogo1000.png" %}{% endif %}
+        {% assign og_image = page.og_image | default: coverimage | default: topic.og_image | default: "/assets/images/GTNLogo1000.png" %}
         <meta property="og:image" content="{{ og_image | prepend: site.baseurl }}">
 
         <script type="application/ld+json">

--- a/_layouts/embed.html
+++ b/_layouts/embed.html
@@ -15,10 +15,7 @@
         <link rel="preload" href="{{ site.baseurl }}/assets/fonts/AtkinsonHyperlegible/Atkinson-Hyperlegible-Regular-102a.woff2" as="font" type="font/woff2" crossorigin>
         <link rel="preload" href="{{ site.baseurl }}/assets/fonts/AtkinsonHyperlegible/Atkinson-Hyperlegible-Bold-102a.woff2" as="font" type="font/woff2" crossorigin>
         <link rel="preload" href="{{ site.baseurl }}/assets/fonts/AtkinsonHyperlegible/Atkinson-Hyperlegible-Italic-102a.woff2" as="font" type="font/woff2" crossorigin>
-        <link rel="preload" href="{{ site.baseurl }}/assets/css/main.css?v=3" as="style">
-        {{ 'load' | bundle_preloads }}
         <link rel="stylesheet" href="{{ site.baseurl }}/assets/css/main.css?v=3">
-        <link rel="manifest" href="{{ site.baseurl }}/manifest.json">
         <meta name="theme-color" content="#2c3143"/>
 
         {{ page | generate_dublin_core: site }}
@@ -28,30 +25,15 @@
         {% if page.title %}
             {% assign og_title = page.title %}
         {% endif %}
-        {% assign og_desc = topic.summary | default: "Collection of tutorials developed and maintained by the worldwide Galaxy community" %}
-        <meta name="description" content="{{ og_desc | strip_html | truncate: 60}}">
+        {% assign og_desc = page.description | default:topic.summary | default: "Collection of tutorials developed and maintained by the worldwide Galaxy community" %}
+        <meta name="description" content="{{ og_desc | strip_html | truncate: 120}}">
         <meta property="og:site_name" content="Galaxy Training Network">
         <meta property="og:title" content="Galaxy Training{% if og_title %}: {{ og_title | truncate: 60}}{% endif %}">
-        <meta property="og:description" content="{{ og_desc | strip_html | truncate: 60}}">
+        <meta property="og:description" content="{{ og_desc | strip_html | truncate: 120}}">
 
-        {%- if page.cover %}{% assign coverimage = page.cover %}
-        {%- elsif page.tags contains "cofest" %}{% assign coverimage = "/assets/images/cofest.png" %}
-        {%- elsif page.tags contains "galaxy" %}{% assign coverimage = "/assets/images/GalaxyNews.png" %}
-        {%- elsif page.tags contains "gat" %}{% assign coverimage = "/assets/images/gat.png" %}
-        {%- else %}{% assign coverimage = "/assets/images/GTNLogo1000.png" %}{% endif %}
-        {% assign og_image = page.og_image | default: coverimage | default: topic.og_image | default: "/assets/images/GTNLogo1000.png" %}
-        <meta property="og:image" content="{{ og_image | prepend: site.baseurl }}">
-
-        {% if page.layout == "tutorial_hands_on" %}
-        <script type="application/ld+json">
-            {% include _includes/material.jsonld material=page topic=topic site=site %}
-        </script>
-        {% endif %}
+        <meta property="og:image" content="/assets/images/GTNLogo1000.png">
     </head>
     <body data-brightness="auto" data-contrast="auto">
-        {{ 'theme' | load_bundle }}
         {{ content }}
-
-        {{ 'main' | load_bundle }}
     </body>
 </html>

--- a/workflows/embed.html
+++ b/workflows/embed.html
@@ -56,20 +56,43 @@ const table  = document.getElementById('results'),
       rows   = table.tBodies[0].rows;
 
 function clean(query){
-	return query.toLowerCase().replace(/[^a-z0-9]/g, '')
+	return query.toLowerCase().replace(/[^a-z0-9 ]/g, '')
 }
 
-function search(textQuery){
-	// If no query, show all.
-	if (textQuery == "") {
-		document.querySelectorAll("#results tr").forEach(r => r.style.display = "");
-		return;
-	}
+function search(params){
+	const textQuery = params.get('query')?.toLowerCase();
+	const filter_all = params.get('all')?.split(" ").map(f => f.trim().toLowerCase());
+	const filter_any = params.get('any')?.split(" ").map(f => f.trim().toLowerCase());
+	const filter_none = params.get('none')?.split(" ").map(f => f.trim().toLowerCase());
 
-	// Otherwise, filter
 	var to_hide = rows.filter(row => {
-		if (clean(row.children[0].innerText + row.children[1].innerText).indexOf(clean(textQuery)) == -1) {
+		var text = clean(row.children[0].innerText.toLowerCase() + " " + 
+			row.children[1].innerText.toLowerCase());
+		if (filter_all) {
+			// Every term in filter_all must be present
+			// Immediately reject if not all present.
+			if (!filter_all.every(f => text.indexOf(f) != -1)) {
+				return true;
+			}
+		}
+		if (filter_none){
+			// Every term in filter_none must not be present
+			// Immediately reject if not all present.
+			if (filter_none.some(f => text.indexOf(f) != -1)) {
+				return true;
+			}
+		}
+		if (filter_any){
+			// At least one term in filter_any must be present
+			// If any failed, exit for sure.
+			if(!filter_any.some(f => text.indexOf(f) != -1)) {
+				return true;
+			}
+		}
+		if (textQuery && textQuery != "" && text.indexOf(textQuery) == -1) {
 			return true;
+		} else {
+			return false;
 		}
 		return false;
 	});
@@ -83,6 +106,5 @@ function search(textQuery){
 // Get the q parameter from URL
 // This is a redeclaration of the `var params` in themes.js, not sure how we want to handle that long term.
 var params = (new URL(document.location)).searchParams;
-paramSearch = params.get('query')
-search(paramSearch)
+search(params)
 </script>

--- a/workflows/embed.html
+++ b/workflows/embed.html
@@ -1,6 +1,7 @@
 ---
 layout: embed
 title: Cross UseGalaxy.* Workflow Search
+description: Search for workflows across all UseGalaxy.* servers and WorkflowHub
 ---
 
 <style>

--- a/workflows/list.html
+++ b/workflows/list.html
@@ -7,16 +7,20 @@ title: Cross UseGalaxy.* Workflow Search
 We are testing a new search experience. Tell us what you think!
 </p>
 
+<label for="title">Search</label>
 <div class="row" id="search-form">
-	<div class="col-md-11">
+	<div class="col-md-8">
 	<div class="form-group">
-		<label for="title">Search</label>
 		<input type="text" class="form-control" id="title" placeholder="Search Materials" oninput="onInputDebounced()">
-		<button class="btn btn-primary" onclick="search()">Search</button>
 	</div>
 	</div>
 
-	<div class="col-md-1">
+	<div class="col-md-2">
+		<button style="width: 100%" class="btn btn-primary" onclick="search()">Search</button>
+	</div>
+
+	<div class="col-md-2">
+		Results: <span id="results-count">{{ site.data['workflows'] | size }}</span>
 	</div>
 </div>
 
@@ -89,6 +93,7 @@ function search(){
 
 	// Which should be hidden
 
+	var count = 0;
 	var to_hide = rows.filter(row => {
 		if (textQuery != "" && (
 			row.children[0].innerText.toLowerCase() + " " + 
@@ -96,8 +101,10 @@ function search(){
 		).indexOf(textQuery.toLowerCase()) == -1) {
 			return true;
 		}
+		count += 1;
 		return false;
 	});
+	document.getElementById("results-count").innerText = count;
 
 	// Display all
 	document.querySelectorAll("#results tr").forEach(r => r.style.display = "");


### PR DESCRIPTION
Fixes https://github.com/galaxyproject/training-material/issues/4494

This does not implement a proper query language which would be more expensive to execute, instead we supply a simpler set of filters:

- all: must include all of these terms
- any: includes *at least one* of these terms
- none: reject anything with these terms.

E.g. `?all=single-cell&any=mehmet+wendi` would find workflows either by @nomadscientist or @mtekman.

Again this doesn't implement a query language that supports arbitrarily complex queries, we keep it simple.

Also includes some changes to the templates to read `page.description` for a better blurb, and more uniform image loading.