### PR TITLE
Add support url to customisations tutorial for GAT

### DIFF
--- a/topics/admin/tutorials/apptainer/tutorial.md
+++ b/topics/admin/tutorials/apptainer/tutorial.md
@@ -178,7 +178,7 @@ Now, we will configure Galaxy to run tools using Apptainer containers, which wil
 >    ```diff
 >    --- a/group_vars/galaxyservers.yml
 >    +++ b/group_vars/galaxyservers.yml
->    @@ -72,6 +72,9 @@ galaxy_config:
+>    @@ -75,6 +75,9 @@ galaxy_config:
 >         tus_upload_store: "{{ galaxy_tus_upload_store }}"
 >         # CVMFS
 >         tool_data_table_config_path: /cvmfs/data.galaxyproject.org/byhand/location/tool_data_table_conf.xml,/cvmfs/data.galaxyproject.org/managed/location/tool_data_table_conf.xml
@@ -188,7 +188,7 @@ Now, we will configure Galaxy to run tools using Apptainer containers, which wil
 >       gravity:
 >         process_manager: systemd
 >         galaxy_root: "{{ galaxy_root }}/server"
->    @@ -111,6 +114,12 @@ galaxy_config_files:
+>    @@ -114,6 +117,12 @@ galaxy_config_files:
 >       - src: files/galaxy/themes.yml
 >         dest: "{{ galaxy_config.galaxy.themes_config_file }}"
 >     

--- a/topics/admin/tutorials/celery/tutorial.md
+++ b/topics/admin/tutorials/celery/tutorial.md
@@ -148,7 +148,7 @@ First we need to add our new Ansible Roles to the `requirements.yml`:
 >        ```diff
 >        --- a/group_vars/galaxyservers.yml
 >        +++ b/group_vars/galaxyservers.yml
->        @@ -279,3 +279,7 @@ rabbitmq_users:
+>        @@ -282,3 +282,7 @@ rabbitmq_users:
 >         # TUS
 >         galaxy_tusd_port: 1080
 >         galaxy_tus_upload_store: /data/tus
@@ -247,7 +247,7 @@ First we need to add our new Ansible Roles to the `requirements.yml`:
 >        ```diff
 >        --- a/group_vars/galaxyservers.yml
 >        +++ b/group_vars/galaxyservers.yml
->        @@ -266,6 +266,7 @@ rabbitmq_config:
+>        @@ -269,6 +269,7 @@ rabbitmq_config:
 >         
 >         rabbitmq_vhosts:
 >           - /pulsar/pulsar_au
@@ -255,7 +255,7 @@ First we need to add our new Ansible Roles to the `requirements.yml`:
 >         
 >         rabbitmq_users:
 >           - user: admin
->        @@ -275,6 +276,13 @@ rabbitmq_users:
+>        @@ -278,6 +279,13 @@ rabbitmq_users:
 >           - user: pulsar_au
 >             password: "{{ vault_rabbitmq_password_vhost }}"
 >             vhost: /pulsar/pulsar_au
@@ -298,7 +298,7 @@ First we need to add our new Ansible Roles to the `requirements.yml`:
 >        ```diff
 >        --- a/group_vars/galaxyservers.yml
 >        +++ b/group_vars/galaxyservers.yml
->        @@ -291,3 +291,22 @@ galaxy_tus_upload_store: /data/tus
+>        @@ -294,3 +294,22 @@ galaxy_tus_upload_store: /data/tus
 >         #Redis
 >         galaxy_additional_venv_packages:
 >           - redis
@@ -372,7 +372,7 @@ First we need to add our new Ansible Roles to the `requirements.yml`:
 >    ```diff
 >    --- a/group_vars/galaxyservers.yml
 >    +++ b/group_vars/galaxyservers.yml
->    @@ -127,6 +127,11 @@ galaxy_config:
+>    @@ -130,6 +130,11 @@ galaxy_config:
 >           preload: true
 >         celery:
 >           concurrency: 2
@@ -393,7 +393,7 @@ First we need to add our new Ansible Roles to the `requirements.yml`:
 >    ```diff
 >    --- a/group_vars/galaxyservers.yml
 >    +++ b/group_vars/galaxyservers.yml
