### PR TITLE
Misc improvements

### DIFF
--- a/.github/workflows/ci-main.yml
+++ b/.github/workflows/ci-main.yml
@@ -70,4 +70,5 @@ jobs:
         with:
           rubocop_version: gemfile
           reporter: github-pr-review
+          rubocop_flags: --except Layout/LineLength,Lint/RedundantCopDisableDirective
           fail_on_error: true

--- a/.github/workflows/matrix.yml
+++ b/.github/workflows/matrix.yml
@@ -40,7 +40,7 @@ jobs:
 
       - name: Send announcements to matrix
         run: |
-            commit=$(git log --since "24 hours ago" --format=%H | tail -n 1)
+            commit=$(git log --since "24 hours ago" --format=%H --first-parent main| tail -n 1)
             bundle exec ruby bin/news.rb -p "${commit}~1" --matrix-post
         env:
             MATRIX_ACCESS_TOKEN: ${{ secrets.matrix_access_token }}

--- a/_layouts/base.html
+++ b/_layouts/base.html
@@ -32,10 +32,10 @@
             {% assign og_title = page.title %}
         {% endif %}
         {% assign og_desc = page.description | default:topic.summary | default: "Collection of tutorials developed and maintained by the worldwide Galaxy community" %}
-        <meta name="description" content="{{ og_desc | strip_html | truncate: 120}}">
+        <meta name="description" content="{{ og_desc | strip_html}}">
         <meta property="og:site_name" content="Galaxy Training Network">
         <meta property="og:title" content="Galaxy Training{% if og_title %}: {{ og_title | truncate: 60}}{% endif %}">
-        <meta property="og:description" content="{{ og_desc | strip_html | truncate: 120}}">
+        <meta property="og:description" content="{{ og_desc | strip_html}}">
 
         {%- if page.cover %}{% assign coverimage = page.cover %}
         {%- elsif page.tags contains "cofest" %}{% assign coverimage = "/assets/images/cofest.png" %}

--- a/_layouts/base.html
+++ b/_layouts/base.html
@@ -34,7 +34,7 @@
         {% assign og_desc = page.description | default:topic.summary | default: "Collection of tutorials developed and maintained by the worldwide Galaxy community" %}
         <meta name="description" content="{{ og_desc | strip_html}}">
         <meta property="og:site_name" content="Galaxy Training Network">
-        <meta property="og:title" content="Galaxy Training{% if og_title %}: {{ og_title | truncate: 60}}{% endif %}">
+	<meta property="og:title" content="[{% if topic.title %}{{ topic.title }}{% endif %}]{% if page.layout == "faq" %}FAQS {% elsif page.layout == "topic" %}Topic: {% endif %}{{ og_title }} {% if page.layout == "workflow-list" %}Workflows{% endif %}">
         <meta property="og:description" content="{{ og_desc | strip_html}}">
 
         {%- if page.cover %}{% assign coverimage = page.cover %}

--- a/_layouts/base_slides.html
+++ b/_layouts/base_slides.html
@@ -30,10 +30,10 @@
             {% assign og_title = page.title %}
         {% endif %}
         {% assign og_desc = page.description | default:topic.summary | default: "Collection of tutorials developed and maintained by the worldwide Galaxy community" %}
-        <meta name="description" content="{{ og_desc | strip_html | truncate: 120}}">
+        <meta name="description" content="{{ og_desc | strip_html }}">
         <meta property="og:site_name" content="Galaxy Training Network">
-        <meta property="og:title" content="Galaxy Training{% if og_title %}: {{ og_title | truncate: 60}}{% endif %}">
-        <meta property="og:description" content="{{ og_desc | strip_html | truncate: 120}}">
+        <meta property="og:title" content="Slide Deck: {{ og_title }}">
+        <meta property="og:description" content="{{ og_desc | strip_html }}">
 
         {%- if page.cover %}{% assign coverimage = page.cover %}
         {%- elsif page.tags contains "cofest" %}{% assign coverimage = "/assets/images/cofest.png" %}

--- a/_layouts/slides-plain.html
+++ b/_layouts/slides-plain.html
@@ -34,7 +34,8 @@ layout: base
 		</ul>
 		{% endif %}
 
-		<div><strong> {% icon last_modification %} Last modification:</strong> {{ page | last_modified_at | date: "%b %-d, %Y"}} </div>
+		<div><strong> {% icon last_modification %} Published:</strong> {{ page | gtn_pub_date | date: "%b %-d, %Y"}} </div>
+		<div><strong> {% icon last_modification %} Last Updated:</strong> {{ page | last_modified_at | date: "%b %-d, %Y"}} </div>
 
 	<hr />
 

