### PR TITLE
Display draft materials on draft pages (draft topics, LPs)

### DIFF
--- a/_includes/tutorial_list.html
+++ b/_includes/tutorial_list.html
@@ -19,9 +19,11 @@
   <tbody class="list">
 
   {% assign subtopic_materials = include.sub[1].materials | default: include.sub %}
+   {{page}}
   {% for material in subtopic_materials %}
         <!-- MAT: {{ material.id }} -->
-      {% if material.draft != true or jekyll.environment != "production" %}
+      {% if page.draft == true or material.draft != true or jekyll.environment != "production"  %}
+      <!-- show materials that are not in draft mode, unless we are in a dev environment or on a draft page such as a learning pathway or topic -->
 
         <tr>
           <td class="tutorial_title">

--- a/_includes/tutorial_list.html
+++ b/_includes/tutorial_list.html
@@ -19,7 +19,6 @@
   <tbody class="list">
 
   {% assign subtopic_materials = include.sub[1].materials | default: include.sub %}
-   {{page}}
   {% for material in subtopic_materials %}
         <!-- MAT: {{ material.id }} -->
       {% if page.draft == true or material.draft != true or jekyll.environment != "production"  %}


### PR DESCRIPTION
Tutorials that are in draft mode can still be shown when the entire page (e.g. topic or learning pathway) is also in draft mode