->    @@ -108,6 +108,11 @@ galaxy_config:
+>    @@ -111,6 +111,11 @@ galaxy_config:
 >         # Data Library Directories
 >         library_import_dir: /libraries/admin
 >         user_library_import_dir: /libraries/user

--- a/topics/admin/tutorials/connect-to-compute-cluster/tutorial.md
+++ b/topics/admin/tutorials/connect-to-compute-cluster/tutorial.md
@@ -125,7 +125,7 @@ be taken into consideration when choosing where to run jobs and what parameters 
 >    ```diff
 >    --- a/group_vars/galaxyservers.yml
 >    +++ b/group_vars/galaxyservers.yml
->    @@ -191,6 +191,16 @@ nginx_ssl_role: usegalaxy_eu.certbot
+>    @@ -194,6 +194,16 @@ nginx_ssl_role: usegalaxy_eu.certbot
 >     nginx_conf_ssl_certificate: /etc/ssl/certs/fullchain.pem
 >     nginx_conf_ssl_certificate_key: /etc/ssl/user/privkey-www-data.pem
 >     

--- a/topics/admin/tutorials/customization/tutorial.md
+++ b/topics/admin/tutorials/customization/tutorial.md
@@ -30,6 +30,7 @@ Customizing your Galaxy instance makes it more recognizable at a glance, and can
 This tutorial will teach you three basic customizations you can make to Galaxy:
 
   - Setting a brand text
+  - Setting the contact information
   - Adding a custom welcome page
   - Customizing the masthead using themes
 
@@ -85,6 +86,35 @@ It is an easy way to set your instance apart, and make it more identifiable.
 >    ![screenshot of fictional "Galaxy Mars" start page, with the brand text set to "Mars"](images/galaxy-mars-brand.png "Your Galaxy start page should now look something like this")
 {: .hands_on}
 
+## Configuring Support
+
+The Galaxy Help Site (https://help.galaxyproject.org) receives a lot of user support questions, sometimes for Galaxies that we do not manage. Including support information inside your Galaxy can help users find the right place to ask about issues with tools or quotas!
+
+> <hands-on-title>Adding Support Information</hands-on-title>
+>
+> 1. Open your `group_vars/galaxyserers.yml` and the following option under `galaxy_config.galaxy`:
+> 
+>    {% raw %}
+>    ```diff
+>    --- a/group_vars/galaxyservers.yml
+>    +++ b/group_vars/galaxyservers.yml
+>    @@ -35,6 +35,9 @@ galaxy_config:
+>         # Branding
+>         brand: Mars 🚀
+>         logo_src: "https://training.galaxyproject.org/training-material/topics/admin/tutorials/customization/images/logo.png"
+>    +    # Support
+>    +    support_url: "https://example.org/support"
+>    +    terms_url: "https://example.org/terms-of-service"
+>         # Main Configuration
+>         admin_users:
+>         - admin@example.org
+>    {% endraw %}
+>    ```
+>    {: data-commit="Add support information"}
+>
+> Ideally this would point to a support URL and a terms of service that are appropriate to *your* deployment of Galaxy. You could, for instance, add a page on your group's blog with the appropriate contents of who should be contacted in case of issue, their email or a ticketing system. These options will help users from your site find you when they need help.
+{: .hands_on}
+
 ## Custom Welcome Page
 
 The welcome page is an html document embedded in Galaxy's start page.
@@ -101,7 +131,7 @@ This page can be used to communicate what your instance is about, and share news
 >    ```diff
 >    --- a/group_vars/galaxyservers.yml
 >    +++ b/group_vars/galaxyservers.yml
->    @@ -93,6 +93,10 @@ galaxy_config:
+>    @@ -96,6 +96,10 @@ galaxy_config:
 >               - job-handlers
 >               - workflow-schedulers
 >     
@@ -208,10 +238,10 @@ You can even offer several options, to allow users to switch to the default if t
 >         brand: Mars 🚀
 >         logo_src: "https://training.galaxyproject.org/training-material/topics/admin/tutorials/customization/images/logo.png"
 >    +    themes_config_file: "{{ galaxy_config_dir }}/themes.yml"