--- a/_layouts/tutorial_hands_on.html
+++ b/_layouts/tutorial_hands_on.html
@@ -149,6 +149,7 @@ We should ONLY be using new_material (if at all possible.)
             {% endif %}
         </ul>
 
+        <div><strong>{% icon last_modification aria=false %} {{ locale['published'] | default: "Published" }}:</strong> {{ page | gtn_pub_date | date: "%b %-d, %Y"}} </div>
         <div><strong>{% icon last_modification aria=false %} {{ locale['last-modification'] | default: "Last modification" }}:</strong> {{ page | last_modified_at | date: "%b %-d, %Y"}} </div>
         <div><strong>{% icon license aria=false %} {{ locale['license'] | default: "License" }}:</strong>
 		{% if page.copyright %}

--- a/_layouts/workflow-list.html
+++ b/_layouts/workflow-list.html
@@ -12,7 +12,8 @@ layout: base
 
     <div class="row">
     {% for workflow in material.workflows %}
-	<div class="card col-md-6">
+	<div class="col-md-6">
+		<div class="card">
 		<div class="card-body">
 			<h5 class="card-title">{{ workflow.title }}</h5>
 			<h6 class="card-subtitle mb-2 text-muted">
@@ -55,10 +56,11 @@ layout: base
   </div>
 </div>
 
-	</div>
 	<pre class="mermaid">{{ workflow.mermaid }}
 	</pre>
-</div>
+		</div><!-- card-body -->
+	</div><!-- card -->
+</div><!-- col -->
 {% endfor %}
 
 </div>

--- a/_plugins/gtn.rb
+++ b/_plugins/gtn.rb
@@ -123,6 +123,22 @@ module Jekyll
     end
 
     ##
+    # Returns the publication date of a page, when it was merged into `main`
+    # Params:
+    # +page+:: The page to get the publication date of
+    # Returns:
+    # +String+:: The publication date of the page
+    #
+    def gtn_pub_date(path)
+      # if it's not a string then log a warning
+      if !path.is_a?(String)
+        path = path['path']
+      end
+      # Automatically strips any leading slashes.
+      Gtn::PublicationTimes.obtain_time(path.gsub(%r{^/}, ''))
+    end
+
+    ##
     # Returns the last modified date of a page
     # Params:
     # +page+:: The page to get the last modified date of

--- a/_plugins/gtn.rb
+++ b/_plugins/gtn.rb
@@ -131,9 +131,7 @@ module Jekyll
     #
     def gtn_pub_date(path)
       # if it's not a string then log a warning
-      if !path.is_a?(String)
-        path = path['path']
-      end
+      path = path['path'] if !path.is_a?(String)
       # Automatically strips any leading slashes.
       Gtn::PublicationTimes.obtain_time(path.gsub(%r{^/}, ''))
     end

--- a/_plugins/gtn/mod.rb
+++ b/_plugins/gtn/mod.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 module Gtn
+
   # Module for obtaining modification times of files.
   # It walks the git history to record the last time a file was modified.
   # This is faster than talking to the file system.
@@ -13,7 +14,7 @@ module Gtn
 
       @@TIME_CACHE = {}
       @@COMMIT_COUNT_CACHE = Hash.new(0)
-      puts '[GTN/MOD] Filling Time Cache'
+      puts '[GTN/Time/Mod] Filling Time Cache'
       `git log --name-only --pretty='GTN_GTN:%ct'`
         .split('GTN_GTN:')
         .map { |x| x.split("\n\n") }
@@ -58,9 +59,55 @@ module Gtn
       end
     end
   end
