### PR TITLE
limits deploy workflow to `galaxyproject` repo

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -12,6 +12,7 @@ on:
 jobs:
   deploy:
     runs-on: ubuntu-latest
+    if: github.repository_owner == 'galaxyproject'
     steps:
       - uses: actions/checkout@v2
         with:


### PR DESCRIPTION
Forks of this repo regularly run deployment workflows to GTN. Such workflows usually fail, since deployment is usually not configured in the forked repo. This regularly produces notifications and emails of failed workflows. To overcome this issue, I suggest limiting the deployment workflow to the original GTN repo (i.e. this repo).