->         # Main Configuration
->         admin_users:
->         - admin@example.org
->    @@ -97,6 +98,10 @@ galaxy_config_files_public:
+>         # Support
+>         support_url: "https://example.org/support"
+>         terms_url: "https://example.org/terms-of-service"
+>    @@ -100,6 +101,10 @@ galaxy_config_files_public:
 >       - src: files/galaxy/welcome.html
 >         dest: "{{ galaxy_mutable_config_dir }}/welcome.html"
 >     

--- a/topics/admin/tutorials/cvmfs/tutorial.md
+++ b/topics/admin/tutorials/cvmfs/tutorial.md
@@ -506,7 +506,7 @@ Now all we need to do is tell Galaxy how to find it! This tutorial assumes that 
 >    ```diff
 >    --- a/group_vars/galaxyservers.yml
 >    +++ b/group_vars/galaxyservers.yml
->    @@ -70,6 +70,8 @@ galaxy_config:
+>    @@ -73,6 +73,8 @@ galaxy_config:
 >         # TUS
 >         galaxy_infrastructure_url: "https://{{ inventory_hostname }}"
 >         tus_upload_store: "{{ galaxy_tus_upload_store }}"

--- a/topics/admin/tutorials/data-library/tutorial.md
+++ b/topics/admin/tutorials/data-library/tutorial.md
@@ -84,7 +84,7 @@ Before we can import local data, we need to configure Galaxy to permit this. Add
 >    ```diff
 >    --- a/group_vars/galaxyservers.yml
 >    +++ b/group_vars/galaxyservers.yml
->    @@ -88,6 +88,9 @@ galaxy_config:
+>    @@ -91,6 +91,9 @@ galaxy_config:
 >         # Tool Dependencies
 >         dependency_resolvers_config_file: "{{ galaxy_config_dir }}/dependency_resolvers_conf.xml"
 >         container_resolvers_config_file: "{{ galaxy_config_dir }}/container_resolvers_conf.yml"

--- a/topics/admin/tutorials/ftp/tutorial.md
+++ b/topics/admin/tutorials/ftp/tutorial.md
@@ -111,7 +111,7 @@ If the terms "Ansible", "role" and "playbook" mean nothing to you, please checko
 >    ```diff
 >    --- a/group_vars/galaxyservers.yml
 >    +++ b/group_vars/galaxyservers.yml
->    @@ -207,11 +207,13 @@ certbot_environment: staging
+>    @@ -210,11 +210,13 @@ certbot_environment: staging
 >     certbot_well_known_root: /srv/nginx/_well-known_root
 >     certbot_share_key_users:
 >       - www-data
@@ -137,7 +137,7 @@ If the terms "Ansible", "role" and "playbook" mean nothing to you, please checko
 >    ```diff
 >    --- a/group_vars/galaxyservers.yml
 >    +++ b/group_vars/galaxyservers.yml
->    @@ -119,6 +119,9 @@ galaxy_config:
+>    @@ -122,6 +122,9 @@ galaxy_config:
 >         sentry_dsn: "{{ vault_galaxy_sentry_dsn }}"
 >         sentry_traces_sample_rate: 0.5
 >         error_report_file: "{{ galaxy_config_dir }}/error_reports_file.yml"
@@ -159,7 +159,7 @@ If the terms "Ansible", "role" and "playbook" mean nothing to you, please checko
 >    ```diff
 >    --- a/group_vars/galaxyservers.yml
 >    +++ b/group_vars/galaxyservers.yml
->    @@ -363,3 +363,24 @@ telegraf_plugins_extra:
+>    @@ -366,3 +366,24 @@ telegraf_plugins_extra:
 >     tiaas_dir: /srv/tiaas
 >     tiaas_admin_user: admin
 >     tiaas_admin_pass: changeme

--- a/topics/admin/tutorials/job-destinations/tutorial.md
+++ b/topics/admin/tutorials/job-destinations/tutorial.md
@@ -107,7 +107,7 @@ To demonstrate a real-life scenario and {TPV}'s role in it, let's plan on settin
 >    ```diff
 >    --- a/group_vars/galaxyservers.yml
 >    +++ b/group_vars/galaxyservers.yml