+
+  # Module for obtaining original publication times of files.
+  # It walks the git history to record the last time a file was modified.
+  # This is faster than talking to the file system.
+  module PublicationTimes
+    @@TIME_CACHE = nil
+
+    def self.init_cache
+      return unless @@TIME_CACHE.nil?
+
+      @@TIME_CACHE = {}
+      puts '[GTN/Time/Pub] Filling Publication Time Cache'
+      `git log --first-parent --name-only --diff-filter=A --pretty='GTN_GTN:%ct' main`
+        .split('GTN_GTN:')
+        .map { |x| x.split("\n\n") }
+        .select { |x| x.length > 1 }
+        .each do |date, files|
+        files.split(/\n/).select{|x| x =~ /\.(md|html)$/}.each do |f|
+          @@TIME_CACHE[f] = Time.at(date.to_i) if !@@TIME_CACHE.key? f
+        end
+      end
+    end
+
+    def self.time_cache
+      @@TIME_CACHE
+    end
+
+    def self.obtain_publication_time(f)
+      init_cache
+      if @@TIME_CACHE.key? f
+        @@TIME_CACHE[f]
+      else
+        begin
+          # Non git file.
+          @@TIME_CACHE[f] = File.mtime(f)
+          @@TIME_CACHE[f]
+        rescue StandardError
+          Time.at(0)
+        end
+      end
+    end
+  end
+
 end
 
 if $PROGRAM_NAME == __FILE__
-  Gtn::ModificationTimes.init_cache
-  pp Gtn::ModificationTimes.commit_count_cache
+  # Gtn::ModificationTimes.init_cache
+  # pp Gtn::ModificationTimes.commit_count_cache
+
+  Gtn::PublicationTimes.init_cache
+  pp Gtn::PublicationTimes.time_cache
 end

--- a/_plugins/gtn/mod.rb
+++ b/_plugins/gtn/mod.rb
@@ -126,8 +126,8 @@ if $PROGRAM_NAME == __FILE__
   # pp Gtn::ModificationTimes.commit_count_cache
 
   Gtn::PublicationTimes.init_cache
-  Gtn::PublicationTimes.time_cache.select { |_, v| 
+  Gtn::PublicationTimes.time_cache.select do |_, v|
     # Things in last 6 months
-    v > Time.now - 6 * 30 * 24 * 60 * 60
-  }.map{|k,v| puts "#{v} #{k}"}
+    v > Time.now - (6 * 30 * 24 * 60 * 60)
+  end.map { |k, v| puts "#{v} #{k}" }
 end

--- a/_plugins/gtn/mod.rb
+++ b/_plugins/gtn/mod.rb
@@ -85,7 +85,7 @@ module Gtn
         .map { |x| x.split("\n\n") }
         .select { |x| x.length > 1 }
         .each do |date, files|
-        files.split(/\n/).grep(/\.(md|html)$/).each do |f|
+        files.split("\n").grep(/\.(md|html)$/).each do |f|
           modification_type, path = f.split("\t")
           if modification_type == 'A'
             # Chase the renames.

--- a/_plugins/gtn/mod.rb
+++ b/_plugins/gtn/mod.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 module Gtn
-
   # Module for obtaining modification times of files.
   # It walks the git history to record the last time a file was modified.
   # This is faster than talking to the file system.
@@ -86,7 +85,7 @@ module Gtn
         .map { |x| x.split("\n\n") }
         .select { |x| x.length > 1 }
         .each do |date, files|
-        files.split(/\n/).select{|x| x =~ /\.(md|html)$/}.each do |f|
+        files.split(/\n/).grep(/\.(md|html)$/).each do |f|
           modification_type, path = f.split("\t")
           if modification_type == 'A'
             # Chase the renames.
@@ -120,7 +119,6 @@ module Gtn
       end
     end
   end
-
 end
 
 if $PROGRAM_NAME == __FILE__

--- a/_plugins/gtn/mod.rb
+++ b/_plugins/gtn/mod.rb
@@ -126,5 +126,8 @@ if $PROGRAM_NAME == __FILE__
   # pp Gtn::ModificationTimes.commit_count_cache
 
   Gtn::PublicationTimes.init_cache
-  pp Gtn::PublicationTimes.time_cache
+  Gtn::PublicationTimes.time_cache.select { |_, v| 
+    # Things in last 6 months
+    v > Time.now - 6 * 30 * 24 * 60 * 60
+  }.map{|k,v| puts "#{v} #{k}"}
 end

--- a/_plugins/jekyll-bundler.rb
+++ b/_plugins/jekyll-bundler.rb
@@ -63,7 +63,7 @@ module Jekyll
         bundle['preload'] == true
       end
 
-      bundles.map do |name, bundle|
+      bundles.map do |_name, bundle|
         bundle_path = "#{baseurl}#{bundle['path']}?v=#{bundle['timestamp']}"
         "<link rel='preload' href='#{bundle_path}' as='script'>"
       end.join("\n")

