### PR TITLE
.dockstore.yml: Change relative file paths to absolute paths for Dockstore 1.15 

### DIFF
--- a/.dockstore.yml
+++ b/.dockstore.yml
@@ -4,20 +4,20 @@ workflows:
   - name: intro-short
     subclass: GALAXY
     publish: true
-    primaryDescriptorPath: topics/introduction/tutorials/galaxy-intro-short/workflows/Galaxy-Workflow-galaxy-intro-short.ga
+    primaryDescriptorPath: /topics/introduction/tutorials/galaxy-intro-short/workflows/Galaxy-Workflow-galaxy-intro-short.ga
   - name: intro-everyone
     subclass: GALAXY
     publish: true
-    primaryDescriptorPath: topics/introduction/tutorials/galaxy-intro-101-everyone/workflows/main_workflow.ga
+    primaryDescriptorPath: /topics/introduction/tutorials/galaxy-intro-101-everyone/workflows/main_workflow.ga
   - name: de-novo
     subclass: GALAXY
     publish: true
-    primaryDescriptorPath: topics/transcriptomics/tutorials/full-de-novo/workflows/main_workflow.ga
+    primaryDescriptorPath: /topics/transcriptomics/tutorials/full-de-novo/workflows/main_workflow.ga
   - name: dip
     subclass: GALAXY
     publish: true
-    primaryDescriptorPath: topics/variant-analysis/tutorials/dip/workflows/diploid.ga
+    primaryDescriptorPath: /topics/variant-analysis/tutorials/dip/workflows/diploid.ga
   - name: genome-annotation
     subclass: GALAXY
     publish: true
-    primaryDescriptorPath: topics/genome-annotation/tutorials/annotation-with-prokka/workflows/Galaxy-Workflow-Workflow_constructed_from_history__prokka-workflow_.ga
+    primaryDescriptorPath: /topics/genome-annotation/tutorials/annotation-with-prokka/workflows/Galaxy-Workflow-Workflow_constructed_from_history__prokka-workflow_.ga


### PR DESCRIPTION
Hello,
I am a software developer at Dockstore and we are approaching our 1.15 release.

Prior to this release, relative paths were being inconsistently and unreliably processed in various parts of our system.
Therefore, in this release, we have more explicitly deprecated the use of relative file paths in our `.dockstore.yml` so all workflows with relative paths will now be deemed as invalid.
Thus, I have created this PR to change the file paths to absolute paths such that your workflows will still be valid after our release.

If you have any questions, please feel free to comment below.

Thank you!
Nayeon - Dockstore