->    @@ -152,6 +152,9 @@ galaxy_config_templates:
+>    @@ -155,6 +155,9 @@ galaxy_config_templates:
 >     galaxy_extra_dirs:
 >       - /data
 >     
@@ -197,7 +197,7 @@ And of course, Galaxy has an Ansible Role for that.
 >    ```diff
 >    --- a/group_vars/galaxyservers.yml
 >    +++ b/group_vars/galaxyservers.yml
->    @@ -135,6 +135,8 @@ galaxy_config:
+>    @@ -138,6 +138,8 @@ galaxy_config:
 >               - job-handlers
 >               - workflow-schedulers
 >     
@@ -206,7 +206,7 @@ And of course, Galaxy has an Ansible Role for that.
 >     galaxy_config_files_public:
 >       - src: files/galaxy/welcome.html
 >         dest: "{{ galaxy_mutable_config_dir }}/welcome.html"
->    @@ -151,6 +153,11 @@ galaxy_config_templates:
+>    @@ -154,6 +156,11 @@ galaxy_config_templates:
 >     
 >     galaxy_extra_dirs:
 >       - /data
@@ -297,7 +297,7 @@ We want our tool to run with more than one core. To do this, we need to instruct
 >       tools:
 >         - class: local # these special tools that aren't parameterized for remote execution - expression tools, upload, etc
 >           environment: local_env
->    @@ -144,6 +128,8 @@ galaxy_config_files_public:
+>    @@ -147,6 +131,8 @@ galaxy_config_files_public:
 >     galaxy_config_files:
 >       - src: files/galaxy/themes.yml
 >         dest: "{{ galaxy_config.galaxy.themes_config_file }}"
@@ -639,7 +639,7 @@ Such form elements can be added to tools without modifying each tool's configura
 >     
 >     galaxy_config:
 >       galaxy:
->    @@ -56,6 +64,7 @@ galaxy_config:
+>    @@ -59,6 +67,7 @@ galaxy_config:
 >         object_store_store_by: uuid
 >         id_secret: "{{ vault_id_secret }}"
 >         job_config: "{{ galaxy_job_config }}" # Use the variable we defined above
@@ -647,7 +647,7 @@ Such form elements can be added to tools without modifying each tool's configura
 >         # SQL Performance
 >         slow_query_log_threshold: 5
 >         enable_per_request_sql_debugging: true
->    @@ -137,6 +146,8 @@ galaxy_config_templates:
+>    @@ -140,6 +149,8 @@ galaxy_config_templates:
 >         dest: "{{ galaxy_config.galaxy.container_resolvers_config_file }}"
 >       - src: templates/galaxy/config/dependency_resolvers_conf.xml
 >         dest: "{{ galaxy_config.galaxy.dependency_resolvers_config_file }}"

--- a/topics/admin/tutorials/monitoring/tutorial.md
+++ b/topics/admin/tutorials/monitoring/tutorial.md
@@ -375,7 +375,7 @@ Setting up Telegraf is again very simple. We just add a single role to our playb
 >    ```diff
 >    --- a/group_vars/galaxyservers.yml
 >    +++ b/group_vars/galaxyservers.yml
->    @@ -327,3 +327,12 @@ flower_ui_users:
+>    @@ -330,3 +330,12 @@ flower_ui_users:
 >     
 >     flower_environment_variables:
 >       GALAXY_CONFIG_FILE: "{{ galaxy_config_file }}"
@@ -402,7 +402,7 @@ Setting up Telegraf is again very simple. We just add a single role to our playb
 >    ```diff
 >    --- a/group_vars/galaxyservers.yml
 >    +++ b/group_vars/galaxyservers.yml
->    @@ -113,6 +113,9 @@ galaxy_config:
+>    @@ -116,6 +116,9 @@ galaxy_config:
 >         celery_conf:
 >           result_backend: "redis://localhost:6379/0"
 >         enable_celery_tasks: true
@@ -798,7 +798,7 @@ You can run the playbook now, or wait until you have configured Telegraf below:
 >    ```diff
 >    --- a/group_vars/galaxyservers.yml
 >    +++ b/group_vars/galaxyservers.yml