--- a/_plugins/jekyll-jsonld.rb
+++ b/_plugins/jekyll-jsonld.rb
@@ -307,6 +307,7 @@ module Jekyll
         # "creator":,
         # "dateCreated":,
         dateModified: Gtn::ModificationTimes.obtain_time(material['path']),
+        datePublished: Gtn::PublicationTimes.obtain_time(material['path']),
         # "datePublished":,
         discussionUrl: site['gitter_url'],
         # "editor":,

--- a/_plugins/jekyll-scholar.rb
+++ b/_plugins/jekyll-scholar.rb
@@ -99,14 +99,14 @@ module Jekyll
       site.config['citation_cache'][source_page].push(@text)
 
       begin
-          doi = site.config['cached_citeproc'].items[@text].doi
-          url = site.config['cached_citeproc'].items[@text].url
-          if !doi.nil?
-            "https://doi.org/#{doi}"
-          elsif !url.nil?
-            url
-          end
-          res = url
+        doi = site.config['cached_citeproc'].items[@text].doi
+        url = site.config['cached_citeproc'].items[@text].url
+        if !doi.nil?
+          "https://doi.org/#{doi}"
+        elsif !url.nil?
+          url
+        end
+        res = url
       rescue StandardError => e
         puts "[GTN/scholar] Could not render #{@text} from #{source_page} (#{e})"
         res = %(<span>https://example.com/ERROR+INVALID+CITATION+#{@text}</span>)

--- a/_plugins/jekyll-topic-filter.rb
+++ b/_plugins/jekyll-topic-filter.rb
@@ -373,13 +373,9 @@ module TopicFilter
     #     B -- No ----> E[End]
 
     output = "flowchart TD\n"
-    wf['steps'].keys.each do |id|
+    wf['steps'].each_key do |id|
       step = wf['steps'][id]
       output += "  #{id}[\"#{step['name']}\"];\n"
-    end
-
-    wf['steps'].keys.each do |id|
-      # Look at the 'input connections' to this step
       step = wf['steps'][id]
       step['input_connections'].each do |_, v|
         # if v is a list

--- a/_plugins/jekyll-topic-filter.rb
+++ b/_plugins/jekyll-topic-filter.rb
@@ -844,16 +844,41 @@ module Jekyll
     # Find the most recently modified tutorials
     # Parameters:
     # +site+:: The +Jekyll::Site+ object, used to get the list of pages.
+    # +exclude_recently_published+:: Do not include ones that were recently
+    #                                published in the slice, to make it look a bit nicer.
     # Returns:
     # +Array+:: An array of the 10 most recently modified pages
     # Example:
     #  {% assign latest_tutorials = site | recently_modified_tutorials %}
-    def recently_modified_tutorials(site)
+    def recently_modified_tutorials(site, exclude_recently_published: true)
       tutorials = site.pages.select { |page| page.data['layout'] == 'tutorial_hands_on' }
 
       latest = tutorials.sort do |x, y|
         Gtn::ModificationTimes.obtain_time(y.path) <=> Gtn::ModificationTimes.obtain_time(x.path)
       end
+
+      latest_published = recently_published_tutorials(site)
+      latest = latest.reject { |x| latest_published.include?(x) } if exclude_recently_published
+
+      latest.slice(0, 10)
+    end
+
+    ##
+    # Find the most recently published tutorials
+    # Parameters:
+    # +site+:: The +Jekyll::Site+ object, used to get the list of pages.
+    # Returns:
+    # +Array+:: An array of the 10 most recently published modified pages
+    # Example:
+    #  {% assign latest_tutorials = site | recently_modified_tutorials %}
+    def recently_published_tutorials(site)
+      tutorials = site.pages.select { |page| page.data['layout'] == 'tutorial_hands_on' }
+
+      latest = tutorials.sort do |x, y|
+        Gtn::PublicationTimes.obtain_time(y.path) <=> Gtn::PublicationTimes.obtain_time(x.path)
+      end
+
+      latest.each { |x| puts [x.path, Gtn::PublicationTimes.obtain_time(x.path)] }
       latest.slice(0, 10)
     end
 

--- a/assets/css/main.scss
+++ b/assets/css/main.scss
@@ -698,8 +698,8 @@ blockquote {
 		border-bottom: 1px solid var(--border-light);
 		padding: 1.25rem;
 		color: var(--brand-color-contrast);
-		margin-left: -15px; // BS has a 15px margin on cards, this makes the card title fill the card.
-		margin-right: -15px;
+		// margin-left: -15px; // BS has a 15px margin on cards, this makes the card title fill the card.
+		// margin-right: -15px;
 	}
 
 	.card-body {

--- a/assets/css/main.scss
+++ b/assets/css/main.scss
@@ -705,6 +705,15 @@ blockquote {
 	.card-body {
 		padding: 0em;
 		flex: 0 1 auto; // Override BS for the workflow listing.
+
+		// We stripped the padding from the card body in the above line
+		// Thus we need to add it back via margins to each element.
+		// We have to manually exclude the card titles
+		// And also canvases because they apparently calculate their area before the CSS has finished.
+		& > :not(.card-title,canvas){
+			margin-left: 1em;
+			margin-right: 1em;
+		}
 	}
 }
 

--- a/search-tools.html
+++ b/search-tools.html
@@ -1,6 +1,6 @@
 ---
 layout: page
-title: Pan Galactic Tool Search
+title: GTN Pan-Galactic Tool Search
 ---
 
 
@@ -78,6 +78,7 @@ function search(){
 		return
 	}
 
+	document.getElementsByTagName("title")[0].innerText = `${textQuery} | GTN Pan-Galactic Tool Search`
 	console.log(`Searching! ${textQuery}`)
 
 	// Which should be hidden

--- a/search.md
+++ b/search.md
@@ -1,6 +1,6 @@
 ---
 layout: page
-title: Search Tutorials
+title: GTN Tutorial Search
 ---
 
 <script src="https://cdnjs.cloudflare.com/ajax/libs/lunr.js/2.3.9/lunr.min.js" integrity="sha512-4xUl/d6D6THrAnXAwGajXkoWaeMNwEKK4iNfq5DotEbLPAfk6FSxSP3ydNxqDgCw1c/0Z1Jg6L8h2j+++9BZmg==" crossorigin="anonymous"></script>
@@ -28,6 +28,9 @@ function search(idx, q, includeFaqs, includeTutorials){
         var results_partial = idx.search(`*${q}*`),
             results_exact = idx.search(`${q}`),
             results_fuzzy = idx.search(`${q}~3`);
+
+	// Include search term in page title
+		document.getElementsByTagName("title")[0].innerText = `${q} | GTN Tutorial Search`
 
         thereMap  = Object.assign({}, ...results_partial.map((x) => ({[x.ref]: x.score})));
 

--- a/search2.html
+++ b/search2.html
@@ -1,6 +1,6 @@
 ---
 layout: page
-title: Search GTN Materials
+title: GTN Materials Search
 ---
 
 <p>
@@ -120,6 +120,8 @@ function search(){
 		return
 	}
 
+	// Include search term in page title
+	document.getElementsByTagName("title")[0].innerText = `${textQuery} | GTN Materials Search`
 	console.log(`Searching! ${textQuery} ${typeFilter} ${levelFilter}`)
 
 	// Which should be hidden

--- a/stats/index.md
+++ b/stats/index.md
@@ -100,7 +100,7 @@ redirect_from:
 
 
 <!-- Latest modified Tutorials -->
-<div class="col-md-12">
+<div class="col-md-6">
  <div class="card">
   <div class="card-body">
    <h5 class="card-title">Recently Updated Tutorials</h5>
@@ -114,7 +114,7 @@ redirect_from:
             {% assign topic_id = tuto | get_topic %}
             {% assign topic = site.data[topic_id] %}
       <tr>
-        <td>{{ tuto.last_modified_at | date: "%b %-d, %Y"  }}</td>
+        <td>{{ tuto.path | gtn_mod_date | date: "%b %-d, %Y"  }}</td>
         <td style="text-align:right">
             <a href="{{ site.baseurl }}/topics/{{ topic_id }}">
                 {{ topic.title }}
@@ -127,8 +127,38 @@ redirect_from:
     {% endfor %}
     </tbody>
    </table>
-    <p class="card-text">Thanks a lot for your contributions!</p>
+   </div>
+ </div>
+</div>
 
+<!-- Latest Added Tutorials -->
+<div class="col-md-6">
+ <div class="card">
+  <div class="card-body">
+   <h5 class="card-title">New Tutorials</h5>
+   {% assign latest_tutorials_published = site | recently_published_tutorials %}
+   <table class="table table-striped">
+    <thead>
+      <tr><th>Date</th><th>Topic</th><th>Title</th></tr>
+    </thead>
+    <tbody>
+    {% for tuto in latest_tutorials_published %}
+            {% assign topic_id = tuto | get_topic %}
+            {% assign topic = site.data[topic_id] %}
+      <tr>
+        <td>{{ tuto.path | gtn_pub_date | date: "%b %-d, %Y"  }}</td>
+        <td style="text-align:right">
+            <a href="{{ site.baseurl }}/topics/{{ topic_id }}">
+                {{ topic.title }}
+            </a>
+</td>
+        <td><a href="{{ site.baseurl }}/{{ tuto.url }}">
+            {{ tuto.title }}
+            </a></td>
+      </tr>
+    {% endfor %}
+    </tbody>
+   </table>
    </div>
  </div>
 </div>

--- a/stats/index.md
+++ b/stats/index.md
@@ -98,39 +98,6 @@ redirect_from:
  </div>
 </div>
 
-
-<!-- Latest modified Tutorials -->
-<div class="col-md-6">
- <div class="card">
-  <div class="card-body">
-   <h5 class="card-title">Recently Updated Tutorials</h5>
-   {% assign latest_tutorials = site | recently_modified_tutorials %}
-   <table class="table table-striped">
-    <thead>
-      <tr><th>Date</th><th>Topic</th><th>Title</th></tr>
-    </thead>
-    <tbody>
-    {% for tuto in latest_tutorials %}
-            {% assign topic_id = tuto | get_topic %}
-            {% assign topic = site.data[topic_id] %}
-      <tr>
-        <td>{{ tuto.path | gtn_mod_date | date: "%b %-d, %Y"  }}</td>
-        <td style="text-align:right">
-            <a href="{{ site.baseurl }}/topics/{{ topic_id }}">
-                {{ topic.title }}
-            </a>
-</td>
-        <td><a href="{{ site.baseurl }}/{{ tuto.url }}">
-            {{ tuto.title }}
-            </a></td>
-      </tr>
-    {% endfor %}
-    </tbody>
-   </table>
-   </div>
- </div>
-</div>
-
 <!-- Latest Added Tutorials -->
 <div class="col-md-6">
  <div class="card">
@@ -163,6 +130,37 @@ redirect_from:
  </div>
 </div>
 
+<!-- Latest modified Tutorials -->
+<div class="col-md-6">
+ <div class="card">
+  <div class="card-body">
+   <h5 class="card-title">Recently Updated Tutorials</h5>
+   {% assign latest_tutorials = site | recently_modified_tutorials %}
+   <table class="table table-striped">
+    <thead>
+      <tr><th>Date</th><th>Topic</th><th>Title</th></tr>
+    </thead>
+    <tbody>
+    {% for tuto in latest_tutorials %}
+            {% assign topic_id = tuto | get_topic %}
+            {% assign topic = site.data[topic_id] %}
+      <tr>
+        <td>{{ tuto.path | gtn_mod_date | date: "%b %-d, %Y"  }}</td>
+        <td style="text-align:right">
+            <a href="{{ site.baseurl }}/topics/{{ topic_id }}">
+                {{ topic.title }}
+            </a>
+</td>
+        <td><a href="{{ site.baseurl }}/{{ tuto.url }}">
+            {{ tuto.title }}
+            </a></td>
+      </tr>
+    {% endfor %}
+    </tbody>
+   </table>
+   </div>
+ </div>
+</div>
 
 <!-- Plausible Graphs -->
 <div class="col-md-12">

--- a/workflows/list.html
+++ b/workflows/list.html
@@ -1,6 +1,6 @@
 ---
 layout: page
-title: Cross UseGalaxy.* Workflow Search
+title: GTN Pan-Galactic Workflow Search
 ---
 
 <p>
@@ -101,6 +101,8 @@ function search(){
 		return
 	}
 
+	// Include search term in page title
+	document.getElementsByTagName("title")[0].innerText = `${textQuery} | GTN Pan-Galactic Workflow Search`
 	console.log(`Searching! ${textQuery}`)
 
 	// Which should be hidden


### PR DESCRIPTION
- improve `<title>` for search pages
- improve OG settings for all pages, removes duplicate "GTN Tutorial: " that wasn't necessary since the 'owner' is shown just above it.
- Fix news based on `--first-parent` in the diff to ensure we're really only selecting new things on the right branch
- Leverage `--first-parent` plus tracing renames to give us the 'first published' date for each material, when it hit the main branch.
- Expose that everywhere, including json-ld.
- Update stats page to show both recently added + modified as two separate lists