### PR TITLE
Introduction to Genomics and Galaxy: Genomic interval tool search part corrected

### DIFF
--- a/topics/introduction/tutorials/galaxy-intro-strands/tutorial.md
+++ b/topics/introduction/tutorials/galaxy-intro-strands/tutorial.md
@@ -411,11 +411,11 @@ Galaxy excels at answering questions about genomic intervals and different sets 
 > * *Explore* the tools in this toolbox, looking for something that we can use to see which genes on opposite strands overlap.
 {: .hands_on}
 
-Of the tools in the **Operate on Genomic Intervals** toolbox, **Join** and particularly **Intersect** have the most promise.  Let's try **Intersect**.
+Although there are the bedtools (section **BED**) and a section **Operate on Genomic Intervals** offering promising tools, the simple **Intersect** tool under **Text Manipulation** appears sufficient.  Let's try **Intersect**.
 
 > <hands-on-title>Genomic Interval Tools</hands-on-title>
 >
-> 1. {% tool [Intersect](toolshed.g2.bx.psu.edu/repos/devteam/intersect/gops_intersect_1/0.0.1) %} with the following parameters:
+> 1. {% tool [Intersect](toolshed.g2.bx.psu.edu/repos/devteam/intersect/gops_intersect_1/1.0.0) %} with the following parameters:
 >     - *"Return"*:  `Overlapping Intervals`.
 >       This looks like it might return whole genes, while `Overlapping pieces` may return only the parts that overlap.  We suspect that whole genes might be more useful.
 >     - {% icon param-files %}*"of"*:  `Genes, forward strand` (the first dataset)


### PR DESCRIPTION
Addressing https://github.com/galaxyproject/training-material/issues/4174

In brief: The 'Intersect' keyword, which is motivated to be typed to the search box, did not give a literal tool result in section "Operate on Genomic Intervals toolbox, Join and particularly Intersect" anymore.