### PR TITLE
Add uni-freiburg affiliation for ElectronicBlueberry

### DIFF
--- a/CONTRIBUTORS.yaml
+++ b/CONTRIBUTORS.yaml
@@ -482,6 +482,8 @@ ElectronicBlueberry:
     joined: 2023-04
     elixir_node: de
     orcid: 0000-0002-2362-9720
+    affiliations:
+      - uni-freiburg
 
 emmaleith:
     name: Emma Leith


### PR DESCRIPTION
Adds an affiliation field for my entry in CONTRIBUTORS.yaml, adding uni-freiburg.