->    @@ -339,3 +339,10 @@ telegraf_plugins_extra:
+>    @@ -342,3 +342,10 @@ telegraf_plugins_extra:
 >           - service_address = ":8125"
 >           - metric_separator = "."
 >           - allowed_pending_messages = 10000

--- a/topics/admin/tutorials/pulsar/tutorial.md
+++ b/topics/admin/tutorials/pulsar/tutorial.md
@@ -271,7 +271,7 @@ More information about the rabbitmq ansible role can be found [in the repository
 >    ```diff
 >    --- a/group_vars/galaxyservers.yml
 >    +++ b/group_vars/galaxyservers.yml
->    @@ -171,8 +171,11 @@ certbot_environment: staging
+>    @@ -174,8 +174,11 @@ certbot_environment: staging
 >     certbot_well_known_root: /srv/nginx/_well-known_root
 >     certbot_share_key_users:
 >       - www-data
@@ -283,7 +283,7 @@ More information about the rabbitmq ansible role can be found [in the repository
 >     certbot_domains:
 >      - "{{ inventory_hostname }}"
 >     certbot_agree_tos: --agree-tos
->    @@ -222,6 +225,47 @@ slurm_config:
+>    @@ -225,6 +228,47 @@ slurm_config:
 >       SelectType: select/cons_res
 >       SelectTypeParameters: CR_CPU_Memory  # Allocate individual cores/memory instead of entire node
 >     

--- a/topics/admin/tutorials/reports/tutorial.md
+++ b/topics/admin/tutorials/reports/tutorial.md
@@ -82,7 +82,7 @@ The reports application is included with the Galaxy codebase and this tutorial a
 >    ```diff
 >    --- a/group_vars/galaxyservers.yml
 >    +++ b/group_vars/galaxyservers.yml
->    @@ -148,6 +148,11 @@ galaxy_config:
+>    @@ -151,6 +151,11 @@ galaxy_config:
 >             pools:
 >               - job-handlers
 >               - workflow-schedulers
@@ -94,7 +94,7 @@ The reports application is included with the Galaxy codebase and this tutorial a
 >     
 >     galaxy_job_config_file: "{{ galaxy_config_dir }}/galaxy.yml"
 >     
->    @@ -168,6 +173,8 @@ galaxy_config_templates:
+>    @@ -171,6 +176,8 @@ galaxy_config_templates:
 >         dest: "{{ galaxy_config.galaxy.dependency_resolvers_config_file }}"
 >       - src: templates/galaxy/config/job_resource_params_conf.xml.j2
 >         dest: "{{ galaxy_config.galaxy.job_resource_params_file }}"

--- a/topics/admin/tutorials/sentry/tutorial.md
+++ b/topics/admin/tutorials/sentry/tutorial.md
@@ -255,7 +255,7 @@ First we need to add our new Ansible role to `requirements.yml`:
 >    ```diff
 >    --- a/group_vars/galaxyservers.yml
 >    +++ b/group_vars/galaxyservers.yml
->    @@ -216,6 +216,7 @@ nginx_servers:
+>    @@ -219,6 +219,7 @@ nginx_servers:
 >       - redirect-ssl
 >     nginx_ssl_servers:
 >       - galaxy
@@ -300,7 +300,7 @@ First we need to add our new Ansible role to `requirements.yml`:
 >    ```diff
 >    --- a/group_vars/galaxyservers.yml
 >    +++ b/group_vars/galaxyservers.yml
->    @@ -116,6 +116,8 @@ galaxy_config:
+>    @@ -119,6 +119,8 @@ galaxy_config:
 >         # Monitoring
 >         statsd_host: localhost
 >         statsd_influxdb: true
@@ -434,7 +434,7 @@ In addition to sending logging errors to Sentry you can also collect failing too
 >    ```diff
 >    --- a/group_vars/galaxyservers.yml
 >    +++ b/group_vars/galaxyservers.yml
->    @@ -118,6 +118,7 @@ galaxy_config:
+>    @@ -121,6 +121,7 @@ galaxy_config:
 >         statsd_influxdb: true
 >         sentry_dsn: "{{ vault_galaxy_sentry_dsn }}"
 >         sentry_traces_sample_rate: 0.5
@@ -442,7 +442,7 @@ In addition to sending logging errors to Sentry you can also collect failing too
 >       gravity:
 >         process_manager: systemd
 >         galaxy_root: "{{ galaxy_root }}/server"
->    @@ -170,6 +171,8 @@ galaxy_config_files:
+>    @@ -173,6 +174,8 @@ galaxy_config_files:
 >         dest: "{{ galaxy_config.galaxy.themes_config_file }}"
 >       - src: files/galaxy/config/tpv_rules_local.yml
 >         dest: "{{ tpv_mutable_dir }}/tpv_rules_local.yml"
@@ -451,7 +451,7 @@ In addition to sending logging errors to Sentry you can also collect failing too
 >     
 >     galaxy_config_templates:
 >       - src: templates/galaxy/config/container_resolvers_conf.yml.j2
->    @@ -191,6 +194,7 @@ tpv_privsep: true
+>    @@ -194,6 +197,7 @@ tpv_privsep: true
 >     
 >     galaxy_local_tools:
 >     - testing.xml

--- a/topics/admin/tutorials/tiaas/tutorial.md
+++ b/topics/admin/tutorials/tiaas/tutorial.md
@@ -91,7 +91,7 @@ This tutorial will go cover how to set up such a service on your own Galaxy serv
 >    ```diff
 >    --- a/group_vars/galaxyservers.yml
 >    +++ b/group_vars/galaxyservers.yml
->    @@ -346,3 +346,8 @@ telegraf_plugins_extra:
+>    @@ -349,3 +349,8 @@ telegraf_plugins_extra:
 >           - timeout = "10s"
 >           - data_format = "influx"
 >           - interval = "15s"

--- a/topics/admin/tutorials/tus/tutorial.md
+++ b/topics/admin/tutorials/tus/tutorial.md
@@ -80,7 +80,7 @@ To allow your user to upload via TUS, you will need to:
 >    ```diff
 >    --- a/group_vars/galaxyservers.yml
 >    +++ b/group_vars/galaxyservers.yml
->    @@ -67,6 +67,9 @@ galaxy_config:
+>    @@ -70,6 +70,9 @@ galaxy_config:
 >         # Tool security
 >         outputs_to_working_directory: true
 >         new_user_dataset_access_role_default_private: true # Make datasets private by default
@@ -90,7 +90,7 @@ To allow your user to upload via TUS, you will need to:
 >       gravity:
 >         process_manager: systemd
 >         galaxy_root: "{{ galaxy_root }}/server"
->    @@ -87,6 +90,10 @@ galaxy_config:
+>    @@ -90,6 +93,10 @@ galaxy_config:
 >         celery:
 >           concurrency: 2
 >           loglevel: DEBUG
@@ -101,7 +101,7 @@ To allow your user to upload via TUS, you will need to:
 >         handlers:
 >           handler:
 >             processes: 2
->    @@ -156,3 +163,7 @@ nginx_conf_http:
+>    @@ -159,3 +166,7 @@ nginx_conf_http:
 >     nginx_ssl_role: usegalaxy_eu.certbot
 >     nginx_conf_ssl_certificate: /etc/ssl/certs/fullchain.pem
 >     nginx_conf_ssl_certificate_key: /etc/ssl/user/privkey-www-data.pem


### PR DESCRIPTION
Based on a recent pull request which was requesting support, and some help forum posts recently which are on a specific server that requires being contacted for tool support

Here we add a small section encouraging admins in training to configure the support and ToS URLs.

@jennaj would you like us to say anything specific in the tutorial? Can you check the wording in this patch for me to see if you think it will be useful?

Given @nomadscientist's [issue](https://github.com/galaxyproject/galaxy/issues/17362), I personally find that the semantic distance between "galaxy help" and "support" is approximately 0 if you squint at it, so I look forward to the conclusion of her issue  when we find a good solution to those, but maybe in the interim this is a good way to push users to useful places. (Honestly I think the optimal solution there is every site has its own Support page that pushes users to help for issues that aren't specific to that galaxy, but, that's also a large burden for admins to implement.)