### PR TITLE
per topic rss feeds

### DIFF
--- a/_layouts/topic.html
+++ b/_layouts/topic.html
@@ -67,7 +67,11 @@ layout: base
 
     {% unless topic.tag_based %}
     <h2 id="topic-faq">Frequently Asked Questions</h2>
-    Common questions regarding this topic have been collected on a <a href="faqs/">dedicated FAQ page </a>. Common questions related to specific tutorials can be accessed from the tutorials themselves.
+    <p>Common questions regarding this topic have been collected on a <a href="faqs/">dedicated FAQ page </a>. Common questions related to specific tutorials can be accessed from the tutorials themselves.</p>
+
+    {% if jekyll.environment == "production" %}
+    <p><a href="feed.xml">Follow topic updates {% icon rss-feed %}</a> with our RSS Feed</p>
+    {% endif %}
     {% endunless %}
 
     {% if topic.editorial_board %}

--- a/_plugins/feeds.rb
+++ b/_plugins/feeds.rb
@@ -1,0 +1,101 @@
+# frozen_string_literal: true
+
+require './_plugins/jekyll-topic-filter'
+require './_plugins/gtn'
+
+def generate_topic_feeds(site)
+  TopicFilter.list_topics(site).each do |topic|
+    feed_path = File.join(site.dest, 'topics', topic, 'feed.xml')
+    Jekyll.logger.debug "Generating feed for #{topic} => #{feed_path}"
+
+    topic_pages = site.pages
+                      .select { |x| x.path =~ %r{^\.?/?topics/#{topic}} }
+                      .select { |x| x.path =~ %r{(tutorial.md|slides.html|faqs/.*.md)} }
+                      .reject { |x| x.path =~ /index.md/ }
+                      .reject { |x| x.data.fetch('draft', '').to_s == 'true' }
+                      .reject { |x| x.url =~ /slides-plain.html/ }
+                      .reject { |x| File.symlink?(x.path) } # Remove symlinks to other faqs/tutorials
+                      .uniq(&:path)
+                      .sort_by { |page| Gtn::PublicationTimes.obtain_time(page.path) }
+                      .reverse
+
+    if topic_pages.empty?
+      Jekyll.logger.warn "No pages for #{topic}"
+      next
+    else
+      Jekyll.logger.debug "Found #{topic_pages.length} pages for #{topic}"
+    end
+
+    builder = Nokogiri::XML::Builder.new(encoding: 'UTF-8') do |xml|
+      # Set stylesheet
+      xml.feed(xmlns: 'http://www.w3.org/2005/Atom') do
+        # Set generator also needs a URI attribute
+        xml.generator('Jekyll', uri: 'https://jekyllrb.com/')
+        xml.link(href: "#{site.config['url']}#{site.baseurl}/topics/#{topic}/feed.xml", rel: 'self')
+        xml.updated(Gtn::ModificationTimes.obtain_time(topic_pages.first.path).to_datetime.rfc3339)
+        xml.id("#{site.config['url']}#{site.baseurl}/topics/#{topic}/feed.xml")
+        topic_title = site.data[topic]['title']
+        xml.title("Galaxy Training Network - #{topic_title}")
+        xml.subtitle("Recently added tutorials, slides, and FAQs in the #{topic} topic")
+
+        topic_pages.each do |page|
+          page_type = if page.path =~ %r{faqs/.*.md}
+                        'faq'
+                      else
+                        page.path.split('/').last.split('.').first
+                      end
+
+          xml.entry do
+            xml.title(page.data['title'])
+            link = "#{site.config['url']}#{site.baseurl}#{page.url}"
+            xml.link(href: link)
+            # Our links are stable
+            xml.id(link)
+
+            # This is a feed of only NEW tutorials, so we only include publication times.
+            # xml.published(Gtn::PublicationTimes.obtain_time(page.path).to_datetime.rfc3339)
+            xml.updated(Gtn::PublicationTimes.obtain_time(page.path).to_datetime.rfc3339)
+
+            # xml.path(page.path)
+            xml.category(term: "new #{page_type}")
+            # xml.content(page.content, type: "html")
+            xml.summary(page.content.strip.split("\n").first, type: 'html')
+
+            Gtn::Contributors.get_authors(page.data).each do |c|
+              xml.author do
+                xml.name(Gtn::Contributors.fetch_name(site, c))
+                xml.uri("#{site.config['url']}#{site.baseurl}/hall-of-fame/#{c}/")
+              end
+            end
+
+            Gtn::Contributors.get_non_authors(page.data).each do |c|
+              xml.contributor do
+                xml.name(Gtn::Contributors.fetch_name(site, c))
+                xml.uri("#{site.config['url']}#{site.baseurl}/hall-of-fame/#{c}/")
+              end
+            end
+          end
+        end
+      end
+    end
+
+    # The builder won't let you add a processing instruction, so we have to
+    # serialise it to a string and then parse it again. Ridiculous.
+    finalised = Nokogiri::XML builder.to_xml
+    pi = Nokogiri::XML::ProcessingInstruction.new(
+      finalised, 'xml-stylesheet',
+      %(type="text/xml" href="#{site.config['url']}#{site.baseurl}/feed.xslt.xml")
+    )
+    finalised.root.add_previous_sibling pi
+    File.write(feed_path, finalised.to_xml)
+  end
+
+  nil
+end
+
+# Basically like `PageWithoutAFile`
+Jekyll::Hooks.register :site, :post_write do |site|
+  if Jekyll.env == 'production'
+    generate_topic_feeds(site)
+  end
+end

--- a/_plugins/gtn/mod.rb
+++ b/_plugins/gtn/mod.rb
@@ -68,7 +68,16 @@ module Gtn
       @@COMMIT_COUNT_CACHE
     end
 
-    def self.obtain_modification_count(f)
+    def self.clean_path(f)
+      if f =~ %r{^\./}
+        f[2..]
+      else
+        f
+      end
+    end
+
+    def self.obtain_modification_count(f_unk)
+      f = clean_path(f_unk)
       init_cache
       if @@COMMIT_COUNT_CACHE.key? f
         @@COMMIT_COUNT_CACHE[f]
@@ -77,7 +86,8 @@ module Gtn
       end
     end
 
-    def self.obtain_time(f)
+    def self.obtain_time(f_unk)
+      f = clean_path(f_unk)
       init_cache
       if @@TIME_CACHE.key? f
         @@TIME_CACHE[f]
@@ -85,7 +95,7 @@ module Gtn
         begin
           # Non git file.
           @@TIME_CACHE[f] = File.mtime(f)
-          Jekyll.logger.warning "[GTN/Time/Mod] No git cached time available for #{f}, defaulting to checkout"
+          Jekyll.logger.warn "[GTN/Time/Mod] No git cached time available for #{f}, defaulting to checkout"
           @@TIME_CACHE[f]
         rescue StandardError
           Time.at(0)
@@ -173,7 +183,16 @@ module Gtn
       @@TIME_CACHE
     end
 
-    def self.obtain_time(f)
+    def self.clean_path(f)
+      if f =~ %r{^\./}
+        f[2..]
+      else
+        f
+      end
+    end
+
+    def self.obtain_time(f_unk)
+      f = clean_path(f_unk)
       init_cache
       if @@TIME_CACHE.key? f
         @@TIME_CACHE[f]
@@ -181,7 +200,7 @@ module Gtn
         begin
           # Non git file.
           @@TIME_CACHE[f] = File.mtime(f)
-          Jekyll.logger.warning "[GTN/Time/Pub] No git cached time available for #{f}, defaulting to checkout"
+          Jekyll.logger.warn "[GTN/Time/Pub] No git cached time available for #{f}, defaulting to checkout"
           @@TIME_CACHE[f]
         rescue StandardError
           Time.at(0)

--- a/_plugins/jekyll-topic-filter.rb
+++ b/_plugins/jekyll-topic-filter.rb
@@ -1049,7 +1049,7 @@ module Jekyll
       topic = page['path'].split('/')[1]
       material = page['path'].split('/')[3]
       ret = TopicFilter.fetch_tutorial_material(site, topic, material)
-      Jekyll.logger.warning "Could not find material #{topic} #{material}" if ret.nil?
+      Jekyll.logger.warn "Could not find material #{topic} #{material}" if ret.nil?
       ret
     end
 

--- a/feed.xslt.xml
+++ b/feed.xslt.xml
@@ -33,7 +33,11 @@
   </xsl:template>
 
   <xsl:template match="atom:feed">
-    <h1>Galaxy Training Network Feed Preview</h1>
+    <h1><xsl:value-of select="atom:title"/> (Feed Preview)</h1>
+    <xsl:if test="atom:subtitle">
+      <p><strong><xsl:value-of select="atom:subtitle"/></strong></p>
+    </xsl:if>
+
     <p>This RSS feed provides the latest posts from the Galaxy Training Network!
 
     <a class="head_link" target="_blank">
@@ -48,9 +52,9 @@
     <h2>What is an RSS feed?</h2>
     <p>An RSS feed is a data format that contains the latest content from a website, blog, or podcast. You can use feeds to <strong>subscribe</strong> to websites and get the <strong>latest content in one place</strong>.</p>
     <ul>
-    	<li><strong>Feeds put you in control.</strong> Unlike social media apps, there is no algorithm deciding what you see or read. You always get the latest content from the creators you care about.</li>
-    	<li><strong>Feed are private by design.</strong> No one owns web feeds, so no one is harvesting your personal information and profiting by selling it to advertisers.</li>
-    	<li><strong>Feeds are spam-proof.</strong> Had enough? Easy, just unsubscribe from the feed.</li>
+        <li><strong>Feeds put you in control.</strong> Unlike social media apps, there is no algorithm deciding what you see or read. You always get the latest content from the creators you care about.</li>
+        <li><strong>Feed are private by design.</strong> No one owns web feeds, so no one is harvesting your personal information and profiting by selling it to advertisers.</li>
+        <li><strong>Feeds are spam-proof.</strong> Had enough? Easy, just unsubscribe from the feed.</li>
     </ul>
     <p>All you need to do to get started is to add the URL (web address) for this feed to a special app called a newsreader. Visit <a href="https://aboutfeeds.com/">About Feeds</a> to get started with newsreaders and subscribing. It’s free. </p>
   </xsl:template>
@@ -65,12 +69,28 @@
           <xsl:value-of select="atom:title"/>
         </a>
       </h3>
-      <p class="authors"><xsl:value-of select="atom:author" /></p>
+      <p class="authors">
+         <xsl:for-each select="atom:author">
+           <a href="{atom:uri}">
+             <xsl:value-of select="atom:name" />
+           </a>
+           <xsl:if test="position() != last()">
+             <xsl:text>, </xsl:text>
+           </xsl:if>
+         </xsl:for-each>
+      </p>
       <p>
         <xsl:value-of select="atom:summary"  disable-output-escaping="yes" />
       </p>
       <small>
-        Published: <xsl:value-of select="atom:updated" />
+        Published: <xsl:value-of select="atom:updated" /> <br/>
+        Tags:
+        <xsl:for-each select="atom:category">
+          <xsl:value-of select="@term" />
+          <xsl:if test="position() != last()">
+            <xsl:text>, </xsl:text>
+          </xsl:if>
+        </xsl:for-each>
       </small>
     </div>
   </xsl:template>


### PR DESCRIPTION
it works. Per-topic RSS feeds announcing new (only, not updated) materials.

We could add more for e.g. updated materials per topic, all material changes, just let us know what's useful.

![image](https://github.com/galaxyproject/training-material/assets/458683/c147bc75-91df-47dd-b669-eb24edf3c5d5)
