### PR TITLE
Add programming language tags and hide non-working text

### DIFF
--- a/topics/single-cell/tutorials/scrna-case_FilterPlotandExploreRStudio/tutorial.md
+++ b/topics/single-cell/tutorials/scrna-case_FilterPlotandExploreRStudio/tutorial.md
@@ -37,6 +37,7 @@ requirements:
 tags:
 - 10x
 - paper-replication
+- R
 
 contributions:
   authorship:

--- a/topics/single-cell/tutorials/scrna-case_JUPYTER-trajectories/tutorial.md
+++ b/topics/single-cell/tutorials/scrna-case_JUPYTER-trajectories/tutorial.md
@@ -33,6 +33,7 @@ requirements:
 tags:
 - 10x
 - paper-replication
+- Python
 
 contributions:
   authorship:

--- a/topics/single-cell/tutorials/scrna-case_alevin-combine-datasets/tutorial.md
+++ b/topics/single-cell/tutorials/scrna-case_alevin-combine-datasets/tutorial.md
@@ -86,6 +86,8 @@ You can access the data for this tutorial in multiple ways:
 
    {% snippet faqs/galaxy/histories_import.md %}
 
+
+<!--
 3. **Uploading from Zenodo** (see below)
 
 
@@ -113,6 +115,8 @@ You can access the data for this tutorial in multiple ways:
 >    {% snippet faqs/galaxy/datasets_change_datatype.md datatype="datatypes" %}
 >
 {: .hands_on}
+
+-->
 
 Inspect the {% icon galaxy-eye %} `Experimental Design` text file. This shows you how each `N70X` corresponds to a sample, and whether that sample was from a male or female. This will be important metadata to add to our sample, which we will add very similarly to how you added the `gene_name` and `mito` metadata previously!
 

--- a/topics/single-cell/tutorials/scrna-case_monocle3-rstudio/tutorial.md
+++ b/topics/single-cell/tutorials/scrna-case_monocle3-rstudio/tutorial.md
@@ -40,6 +40,7 @@ requirements:
 tags:
 - 10x
 - paper-replication
+- R
 
 contributions:
   authorship:

--- a/topics/single-cell/tutorials/scrna-case_monocle3-trajectories/tutorial.md
+++ b/topics/single-cell/tutorials/scrna-case_monocle3-trajectories/tutorial.md
@@ -38,6 +38,7 @@ requirements:
 tags:
 - 10x
 - paper-replication
+- R
 
 contributions:
   authorship:


### PR DESCRIPTION
I added python & R tags to relevant tutorials because their titles looked messy

Also hid a section in the Combining datasets that a user reported is erroring out, have followed up to figure out why, in the mean time hiding it