### PR TITLE
Use material ID instead of title + topic title for aggregating feedback

### DIFF
--- a/_layouts/tutorial_hands_on.html
+++ b/_layouts/tutorial_hands_on.html
@@ -327,7 +327,7 @@ download.file("{{ site.url }}{{ site.baseurl }}/{{ page.path | replace: ".md", "
                 <br>{{ locale['feedback-text-learner'] | default: "Did you use this material as a learner or student? Click the form below to leave feedback." }}<i class="fas fa-hand-point-down"></i>
                 </p>
 
-                <a href="https://docs.google.com/forms/d/e/1FAIpQLSd4VZptFTQ03kHkMz0JyW9b6_S8geU5KjNE_tLM0dixT3ZQmA/viewform?embedded=true&entry.1235803833={{ page.title }} ({{ topic.title }})" alt="Feedback form link">
+                <a href="https://docs.google.com/forms/d/e/1FAIpQLSd4VZptFTQ03kHkMz0JyW9b6_S8geU5KjNE_tLM0dixT3ZQmA/viewform?embedded=true&entry.1235803833={{ own_material.id }}" alt="Feedback form link">
                     <img src="/training-material/shared/images/feedback.png" alt="Preview of the google form" />
                 </a>
 

--- a/_plugins/api.rb
+++ b/_plugins/api.rb
@@ -376,23 +376,23 @@ Jekyll::Hooks.register :site, :post_write do |site|
   dir = File.join(site.dest, 'api', 'workflows')
 
   # Public tool listing: reorganised
-  if site.data['public-server-tools'] and site.data['public-server-tools']['tools']
+  if site.data['public-server-tools'] && site.data['public-server-tools']['tools']
     site.data['public-server-tools']['tools'].each do |tool, version_data|
       path = File.join(site.dest, 'api', 'psl', "#{tool}.json")
       dir = File.dirname(path)
       FileUtils.mkdir_p(dir) unless File.directory?(dir)
 
       d = version_data.dup
-      d.keys.each do |k|
+      d.each_key do |k|
         # Replace the indexes with the server URLs from site['public-server-tools']['servers']
         d[k] = d[k].map { |v| site.data['public-server-tools']['servers'][v] }
       end
 
       File.write(path, JSON.generate(d))
     end
-    Jekyll.logger.debug "[GTN/API/PSL] PSL written"
+    Jekyll.logger.debug '[GTN/API/PSL] PSL written'
   else
-    Jekyll.logger.debug "[GTN/API/PSL] PSL Dataset not available, are you in a CI environment?"
+    Jekyll.logger.debug '[GTN/API/PSL] PSL Dataset not available, are you in a CI environment?'
   end
 
   # ro-crate-metadata.json

--- a/bin/prepare_feedback.rb
+++ b/bin/prepare_feedback.rb
@@ -4,101 +4,7 @@
 require 'yaml'
 require 'csv'
 
-renamed_tutorials = {
-  '16S Microbial Analysis with Mothur' => '16S Microbial Analysis with mothur (extended)',
-  '16S Microbial Analysis with mothur' => '16S Microbial Analysis with mothur (extended)',
-  'Quality Control ' => 'Quality Control',
-  'RNA-Seq reads to counts' => '1: RNA-Seq reads to counts',
-  'RNA-seq counts to genes' => '2: RNA-seq counts to genes',
-  'RNA-seq genes to pathways' => '3: RNA-seq genes to pathways',
-  'Introduction to Genome Assembly' => 'An Introduction to Genome Assembly',
-  'EWAS data analysis of 450k data' => 'Infinium Human Methylation BeadChip',
-  'Creating a new tutorial - Defining the technical infrastructure' => 'Tools, Data, and Workflows for tutorials',
-  'Creating a new tutorial - Writing content in Markdown' => 'Creating content in Markdown',
-  'Running the Galaxy Training material website locally' => 'Running the GTN website locally',
-  'Visualizations: JavaScript plugins' => 'JavaScript plugins',
-  'Compute and analyze Essential Biodiversity Variables with PAMPA toolsuite' =>
-    'Compute and analyze biodiversity metrics with PAMPA toolsuite',
-  'Ephemeris for Galaxy Tool Management' => 'Galaxy Tool Management with Ephemeris',
-  'Collections: Rule Based Uploader' => 'Rule Based Uploader',
-  'Collections: Using dataset collection' => 'Using dataset collections',
-  'Data: Downloading and Deleting Data in Galaxy' => 'Downloading and Deleting Data in Galaxy',
-  'Histories: Understanding Galaxy history system' => 'Understanding Galaxy history system',
-  'Jupyter: Use Jupyter notebooks in Galaxy' => 'Use Jupyter notebooks in Galaxy',
-  'Using dataset collection' => 'Using dataset collections',
-  'Workflows: Extracting Workflows from Histories' => 'Extracting Workflows from Histories',
-  'Workflows: Using Workflow Parameters' => 'Using Workflow Parameters',
-  'Exome sequencing data analysis' => 'Exome sequencing data analysis for diagnosing a genetic disease',
-  'Galaxy Tool Management' => 'Galaxy Tool Management with Ephemeris',
-  'Virtual screening of the SARS-CoV-2 main protease with rDock and pose scoring' =>
-    'Virtual screening of the SARS-CoV-2 main protease with rxDock and pose scoring',
-  'Refining Genome Annotations with Apollo' => 'Refining Genome Annotations with Apollo (prokaryotes)',
-  'Mass spectrometry imaging 1: Loading and exploring MSI data' =>
-    'Mass spectrometry imaging: Loading and exploring MSI data',
-  'Trajectory Analysis using Python (Jupyter Notebook) in Galaxy' =>
-    'Inferring Trajectories using Python (Jupyter Notebook) in Galaxy',
-  'Submitting raw sequencing reads to ENA' => 'Submitting sequence data to ENA'
-}
 
-moved_topics_by_tutorial = {
-  'Formation of the Super-Structures on the Inactive X' => 'Epigenetics',
-  'Identification of the binding sites of the Estrogen receptor' => 'Epigenetics',
-  'Identification of the binding sites of the T-cell acute lymphocytic leukemia protein 1 (TAL1)' => 'Epigenetics',
-  'RAD-Seq Reference-based data analysis' => 'Ecology',
-  'RAD-Seq de-novo data analysis' => 'Ecology',
-  'RAD-Seq to construct genetic maps' => 'Ecology',
-  'Advanced R in Galaxy' => 'Foundations of Data Science',
-  'R basics in Galaxy' => 'Foundations of Data Science',
-  'Pre-processing of 10X Single-Cell RNA Datasets' => 'Single Cell',
-  'Pre-processing of Single-Cell RNA Data' => 'Single Cell',
-  'Generating a single cell matrix using Alevin' => 'Single Cell',
-  'Downstream Single-cell RNA analysis with RaceID' => 'Single Cell',
-  'Clustering 3K PBMCs with Scanpy' => 'Single Cell',
-  'Understanding Barcodes' => 'Single Cell',
-  'Filter, Plot and Explore Single-cell RNA-seq Data' => 'Single Cell',
-  'Trajectory Analysis using Python (Jupyter Notebook) in Galaxy' => 'Single Cell',
-  'Inferring Trajectories using Python (Jupyter Notebook) in Galaxy' => 'Single Cell',
-  'Bulk RNA Deconvolution with MuSiC' => 'Single Cell'
-}
-
-renamed_topics = {
-  'User Interface and Features' => 'Using Galaxy and Managing your Data',
-  'Data Manipulation' => 'Using Galaxy and Managing your Data',
-  'User Interface and Data Manipulation' => 'Using Galaxy and Managing your Data',
-  'Assembly) is not working I can do up to multiQC and after unicycler not working' => 'Assembly',
-  'Metagenomics' => 'Microbiome'
-}
-
-ACCEPTABLE_TOPICS = [
-  'Assembly',
-  'Climate',
-  'Computational chemistry',
-  'Contributing to the Galaxy Training Material',
-  'Development in Galaxy',
-  'Ecology',
-  'Epigenetics',
-  'Foundations of Data Science',
-  'Galaxy Server administration',
-  'Genome Annotation',
-  'Imaging',
-  'Introduction to Galaxy Analyses',
-  'Metabolomics',
-  'Microbiome',
-  'Proteomics',
-  'Sequence analysis',
-  'Single Cell',
-  'Statistics and machine learning',
-  'Teaching and Hosting Galaxy training',
-  'Transcriptomics',
-  'Using Galaxy and Managing your Data',
-  'Variant Analysis',
-  'Visualisation'
-]
-
-DEAD_TUTORIALS = [
-  'RNA-seq counts to genes and pathways',
-  'Recording Job Metrics'
-]
 
 TEST_PHRASES = [
   'TESTING',
@@ -107,6 +13,7 @@ TEST_PHRASES = [
 ]
 
 TITLE_TOPIC = /^(?<tutorial>.*) \((?<topic>.*)\)$/
+TUTO_ID = /^(?<tutorial>[A-Za-z0-9_-]*)\/(?<topic>[A-Za-z0-9_-]*):?(?<lang>[a-zA-Z][a-zA-Z])?$/
 
 data = CSV.parse($stdin.read, col_sep: "\t", headers: true, quote_char: '|')
 data = data.map do |x|
@@ -115,6 +22,7 @@ data = data.map do |x|
   x[:pro] = x['What did you like?']
   x[:con] = x['What could be improved?']
   x[:tutorial_topic] = x['Tutorial']
+  x[:id] = x['Temporary Tutorial ID']
 
   x.delete('Timestamp')
   x.delete('How much did you like this tutorial?')
@@ -130,7 +38,10 @@ data = data.reject { |x| x[:timestamp].nil? }
            .reject { |x| (x[:rating].nil? && x[:pro].nil? && x[:con].nil?) }
            # Ensure that they properly have a tutorial name and title
            # If this returns NIL, then we'll ignore those.
-           .select { |x| TITLE_TOPIC.match(x[:tutorial_topic]) }
+           # .select { |x| TITLE_TOPIC.match(x[:tutorial_topic]) }
+           .reject { |x| x[:id].nil? or x[:id].empty? }
+  # .reject{ |x| x[:id] =~ / / }
+           .select { |x| TUTO_ID.match(x[:id]) }
 
 # Mutate
 data.each do |x| # Various cleanups/extractions
@@ -144,39 +55,37 @@ data.each do |x| # Various cleanups/extractions
   # Extract tutorial/topic
   m = TITLE_TOPIC.match(x[:tutorial_topic])
   x.delete('tutorial_topic')
-  x[:topic] = m[:topic]
-  x[:tutorial] = m[:tutorial]
+  mq = TUTO_ID.match(x[:id])
+  x[:lang] = mq[:lang].downcase if mq[:lang]
+  x[:topic] = mq[:topic]
+  x[:tutorial] = mq[:tutorial]
 
   # Replace N/As with nil
   x[:pro] = x[:pro] == 'N/A' || x[:pro] == 'NA' ? nil : x[:pro]
   x[:con] = x[:con] == 'N/A' || x[:con] == 'NA' ? nil : x[:con]
 
-  # Fix renamed topics
-  x[:topic] = renamed_topics.fetch(x[:topic], x[:topic])
-  x[:tutorial] = renamed_tutorials.fetch(x[:tutorial], x[:tutorial])
-  x[:topic] = moved_topics_by_tutorial.fetch(x[:tutorial], x[:topic])
 end
-    .select { |x| ACCEPTABLE_TOPICS.include? x[:topic] }
-    .reject { |x| DEAD_TUTORIALS.include? x[:tutorial] }
-    .select do |x|
-  !TEST_PHRASES.include? x[:pro] and !TEST_PHRASES.include? x[:con] and !x[:pro].to_s.include? 'Helena Testing'
-end
+  .select do |x|
+    !TEST_PHRASES.include? x[:pro] and !TEST_PHRASES.include? x[:con] and !x[:pro].to_s.include? 'Helena Testing'
+  end
 
 CSV.open('metadata/feedback.csv', 'wb') do |csv|
-  csv << [nil, 'note', 'pro', 'con', 'anonymous', 'tutorial', 'topic', 'month', 'date']
+  csv << [nil, 'note', 'pro', 'con', 'anonymous', 'tutorial', 'topic', 'month', 'date', 'lang']
   data.each.with_index do |row, index|
-    csv << [index, row[:rating], row[:pro], row[:con], nil, row[:tutorial], row[:topic], row[:month], row[:date]]
+    csv << [index, row[:rating], row[:pro], row[:con], nil, row[:tutorial], row[:topic], row[:month], row[:date], row[:lang]]
   end
 end
 
-# feedback_over_month = Hash.new
-#
-# topics = Dir.glob('topics/*/metadata.yaml').map{|f|
-#  d = YAML.load(File.open(f).read)
-#  {
-#    "title" => d['title'],
-#    "name" => d['name'],
-#  }
-# }
-#
-# pp topics
+# Also save as yaml
+File.open('metadata/feedback2.yaml', 'w') do |file|
+  file.write(
+    data.group_by { |x| x[:tutorial] }.map do |tutorial, feedback|
+      fg = feedback.group_by { |x| x[:topic] }
+        .map do |topic, feedback|
+          [topic, feedback.map { |x| {"rating" => x[:rating], "pro" => x[:pro], "con" => x[:con], "date" => x[:date], "lang" => x[:lang]} }]
+        end
+      [tutorial, fg.to_h]
+    end.to_h.to_yaml
+  )
+end
+

--- a/bin/prepare_feedback.rb
+++ b/bin/prepare_feedback.rb
@@ -4,8 +4,6 @@
 require 'yaml'
 require 'csv'
 
-
-
 TEST_PHRASES = [
   'TESTING',
   'test',
@@ -13,7 +11,7 @@ TEST_PHRASES = [
 ]
 
 TITLE_TOPIC = /^(?<tutorial>.*) \((?<topic>.*)\)$/
-TUTO_ID = /^(?<tutorial>[A-Za-z0-9_-]*)\/(?<topic>[A-Za-z0-9_-]*):?(?<lang>[a-zA-Z][a-zA-Z])?$/
+TUTO_ID = %r{^(?<topic>[A-Za-z0-9_-]*)/(?<tutorial>[A-Za-z0-9_-]*):?(?<lang>[a-zA-Z][a-zA-Z])?$}
 
 data = CSV.parse($stdin.read, col_sep: "\t", headers: true, quote_char: '|')
 data = data.map do |x|
@@ -21,7 +19,6 @@ data = data.map do |x|
   x[:rating] = x['How much did you like this tutorial?']
   x[:pro] = x['What did you like?']
   x[:con] = x['What could be improved?']
-  x[:tutorial_topic] = x['Tutorial']
   x[:id] = x['Temporary Tutorial ID']
 
   x.delete('Timestamp')
@@ -33,14 +30,43 @@ data = data.map do |x|
   x
 end
 
+def lookup_tuto(topic_id, tuto_id)
+  @cache ||= {}
+  @cache.fetch("#{topic_id}/#{tuto_id}") do |key|
+    @cache[key] = nil
+
+    file = "topics/#{topic_id}/tutorials/#{tuto_id}/tutorial.md"
+    if File.exist? file
+      data = YAML.load_file(file)
+      @cache[key] = data['title']
+    else
+      file = "topics/#{topic_id}/tutorials/#{tuto_id}/slides.html"
+      if File.exist? file
+        data = YAML.load_file(file)
+        @cache[key] = data['title']
+      else
+        puts "No file for #{topic_id}/#{tuto_id}"
+      end
+    end
+  end
+end
+
+def lookup_topic(topic_id)
+  @cache ||= {}
+  @cache.fetch(topic_id) do |key|
+    file = "metadata/#{topic_id}.yaml"
+    return nil unless File.exist? file
+
+    data = YAML.load_file(file)
+    @cache[key] = data['title']
+  end
+end
+
 data = data.reject { |x| x[:timestamp].nil? }
            # remove rows with NaN on note, pro and con
            .reject { |x| (x[:rating].nil? && x[:pro].nil? && x[:con].nil?) }
            # Ensure that they properly have a tutorial name and title
-           # If this returns NIL, then we'll ignore those.
-           # .select { |x| TITLE_TOPIC.match(x[:tutorial_topic]) }
            .reject { |x| x[:id].nil? or x[:id].empty? }
-  # .reject{ |x| x[:id] =~ / / }
            .select { |x| TUTO_ID.match(x[:id]) }
 
 # Mutate
@@ -53,39 +79,38 @@ data.each do |x| # Various cleanups/extractions
   x[:month] = DateTime.parse(x[:timestamp]).strftime('%Y-%m')
 
   # Extract tutorial/topic
-  m = TITLE_TOPIC.match(x[:tutorial_topic])
-  x.delete('tutorial_topic')
   mq = TUTO_ID.match(x[:id])
   x[:lang] = mq[:lang].downcase if mq[:lang]
-  x[:topic] = mq[:topic]
-  x[:tutorial] = mq[:tutorial]
+  x[:topic_id] = mq[:topic]
+  x[:tutorial_id] = mq[:tutorial]
+
+  x[:topic] = lookup_topic(x[:topic_id])
+  x[:tutorial] = lookup_tuto(x[:topic_id], x[:tutorial_id])
+  # p "Lookup #{x[:topic_id]}/#{x[:tutorial_id]} => #{x[:tutorial]} (#{x[:topic]})"
 
   # Replace N/As with nil
   x[:pro] = x[:pro] == 'N/A' || x[:pro] == 'NA' ? nil : x[:pro]
   x[:con] = x[:con] == 'N/A' || x[:con] == 'NA' ? nil : x[:con]
-
 end
-  .select do |x|
-    !TEST_PHRASES.include? x[:pro] and !TEST_PHRASES.include? x[:con] and !x[:pro].to_s.include? 'Helena Testing'
-  end
+    .select do |x|
+  !TEST_PHRASES.include? x[:pro] and !TEST_PHRASES.include? x[:con] and !x[:pro].to_s.include? 'Helena Testing'
+end
 
 CSV.open('metadata/feedback.csv', 'wb') do |csv|
-  csv << [nil, 'note', 'pro', 'con', 'anonymous', 'tutorial', 'topic', 'month', 'date', 'lang']
+  csv << [nil, 'note', 'pro', 'con', 'anonymous', 'tutorial', 'topic', 'month', 'date']
   data.each.with_index do |row, index|
-    csv << [index, row[:rating], row[:pro], row[:con], nil, row[:tutorial], row[:topic], row[:month], row[:date], row[:lang]]
+    csv << [index, row[:rating], row[:pro], row[:con], nil, row[:tutorial], row[:topic], row[:month], row[:date]]
   end
 end
 
 # Also save as yaml
-File.open('metadata/feedback2.yaml', 'w') do |file|
-  file.write(
-    data.group_by { |x| x[:tutorial] }.map do |tutorial, feedback|
-      fg = feedback.group_by { |x| x[:topic] }
-        .map do |topic, feedback|
-          [topic, feedback.map { |x| {"rating" => x[:rating], "pro" => x[:pro], "con" => x[:con], "date" => x[:date], "lang" => x[:lang]} }]
-        end
-      [tutorial, fg.to_h]
-    end.to_h.to_yaml
-  )
-end
-
+yaml_data = data.group_by { |x| x[:topic_id] }.to_h do |topic, feedback|
+  fg = feedback.group_by { |x| x[:tutorial_id] }
+               .map do |tutorial, feedback|
+    [tutorial, feedback.map do |x|
+                 { 'rating' => x[:rating], 'pro' => x[:pro], 'con' => x[:con], 'date' => x[:date], 'lang' => x[:lang] }
+               end]
+  end
+  [topic, fg.to_h]
+end.to_yaml
+File.write('metadata/feedback2.yaml', yaml_data)

--- a/bin/prepare_feedback.rb
+++ b/bin/prepare_feedback.rb
@@ -19,7 +19,7 @@ data = data.map do |x|
   x[:rating] = x['How much did you like this tutorial?']
   x[:pro] = x['What did you like?']
   x[:con] = x['What could be improved?']
-  x[:id] = x['Temporary Tutorial ID']
+  x[:id] = x['Tutorial']
 
   x.delete('Timestamp')
   x.delete('How much did you like this tutorial?')

--- a/metadata/feedback.csv
+++ b/metadata/feedback.csv
@@ -3,7 +3,7 @@
 1,5,"very detailed and easy to follow, thank you",,,Introduction to Genomics and Galaxy,Introduction to Galaxy Analyses,2018-09,2018-09-15
 2,2,,,,Identification of the binding sites of the Estrogen receptor,Epigenetics,2018-09,2018-09-16
 3,5,"Well structured, easy to understand.",,,From peaks to genes,Introduction to Galaxy Analyses,2018-09,2018-09-17
-4,5,The data clean-up was thoroughly covered. Every step was well explained,Using the mock community. More light on rationale,,16S Microbial Analysis with mothur (extended),Metagenomics,2018-09,2018-09-17
+4,5,The data clean-up was thoroughly covered. Every step was well explained,Using the mock community. More light on rationale,,16S Microbial Analysis with mothur (extended),Microbiome,2018-09,2018-09-17
 5,5,,,,From peaks to genes,Introduction to Galaxy Analyses,2018-09,2018-09-17
 6,5,well explained,maybe by adding more pictures next to the explanations?,,From peaks to genes,Introduction to Galaxy Analyses,2018-09,2018-09-17
 7,4,Well-structured and helpful,More information on the flanking region tool (how it works),,From peaks to genes,Introduction to Galaxy Analyses,2018-09,2018-09-17
@@ -58,15 +58,15 @@
 56,5,,,,A short introduction to Galaxy,Introduction to Galaxy Analyses,2018-10,2018-10-18
 57,5,"explorations, explanations",,,A short introduction to Galaxy,Introduction to Galaxy Analyses,2018-10,2018-10-18
 58,5,,,,A short introduction to Galaxy,Introduction to Galaxy Analyses,2018-10,2018-10-18
-59,3,Clarity and background details,"Need a step on how to remove barcodes, adapters and primers from raw FASTAq sequences",,16S Microbial Analysis with mothur (extended),Metagenomics,2018-10,2018-10-19
+59,3,Clarity and background details,"Need a step on how to remove barcodes, adapters and primers from raw FASTAq sequences",,16S Microbial Analysis with mothur (extended),Microbiome,2018-10,2018-10-19
 60,5,Topic and completeness of the scope,I think there is an error: Join two Datasets tool  * with (output of the last Filter tool)  --> Should be with (output of Concatenate tool) ,,Reference-based RNA-Seq data analysis,Transcriptomics,2018-10,2018-10-19
 61,5,,,,From peaks to genes,Introduction to Galaxy Analyses,2018-10,2018-10-21
 62,5,Very very straightforward !,Nothing...,,Running the GTN website locally,Contributing to the Galaxy Training Material,2018-10,2018-10-22
-63,5,,,,RNA-seq counts to genes and pathways,Transcriptomics,2018-10,2018-10-26
+63,5,,,,2: RNA-seq counts to genes,Transcriptomics,2018-10,2018-10-26
 64,1,,,,Calling variants in diploid systems,Variant Analysis,2018-10,2018-10-29
-65,2,Krona,"It needs to be updated, some returns error and some is missing. Be more detail and specific",,Analyses of metagenomics data - The global picture,Metagenomics,2018-10,2018-10-29
+65,2,Krona,"It needs to be updated, some returns error and some is missing. Be more detail and specific",,Analyses of metagenomics data - The global picture,Microbiome,2018-10,2018-10-29
 66,4,"""Easiness"", ","You could link to short description of what a fastq format is, etc... and warn that Filterbyquality sometimes is not present. I could not find it. I use FilterFASTQ instead",,A short introduction to Galaxy,Introduction to Galaxy Analyses,2018-10,2018-10-29
-67,1,"Some instructions were not clear at all, please be more specific as i encounter errors very likely despite following the steps",Please review the protocol and revise some segments ,,Analyses of metagenomics data - The global picture,Metagenomics,2018-10,2018-10-30
+67,1,"Some instructions were not clear at all, please be more specific as i encounter errors very likely despite following the steps",Please review the protocol and revise some segments ,,Analyses of metagenomics data - The global picture,Microbiome,2018-10,2018-10-30
 68,5,It's easy to follow.,"For clean Ubuntu 18.04 Ansible couldn't find python (it was not installed, weird), so it crashed. There should be rule added to check and install python if it is not installed. Refer to this solution - https://gist.github.com/gwillem/4ba393dceb55e5ae276a87300f6b8e6f.",,Ansible,Galaxy Server administration,2018-10,2018-10-30
 69,5,,,,Mapping,Sequence analysis,2018-10,2018-10-30
 70,5,all of it!,how to rmemeber steps....,,Quality Control,Sequence analysis,2018-10,2018-10-31
@@ -82,8 +82,8 @@
 80,5,,,,An Introduction to Genome Assembly,Assembly,2018-11,2018-11-05
 81,5,,,,Galaxy 101,Introduction to Galaxy Analyses,2018-11,2018-11-10
 82,4,,,,IGV Introduction,Introduction to Galaxy Analyses,2018-11,2018-11-12
-83,4,The overview of all the tools available.,The time for the processes on Galaxy.,,Analyses of metagenomics data - The global picture,Metagenomics,2018-11,2018-11-14
-84,4,clear step by step module,,,Analyses of metagenomics data - The global picture,Metagenomics,2018-11,2018-11-14
+83,4,The overview of all the tools available.,The time for the processes on Galaxy.,,Analyses of metagenomics data - The global picture,Microbiome,2018-11,2018-11-14
+84,4,clear step by step module,,,Analyses of metagenomics data - The global picture,Microbiome,2018-11,2018-11-14
 85,4,,,,Galaxy 101,Introduction to Galaxy Analyses,2018-11,2018-11-15
 86,5,Thorough step by step directions. Does not assume you know stuff already.,"Naming the output files was a little confusing, especially when I was left on my own to continue to name all the rest of them. Why doesn't the new name show up in the workflow boxes after you name them?",,Extracting Workflows from Histories,Using Galaxy and Managing your Data,2018-11,2018-11-15
 87,3,TEST,TEST,,Ansible,Galaxy Server administration,2018-11,2018-11-15
@@ -102,10 +102,10 @@
 100,5,,,,Galaxy 101,Introduction to Galaxy Analyses,2018-11,2018-11-28
 101,5,,,,Galaxy 101,Introduction to Galaxy Analyses,2018-11,2018-11-28
 102,4,The explanations and solutions to check our output,Explanations of the plots,,De novo transcriptome reconstruction with RNA-Seq,Transcriptomics,2018-12,2018-12-01
-103,5,,,,16S Microbial Analysis with mothur (extended),Metagenomics,2018-12,2018-12-03
+103,5,,,,16S Microbial Analysis with mothur (extended),Microbiome,2018-12,2018-12-03
 104,4,step-by-step configuration,colors to enhance instructions clarity ,,Reference-based RNA-Seq data analysis,Transcriptomics,2018-12,2018-12-03
 105,1,,,,Visualization of RNA-Seq results with CummeRbund,Transcriptomics,2018-12,2018-12-04
-106,5,,,,16S Microbial Analysis with mothur (extended),Metagenomics,2018-12,2018-12-04
+106,5,,,,16S Microbial Analysis with mothur (extended),Microbiome,2018-12,2018-12-04
 107,5,,,,An Introduction to Genome Assembly,Assembly,2018-12,2018-12-04
 108,4,Tutorial is absolutely awesome! Thaks a lot for the work you made! ,Maybe you could make the tutorial more detailed. Write all the commands exactly as they should be written in the terminal. I catch lots of failures and can't improve them by myself.(,,Peptide and Protein ID using SearchGUI and PeptideShaker,Proteomics,2018-12,2018-12-05
 109,4,"Nice explanation, really easy!",what is the next step?,,Quality Control,Sequence analysis,2018-12,2018-12-10
@@ -165,10 +165,10 @@
 163,1,"most but if the files that need to be downloaded do not exist at UCSC, this tutorial is useless",go through the process and correct,,From peaks to genes,Introduction to Galaxy Analyses,2019-03,2019-03-05
 164,4,,,,Formation of the Super-Structures on the Inactive X,Epigenetics,2019-03,2019-03-06
 165,5,very straightforward tutorial,,,Basics of machine learning,Statistics and machine learning,2019-03,2019-03-08
-166,5,"Step-by-step guidance to complete tutorial, comprehensive and easy to understand and follow along",,,16S Microbial Analysis with mothur (extended),Metagenomics,2019-03,2019-03-09
-167,4,that it went right from the beginning (fastq) with explanations at each point of what I was looking at,"the galaxy biom1 file output does not open successfully in Phinch, preventing the final visualisation",,16S Microbial Analysis with mothur (extended),Metagenomics,2019-03,2019-03-10
-168,5,,,,16S Microbial Analysis with mothur (extended),Metagenomics,2019-03,2019-03-11
-169,5,Clear explanations of the tools; helpful workflow; I think the Hand On opportunities and prompt questions are really beneficial.,"Descriptions of which files to use were not always clear enough for me to determine which one to use. The justification of some selections for tool options could be expanded on, or additional links to papers noted where appropriate.",,16S Microbial Analysis with mothur (extended),Metagenomics,2019-03,2019-03-12
+166,5,"Step-by-step guidance to complete tutorial, comprehensive and easy to understand and follow along",,,16S Microbial Analysis with mothur (extended),Microbiome,2019-03,2019-03-09
+167,4,that it went right from the beginning (fastq) with explanations at each point of what I was looking at,"the galaxy biom1 file output does not open successfully in Phinch, preventing the final visualisation",,16S Microbial Analysis with mothur (extended),Microbiome,2019-03,2019-03-10
+168,5,,,,16S Microbial Analysis with mothur (extended),Microbiome,2019-03,2019-03-11
+169,5,Clear explanations of the tools; helpful workflow; I think the Hand On opportunities and prompt questions are really beneficial.,"Descriptions of which files to use were not always clear enough for me to determine which one to use. The justification of some selections for tool options could be expanded on, or additional links to papers noted where appropriate.",,16S Microbial Analysis with mothur (extended),Microbiome,2019-03,2019-03-12
 170,5,,,,Unicycler Assembly,Assembly,2019-03,2019-03-13
 171,4,,,,Deploying a compute cluster in OpenStack via Terraform,Galaxy Server administration,2019-03,2019-03-14
 172,1,,,,Identification of somatic and germline variants from tumor and normal sample pairs,Variant Analysis,2019-03,2019-03-14
@@ -192,11 +192,11 @@
 190,5,,,,A short introduction to Galaxy,Introduction to Galaxy Analyses,2019-04,2019-04-09
 191,5,everything,,,A short introduction to Galaxy,Introduction to Galaxy Analyses,2019-04,2019-04-10
 192,5,,,,Reference-based RNA-Seq data analysis,Transcriptomics,2019-04,2019-04-11
-193,4,,,,16S Microbial Analysis with mothur (extended),Metagenomics,2019-04,2019-04-11
+193,4,,,,16S Microbial Analysis with mothur (extended),Microbiome,2019-04,2019-04-11
 194,5,Most complete tuto with lot of aspect.,Maybe add so MULTIQC (for inferexperiment for example) for an easiest visualisation.,,Reference-based RNA-Seq data analysis,Transcriptomics,2019-04,2019-04-12
 195,5,,,,Set up a Galaxy for Training,Teaching and Hosting Galaxy training,2019-04,2019-04-12
-196,3,,,,Analyses of metagenomics data - The global picture,Metagenomics,2019-04,2019-04-12
-197,4,step by step very well described,data analysis with OTU / phylotype,,Analyses of metagenomics data - The global picture,Metagenomics,2019-04,2019-04-13
+196,3,,,,Analyses of metagenomics data - The global picture,Microbiome,2019-04,2019-04-12
+197,4,step by step very well described,data analysis with OTU / phylotype,,Analyses of metagenomics data - The global picture,Microbiome,2019-04,2019-04-13
 198,5,,,,Visualization of RNA-Seq results with Volcano Plot,Transcriptomics,2019-04,2019-04-13
 199,5,,,,A short introduction to Galaxy,Introduction to Galaxy Analyses,2019-04,2019-04-14
 200,4,,,,Genome annotation with Prokka,Genome Annotation,2019-04,2019-04-16
@@ -213,20 +213,20 @@
 211,5,Very graphical and easy to follow,"If you make a question, include always the answer with an appropiate explanation to make everything clear. Why in the case you use the 36 filter there are so many reads discarded? Do not Forget most of people is the first time they work with this online tool.  ",,A short introduction to Galaxy,Introduction to Galaxy Analyses,2019-04,2019-04-22
 212,5,Very straight forward and convenient to catch up!,None,,A short introduction to Galaxy,Introduction to Galaxy Analyses,2019-04,2019-04-22
 213,5,,,,A short introduction to Galaxy,Introduction to Galaxy Analyses,2019-04,2019-04-23
-214,5,Everything,,,16S Microbial Analysis with mothur (extended),Metagenomics,2019-04,2019-04-24
+214,5,Everything,,,16S Microbial Analysis with mothur (extended),Microbiome,2019-04,2019-04-24
 215,5,,,,A short introduction to Galaxy,Introduction to Galaxy Analyses,2019-04,2019-04-24
 216,3,explanations were very clear !,this is a bit too long,,Galaxy 101,Introduction to Galaxy Analyses,2019-04,2019-04-25
 217,1,,still to complex to make sense,,Detection and quantitation of N-termini (degradomics) via N-TAILS,Proteomics,2019-04,2019-04-26
 218,4,,,,Unicycler Assembly,Assembly,2019-04,2019-04-26
 219,5,,,,Label-free versus Labelled - How to Choose Your Quantitation Method,Proteomics,2019-04,2019-04-27
-220,5,,,,16S Microbial Analysis with mothur (extended),Metagenomics,2019-04,2019-04-27
+220,5,,,,16S Microbial Analysis with mothur (extended),Microbiome,2019-04,2019-04-27
 221,5,,,,A short introduction to Galaxy,Introduction to Galaxy Analyses,2019-04,2019-04-27
 222,5,It was easy to follow and very clear,,,A short introduction to Galaxy,Introduction to Galaxy Analyses,2019-04,2019-04-27
 223,5,,,,Downstream Single-cell RNA analysis with RaceID,Single Cell,2019-04,2019-04-29
 224,3,I liked the videos.,I would suggest to make the videos longer and theory shorter.,,NGS data logistics,Introduction to Galaxy Analyses,2019-04,2019-04-30
 225,5,Instructive,I do not know - I know only Biopython,,Galaxy 101,Introduction to Galaxy Analyses,2019-05,2019-05-01
-226,5,easy step by step guide to analysing 16s rRNA data,"When you say skip mock test if time retrain, skip whole section to OTU step? More information of the choice of databases used and do we use all etc?",,16S Microbial Analysis with mothur (extended),Metagenomics,2019-05,2019-05-03
-227,5,,,,Antibiotic resistance detection,Metagenomics,2019-05,2019-05-03
+226,5,easy step by step guide to analysing 16s rRNA data,"When you say skip mock test if time retrain, skip whole section to OTU step? More information of the choice of databases used and do we use all etc?",,16S Microbial Analysis with mothur (extended),Microbiome,2019-05,2019-05-03
+227,5,,,,Antibiotic resistance detection,Microbiome,2019-05,2019-05-03
 228,5,,,,A short introduction to Galaxy,Introduction to Galaxy Analyses,2019-05,2019-05-09
 229,0,,"Tutorial doesn't have any public servers listed. Maybe a tool version conflict? Latest version is 0.0.3 and is installed at EU (and I made a request to add it to ORG). Are probably more tutorials like this -- seems the lists of ""instances"" is decreasing overall (bigger project, maybe good for the GTN or GCC co-fests)",,Visualization of RNA-Seq results with Volcano Plot,Transcriptomics,2019-05,2019-05-09
 230,5,"the ""step by step """,,,Reference-based RNA-Seq data analysis,Transcriptomics,2019-05,2019-05-10
@@ -234,8 +234,8 @@
 232,5,solid logic and small amount of valuable information,"Probably as we are not trimming any adaptors in this tutorial, Trimmomatic can also be used on datasets provided.",,Quality Control,Sequence analysis,2019-05,2019-05-14
 233,5,,,,1: RNA-Seq reads to counts,Transcriptomics,2019-05,2019-05-15
 234,5,,,,A short introduction to Galaxy,Introduction to Galaxy Analyses,2019-05,2019-05-16
-235,4,,,,16S Microbial Analysis with mothur (extended),Metagenomics,2019-05,2019-05-16
-236,4,,,,16S Microbial Analysis with mothur (extended),Metagenomics,2019-05,2019-05-16
+235,4,,,,16S Microbial Analysis with mothur (extended),Microbiome,2019-05,2019-05-16
+236,4,,,,16S Microbial Analysis with mothur (extended),Microbiome,2019-05,2019-05-16
 237,5,Ease of understanding,Adding more examples of its applications and how it is used in real time,,Galaxy 101,Introduction to Galaxy Analyses,2019-05,2019-05-16
 238,5,,,,Reference Data with CVMFS,Galaxy Server administration,2019-05,2019-05-20
 239,5,,,,A short introduction to Galaxy,Introduction to Galaxy Analyses,2019-05,2019-05-20
@@ -266,8 +266,8 @@
 264,5,Clearly explained. ,"In the first step (install requirements) - does there need to be an extra step before step 5, that says ""conda activate galaxy_training_material"" ? ",,Running the GTN website locally,Contributing to the Galaxy Training Material,2019-06,2019-06-19
 265,4,,,,A short introduction to Galaxy,Introduction to Galaxy Analyses,2019-06,2019-06-19
 266,5,"complete, with examples (questions+solutions)",,,Visualization of RNA-Seq results with Volcano Plot,Transcriptomics,2019-06,2019-06-20
-267,5,,,,16S Microbial Analysis with mothur (extended),Metagenomics,2019-06,2019-06-23
-268,1,,,,16S Microbial Analysis with mothur (extended),Metagenomics,2019-06,2019-06-23
+267,5,,,,16S Microbial Analysis with mothur (extended),Microbiome,2019-06,2019-06-23
+268,1,,,,16S Microbial Analysis with mothur (extended),Microbiome,2019-06,2019-06-23
 269,5,the layout was great,will not know until I work on my own data,,A short introduction to Galaxy,Introduction to Galaxy Analyses,2019-06,2019-06-23
 270,5,Examples and documentation are easy to follow,,,Ansible,Galaxy Server administration,2019-07,2019-07-01
 271,3,,Too long and too much details with screenshots to be able to gasp the main thing just with quick browse through material. Short summary of key points would be very helpful.,,Using Workflow Parameters,Using Galaxy and Managing your Data,2019-07,2019-07-01
@@ -277,7 +277,7 @@
 275,5,extremely well done - thank you training material authors and presenters,"1) ssh connection timeout is too short, disconnects while running playbooks. (2) sometimes the insertion point for yaml section in the exercices could be more explicit",,Galaxy Installation with Ansible,Galaxy Server administration,2019-07,2019-07-01
 276,5,,,,Galaxy Installation with Ansible,Galaxy Server administration,2019-07,2019-07-01
 277,5,,,,Galaxy 101,Introduction to Galaxy Analyses,2019-07,2019-07-01
-278,5,,,,16S Microbial Analysis with mothur (extended),Metagenomics,2019-07,2019-07-02
+278,5,,,,16S Microbial Analysis with mothur (extended),Microbiome,2019-07,2019-07-02
 279,5,this was way super cool,"maybe specify that the parts in Setting admin... part 1 should go under the galaxy: heading for those not as familiar with galaxy configs? or can we assume they're all savvy? templates/deployment_web.yaml -> dash, not underscore",,Managing Galaxy on Kubernetes,Galaxy Server administration,2019-07,2019-07-03
 280,5,,"the samples are great and its great to have the copy capacity, but some of those copies could mess people up (ones with ..., snippets of yaml that start with ---, etc)",,Reference Data with CVMFS,Galaxy Server administration,2019-07,2019-07-04
 281,5,,,,Microbial Variant Calling,Variant Analysis,2019-07,2019-07-05
@@ -301,22 +301,22 @@
 299,5,,,,Galaxy 101,Introduction to Galaxy Analyses,2019-07,2019-07-23
 300,5,,,,A short introduction to Galaxy,Introduction to Galaxy Analyses,2019-07,2019-07-24
 301,4,,"The step ""Select all outputs"" in ""Hands-on: Run Snippy"" is not obvious what to do exactly. ",,Microbial Variant Calling,Variant Analysis,2019-07,2019-07-24
-302,5,,,,16S Microbial Analysis with mothur (extended),Metagenomics,2019-07,2019-07-24
+302,5,,,,16S Microbial Analysis with mothur (extended),Microbiome,2019-07,2019-07-24
 303,4,Clear step-by-step instructions,Suggestions of what to do next once the count matrix has been constructed. Can one just use standard methods such as DESeq2 for differential expression? Some examples of PCA?,,Pre-processing of Single-Cell RNA Data,Single Cell,2019-07,2019-07-24
 304,4,,,,Reference-based RNA-Seq data analysis,Transcriptomics,2019-07,2019-07-24
-305,4,,,,16S Microbial Analysis with mothur (extended),Metagenomics,2019-07,2019-07-25
+305,4,,,,16S Microbial Analysis with mothur (extended),Microbiome,2019-07,2019-07-25
 306,5,looking at genes,,,Exome sequencing data analysis for diagnosing a genetic disease,Variant Analysis,2019-07,2019-07-26
 307,5,Even simple steps were explained.,,,Exome sequencing data analysis for diagnosing a genetic disease,Variant Analysis,2019-07,2019-07-26
 308,5,step by step instruction,don't know,,Quality Control,Sequence analysis,2019-07,2019-07-27
 309,5,a very clear and concise introduction.,The history names in fig 1 could be showing as the next-analysis and my-analysis.,,A short introduction to Galaxy,Introduction to Galaxy Analyses,2019-07,2019-07-28
 310,3,,,,Including a new topic,Contributing to the Galaxy Training Material,2019-07,2019-07-29
 311,5,,,,Introduction to image analysis using Galaxy,Imaging,2019-07,2019-07-29
-312,5,,,,16S Microbial Analysis with mothur (extended),Metagenomics,2019-07,2019-07-30
+312,5,,,,16S Microbial Analysis with mothur (extended),Microbiome,2019-07,2019-07-30
 313,5,,,,A short introduction to Galaxy,Introduction to Galaxy Analyses,2019-07,2019-07-30
 314,5,,,,Mapping,Sequence analysis,2019-07,2019-07-30
 315,5,,,,Quality Control,Sequence analysis,2019-07,2019-07-31
-316,4,,The mouse.dpw.metadata is not in the downloads at start nor linked at bottom. Please add to tutorial.,,16S Microbial Analysis with mothur (extended),Metagenomics,2019-08,2019-08-02
-317,4,,"The Krona plot - this appears to be of all samples. Would be good to per sample. Might not be possible with Phinch. As for Phinch, that is no longer web accessible but standalone and has dropped functionality.",,16S Microbial Analysis with mothur (short),Metagenomics,2019-08,2019-08-02
+316,4,,The mouse.dpw.metadata is not in the downloads at start nor linked at bottom. Please add to tutorial.,,16S Microbial Analysis with mothur (extended),Microbiome,2019-08,2019-08-02
+317,4,,"The Krona plot - this appears to be of all samples. Would be good to per sample. Might not be possible with Phinch. As for Phinch, that is no longer web accessible but standalone and has dropped functionality.",,16S Microbial Analysis with mothur (short),Microbiome,2019-08,2019-08-02
 318,0,The easy step by step guide.,It's good already!,,Reference-based RNA-Seq data analysis,Transcriptomics,2019-08,2019-08-02
 319,5,,,,Introduction to image analysis using Galaxy,Imaging,2019-08,2019-08-02
 320,5,"I liked how easily it flows, some concepts of biology are briefly explained, it helps a lot! ","Maybe add more examples, more explanations on the datasets used. ",,Galaxy 101,Introduction to Galaxy Analyses,2019-08,2019-08-02
@@ -359,7 +359,7 @@
 357,5,The step by step teaching,More publicity to make this fantastic site more popular to bioinformatic field,,A short introduction to Galaxy,Introduction to Galaxy Analyses,2019-09,2019-09-01
 358,4,Short and efficient primer,The theory behind the method in this particular example could be more expanded,,Machine learning: classification and regression,Statistics and machine learning,2019-09,2019-09-02
 359,5,,,,A short introduction to Galaxy,Introduction to Galaxy Analyses,2019-09,2019-09-04
-360,5, ,,,16S Microbial Analysis with mothur (extended),Metagenomics,2019-09,2019-09-05
+360,5, ,,,16S Microbial Analysis with mothur (extended),Microbiome,2019-09,2019-09-05
 361,5,,,,A short introduction to Galaxy,Introduction to Galaxy Analyses,2019-09,2019-09-05
 362,5,Very easy to follow,Ability to zoom on the graphics,,Galaxy 101,Introduction to Galaxy Analyses,2019-09,2019-09-06
 363,5,,,,Differential abundance testing of small RNAs,Transcriptomics,2019-09,2019-09-06
@@ -377,7 +377,7 @@
 375,5,very user friendly ,,,1: RNA-Seq reads to counts,Transcriptomics,2019-09,2019-09-16
 376,5,The detailed explanation behind the steps. It was awesome,,,Mass spectrometry: LC-MS analysis,Metabolomics,2019-09,2019-09-18
 377,5,The step by step,,,A short introduction to Galaxy,Introduction to Galaxy Analyses,2019-09,2019-09-19
-378,5,,,,16S Microbial Analysis with mothur (extended),Metagenomics,2019-09,2019-09-20
+378,5,,,,16S Microbial Analysis with mothur (extended),Microbiome,2019-09,2019-09-20
 379,1,,,,From peaks to genes,Introduction to Galaxy Analyses,2019-09,2019-09-23
 380,4,,,,Microbial Variant Calling,Variant Analysis,2019-09,2019-09-23
 381,5,,,,Quality Control,Sequence analysis,2019-09,2019-09-23
@@ -400,7 +400,7 @@
 398,5,,,,Genome annotation with Prokka,Genome Annotation,2019-09,2019-09-30
 399,4,,,,Using dataset collections,Using Galaxy and Managing your Data,2019-09,2019-09-30
 400,5,,,,Quality Control,Sequence analysis,2019-10,2019-10-01
-401,5,Perfectly explained,The use of the  Venn software was not available,,16S Microbial Analysis with mothur (extended),Metagenomics,2019-10,2019-10-02
+401,5,Perfectly explained,The use of the  Venn software was not available,,16S Microbial Analysis with mothur (extended),Microbiome,2019-10,2019-10-02
 402,5,"very clear, good sample data ",,,3: RNA-seq genes to pathways,Transcriptomics,2019-10,2019-10-03
 403,4,,,,Rule Based Uploader,Using Galaxy and Managing your Data,2019-10,2019-10-04
 404,5,,,,Unicycler Assembly,Assembly,2019-10,2019-10-06
@@ -500,8 +500,8 @@
 498,5,,,,A short introduction to Galaxy,Introduction to Galaxy Analyses,2019-12,2019-12-19
 499,5,Stepwise procedure is helpful,"Additional GUI based support tool and environment , parameters like isoforms, splice variant, etc can also be explained in detail",,1: RNA-Seq reads to counts,Transcriptomics,2019-12,2019-12-24
 500,5,all of the web,,,A short introduction to Galaxy,Introduction to Galaxy Analyses,2019-12,2019-12-27
-501,5,flow of the tutorial ,more accurate galaxy functions reference. ,,Analyses of metagenomics data - The global picture,Metagenomics,2019-12,2019-12-29
-502,3,I liked the step-by-step how to instructions,"I got lost at ""make.contigs"" - could not find out how to use that tool in Galaxy :(",,16S Microbial Analysis with mothur (extended),Metagenomics,2019-12,2019-12-30
+501,5,flow of the tutorial ,more accurate galaxy functions reference. ,,Analyses of metagenomics data - The global picture,Microbiome,2019-12,2019-12-29
+502,3,I liked the step-by-step how to instructions,"I got lost at ""make.contigs"" - could not find out how to use that tool in Galaxy :(",,16S Microbial Analysis with mothur (extended),Microbiome,2019-12,2019-12-30
 503,5,"simple, informative and straightforward ",,,A short introduction to Galaxy,Introduction to Galaxy Analyses,2019-12,2019-12-31
 504,5,,,,Deploying a compute cluster in OpenStack via Terraform,Galaxy Server administration,2019-12,2019-12-31
 505,5,,,,Set up a Galaxy for Training,Teaching and Hosting Galaxy training,2020-01,2020-01-02
@@ -555,7 +555,7 @@
 553,5,"The instructions were clear and neat. Also, it covers important aspects of the language.",There should be one task that push us to combine and use the learned knowledge.,,R basics in Galaxy,Foundations of Data Science,2020-02,2020-02-12
 554,4,It is easy to follow and summurazing many tools features as much as possible.,A real-life and frequently performed  case tutorial could be shown for demonstrating what could be done in IGV.,,IGV Introduction,Introduction to Galaxy Analyses,2020-02,2020-02-12
 555,5,,,,A short introduction to Galaxy,Introduction to Galaxy Analyses,2020-02,2020-02-13
-556,5,It was quite easy to follow and understand,"I saw 0.31 instead of 0.03 in the cut off box several times, would be better if it is corrected to 0.03 which is equal to 97% ",,16S Microbial Analysis with mothur (extended),Metagenomics,2020-02,2020-02-14
+556,5,It was quite easy to follow and understand,"I saw 0.31 instead of 0.03 in the cut off box several times, would be better if it is corrected to 0.03 which is equal to 97% ",,16S Microbial Analysis with mothur (extended),Microbiome,2020-02,2020-02-14
 557,5,"Step-by-Step guide, simple and well informative",,,Ansible,Galaxy Server administration,2020-02,2020-02-14
 558,5,Everthing,,,Galaxy Installation with Ansible,Galaxy Server administration,2020-02,2020-02-14
 559,4,The format of the tutorial is easy to follow and the instructions are clear.  The organization is such that it was easy to find where I had left off from the day before.,"I ran into technical difficulties that I cannot resolve;  it's hard to say whether this is due to the tutorial itself (visualizations hasn't worked yet;  the first analysis went fine, but the second yielded an empty data set).  Also, it took FAR longer than 3 hours; I do wonder if having a smaller mock data set would have helped this problem.    I'm trying to learn galaxy in order to incorporate an activity into my undergraduate course.  This tutorial seemed more relevant for training people who will use galaxy for their research.  A toned-down version with a smaller data set, perhaps without so many necessary file preparation steps would have been appreciated for my particular goals.  Having said that, I am guessing I am not the target audience, so I can see how this tutorial would be very useful for another audience.",,From peaks to genes,Introduction to Galaxy Analyses,2020-02,2020-02-14
@@ -585,12 +585,12 @@
 583,5,Very comprehensive tutorial. Helped me a lot,,,Running Jobs on Remote Resources with Pulsar,Galaxy Server administration,2020-03,2020-03-04
 584,5,Content,Maybe still take it slow when editing the various files. It's sometimes hard to follow with the numerous kind of configuration files.,,Running Jobs on Remote Resources with Pulsar,Galaxy Server administration,2020-03,2020-03-04
 585,5,"Thanks to ansible, easy to install :)",,,Galaxy Monitoring with Reports,Galaxy Server administration,2020-03,2020-03-04
-586,5,,,,16S Microbial Analysis with mothur (extended),Metagenomics,2020-03,2020-03-06
+586,5,,,,16S Microbial Analysis with mothur (extended),Microbiome,2020-03,2020-03-06
 587,5,,,,Galaxy 101,Introduction to Galaxy Analyses,2020-03,2020-03-08
 588,5,,,,Extracting Workflows from Histories,Using Galaxy and Managing your Data,2020-03,2020-03-09
 589,5,,,,From peaks to genes,Introduction to Galaxy Analyses,2020-03,2020-03-10
 590,4,"I have to say the full workflow is very useful for the people who did't know this for a long time, thank you so much. but the tool 'Genrich',I  did't find it on the Galaxy...","I can't find some tools in Galaxy,",,ATAC-Seq data analysis,Epigenetics,2020-03,2020-03-10
-591,5,,,,Analyses of metagenomics data - The global picture,Metagenomics,2020-03,2020-03-10
+591,5,,,,Analyses of metagenomics data - The global picture,Microbiome,2020-03,2020-03-10
 592,1,easy to start and its not completely frustrating like the university slides. It's quite astonishing that our university can't provide clear instructions how stuff works but the platform that is aimed at scientists does a better job explaining it. Thanks a lot,explanation part for hypergeometrical distribution is confusing me because the same words are used over and over again. maby include graphics to visualize the frequencies ,,GO Enrichment Analysis,Transcriptomics,2020-03,2020-03-10
 593,4,,,,Quality Control,Sequence analysis,2020-03,2020-03-11
 594,4,,Explanation how to use UCSC browser to see user track,,Galaxy 101,Introduction to Galaxy Analyses,2020-03,2020-03-12
@@ -601,7 +601,7 @@
 599,5,,,,RNA-RNA interactome data analysis,Transcriptomics,2020-03,2020-03-16
 600,5,,,,A short introduction to Galaxy,Introduction to Galaxy Analyses,2020-03,2020-03-16
 601,5,Steps are clearly explained,,,Introduction to Genomics and Galaxy,Introduction to Galaxy Analyses,2020-03,2020-03-17
-602,4,,,,Analyses of metagenomics data - The global picture,Metagenomics,2020-03,2020-03-17
+602,4,,,,Analyses of metagenomics data - The global picture,Microbiome,2020-03,2020-03-17
 603,5,very basic.   I need that,How do you get back to a single history showing and the other two panels,,A short introduction to Galaxy,Introduction to Galaxy Analyses,2020-03,2020-03-18
 604,5,,,,1: RNA-Seq reads to counts,Transcriptomics,2020-03,2020-03-18
 605,5,,,,A short introduction to Galaxy,Introduction to Galaxy Analyses,2020-03,2020-03-19
@@ -637,7 +637,7 @@
 635,3,Easy to follow for beginners,Need more information about non default setting of Bowtie2 and SAMtools,,Mapping,Sequence analysis,2020-04,2020-04-08
 636,4,,,,A short introduction to Galaxy,Introduction to Galaxy Analyses,2020-04,2020-04-08
 637,4,The tutorial is clear and easy to be understand,everything is great :),,Quality Control,Sequence analysis,2020-04,2020-04-09
-638,5,The fact that there was an exlpanation on why we are doing all these steps,Maybe adding PCA,,16S Microbial Analysis with mothur (extended),Metagenomics,2020-04,2020-04-09
+638,5,The fact that there was an exlpanation on why we are doing all these steps,Maybe adding PCA,,16S Microbial Analysis with mothur (extended),Microbiome,2020-04,2020-04-09
 639,3,,,,Quality Control,Sequence analysis,2020-04,2020-04-09
 640,5,step by step approach,"adding more pictorial description of for example the exact place of the tool in the tool search, it took me long to find the tool I needed, and they didn't have that monkey-wrench image next to them",,A short introduction to Galaxy,Introduction to Galaxy Analyses,2020-04,2020-04-09
 641,2,,,,Mapping,Sequence analysis,2020-04,2020-04-10
@@ -672,13 +672,13 @@
 670,5,Having comprehension questions after each part of the lessons,,,A short introduction to Galaxy,Introduction to Galaxy Analyses,2020-05,2020-05-05
 671,3,Tutorial includes code steps very clearly.,This is focused for paid distros.  Centos 7/8 builds do not work due to package requirements and availability,,Galaxy Installation with Ansible,Galaxy Server administration,2020-05,2020-05-05
 672,5,,,,Annotating a protein list identified by LC-MS/MS experiments,Proteomics,2020-05,2020-05-06
-673,5,,,,Analyses of metagenomics data - The global picture,Metagenomics,2020-05,2020-05-06
+673,5,,,,Analyses of metagenomics data - The global picture,Microbiome,2020-05,2020-05-06
 674,4,,,,Using dataset collections,Using Galaxy and Managing your Data,2020-05,2020-05-07
 675,4,,,,A short introduction to Galaxy,Introduction to Galaxy Analyses,2020-05,2020-05-08
 676,4,,"The difference between galaxy_server_dir and galaxy_root is unclear. Should they be nested? Which of these is needed in a shared file-system? Maybe provide best-practice values for both, so it becomes more clear how they interact with each other.",,Galaxy Installation with Ansible,Galaxy Server administration,2020-05,2020-05-08
 677,5,,,,Clustering 3K PBMCs with Scanpy,Single Cell,2020-05,2020-05-08
 678,5,clarity of the text,improving my knowledge about galaxy panel,,A short introduction to Galaxy,Introduction to Galaxy Analyses,2020-05,2020-05-08
-679,4,it is hands on course,I did not understand meaning of many options.,,16S Microbial Analysis with mothur (extended),Metagenomics,2020-05,2020-05-12
+679,4,it is hands on course,I did not understand meaning of many options.,,16S Microbial Analysis with mothur (extended),Microbiome,2020-05,2020-05-12
 680,4,,,,Genome Annotation,Genome Annotation,2020-05,2020-05-13
 681,5,,,,A short introduction to Galaxy,Introduction to Galaxy Analyses,2020-05,2020-05-13
 682,5,Well explained and simple to understand,,,Visualization of RNA-Seq results with Volcano Plot,Transcriptomics,2020-05,2020-05-14
@@ -701,7 +701,7 @@
 699,5,,,,From peaks to genes,Introduction to Galaxy Analyses,2020-05,2020-05-24
 700,5,straight forward easy to follow,,,Reference-based RNA-Seq data analysis,Transcriptomics,2020-05,2020-05-25
 701,5,Quite easy to follow,Bit more interpretation of output,,ATAC-Seq data analysis,Epigenetics,2020-05,2020-05-28
-702,5,,,,Metatranscriptomics analysis using microbiome RNA-seq data,Metagenomics,2020-05,2020-05-28
+702,5,,,,Metatranscriptomics analysis using microbiome RNA-seq data,Microbiome,2020-05,2020-05-28
 703,5,Detailed explanation of each step,Comparison of two ATAC-Seq datasets,,ATAC-Seq data analysis,Epigenetics,2020-05,2020-05-29
 704,5,everything works as expected,,,A short introduction to Galaxy,Introduction to Galaxy Analyses,2020-06,2020-06-01
 705,5,Well explained/detailed,,,A short introduction to Galaxy,Introduction to Galaxy Analyses,2020-06,2020-06-01
@@ -714,7 +714,7 @@
 712,5,The pace and the content covered are great!!!,,,An Introduction to Genome Assembly,Assembly,2020-06,2020-06-09
 713,1,I like that it exists,It is either outdated for the current Galaxy modules or the Galaxy interface has had major changes. Many steps in this tutorial do not match up to Galaxy- I am unable to produce any results.,,CLIP-Seq data analysis from pre-processing to motif detection,Transcriptomics,2020-06,2020-06-09
 714,5,It was a very good explanation!,,,A short introduction to Galaxy,Introduction to Galaxy Analyses,2020-06,2020-06-09
-715,5,Very interactive and gave detailed instructions about what to do and why. Very beginner friendly,Give brief introduction about the files extensions (for example what is a FASTQ/FASTA file?),,16S Microbial Analysis with mothur (extended),Metagenomics,2020-06,2020-06-09
+715,5,Very interactive and gave detailed instructions about what to do and why. Very beginner friendly,Give brief introduction about the files extensions (for example what is a FASTQ/FASTA file?),,16S Microbial Analysis with mothur (extended),Microbiome,2020-06,2020-06-09
 716,1,Very little,Incredibly hard to follow,,From peaks to genes,Introduction to Galaxy Analyses,2020-06,2020-06-11
 717,5,I like the brief but detailed and easy to understand instructions with explanations,the section on Visualize the overlapping genes could do with some improvement. I struggled to understand what scale track was and how to click it at the begining but eventually got around it. Maybe other users found it easy but that was my challenge.,,Introduction to Genomics and Galaxy,Introduction to Galaxy Analyses,2020-06,2020-06-11
 718,4,I liked that it was very specific and went step by step on how to do everything. nothing was left out.,I would like to know how to take the vcf file and identify polymorphic sites in all three individuals. ,,Exome sequencing data analysis for diagnosing a genetic disease,Variant Analysis,2020-06,2020-06-12
@@ -772,9 +772,9 @@
 770,5,,,,3: RNA-seq genes to pathways,Transcriptomics,2020-07,2020-07-09
 771,5,"very good examples, easy to follow",,,Clustering in Machine Learning,Statistics and machine learning,2020-07,2020-07-09
 772,3,,,,A short introduction to Galaxy,Introduction to Galaxy Analyses,2020-07,2020-07-09
-773,2,,,,Metatranscriptomics analysis using microbiome RNA-seq data,Metagenomics,2020-07,2020-07-10
+773,2,,,,Metatranscriptomics analysis using microbiome RNA-seq data,Microbiome,2020-07,2020-07-10
 774,5,Simple to follow,"I used the docker image and forgot to login, so I couldn't find the history rename / add new history options",,A short introduction to Galaxy,Introduction to Galaxy Analyses,2020-07,2020-07-11
-775,4,well described,help when stuck ,,Analyses of metagenomics data - The global picture,Metagenomics,2020-07,2020-07-11
+775,4,well described,help when stuck ,,Analyses of metagenomics data - The global picture,Microbiome,2020-07,2020-07-11
 776,5,,,,An Introduction to Genome Assembly,Assembly,2020-07,2020-07-11
 777,5,,,,Regression in Machine Learning,Statistics and machine learning,2020-07,2020-07-14
 778,3,This is something new. I enjoyed it. ,,,Ansible,Galaxy Server administration,2020-07,2020-07-17
@@ -806,7 +806,7 @@
 804,5,,,,A short introduction to Galaxy,Introduction to Galaxy Analyses,2020-08,2020-08-18
 805,5,The detailed step-by-step commands,,,A short introduction to Galaxy,Introduction to Galaxy Analyses,2020-08,2020-08-20
 806,5,,,,Quality Control,Sequence analysis,2020-08,2020-08-25
-807,5,Absolutamente todo. Cada sección perfectamente bien ejemplificado con teoría,,,16S Microbial Analysis with mothur (extended),Metagenomics,2020-08,2020-08-29
+807,5,Absolutamente todo. Cada sección perfectamente bien ejemplificado con teoría,,,16S Microbial Analysis with mothur (extended),Microbiome,2020-08,2020-08-29
 808,5,,,,Reference-based RNA-Seq data analysis,Transcriptomics,2020-08,2020-08-30
 809,3,Clear instructions,The Homo_sapiens.GRCh37.75.gtf file seems to not work,,Pre-processing of 10X Single-Cell RNA Datasets,Single Cell,2020-09,2020-09-02
 810,5,,,,A short introduction to Galaxy,Introduction to Galaxy Analyses,2020-09,2020-09-02
@@ -894,11 +894,11 @@
 892,5,so easy and clear,,,Advanced R in Galaxy,Foundations of Data Science,2020-12,2020-12-03
 893,5,,,,Basics of machine learning,Statistics and machine learning,2020-12,2020-12-04
 894,5,,,,Introduction to deep learning,Statistics and machine learning,2020-12,2020-12-04
-895,5,User-friendly ,/,,Antibiotic resistance detection,Metagenomics,2020-12,2020-12-05
+895,5,User-friendly ,/,,Antibiotic resistance detection,Microbiome,2020-12,2020-12-05
 896,4,,,,A short introduction to Galaxy,Introduction to Galaxy Analyses,2020-12,2020-12-08
 897,4,,,,A short introduction to Galaxy,Introduction to Galaxy Analyses,2020-12,2020-12-08
 898,5,,,,Quality Control,Sequence analysis,2020-12,2020-12-08
-899,5,"easy to follow, well explained",more insight on the different options,,16S Microbial analysis with Nanopore data,Metagenomics,2020-12,2020-12-18
+899,5,"easy to follow, well explained",more insight on the different options,,16S Microbial analysis with Nanopore data,Microbiome,2020-12,2020-12-18
 900,1,Everything was perfect!,Nothing specific.,,A short introduction to Galaxy,Introduction to Galaxy Analyses,2020-12,2020-12-21
 901,5,"concise, clear fast to perform",,,Basics of machine learning,Statistics and machine learning,2020-12,2020-12-23
 902,5,,,,Quality Control,Sequence analysis,2020-12,2020-12-26
@@ -912,1265 +912,1590 @@
 910,2,Clear Explanations,"I noticed the ""Note: this tool is heuristic; your results may differ slightly from the results here, and if repeated.""  But mine only showed one contig, with a length of 158kbp. I would consider this very different, not slightly different. Maybe add a few more examples of ""slightly different"" results  I am running the tool again to see what I get.  Additionally it took a long time to run this tool; almost an hour.   So it would be nice to know approximately how long a tool is going to take, (given the fastq file & runtime parameters), or maybe show the log file while it is running (assuming the actual tool writes to the log file rather than just storing the info in memory and writing the log at the end...)",,Chloroplast genome assembly,Assembly,2021-01,2021-01-02
 911,4,,In a previous version of this tutorial a join was performed to add exon info to the number of snps. This step was removed in a later version of the tutorial.,,Galaxy 101,Introduction to Galaxy Analyses,2021-01,2021-01-06
 912,5,,,,Deploying a compute cluster in OpenStack via Terraform,Galaxy Server administration,2021-01,2021-01-06
-913,5,The explaination about each step,,,16S Microbial Analysis with mothur (extended),Metagenomics,2021-01,2021-01-07
+913,5,The explaination about each step,,,16S Microbial Analysis with mothur (extended),Microbiome,2021-01,2021-01-07
 914,5,,,,Label-free data analysis using MaxQuant,Proteomics,2021-01,2021-01-08
 915,2,The explaination about how to use Prokka,"JBrowse doesn't work with this parameters, you should update this tutorial",,Genome annotation with Prokka,Genome Annotation,2021-01,2021-01-08
-916,3,,,,16S Microbial analysis with Nanopore data,Metagenomics,2021-01,2021-01-10
+916,3,,,,16S Microbial analysis with Nanopore data,Microbiome,2021-01,2021-01-10
 917,5,,,,3: RNA-seq genes to pathways,Transcriptomics,2021-01,2021-01-14
 918,5,,,,A short introduction to Galaxy,Introduction to Galaxy Analyses,2021-01,2021-01-15
-919,5,,,,Galaxy 101,Introduction to Galaxy Analyses,2021-01,2021-01-15
-920,5,,This tutorial would benefit from the addition of an updated data import section for the Zenodo inputs. Seems like a good candidate for a Co-Fest GTN+Papercuts contribution (should be quick to do + examples in other tutos). reminder @jennaj,,GO Enrichment Analysis,Transcriptomics,2021-01,2021-01-15
-921,5,Très didactique,"Peut être ajouter des copies d'écrans de l'historique ? (repérer les numéro d'actions) Mais peut être ""anxiogène"" si on a refait certaines opérations et que l'on perd ce repère de numéro...Donc non en fait :)",,Unicycler assembly of SARS-CoV-2 genome with preprocessing to remove human genome reads,Assembly,2021-01,2021-01-19
-922,5,it's cleanness and clarity and simplicity. it is ideal for start,,,A short introduction to Galaxy,Introduction to Galaxy Analyses,2021-01,2021-01-19
-923,5,Very clear,Where to find the tools (not always easy in the toolbar),,Compute and analyze biodiversity metrics with PAMPA toolsuite,Ecology,2021-01,2021-01-20
-924,5,,,,Mass spectrometry imaging: Examining the spatial distribution of analytes,Metabolomics,2021-01,2021-01-20
-925,5,,,,Visualization of RNA-Seq results with heatmap2,Transcriptomics,2021-01,2021-01-21
-926,3,"I think it's supposed to be an introductory course, but it got too complicated and theoretical. I am familiar with sequencing terminologies but I didn't understand what do you mean bye peak and broadness of the peaks!! Thanks BTW",I think the theoretical part of this tutorial should be explained in details,,From peaks to genes,Introduction to Galaxy Analyses,2021-01,2021-01-22
-927,4,Clear examples,More information on using git repos with ansible would be helpful,,Ansible,Galaxy Server administration,2021-01,2021-01-25
-928,0,very structured and understandable,"templates/nginx/galaxy.j2 -> ""uwsgi_pass 127.0.0.1:8080"" should not be configured statically and changed to a variable from the groups_vars if the port is changed there in the uwsgi variable settings",,Galaxy Installation with Ansible,Galaxy Server administration,2021-01,2021-01-25
-929,5,It is easy to follow,,,Ansible,Galaxy Server administration,2021-01,2021-01-25
-930,5,very easy to follow; excellent documentation,note about using non- let's encrypt certificate,,Galaxy Installation with Ansible,Galaxy Server administration,2021-01,2021-01-25
-931,4,,"specifiying that all commands (including andible-galaxy) should be rin in the `intro` directory, I had to rsync my new `~/roles` folder to intro",,Ansible,Galaxy Server administration,2021-01,2021-01-25
-932,0,The incremental approach to a rather complex system,"I was confused at first by the ""service"" service. More real, less abstract examples would be clearer, IMO",,Ansible,Galaxy Server administration,2021-01,2021-01-25
-933,5,Everything is great. ,"sysadmin part could be little bit slower, its hard to catch on for us who are not from purely IT background. ",,Use Singularity containers for running Galaxy jobs,Galaxy Server administration,2021-01,2021-01-26
-934,5,,,,Galaxy Installation with Ansible,Galaxy Server administration,2021-01,2021-01-26
-935,5,,,,Use Singularity containers for running Galaxy jobs,Galaxy Server administration,2021-01,2021-01-26
-936,5,"Everything, from top to bottom. ",,,Galaxy Tool Management with Ephemeris,Galaxy Server administration,2021-01,2021-01-26
-937,0,very beneficial pace!,,,Galaxy Tool Management with Ephemeris,Galaxy Server administration,2021-01,2021-01-26
-938,5,You guys rock! this CVMFS thing is so coool!,,,Reference Data with CVMFS,Galaxy Server administration,2021-01,2021-01-26
-939,5,,,,Use Singularity containers for running Galaxy jobs,Galaxy Server administration,2021-01,2021-01-26
-940,5,"Nice, easy to follow","I'm coming at this as a non-galaxy user so jumping straight into the interface  was initially a bit confusing, a quick video tour of the Galaxy interface (~5 minutes) beforehand would have made this easier for me",,Use Singularity containers for running Galaxy jobs,Galaxy Server administration,2021-01,2021-01-26
-941,5,,,,Galaxy Tool Management with Ephemeris,Galaxy Server administration,2021-01,2021-01-26
-942,5,,,,Reference Data with CVMFS,Galaxy Server administration,2021-01,2021-01-26
-943,4,,,,Data Libraries,Galaxy Server administration,2021-01,2021-01-26
-944,3,all the examples worked,"The flow of the tutorial feels awkward in places - you extract the workflow but then  install a tool singly before going back to the extracted .yml to do a batch.  Not directly related to this tutorial but coming from the previous Galaxy setup tutorials, I'm left thinking - what happened to Ansible and the concept of reinstalling the entire Galaxy in one playbook?",,Galaxy Tool Management with Ephemeris,Galaxy Server administration,2021-01,2021-01-26
-945,5,,,,Data Libraries,Galaxy Server administration,2021-01,2021-01-26
-946,0,Holy crap this is a cool feature!,I still dream of the ability to set a title of a the output dataset before clicking EXECUTE,,Name tags for following complex histories,Using Galaxy and Managing your Data,2021-01,2021-01-26
-947,5,"Great clarity. Thorough tutorial, leaves no stones unturned","""Modify the file"" parts (e.g. points 1. and 5. of ""Hands-on: Configure Galaxy to use Singularity"") are clear and a useful exercise to better understand the ansible and galaxy hierarchy, but if for some reason you made a mistake in a previous step, it could be useful to also have a snippet of the whole modified code to fasten the correction process and avoid backtracking.",,Use Singularity containers for running Galaxy jobs,Galaxy Server administration,2021-01,2021-01-26
-948,5,It shows me a really easy way of installing tools from tool shed avoiding the use of the graphical interface. That is perfect when you need to install many tools at once.,It could be explained how to include this tasks in the ansible playbook (if possible) in the case of a full re-installation of Galaxy. Or maybe better separate the two steps...,,Galaxy Tool Management with Ephemeris,Galaxy Server administration,2021-01,2021-01-26
-949,5,"Clear, straightforward, brief and complete",,,Reference Data with CVMFS,Galaxy Server administration,2021-01,2021-01-26
-950,5,This is really cool!!!!,"For the most used datasets (for ex. hg38) could we have a local copy, or would that be irrelevant? Could you explain how to calculate a good cache space?  If I use a cluster, will I need to configure this FS in each node (given that the folder is at / directly)?",,Reference Data with CVMFS,Galaxy Server administration,2021-01,2021-01-27
-951,5,,,,Connecting Galaxy to a compute cluster,Galaxy Server administration,2021-01,2021-01-27
+919,0,the explanations are well ,,,Unicycler Assembly,Assembly,2021-01,2021-01-15
+920,5,,,,Galaxy 101,Introduction to Galaxy Analyses,2021-01,2021-01-15
+921,5,,This tutorial would benefit from the addition of an updated data import section for the Zenodo inputs. Seems like a good candidate for a Co-Fest GTN+Papercuts contribution (should be quick to do + examples in other tutos). reminder @jennaj,,GO Enrichment Analysis,Transcriptomics,2021-01,2021-01-15
+922,5,Très didactique,"Peut être ajouter des copies d'écrans de l'historique ? (repérer les numéro d'actions) Mais peut être ""anxiogène"" si on a refait certaines opérations et que l'on perd ce repère de numéro...Donc non en fait :)",,Unicycler assembly of SARS-CoV-2 genome with preprocessing to remove human genome reads,Assembly,2021-01,2021-01-19
+923,5,it's cleanness and clarity and simplicity. it is ideal for start,,,A short introduction to Galaxy,Introduction to Galaxy Analyses,2021-01,2021-01-19
+924,5,Very clear,Where to find the tools (not always easy in the toolbar),,Compute and analyze biodiversity metrics with PAMPA toolsuite,Ecology,2021-01,2021-01-20
+925,5,,,,Mass spectrometry imaging: Examining the spatial distribution of analytes,Metabolomics,2021-01,2021-01-20
+926,5,,,,Visualization of RNA-Seq results with heatmap2,Transcriptomics,2021-01,2021-01-21
+927,3,"I think it's supposed to be an introductory course, but it got too complicated and theoretical. I am familiar with sequencing terminologies but I didn't understand what do you mean bye peak and broadness of the peaks!! Thanks BTW",I think the theoretical part of this tutorial should be explained in details,,From peaks to genes,Introduction to Galaxy Analyses,2021-01,2021-01-22
+928,4,Clear examples,More information on using git repos with ansible would be helpful,,Ansible,Galaxy Server administration,2021-01,2021-01-25
+929,0,very structured and understandable,"templates/nginx/galaxy.j2 -> ""uwsgi_pass 127.0.0.1:8080"" should not be configured statically and changed to a variable from the groups_vars if the port is changed there in the uwsgi variable settings",,Galaxy Installation with Ansible,Galaxy Server administration,2021-01,2021-01-25
+930,5,It is easy to follow,,,Ansible,Galaxy Server administration,2021-01,2021-01-25
+931,5,very easy to follow; excellent documentation,note about using non- let's encrypt certificate,,Galaxy Installation with Ansible,Galaxy Server administration,2021-01,2021-01-25
+932,4,,"specifiying that all commands (including andible-galaxy) should be rin in the `intro` directory, I had to rsync my new `~/roles` folder to intro",,Ansible,Galaxy Server administration,2021-01,2021-01-25
+933,0,The incremental approach to a rather complex system,"I was confused at first by the ""service"" service. More real, less abstract examples would be clearer, IMO",,Ansible,Galaxy Server administration,2021-01,2021-01-25
+934,5,Everything is great. ,"sysadmin part could be little bit slower, its hard to catch on for us who are not from purely IT background. ",,Use Apptainer containers for running Galaxy jobs,Galaxy Server administration,2021-01,2021-01-26
+935,5,,,,Galaxy Installation with Ansible,Galaxy Server administration,2021-01,2021-01-26
+936,5,,,,Use Apptainer containers for running Galaxy jobs,Galaxy Server administration,2021-01,2021-01-26
+937,5,"Everything, from top to bottom. ",,,Galaxy Tool Management with Ephemeris,Galaxy Server administration,2021-01,2021-01-26
+938,0,very beneficial pace!,,,Galaxy Tool Management with Ephemeris,Galaxy Server administration,2021-01,2021-01-26
+939,5,You guys rock! this CVMFS thing is so coool!,,,Reference Data with CVMFS,Galaxy Server administration,2021-01,2021-01-26
+940,5,,,,Use Apptainer containers for running Galaxy jobs,Galaxy Server administration,2021-01,2021-01-26
+941,5,"Nice, easy to follow","I'm coming at this as a non-galaxy user so jumping straight into the interface  was initially a bit confusing, a quick video tour of the Galaxy interface (~5 minutes) beforehand would have made this easier for me",,Use Apptainer containers for running Galaxy jobs,Galaxy Server administration,2021-01,2021-01-26
+942,5,,,,Galaxy Tool Management with Ephemeris,Galaxy Server administration,2021-01,2021-01-26
+943,5,,,,Reference Data with CVMFS,Galaxy Server administration,2021-01,2021-01-26
+944,4,,,,Data Libraries,Galaxy Server administration,2021-01,2021-01-26
+945,3,all the examples worked,"The flow of the tutorial feels awkward in places - you extract the workflow but then  install a tool singly before going back to the extracted .yml to do a batch.  Not directly related to this tutorial but coming from the previous Galaxy setup tutorials, I'm left thinking - what happened to Ansible and the concept of reinstalling the entire Galaxy in one playbook?",,Galaxy Tool Management with Ephemeris,Galaxy Server administration,2021-01,2021-01-26
+946,5,,,,Data Libraries,Galaxy Server administration,2021-01,2021-01-26
+947,0,Holy crap this is a cool feature!,I still dream of the ability to set a title of a the output dataset before clicking EXECUTE,,Name tags for following complex histories,Using Galaxy and Managing your Data,2021-01,2021-01-26
+948,5,"Great clarity. Thorough tutorial, leaves no stones unturned","""Modify the file"" parts (e.g. points 1. and 5. of ""Hands-on: Configure Galaxy to use Singularity"") are clear and a useful exercise to better understand the ansible and galaxy hierarchy, but if for some reason you made a mistake in a previous step, it could be useful to also have a snippet of the whole modified code to fasten the correction process and avoid backtracking.",,Use Apptainer containers for running Galaxy jobs,Galaxy Server administration,2021-01,2021-01-26
+949,5,It shows me a really easy way of installing tools from tool shed avoiding the use of the graphical interface. That is perfect when you need to install many tools at once.,It could be explained how to include this tasks in the ansible playbook (if possible) in the case of a full re-installation of Galaxy. Or maybe better separate the two steps...,,Galaxy Tool Management with Ephemeris,Galaxy Server administration,2021-01,2021-01-26
+950,5,"Clear, straightforward, brief and complete",,,Reference Data with CVMFS,Galaxy Server administration,2021-01,2021-01-26
+951,5,This is really cool!!!!,"For the most used datasets (for ex. hg38) could we have a local copy, or would that be irrelevant? Could you explain how to calculate a good cache space?  If I use a cluster, will I need to configure this FS in each node (given that the folder is at / directly)?",,Reference Data with CVMFS,Galaxy Server administration,2021-01,2021-01-27
 952,5,,,,Connecting Galaxy to a compute cluster,Galaxy Server administration,2021-01,2021-01-27
-953,5,,,,Mapping Jobs to Destinations,Galaxy Server administration,2021-01,2021-01-27
-954,5,,,,Recording Job Metrics,Galaxy Server administration,2021-01,2021-01-27
-955,5,,,,Mapping Jobs to Destinations,Galaxy Server administration,2021-01,2021-01-27
-956,5,"Just the right amount of content, Slurm is so large it would have been easy to get over complicated","Minor: the references to pulsar in the examples could be confusing, might be worth adding a warning for anyone who is going through this tutorial before the pulsar tutorial",,Connecting Galaxy to a compute cluster,Galaxy Server administration,2021-01,2021-01-27
-957,0,the step by step exercises,for me as a noob some diagrams or schemes would often be helpful to see how things relate to each others,,Galaxy Installation with Ansible,Galaxy Server administration,2021-01,2021-01-27
-958,5,,,,Use Singularity containers for running Galaxy jobs,Galaxy Server administration,2021-01,2021-01-27
-959,5,all of it!,maybe some notes about what may require proxies,,Use Singularity containers for running Galaxy jobs,Galaxy Server administration,2021-01,2021-01-27
-960,5,easy to understand and follow,,,Galaxy Tool Management with Ephemeris,Galaxy Server administration,2021-01,2021-01-27
-961,4,I feel like I understand how to manage this quite well now,"The Python code and some of the xml seems to paste into the cli with loads of new tab characters, in vim I used ':set paste' to switch off auto indent. Doesn't happen with the yml though",,Mapping Jobs to Destinations,Galaxy Server administration,2021-01,2021-01-27
-962,5,very easy to follow and understand. ,,,Reference Data with CVMFS,Galaxy Server administration,2021-01,2021-01-27
-963,5,,,,Recording Job Metrics,Galaxy Server administration,2021-01,2021-01-27
-964,0,very helpful,some video issue around 8m,,Data Libraries,Galaxy Server administration,2021-01,2021-01-27
-965,5,"fantastic, incredibly helpful. trainer is really great.","Would like info on adding to existing clusters (ie., SGE, etc)",,Connecting Galaxy to a compute cluster,Galaxy Server administration,2021-01,2021-01-27
-966,5,Easily digestible,,,Recording Job Metrics,Galaxy Server administration,2021-01,2021-01-27
-967,5,"The clear explanation of every part of the roles, modules etc. What they do why they're there. Even if I wasn't interested in everything it's good to know that if I ever need that information I can look back to this tutorial","I don't know if it can be improved but the actual time of the tutorial is really long. After watching it, I totally understand why but if it could be something like 1 hour videos (or less) that would be less tiring. Of course I am fully aware that there is a broad range of topics that need to be covered.",,Galaxy Installation with Ansible,Galaxy Server administration,2021-01,2021-01-27
-968,5,,,,Mapping Jobs to Destinations,Galaxy Server administration,2021-01,2021-01-27
-969,5,,,,Use Singularity containers for running Galaxy jobs,Galaxy Server administration,2021-01,2021-01-27
-970,5,,,,Reference Data with CVMFS,Galaxy Server administration,2021-01,2021-01-27
-971,5,I really need this knowledge. ,"I have stuck in the part of editing templates/galaxy/config/job_conf.xml.j2 because some lines differ from the resulting file from previous session (namely singularity was set as default) and I had to compare the file showed in the video with the file I had. I took some time, but it worked at the end.  It seems not so complicated now, but it will be when connecting to a living cluster. What happens when I have SLURM already configured at the server? And MUNGE (this guy made some nodes crash here because of very large log files), do I need to configure it in the cluster? It was not clear.",,Connecting Galaxy to a compute cluster,Galaxy Server administration,2021-01,2021-01-27
-972,5,This is amazing!,,,Running Jobs on Remote Resources with Pulsar,Galaxy Server administration,2021-01,2021-01-28
-973,5,,,,Running Jobs on Remote Resources with Pulsar,Galaxy Server administration,2021-01,2021-01-28
-974,4,This is a powerful way of controlling the resource usage according to tool requirements.,"This task includes many layers of complexity. It would be nice if, at the beginning or ending of each subtopic the needed changes were pointed in the file tree. For example, using the 'tree' command and then highlight all the files that have to be created / edited for this feature to work. It is just for better visualization of the modifications. I get something useful when calling git status.",,Mapping Jobs to Destinations,Galaxy Server administration,2021-01,2021-01-28
-975,5,Easy and useful,"Regarding 'expose_potentially_sensitive_job_metrics' , is there an option to expose different metrics for admins and general users? For example, creating different profiles in templates/galaxy/config/job_metrics_conf.xml.j2 ",,Recording Job Metrics,Galaxy Server administration,2021-01,2021-01-28
-976,5,Good detail,The tutorial assumes a bit more knowledge than a lot of the others so it won't be as useful for someone who comes to it stand-alone as a pulsar via ansible setup guide,,Running Jobs on Remote Resources with Pulsar,Galaxy Server administration,2021-01,2021-01-28
-977,5,,,,Use Singularity containers for running Galaxy jobs,Galaxy Server administration,2021-01,2021-01-28
-978,4,"Easy to add local storage, the dropbox integration is good","""Warning: switching object store types will cause issues"" - suggest putting that at the top and emphasise that this is a tutorial that shouldn't be blindly followed on a proper install.  The S3 section assumed quite a lot of knowledge - I didn't understand, but expect someone who manages data in an S3 bucket will!  ",,Distributed Object Storage,Galaxy Server administration,2021-01,2021-01-28
-979,4,,,,Data Libraries,Galaxy Server administration,2021-01,2021-01-28
-980,4,,,,Galaxy Monitoring with gxadmin,Galaxy Server administration,2021-01,2021-01-28
-981,5,,,,Galaxy Tool Management with Ephemeris,Galaxy Server administration,2021-01,2021-01-28
-982,5,,,,Galaxy Monitoring with Telegraf and Grafana,Galaxy Server administration,2021-01,2021-01-28
-983,5,CVMFS is a great addition both for Galaxy and in general. It was a great thing to know.,In the tutorial nothing. It's perfect. I would like CVMFS to include reference genomes indexed for methylation analysis (e.g. with Bismark). I dropped a question about it in slack as well.,,Reference Data with CVMFS,Galaxy Server administration,2021-01,2021-01-28
-984,5,This is a very well written tutorial.  I really appreciated how we were shown ways to thoroughly check that rabbitmq was working as expected before moving on to the next step.,,,Running Jobs on Remote Resources with Pulsar,Galaxy Server administration,2021-01,2021-01-28
-985,5,Each part was beside its example.,Add more images to each part and more questions to assure learning.,,A short introduction to Galaxy,Introduction to Galaxy Analyses,2021-01,2021-01-29
-986,4,,There is a big chunk of the tutorial misssing from the video (the video is stuck in the setup stage).,,Data Libraries,Galaxy Server administration,2021-01,2021-01-29
-987,3,Ansible instructions worked,"I found the content on Grafana and monitoring/alerts really confusing, it felt almost like it is for an older version of Grafana.",,Galaxy Monitoring with Telegraf and Grafana,Galaxy Server administration,2021-01,2021-01-29
-988,5,The whole concept of being able to separate training needs vs production needs is brilliant,3. We next need to configure this plugin in our job configuration (files/galaxy/config/job_conf.xml): Should be templates/galaxy/config/job_conf.xml.j2 to match rest of training?,,Training Infrastructure as a Service (TIaaS),Galaxy Server administration,2021-01,2021-01-29
-989,5,,,,Connecting Galaxy to a compute cluster,Galaxy Server administration,2021-01,2021-01-29
-990,5,quick and easy,Link to guide on how to secure it,,Galaxy Monitoring with Reports,Galaxy Server administration,2021-01,2021-01-29
-991,5,,,,Mapping Jobs to Destinations,Galaxy Server administration,2021-01,2021-01-29
-992,5,,,,Recording Job Metrics,Galaxy Server administration,2021-01,2021-01-29
-993,5,Concise and clear. Thank you!,,,Genome annotation with Prokka,Genome Annotation,2021-01,2021-01-29
-994,4,It gave an excellent crash course in Ansible and how best to use it in Galaxy,"Possibly one or two links to other Ansible resources in the docco, but can't think of anything else.",,Ansible,Galaxy Server administration,2021-02,2021-02-01
-995,5,Realy clear and solid explanations of how to use Ansible for Galaxy installation,,,Galaxy Installation with Ansible,Galaxy Server administration,2021-02,2021-02-01
-996,4,"Some good things to note and keep track of regarding moving to production, especially updating the version.",,,Galaxy Installation with Ansible,Galaxy Server administration,2021-02,2021-02-01
-997,5,,,,Quality Control,Sequence analysis,2021-02,2021-02-01
-998,4,Covered all the steps,Parameters could have been explained,,Hi-C analysis of Drosophila melanogaster cells using HiCExplorer,Epigenetics,2021-02,2021-02-01
-999,5,,,,Data Libraries,Galaxy Server administration,2021-02,2021-02-02
-1000,5,,,,Connecting Galaxy to a compute cluster,Galaxy Server administration,2021-02,2021-02-02
-1001,5,Background information about NGS data progressing and file types,Perhaps could includes some information about how to view or check the SAM/BAM file.,,NGS data logistics,Introduction to Galaxy Analyses,2021-02,2021-02-03
-1002,5,The simplicity,Add a short section on using nginx basic authentication to secure it from public eyes,,Galaxy Monitoring with Reports,Galaxy Server administration,2021-02,2021-02-05
-1003,4,Achievable within 2hrs,Some clarity on assumptions such as recessive mutation and the purpose of the mapping strain (for non-geneticists). And SnpEff4.1 is no longer available. Can this be patched? ,,Mapping and molecular identification of phenotype-causing mutations,Variant Analysis,2021-02,2021-02-05
-1004,5,,,,Quality Control,Sequence analysis,2021-02,2021-02-06
-1005,4,,,,Mapping,Sequence analysis,2021-02,2021-02-06
-1006,0,,you may show the progression files in green to show us the file we have after each step i have problem with FASTQ interlacer i follow the tutorials and after this step i have two files one of them is empty and it's not working for the further stem with velveth so i'm stock at this step i don'understand why,,An Introduction to Genome Assembly,Assembly,2021-02,2021-02-10
-1007,0,i like it!,,,Group tags for complex experimental designs,Using Galaxy and Managing your Data,2021-02,2021-02-10
-1008,5,,,,Reference-based RNA-Seq data analysis,Transcriptomics,2021-02,2021-02-11
-1009,5,Very informative.,,,Introduction to Genomics and Galaxy,Introduction to Galaxy Analyses,2021-02,2021-02-15
-1010,5,The detail and complexity. Fantastic! ,Possibly broken into smaller tutorials?,,Reference-based RNA-Seq data analysis,Transcriptomics,2021-02,2021-02-15
-1011,5,"Very clear, all tools are clearly explained, small questions to help us understand the output results",,,Quality Control,Sequence analysis,2021-02,2021-02-15
-1012,5,"Very clear presentation, the results are clearly explained helping bioinformatician/biologist to understand the output","Some tools were not in the right column, maybe use 'search tools' instead of looking for tools in a specific section (when the tool is actually in another section). Especially for Galaxy beginners",,Introduction to Genomics and Galaxy,Introduction to Galaxy Analyses,2021-02,2021-02-15
-1013,5,Very helpful to rerun the same steps in one go instead of running each step individually! Workflows save time!!,,,Extracting Workflows from Histories,Using Galaxy and Managing your Data,2021-02,2021-02-15
-1014,5,Very clear and interesting. IGV and JBrowse are indeed very interesting tools to view alignment !,,,Mapping,Sequence analysis,2021-02,2021-02-15
-1015,4,How workflow idea was introduced.,,,Extracting Workflows from Histories,Using Galaxy and Managing your Data,2021-02,2021-02-15
-1016,4,,,,Introduction to Genomics and Galaxy,Introduction to Galaxy Analyses,2021-02,2021-02-15
+953,5,,,,Connecting Galaxy to a compute cluster,Galaxy Server administration,2021-01,2021-01-27
+954,5,,,,Mapping Jobs to Destinations using TPV,Galaxy Server administration,2021-01,2021-01-27
+955,5,,,,Connecting Galaxy to a compute cluster,Galaxy Server administration,2021-01,2021-01-27
+956,5,,,,Mapping Jobs to Destinations using TPV,Galaxy Server administration,2021-01,2021-01-27
+957,5,"Just the right amount of content, Slurm is so large it would have been easy to get over complicated","Minor: the references to pulsar in the examples could be confusing, might be worth adding a warning for anyone who is going through this tutorial before the pulsar tutorial",,Connecting Galaxy to a compute cluster,Galaxy Server administration,2021-01,2021-01-27
+958,0,the step by step exercises,for me as a noob some diagrams or schemes would often be helpful to see how things relate to each others,,Galaxy Installation with Ansible,Galaxy Server administration,2021-01,2021-01-27
+959,5,,,,Use Apptainer containers for running Galaxy jobs,Galaxy Server administration,2021-01,2021-01-27
+960,5,all of it!,maybe some notes about what may require proxies,,Use Apptainer containers for running Galaxy jobs,Galaxy Server administration,2021-01,2021-01-27
+961,5,easy to understand and follow,,,Galaxy Tool Management with Ephemeris,Galaxy Server administration,2021-01,2021-01-27
+962,4,I feel like I understand how to manage this quite well now,"The Python code and some of the xml seems to paste into the cli with loads of new tab characters, in vim I used ':set paste' to switch off auto indent. Doesn't happen with the yml though",,Mapping Jobs to Destinations using TPV,Galaxy Server administration,2021-01,2021-01-27
+963,5,very easy to follow and understand. ,,,Reference Data with CVMFS,Galaxy Server administration,2021-01,2021-01-27
+964,5,,,,Connecting Galaxy to a compute cluster,Galaxy Server administration,2021-01,2021-01-27
+965,0,very helpful,some video issue around 8m,,Data Libraries,Galaxy Server administration,2021-01,2021-01-27
+966,5,"fantastic, incredibly helpful. trainer is really great.","Would like info on adding to existing clusters (ie., SGE, etc)",,Connecting Galaxy to a compute cluster,Galaxy Server administration,2021-01,2021-01-27
+967,5,Easily digestible,,,Connecting Galaxy to a compute cluster,Galaxy Server administration,2021-01,2021-01-27
+968,5,"The clear explanation of every part of the roles, modules etc. What they do why they're there. Even if I wasn't interested in everything it's good to know that if I ever need that information I can look back to this tutorial","I don't know if it can be improved but the actual time of the tutorial is really long. After watching it, I totally understand why but if it could be something like 1 hour videos (or less) that would be less tiring. Of course I am fully aware that there is a broad range of topics that need to be covered.",,Galaxy Installation with Ansible,Galaxy Server administration,2021-01,2021-01-27
+969,5,,,,Mapping Jobs to Destinations using TPV,Galaxy Server administration,2021-01,2021-01-27
+970,5,,,,Use Apptainer containers for running Galaxy jobs,Galaxy Server administration,2021-01,2021-01-27
+971,5,,,,Reference Data with CVMFS,Galaxy Server administration,2021-01,2021-01-27
+972,5,I really need this knowledge. ,"I have stuck in the part of editing templates/galaxy/config/job_conf.xml.j2 because some lines differ from the resulting file from previous session (namely singularity was set as default) and I had to compare the file showed in the video with the file I had. I took some time, but it worked at the end.  It seems not so complicated now, but it will be when connecting to a living cluster. What happens when I have SLURM already configured at the server? And MUNGE (this guy made some nodes crash here because of very large log files), do I need to configure it in the cluster? It was not clear.",,Connecting Galaxy to a compute cluster,Galaxy Server administration,2021-01,2021-01-27
+973,5,This is amazing!,,,Running Jobs on Remote Resources with Pulsar,Galaxy Server administration,2021-01,2021-01-28
+974,5,,,,Running Jobs on Remote Resources with Pulsar,Galaxy Server administration,2021-01,2021-01-28
+975,4,This is a powerful way of controlling the resource usage according to tool requirements.,"This task includes many layers of complexity. It would be nice if, at the beginning or ending of each subtopic the needed changes were pointed in the file tree. For example, using the 'tree' command and then highlight all the files that have to be created / edited for this feature to work. It is just for better visualization of the modifications. I get something useful when calling git status.",,Mapping Jobs to Destinations using TPV,Galaxy Server administration,2021-01,2021-01-28
+976,5,Easy and useful,"Regarding 'expose_potentially_sensitive_job_metrics' , is there an option to expose different metrics for admins and general users? For example, creating different profiles in templates/galaxy/config/job_metrics_conf.xml.j2 ",,Connecting Galaxy to a compute cluster,Galaxy Server administration,2021-01,2021-01-28
+977,5,Good detail,The tutorial assumes a bit more knowledge than a lot of the others so it won't be as useful for someone who comes to it stand-alone as a pulsar via ansible setup guide,,Running Jobs on Remote Resources with Pulsar,Galaxy Server administration,2021-01,2021-01-28
+978,5,,,,Use Apptainer containers for running Galaxy jobs,Galaxy Server administration,2021-01,2021-01-28
+979,4,"Easy to add local storage, the dropbox integration is good","""Warning: switching object store types will cause issues"" - suggest putting that at the top and emphasise that this is a tutorial that shouldn't be blindly followed on a proper install.  The S3 section assumed quite a lot of knowledge - I didn't understand, but expect someone who manages data in an S3 bucket will!  ",,Distributed Object Storage,Galaxy Server administration,2021-01,2021-01-28
+980,4,,,,Data Libraries,Galaxy Server administration,2021-01,2021-01-28
+981,4,,,,Galaxy Monitoring with gxadmin,Galaxy Server administration,2021-01,2021-01-28
+982,5,,,,Galaxy Tool Management with Ephemeris,Galaxy Server administration,2021-01,2021-01-28
+983,5,,,,Galaxy Monitoring with Telegraf and Grafana,Galaxy Server administration,2021-01,2021-01-28
+984,5,CVMFS is a great addition both for Galaxy and in general. It was a great thing to know.,In the tutorial nothing. It's perfect. I would like CVMFS to include reference genomes indexed for methylation analysis (e.g. with Bismark). I dropped a question about it in slack as well.,,Reference Data with CVMFS,Galaxy Server administration,2021-01,2021-01-28
+985,5,This is a very well written tutorial.  I really appreciated how we were shown ways to thoroughly check that rabbitmq was working as expected before moving on to the next step.,,,Running Jobs on Remote Resources with Pulsar,Galaxy Server administration,2021-01,2021-01-28
+986,5,Each part was beside its example.,Add more images to each part and more questions to assure learning.,,A short introduction to Galaxy,Introduction to Galaxy Analyses,2021-01,2021-01-29
+987,4,,There is a big chunk of the tutorial misssing from the video (the video is stuck in the setup stage).,,Data Libraries,Galaxy Server administration,2021-01,2021-01-29
+988,3,Ansible instructions worked,"I found the content on Grafana and monitoring/alerts really confusing, it felt almost like it is for an older version of Grafana.",,Galaxy Monitoring with Telegraf and Grafana,Galaxy Server administration,2021-01,2021-01-29
+989,5,The whole concept of being able to separate training needs vs production needs is brilliant,3. We next need to configure this plugin in our job configuration (files/galaxy/config/job_conf.xml): Should be templates/galaxy/config/job_conf.xml.j2 to match rest of training?,,Training Infrastructure as a Service (TIaaS),Galaxy Server administration,2021-01,2021-01-29
+990,5,,,,Connecting Galaxy to a compute cluster,Galaxy Server administration,2021-01,2021-01-29
+991,5,quick and easy,Link to guide on how to secure it,,Galaxy Monitoring with Reports,Galaxy Server administration,2021-01,2021-01-29
+992,5,,,,Mapping Jobs to Destinations using TPV,Galaxy Server administration,2021-01,2021-01-29
+993,5,,,,Connecting Galaxy to a compute cluster,Galaxy Server administration,2021-01,2021-01-29
+994,5,Concise and clear. Thank you!,,,Genome annotation with Prokka,Genome Annotation,2021-01,2021-01-29
+995,4,It gave an excellent crash course in Ansible and how best to use it in Galaxy,"Possibly one or two links to other Ansible resources in the docco, but can't think of anything else.",,Ansible,Galaxy Server administration,2021-02,2021-02-01
+996,5,Realy clear and solid explanations of how to use Ansible for Galaxy installation,,,Galaxy Installation with Ansible,Galaxy Server administration,2021-02,2021-02-01
+997,4,"Some good things to note and keep track of regarding moving to production, especially updating the version.",,,Galaxy Installation with Ansible,Galaxy Server administration,2021-02,2021-02-01
+998,5,,,,Quality Control,Sequence analysis,2021-02,2021-02-01
+999,4,Covered all the steps,Parameters could have been explained,,Hi-C analysis of Drosophila melanogaster cells using HiCExplorer,Epigenetics,2021-02,2021-02-01
+1000,5,,,,Data Libraries,Galaxy Server administration,2021-02,2021-02-02
+1001,5,,,,Connecting Galaxy to a compute cluster,Galaxy Server administration,2021-02,2021-02-02
+1002,5,Background information about NGS data progressing and file types,Perhaps could includes some information about how to view or check the SAM/BAM file.,,NGS data logistics,Introduction to Galaxy Analyses,2021-02,2021-02-03
+1003,5,The simplicity,Add a short section on using nginx basic authentication to secure it from public eyes,,Galaxy Monitoring with Reports,Galaxy Server administration,2021-02,2021-02-05
+1004,4,Achievable within 2hrs,Some clarity on assumptions such as recessive mutation and the purpose of the mapping strain (for non-geneticists). And SnpEff4.1 is no longer available. Can this be patched? ,,Mapping and molecular identification of phenotype-causing mutations,Variant Analysis,2021-02,2021-02-05
+1005,5,,,,Quality Control,Sequence analysis,2021-02,2021-02-06
+1006,4,,,,Mapping,Sequence analysis,2021-02,2021-02-06
+1007,0,,you may show the progression files in green to show us the file we have after each step i have problem with FASTQ interlacer i follow the tutorials and after this step i have two files one of them is empty and it's not working for the further stem with velveth so i'm stock at this step i don'understand why,,An Introduction to Genome Assembly,Assembly,2021-02,2021-02-10
+1008,0,i like it!,,,Group tags for complex experimental designs,Using Galaxy and Managing your Data,2021-02,2021-02-10
+1009,5,,,,Reference-based RNA-Seq data analysis,Transcriptomics,2021-02,2021-02-11
+1010,5,Very informative.,,,Introduction to Genomics and Galaxy,Introduction to Galaxy Analyses,2021-02,2021-02-15
+1011,5,The detail and complexity. Fantastic! ,Possibly broken into smaller tutorials?,,Reference-based RNA-Seq data analysis,Transcriptomics,2021-02,2021-02-15
+1012,5,"Very clear, all tools are clearly explained, small questions to help us understand the output results",,,Quality Control,Sequence analysis,2021-02,2021-02-15
+1013,5,"Very clear presentation, the results are clearly explained helping bioinformatician/biologist to understand the output","Some tools were not in the right column, maybe use 'search tools' instead of looking for tools in a specific section (when the tool is actually in another section). Especially for Galaxy beginners",,Introduction to Genomics and Galaxy,Introduction to Galaxy Analyses,2021-02,2021-02-15
+1014,5,Very helpful to rerun the same steps in one go instead of running each step individually! Workflows save time!!,,,Extracting Workflows from Histories,Using Galaxy and Managing your Data,2021-02,2021-02-15
+1015,5,Very clear and interesting. IGV and JBrowse are indeed very interesting tools to view alignment !,,,Mapping,Sequence analysis,2021-02,2021-02-15
+1016,4,How workflow idea was introduced.,,,Extracting Workflows from Histories,Using Galaxy and Managing your Data,2021-02,2021-02-15
 1017,4,,,,Introduction to Genomics and Galaxy,Introduction to Galaxy Analyses,2021-02,2021-02-15
-1018,4,Overall good structure,"It is rather specific, a short introduction ahead on the tools and ideas might be helpful",,Introduction to Genomics and Galaxy,Introduction to Galaxy Analyses,2021-02,2021-02-15
-1019,5,,,,A short introduction to Galaxy,Introduction to Galaxy Analyses,2021-02,2021-02-15
-1020,5,Complex but very interesting!! All steps are clearly explained.,"As i said, the data analysis was complex. So detailing the results would have helped to better understand. ",,NGS data logistics,Introduction to Galaxy Analyses,2021-02,2021-02-15
-1021,5,Very helpful basics of R,,,R basics in Galaxy,Foundations of Data Science,2021-02,2021-02-15
-1022,5,Very interesting libraries (tidyr and dplyr) for data analysis,More self training exercise,,Advanced R in Galaxy,Foundations of Data Science,2021-02,2021-02-15
-1023,5,very interesting library to visualize data,,,RNA Seq Counts to Viz in R,Transcriptomics,2021-02,2021-02-15
-1024,4,,,,Mapping,Sequence analysis,2021-02,2021-02-15
-1025,5,It was clear and easy to follow.,,,Quality Control,Sequence analysis,2021-02,2021-02-15
-1026,5,,,,Introduction to Genomics and Galaxy,Introduction to Galaxy Analyses,2021-02,2021-02-15
-1027,5,,,,Quality Control,Sequence analysis,2021-02,2021-02-15
-1028,5,Clear and easy,,,Chloroplast genome assembly,Assembly,2021-02,2021-02-15
-1029,5,,,,Quality Control,Sequence analysis,2021-02,2021-02-16
-1030,5,The tutorial and the goals were clear,,,Introduction to Genomics and Galaxy,Introduction to Galaxy Analyses,2021-02,2021-02-16
-1031,3,,,,Quality Control,Sequence analysis,2021-02,2021-02-16
-1032,5,Loved the self training with new data at the end. Helps user create a workflow to re run the steps rapidly and compare results. The tutorials were very clear and easy to understand,,,Chloroplast genome assembly,Assembly,2021-02,2021-02-16
-1033,3,Very easy to follow,,,Quality Control,Sequence analysis,2021-02,2021-02-16
-1034,5,Practical,Error of concept of nucleotides vrs amino acids,,Introduction to Genomics and Galaxy,Introduction to Galaxy Analyses,2021-02,2021-02-16
-1035,5,"Very clear explanation. Video makes it easier to understand results. The small questions are very good, helps to better understand results. Functional enrichment of DEGs was very interesting with clear visualization. ",,,Reference-based RNA-Seq data analysis,Transcriptomics,2021-02,2021-02-16
-1036,3,,,,Chloroplast genome assembly,Assembly,2021-02,2021-02-16
-1037,5,,,,Quality Control,Sequence analysis,2021-02,2021-02-16
+1018,4,,,,Introduction to Genomics and Galaxy,Introduction to Galaxy Analyses,2021-02,2021-02-15
+1019,4,Overall good structure,"It is rather specific, a short introduction ahead on the tools and ideas might be helpful",,Introduction to Genomics and Galaxy,Introduction to Galaxy Analyses,2021-02,2021-02-15
+1020,5,,,,A short introduction to Galaxy,Introduction to Galaxy Analyses,2021-02,2021-02-15
+1021,5,Complex but very interesting!! All steps are clearly explained.,"As i said, the data analysis was complex. So detailing the results would have helped to better understand. ",,NGS data logistics,Introduction to Galaxy Analyses,2021-02,2021-02-15
+1022,5,Very helpful basics of R,,,R basics in Galaxy,Foundations of Data Science,2021-02,2021-02-15
+1023,5,Very interesting libraries (tidyr and dplyr) for data analysis,More self training exercise,,Advanced R in Galaxy,Foundations of Data Science,2021-02,2021-02-15
+1024,5,very interesting library to visualize data,,,RNA Seq Counts to Viz in R,Transcriptomics,2021-02,2021-02-15
+1025,4,,,,Mapping,Sequence analysis,2021-02,2021-02-15
+1026,5,It was clear and easy to follow.,,,Quality Control,Sequence analysis,2021-02,2021-02-15
+1027,5,,,,Introduction to Genomics and Galaxy,Introduction to Galaxy Analyses,2021-02,2021-02-15
+1028,5,,,,Quality Control,Sequence analysis,2021-02,2021-02-15
+1029,5,Clear and easy,,,Chloroplast genome assembly,Assembly,2021-02,2021-02-15
+1030,5,,,,Quality Control,Sequence analysis,2021-02,2021-02-16
+1031,5,The tutorial and the goals were clear,,,Introduction to Genomics and Galaxy,Introduction to Galaxy Analyses,2021-02,2021-02-16
+1032,3,,,,Quality Control,Sequence analysis,2021-02,2021-02-16
+1033,5,Loved the self training with new data at the end. Helps user create a workflow to re run the steps rapidly and compare results. The tutorials were very clear and easy to understand,,,Chloroplast genome assembly,Assembly,2021-02,2021-02-16
+1034,3,Very easy to follow,,,Quality Control,Sequence analysis,2021-02,2021-02-16
+1035,5,Practical,Error of concept of nucleotides vrs amino acids,,Introduction to Genomics and Galaxy,Introduction to Galaxy Analyses,2021-02,2021-02-16
+1036,5,"Very clear explanation. Video makes it easier to understand results. The small questions are very good, helps to better understand results. Functional enrichment of DEGs was very interesting with clear visualization. ",,,Reference-based RNA-Seq data analysis,Transcriptomics,2021-02,2021-02-16
+1037,3,,,,Chloroplast genome assembly,Assembly,2021-02,2021-02-16
 1038,5,,,,Quality Control,Sequence analysis,2021-02,2021-02-16
-1039,4,,,,RStudio in Galaxy,Using Galaxy and Managing your Data,2021-02,2021-02-16
-1040,5,Everything about the lesson was crisp in explanation and content,I believe the tutorial is next to perfect,,Quality Control,Sequence analysis,2021-02,2021-02-16
-1041,5,,,,Introduction to Genomics and Galaxy,Introduction to Galaxy Analyses,2021-02,2021-02-16
-1042,4,,,,Chloroplast genome assembly,Assembly,2021-02,2021-02-16
-1043,5,,,,Introduction to Genomics and Galaxy,Introduction to Galaxy Analyses,2021-02,2021-02-16
-1044,4,,,,Reference-based RNA-Seq data analysis,Transcriptomics,2021-02,2021-02-16
-1045,0,The tutorial was easy to follow.,There are very many different choices to make  - a fold-out in the tutorial of just some of themwould be nice.   ,,Mapping,Sequence analysis,2021-02,2021-02-16
-1046,5,,,,Reference-based RNA-Seq data analysis,Transcriptomics,2021-02,2021-02-17
-1047,3,,,,Reference-based RNA-Seq data analysis,Transcriptomics,2021-02,2021-02-17
-1048,0,"I like the examples,being related to genomics .",I am not sure if I would grasp it without previous knowledge. ,,R basics in Galaxy,Foundations of Data Science,2021-02,2021-02-17
-1049,5,very concise and helpful !,,,RNA Seq Counts to Viz in R,Transcriptomics,2021-02,2021-02-17
-1050,5,,,,R basics in Galaxy,Foundations of Data Science,2021-02,2021-02-17
-1051,4,,,,Advanced R in Galaxy,Foundations of Data Science,2021-02,2021-02-17
-1052,5,well explained ,I would include some links with more options such as color palettes... shapes... ,,RNA Seq Counts to Viz in R,Transcriptomics,2021-02,2021-02-17
-1053,5,Complete pipeline to analyse nanopore data. Easy tutorial and results are very clear with a visualisation with krona,,,16S Microbial analysis with Nanopore data,Metagenomics,2021-02,2021-02-17
-1054,5,,,,R basics in Galaxy,Foundations of Data Science,2021-02,2021-02-17
-1055,0,I've never done a single cell analysis before!,It was a little bit fast.,,Understanding Barcodes,Single Cell,2021-02,2021-02-17
-1056,5,Very good level of detail. Just appropriate. ,,,Reference-based RNA-Seq data analysis,Transcriptomics,2021-02,2021-02-17
-1057,3,,,,Understanding Barcodes,Single Cell,2021-02,2021-02-17
-1058,5,Easy to follow,"We use FastQC.  it would be nice to have some information about ""Contaminant list "", ""Adapter list"", ""Submodule and Limit specifing file"" etc",,A short introduction to Galaxy,Introduction to Galaxy Analyses,2021-02,2021-02-17
-1059,5,"very clear instructions, step by step to go back and repeat if need to do","not sure, but also following the video to complement the instructions was great",,Quality Control,Sequence analysis,2021-02,2021-02-17
-1060,1,,what will the preprocessing be useful for - perhaps this should be explained?,,Understanding Barcodes,Single Cell,2021-02,2021-02-17
-1061,4,,,,Understanding Barcodes,Single Cell,2021-02,2021-02-18
-1062,3,,,,Pre-processing of 10X Single-Cell RNA Datasets,Single Cell,2021-02,2021-02-18
-1063,5,Easy to follow tutorial. I learnt about so many tools used for data analysis.,,,Clustering 3K PBMCs with Scanpy,Single Cell,2021-02,2021-02-18
-1064,5,Simple and easy to demonstrate gene annotation using contigs,,,Genome annotation with Prokka,Genome Annotation,2021-02,2021-02-18
-1065,5,Very easy and simple to understand,,,Introduction to deep learning,Statistics and machine learning,2021-02,2021-02-18
-1066,4,Very illustrative,The link to the full pipeline 'A full pipeline which produces both an AnnData and tabular file for inspection is provided here.' directs to a file scrna_tenx.ga - what are .ga files and what program should be used for these?,,Pre-processing of 10X Single-Cell RNA Datasets,Single Cell,2021-02,2021-02-18
-1067,4,,,,Chloroplast genome assembly,Assembly,2021-02,2021-02-18
-1068,5,How easy and friendly is the tutorial ,Nothing,,A short introduction to Galaxy,Introduction to Galaxy Analyses,2021-02,2021-02-18
-1069,5,very clear descriptions of all steps,,,Proteogenomics 1: Database Creation,Proteomics,2021-02,2021-02-18
-1070,5,clear and concise descriptions of each step,provide all necessary input files from tutorial 1 on zenodo,,Proteogenomics 2: Database Search,Proteomics,2021-02,2021-02-18
-1071,5,,,,Reference-based RNA-Seq data analysis,Transcriptomics,2021-02,2021-02-18
-1072,5,Very clear and helpful for first time users,,,Quality Control,Sequence analysis,2021-02,2021-02-18
-1073,4,,,,Proteogenomics 2: Database Search,Proteomics,2021-02,2021-02-18
-1074,5,,,,Understanding Barcodes,Single Cell,2021-02,2021-02-18
-1075,5,,,,Pre-processing of 10X Single-Cell RNA Datasets,Single Cell,2021-02,2021-02-18
-1076,3,that there were several examples,,,Visualisation with Circos,Visualisation,2021-02,2021-02-18
-1077,5,,,,Clustering 3K PBMCs with Scanpy,Single Cell,2021-02,2021-02-19
-1078,5,it was very helpful.,,,Unicycler assembly of SARS-CoV-2 genome with preprocessing to remove human genome reads,Assembly,2021-02,2021-02-19
-1079,5,Very informative yet concise. Did an excellent job of walking through the parameters needed for each step. Also appreciated the walking through of visualization and statistical significance rather than ending at the OTU clustering. ,,,16S Microbial Analysis with mothur (extended),Metagenomics,2021-02,2021-02-19
-1080,5,How in depth and clear it was.,,,Unicycler assembly of SARS-CoV-2 genome with preprocessing to remove human genome reads,Assembly,2021-02,2021-02-19
-1081,4,,,,RNA Seq Counts to Viz in R,Transcriptomics,2021-02,2021-02-19
-1082,4,,,,Visualisation with Circos,Visualisation,2021-02,2021-02-19
-1083,5,,,,Proteogenomics 3: Novel peptide analysis,Proteomics,2021-02,2021-02-19
-1084,5,"The presentation was great: first the explanantion what we will do and why, and then tutorial.",,,Proteogenomics 2: Database Search,Proteomics,2021-02,2021-02-19
-1085,5,The clarity and order of the explanation,,,Reference-based RNA-Seq data analysis,Transcriptomics,2021-02,2021-02-19
-1086,3,,,,Proteogenomics 1: Database Creation,Proteomics,2021-02,2021-02-19
-1087,5,Concentration on the essential aspects with the possibility to further deepen the knowledge about the individual tools,,,Exome sequencing data analysis for diagnosing a genetic disease,Variant Analysis,2021-02,2021-02-19
-1088,5,The steps were very clear,Make a tutorial for miRNAs in humans,,Reference-based RNA-Seq data analysis,Transcriptomics,2021-02,2021-02-19
-1089,5,"I like that it has a clear relation to the NGS topic, this helped to keep me motivated","Actually it was very well developed, maybe one for heatmaps would be a great addition",,RNA Seq Counts to Viz in R,Transcriptomics,2021-02,2021-02-19
-1090,5,,,,Antibiotic resistance detection,Metagenomics,2021-02,2021-02-20
-1091,5,"I´d like to know how I can get a unique assemble using more than one pair of Illumina reads for the same DNA, for example the same bacterial strain. It is possible? ",,,Chloroplast genome assembly,Assembly,2021-02,2021-02-20
-1092,5,,,,Galaxy 101 for everyone,Introduction to Galaxy Analyses,2021-02,2021-02-20
-1093,5,So useful from getting the data to pathway analysis!!,,,Reference-based RNA-Seq data analysis,Transcriptomics,2021-02,2021-02-21
-1094,3,Handy,Tutorial video went too fast with no much explanation.,,Understanding Barcodes,Single Cell,2021-02,2021-02-21
-1095,3,,Tutorial video went too fast with no much explanation.,,Pre-processing of 10X Single-Cell RNA Datasets,Single Cell,2021-02,2021-02-21
-1096,5,Very good material ,,,NGS data logistics,Introduction to Galaxy Analyses,2021-02,2021-02-22
-1097,5,,,,Identification of somatic and germline variants from tumor and normal sample pairs,Variant Analysis,2021-02,2021-02-22
-1098,5,Easy to follow and clear,,,A short introduction to Galaxy,Introduction to Galaxy Analyses,2021-02,2021-02-23
-1099,5,,,,Quality Control,Sequence analysis,2021-02,2021-02-23
-1100,3,,,,From peaks to genes,Introduction to Galaxy Analyses,2021-02,2021-02-24
-1101,4,,,,Chloroplast genome assembly,Assembly,2021-02,2021-02-25
-1102,5,"the work flow and associated explanations. Perfect for my students to get acquainted with the workflow, inputs and outputs, and then move to HPC learning","incorporate UMI-based workflows (e.g., duplex consensus)",,Identification of somatic and germline variants from tumor and normal sample pairs,Variant Analysis,2021-02,2021-02-25
-1103,5,The hands-on tutorial which is straight forward and easy to follow,,,Introduction to Genomics and Galaxy,Introduction to Galaxy Analyses,2021-02,2021-02-26
-1104,5,"The tutorial is hands-on, straight forward and easy to follow",,,Introduction to Genomics and Galaxy,Introduction to Galaxy Analyses,2021-02,2021-02-26
-1105,5,"Clear and easy to follow, and tones of additional information.",More images perhaps,,Quality Control,Sequence analysis,2021-02,2021-02-27
-1106,5,Explanations and step by by procedure explained,,,High Throughput Molecular Dynamics and Analysis,Computational chemistry,2021-02,2021-02-28
-1107,3,,,,Pre-processing of 10X Single-Cell RNA Datasets,Single Cell,2021-03,2021-03-01
-1108,5,Very good guiding,cant think of something..,,Galaxy 101 for everyone,Introduction to Galaxy Analyses,2021-03,2021-03-02
-1109,5,,,,A short introduction to Galaxy,Introduction to Galaxy Analyses,2021-03,2021-03-03
-1110,5,The instructions are very detailed and clearly presented. ,Some pictures in the tutorial are not up-to-date.,,Galaxy 101 for everyone,Introduction to Galaxy Analyses,2021-03,2021-03-04
-1111,5,It is so clear to show the process step by step.,,,1: RNA-Seq reads to counts,Transcriptomics,2021-03,2021-03-04
-1112,5,,,,Galaxy 101,Introduction to Galaxy Analyses,2021-03,2021-03-05
-1113,5,,,,Galaxy 101,Introduction to Galaxy Analyses,2021-03,2021-03-05
-1114,1,,It doesn't show you where to begin. It gives you steps but doesn't show you how to get to each step. Very frustrating ,,Genome annotation with Prokka,Genome Annotation,2021-03,2021-03-10
-1115,5,It's very precise and explain the most important characteristics of how to use the platform,,,A short introduction to Galaxy,Introduction to Galaxy Analyses,2021-03,2021-03-11
-1116,5,It was clear and well structured.,Nothing! Galaxy is awesome,,Introduction to Genomics and Galaxy,Introduction to Galaxy Analyses,2021-03,2021-03-11
-1117,0,All steps were clearly described and easily understood. ,"I could not find the tool""filter bam dataset on a variety of attributes"" in tool panel of Galaxy-human cell atlas , so I could not follow.",,Pre-processing of Single-Cell RNA Data,Single Cell,2021-03,2021-03-11
-1118,0,,"I wanted to follow ""Hands-on: Remove genes found in less than 3 cells"" with tool ""filter with scanpy"", had given the every parameter correctly, but could not be successful every time.   ",,Clustering 3K PBMCs with Scanpy,Single Cell,2021-03,2021-03-12
-1119,4,Thorough engagement with complex process of this analysis,"Some specifics:  * No BAM to FastQ (used SamToFastq) * not clear what ""the reference mRNA and TE fasta file"" is * In ""siRNA differential abundance testing"" surely it should be Symp vs Blank? * Visualization section is missing * the miRNA reads are ""removed for separate analysis"" - what analysis is this? * Add some hats (this is hard!)  I also resorted to writing some mini-workflows to make it easier to do some of the repetitive parts of the tutorial ",,Differential abundance testing of small RNAs,Transcriptomics,2021-03,2021-03-12
-1120,2,"Part1, the Repeat workflow is not working. The manual is different from for actual workflow in galaxy.",,,From peaks to genes,Introduction to Galaxy Analyses,2021-03,2021-03-12
-1121,5,,,,A short introduction to Galaxy,Introduction to Galaxy Analyses,2021-03,2021-03-19
-1122,5,easy to follow,,,A short introduction to Galaxy,Introduction to Galaxy Analyses,2021-03,2021-03-22
-1123,5,Easy to follow steps,"""Where to go next"" button to jump into another training session",,Galaxy 101,Introduction to Galaxy Analyses,2021-03,2021-03-22
-1124,5,,,,Microbial Variant Calling,Variant Analysis,2021-03,2021-03-23
-1125,5,Brief description of key issues,,,Label-free versus Labelled - How to Choose Your Quantitation Method,Proteomics,2021-03,2021-03-26
-1126,5,,,,2: RNA-seq counts to genes,Transcriptomics,2021-03,2021-03-28
-1127,5,"Simple languange, hands-on example and exercises with answers hidden.","I know it is a lot to ask, but adding matrices would be helpful",,R basics in Galaxy,Foundations of Data Science,2021-03,2021-03-28
-1128,5,Going to use this in Australia soon (late May 2021)- excited about it. More feedback to come afterwards no doubt!,"I can see in the intro that this tutorial is set up for raw (fastq) and BAM data entry points. This is great but I was hoping you could include a workflow for fastq to BAM. I realise it is in the full workflow so I took the liberty of comparing the two offered workflows and trimmed down to a QC to BAM workflow (https://usegalaxy.org.au/u/gareth-qfab/w/copy-of-exome-seq-training-full-w-cached-ref-imported-from-uploaded-file ). I understand we can do this elsewhere but good to have it consistent within this tutorial. Tested on Zenodo data and works fine. Thanks, Gareth",,Exome sequencing data analysis for diagnosing a genetic disease,Variant Analysis,2021-03,2021-03-30
-1129,5,,,,Exome sequencing data analysis for diagnosing a genetic disease,Variant Analysis,2021-03,2021-03-30
-1130,5,very friendly people and very informative.,nothing,,1: RNA-Seq reads to counts,Transcriptomics,2021-03,2021-03-31
-1131,5,It was really clear and easy to follow. ,,,2: RNA-seq counts to genes,Transcriptomics,2021-03,2021-03-31
-1132,5,,,,Reference-based RNAseq data analysis (long),Transcriptomics,2021-03,2021-03-31
-1133,0,"clearly described, can be followed step by step, idea for new-users.",,,Clustering 3K PBMCs with Scanpy,Single Cell,2021-03,2021-03-31
-1134,2,It seemed clear - just didn't work.,I read the tutorial as I tried to duplicate it in Galaxy with a phage genome sequence. The tutorial did not correspond with what was in Galaxy. JBrowse did not work - no indication why.,,Genome annotation with Prokka,Genome Annotation,2021-04,2021-04-03
-1135,0,"clearly described, can be followed step by step, super tutorial for new users.",,,Clustering 3K PBMCs with Scanpy,Single Cell,2021-04,2021-04-03
-1136,5,,,,Quality Control,Sequence analysis,2021-04,2021-04-05
-1137,5,really detailed and clear!,"some tools have different names (e.g. it's now 'Pathway enrichment analysis [Reactome]' instead of 'Query pathway database [Reactome]', I think; in other words I couldn't find 'Query pathway database [Reactome]' so I improvised with 'Pathway enrichment analysis [Reactome]'). Also it would be good to include some tools to analise data other than these 3 species.",,Annotating a protein list identified by LC-MS/MS experiments,Proteomics,2021-04,2021-04-06
-1138,3,,"This tutorial works with the input files. However, working with non-model organisms is a problem. Download the genbank entry is nice, but which one - on BioSample or else? What should it look like? Any requirements? Only the easy way is shown. How can a reference genome fasta be used along with a gff3 file? That does not work at all with files other than built in or sample files. The tutorial is meant well, but it should be improved to enable also people not working with yeast, mouse or human to use it and prevent problems. Thanks a lot!",,Microbial Variant Calling,Variant Analysis,2021-04,2021-04-07
-1139,5,"All aspects: clear, step by step illustration. ",,,A short introduction to Galaxy,Introduction to Galaxy Analyses,2021-04,2021-04-09
-1140,4,,,,Galaxy 101 for everyone,Introduction to Galaxy Analyses,2021-04,2021-04-11
-1141,5,Very detailed walk-through the tutorial!,,,Using dataset collections,Using Galaxy and Managing your Data,2021-04,2021-04-11
-1142,1,,the code,,Visualization of RNA-Seq results with Volcano Plot,Transcriptomics,2021-04,2021-04-12
-1143,5,"I very much enjoy this tutorial! coming back from extensive R experience using limma, DEseq, still find this Galaxy thing makes things easier",,,2: RNA-seq counts to genes,Transcriptomics,2021-04,2021-04-14
-1144,5,It was easy and great with visuals as well,,,A short introduction to Galaxy,Introduction to Galaxy Analyses,2021-04,2021-04-14
-1145,4,I liked that it is possible to use real data and explore multiple tools. It was relatively easy to follow all the way to the final step. I could also take the Structure output and run it through Structure in Galaxy or in my own PC to further demonstrate that the SNP data can be analysed with population genomic software.,"Some of the instructions need to be updated to the latest versions of the tools available in Galaxy. I could not tell which population (1 or 2) was the freshwater and which one was the oceanic, so I assumed 1=freshwater, 2=oceanic. It would also be good to see some of the ""expected"" results, just to verify that what has been done is working fine and that students are on the right track.",,RAD-Seq Reference-based data analysis,Ecology,2021-04,2021-04-14
-1146,5,,,,Quality Control,Sequence analysis,2021-04,2021-04-19
-1147,5,Good for a beginner,,,A short introduction to Galaxy,Introduction to Galaxy Analyses,2021-04,2021-04-20
-1148,5,,,,Peptide and Protein ID using OpenMS tools,Proteomics,2021-04,2021-04-21
-1149,5,Easy to follow,,,ATAC-Seq data analysis,Epigenetics,2021-04,2021-04-21
-1150,3,The solutions after each question,Te previous tutorial (quality control) was more easy to follow the different steps,,Mapping,Sequence analysis,2021-04,2021-04-22
-1151,4,,,,Whole transcriptome analysis of Arabidopsis thaliana,Transcriptomics,2021-04,2021-04-22
-1152,4,,,,Whole transcriptome analysis of Arabidopsis thaliana,Transcriptomics,2021-04,2021-04-22
-1153,5,,,,Understanding Barcodes,Single Cell,2021-04,2021-04-22
-1154,4,I like all the indications step by step. Very clear. I would like to have some information about others parameters that are setted by default. ,"I only correct one part where there are 2 mistakes. In ""Filter significantly differentially expressed mRNAs"" section, Hands-on: Extract significantly DE genes in point 3) Filter “Filter”: Differentially expressed miRNAs (replace by mRNAs)  And in point 5) Filter “Filter”: Differentially expressed miRNAs (replace by mRNAs). This is about the text. ",,Whole transcriptome analysis of Arabidopsis thaliana,Transcriptomics,2021-04,2021-04-23
-1155,5,"the detail in the explanations, the examples included",,,Quality Control,Sequence analysis,2021-04,2021-04-24
-1156,5,,,,Genome Assembly of MRSA using Illumina MiSeq Data,Assembly,2021-04,2021-04-26
-1157,4,Clear and well explained,Another example to work through. ,,Name tags for following complex histories,Using Galaxy and Managing your Data,2021-04,2021-04-26
-1158,5,,,,Name tags for following complex histories,Using Galaxy and Managing your Data,2021-04,2021-04-26
-1159,5,,,,Name tags for following complex histories,Using Galaxy and Managing your Data,2021-04,2021-04-26
-1160,4,easy to follow,interactive plots could not be opened https://usegalaxy.org/datasets/bbd44e69cb8906b52089f52da217dea4/display/glimma_basalpregnant-basallactate/MD-Plot.html,,2: RNA-seq counts to genes,Transcriptomics,2021-04,2021-04-28
-1161,5,,,,3: RNA-seq genes to pathways,Transcriptomics,2021-04,2021-04-30
-1162,5,,,,A short introduction to Galaxy,Introduction to Galaxy Analyses,2021-05,2021-05-03
-1163,4,,Sometimes it is hard to find a specific thing that we need to click on when we don't know where it is located on the screen.,,Functionally Assembled Terrestrial Ecosystem Simulator (FATES),Climate,2021-05,2021-05-05
-1164,5,TESTING,TESTING,,A short introduction to Galaxy,Introduction to Galaxy Analyses,2021-05,2021-05-06
-1165,2,,"It is not clear which files to choose, because ""C2C12"" clearly isnt available.",,IGV Introduction,Introduction to Galaxy Analyses,2021-05,2021-05-07
-1166,5,"The depth of the tutorial, the examples of bad quality data, the explanation why these tools are used and sometimes alternatives, and the overview figure in the conclusion.",,,ATAC-Seq data analysis,Epigenetics,2021-05,2021-05-10
-1167,5,"It is a very clear step by step, well defined tutorial. ",The difference between method 1 and 2. The peak summit concept may need more explanation.,,From peaks to genes,Introduction to Galaxy Analyses,2021-05,2021-05-11
-1168,5,"The trimming and filtering part is the most important stage of RNA-seq data analysis. Generally, adapter sequences are not given with SRA data in NCBI . Therefore, I was shot in the dark while using the trimmomatic, cuadapt and other tools whose results are not that much satisfactory. The information given in the tutorial seems to work for one of the messiest data.",I think it would be great to see usage of filtering and trimming tools on one or two messy data. It will give us insights about how to deal with such data,,A short introduction to Galaxy,Introduction to Galaxy Analyses,2021-05,2021-05-12
-1169,5,The basics of each step explained very clearly.,Maybe the names of the files which need to be put in the field for the tool. Took a bit of time to understand in few places.,,Unicycler assembly of SARS-CoV-2 genome with preprocessing to remove human genome reads,Assembly,2021-05,2021-05-18
-1170,5,That it is a step by step <3 ,The master branch on my side is called main,,Contributing with GitHub via command-line,Contributing to the Galaxy Training Material,2021-05,2021-05-19
-1171,5,,,,A short introduction to Galaxy,Introduction to Galaxy Analyses,2021-05,2021-05-19
-1172,5,Everything :) ,"""topics/introduction/tutorials/galaxy-intro-peaks2genes/tutorial.md"" is no longer found, example can be changed to ""topics/introduction/tutorials/r-basics/r_introduction.md"" instead  ",,Running the GTN website locally,Contributing to the Galaxy Training Material,2021-05,2021-05-19
-1173,5,,,,An Introduction to Genome Assembly,Assembly,2021-05,2021-05-20
-1174,5,,,,ATAC-Seq data analysis,Epigenetics,2021-05,2021-05-20
-1175,5,It was clear and easy to follow,,,A short introduction to Galaxy,Introduction to Galaxy Analyses,2021-05,2021-05-21
-1176,5,,,,From peaks to genes,Introduction to Galaxy Analyses,2021-05,2021-05-21
-1177,5,The graphs and Q&A,Additional examples,,Visualization of RNA-Seq results with Volcano Plot,Transcriptomics,2021-05,2021-05-21
-1178,4,,,,Reference-based RNAseq data analysis (long),Transcriptomics,2021-05,2021-05-22
-1179,5,well explained!,,,A short introduction to Galaxy,Introduction to Galaxy Analyses,2021-05,2021-05-22
-1180,5,,,,Galaxy 101,Introduction to Galaxy Analyses,2021-05,2021-05-22
-1181,5,,,,NGS data logistics,Introduction to Galaxy Analyses,2021-05,2021-05-23
-1182,5,clear and to the point,,,Galaxy 101,Introduction to Galaxy Analyses,2021-05,2021-05-23
-1183,5,Very informative and clear,Nothing,,Using Workflow Parameters,Using Galaxy and Managing your Data,2021-05,2021-05-24
-1184,5,Very clear,Nothing,,Downloading and Deleting Data in Galaxy,Using Galaxy and Managing your Data,2021-05,2021-05-24
-1185,5,"Gareth, Melissa and Khalid (I was in breakout room 3) were all incredibly helpful and it went at a good pace. It was VERY helpful getting the course material ahead of the workshop, which allowed time to familiarise myself with the content. ",I think it was on the mark for me. ,,Exome sequencing data analysis for diagnosing a genetic disease,Variant Analysis,2021-05,2021-05-25
-1186,4,,,,Galaxy 101,Introduction to Galaxy Analyses,2021-05,2021-05-25
-1187,5,all of it,nothing - it's perfect,,Exome sequencing data analysis for diagnosing a genetic disease,Variant Analysis,2021-05,2021-05-26
-1188,5,,,,Galaxy 101 for everyone,Introduction to Galaxy Analyses,2021-05,2021-05-27
-1189,4,,,,Introduction to Genomics and Galaxy,Introduction to Galaxy Analyses,2021-05,2021-05-27
-1190,5,,,,Calling variants in diploid systems,Variant Analysis,2021-05,2021-05-28
-1191,5,Step by step process and questions to think about,Maybe screenshots of selections ,,Quality Control,Sequence analysis,2021-05,2021-05-31
-1192,3,Quite clear overall,"There is no way to find out the p-values corresponding to the different colors, the meaning of the dotted and solid arrows, etc. Please add those information if you want to make your plots more comprehensible! ",,GO Enrichment Analysis,Transcriptomics,2021-06,2021-06-02
-1193,5,very clear and complete,,,A short introduction to Galaxy,Introduction to Galaxy Analyses,2021-06,2021-06-02
-1194,5,,,,Exome sequencing data analysis for diagnosing a genetic disease,Variant Analysis,2021-06,2021-06-02
-1195,5,The details that were explained are hard to get elsewhere and they were explained in a very lucid and uncomplicated manner that made it a pleasure to read on,Perhaps a more detailed conclusion about the final results obtained in a paragraph style will be the best way to end the discussion.,,Reference-based RNA-Seq data analysis,Transcriptomics,2021-06,2021-06-05
-1196,5,,,,Visualization of RNA-Seq results with heatmap2,Transcriptomics,2021-06,2021-06-05
-1197,5,,,,From peaks to genes,Introduction to Galaxy Analyses,2021-06,2021-06-09
-1198,5,,,,High Throughput Molecular Dynamics and Analysis,Computational chemistry,2021-06,2021-06-09
-1199,5,,,,Clustering 3K PBMCs with Scanpy,Single Cell,2021-06,2021-06-10
-1200,5,Easy to follow for the most part.,"You forgot to describe how to create an hmm database for the hmmscan step. I think hmmbuild can be used for this, but more detail would be needed about what input to feed hmmbuild so it can generate a model that can be effectively used with hmmscan.",,"De novo transcriptome assembly, annotation, and differential expression analysis",Transcriptomics,2021-06,2021-06-11
-1201,5,very simple ,,,"Creating, Editing and Importing Galaxy Workflows",Using Galaxy and Managing your Data,2021-06,2021-06-11
-1202,4,,,,A short introduction to Galaxy,Introduction to Galaxy Analyses,2021-06,2021-06-12
-1203,5,,,,Quality Control,Sequence analysis,2021-06,2021-06-12
-1204,3,,,,Mapping,Sequence analysis,2021-06,2021-06-12
-1205,4,,,,Reference-based RNA-Seq data analysis,Transcriptomics,2021-06,2021-06-13
-1206,5,The explanation to implement each step,nothing,,Galaxy 101,Introduction to Galaxy Analyses,2021-06,2021-06-17
-1207,5,"Everything was explained in detail, easy to follow",,,ATAC-Seq data analysis,Epigenetics,2021-06,2021-06-18
-1208,5,very intuitive,everything is great,,Clustering in Machine Learning,Statistics and machine learning,2021-06,2021-06-18
-1209,5,It helps me to understand about the basic of data type,-,,A short introduction to Galaxy,Introduction to Galaxy Analyses,2021-06,2021-06-19
-1210,5,,,,Identification of somatic and germline variants from tumor and normal sample pairs,Variant Analysis,2021-06,2021-06-21
-1211,5,Clear explanation about QC reports,Adaptor trimming,,Quality Control,Sequence analysis,2021-06,2021-06-22
-1212,5,,,,A short introduction to Galaxy,Introduction to Galaxy Analyses,2021-06,2021-06-22
-1213,5,,,,Galaxy 101 for everyone,Introduction to Galaxy Analyses,2021-06,2021-06-23
-1214,4,,,,NGS data logistics,Introduction to Galaxy Analyses,2021-06,2021-06-24
-1215,3,realistc examples,More details regarding used scripts and templates,,Deploying a compute cluster in OpenStack via Terraform,Galaxy Server administration,2021-06,2021-06-24
-1216,5,,,,Quality Control,Sequence analysis,2021-06,2021-06-25
-1217,5,All,Nothing,,Galaxy 101,Introduction to Galaxy Analyses,2021-06,2021-06-25
-1218,5,Clear and concise; had images to show where things are;,"I got a little confused at the end where it said to click on Analyze Data in the top panel (step 3 in the ""Look at all your histories"") and could not find a way back without clicking the home button again.",,A short introduction to Galaxy,Introduction to Galaxy Analyses,2021-06,2021-06-25
-1219,5,Simple and Elegant,,,A short introduction to Galaxy,Introduction to Galaxy Analyses,2021-06,2021-06-26
-1220,5,The explanations were easy to understand while explaining the intuition behind the graphs and the quality of the data.,The sound has sudden drops and highs making it hard to follow at specific points.,,Quality Control,Sequence analysis,2021-06,2021-06-27
-1221,5,All points were very well explained,,,Galaxy Installation with Ansible,Galaxy Server administration,2021-06,2021-06-28
-1222,5,,,,Introduction to Genomics and Galaxy,Introduction to Galaxy Analyses,2021-06,2021-06-28
-1223,4,,,,Rule Based Uploader,Using Galaxy and Managing your Data,2021-06,2021-06-28
-1224,4,,,,Rule Based Uploader,Using Galaxy and Managing your Data,2021-06,2021-06-29
-1225,5,"Very interesting, the step by step approach is very clear",,,Use Singularity containers for running Galaxy jobs,Galaxy Server administration,2021-06,2021-06-29
-1226,5,The practical approach,,,Galaxy Tool Management with Ephemeris,Galaxy Server administration,2021-06,2021-06-29
-1227,5,Completness,,,Galaxy 101,Introduction to Galaxy Analyses,2021-06,2021-06-29
-1228,5,Very clear explanation,,,Reference Data with CVMFS,Galaxy Server administration,2021-06,2021-06-29
-1229,5,Very clear step by step,,,Data Libraries,Galaxy Server administration,2021-06,2021-06-29
-1230,5,,,,Reference Data with CVMFS,Galaxy Server administration,2021-06,2021-06-29
-1231,5,,,,Ansible,Galaxy Server administration,2021-06,2021-06-29
-1232,5,,,,Use Singularity containers for running Galaxy jobs,Galaxy Server administration,2021-06,2021-06-29
-1233,5,,,,Galaxy Tool Management with Ephemeris,Galaxy Server administration,2021-06,2021-06-29
-1234,5,,,,Quality Control,Sequence analysis,2021-06,2021-06-29
-1235,5,,,,Quality Control,Sequence analysis,2021-06,2021-06-29
-1236,4,,,,Mapping,Sequence analysis,2021-06,2021-06-29
-1237,5,,,,Mapping,Sequence analysis,2021-06,2021-06-29
-1238,4,,,,Chloroplast genome assembly,Assembly,2021-06,2021-06-29
-1239,4,,,,Chloroplast genome assembly,Assembly,2021-06,2021-06-29
-1240,5,,,,Quality Control,Sequence analysis,2021-06,2021-06-30
-1241,5,Very clear explanations,,,Connecting Galaxy to a compute cluster,Galaxy Server administration,2021-06,2021-06-30
-1242,5,Great introduction and very useful starting point for beginning to apply these features,,,Mapping Jobs to Destinations,Galaxy Server administration,2021-06,2021-06-30
-1243,5,Oustanding material!,Nothing!,,Exome sequencing data analysis for diagnosing a genetic disease,Variant Analysis,2021-06,2021-06-30
-1244,4,,,,From peaks to genes,Introduction to Galaxy Analyses,2021-06,2021-06-30
-1245,5,,,,Mapping Jobs to Destinations,Galaxy Server administration,2021-06,2021-06-30
-1246,4,The idea of comparing long and short reads and how to use short reads to polish the results,It would be great if there was a little explanation of how the tools work,,Chloroplast genome assembly,Assembly,2021-06,2021-06-30
-1247,5,,,,Reference-based RNA-Seq data analysis,Transcriptomics,2021-06,2021-06-30
-1248,5,"Plenty of detail, teaching by example, and context provided","> Written in markdown  ### General - Should I be working in a clone of `galaxyproject/galaxy`? - Where are all the galaxy tools? They don't seem to be in the galaxy/tools/ dir? This is covered well in the ""contributing"" video at the end but could have mentioned briefly at the start. More generally, it would be good to explain that `galaxy-core` has built-in tools (with no `.shed.yml` file) and that all contributed tools (like we're building) are installed from an available toolshed. - I'm not sure if I should actually be following along with all of this... should I actually make a PR for a new Bioconda package in a tutorial? It would be great to clarify what the participant should be doing NOW versus what they would do in a genuine tool wrap. Also, presumably the package sometimes exists already in Bioconda? (I used an existing conda package in my 'practice' tool wrap). - At the end of the ""Toolshed file"" section:   ""In the case where the directory represents a group of tools or a ‘suite’, there are additional overarching sections into which the above tags fall""   ... seems to imply that parent dirs can/should have a `.shed.yml` file too? Or is it only in `suite` and `suite/tool` dirs? Would be great to clarify or provide a link to a toolshed on GitHub as an example. - ""Macros"" section: should note that whitespace inside `<token>` tags matters, and it will not be trimmed by the XML parser! (Should be picked up by the `planemo lint`)   ### Typos - `bellerophon.xml` typo under ""discover datasets"":   `directory=""outputs""/>>` - And ""Outputs section"" (should have closing `/>` on `<data>` according to planemo):   `<data name=""outfile"" label=""${tool.name} on ${on_string}"" format=""bam"">` - ""crate an ad-hoc Galaxy""   ### Planemo - Didn't work when `pip` installed into `conda` env (dependancy errors). `pip` install into a `virtualenv` env worked. - `pip` installing `planemo` into virtualenv requires `apt install python3-venv` as a dependancy  **Some small issues with Planemo** - `tool_test_output.html` output is a bit weird to navigate - buttons don't look like buttons (no hover effect) so most of the content is hidden until you realise there are clickable elements - `planemo serve` doesn't print the local address at the end of output (had to scroll up a few pages to find `http://127.0.0.1:9090`)",,Creating Galaxy tools from Conda Through Deployment,Development in Galaxy,2021-07,2021-07-01
-1249,5,"explanations which were easy to understand, explaining concepts well without going into overwhelming amounts of detail; defined any foreign terms clearly",,,Introduction to Genomics and Galaxy,Introduction to Galaxy Analyses,2021-07,2021-07-01
-1250,1,,update is required,,Infinium Human Methylation BeadChip,Epigenetics,2021-07,2021-07-01
-1251,5,"Very clear, even though the material is complex",,,Running Jobs on Remote Resources with Pulsar,Galaxy Server administration,2021-07,2021-07-01
-1252,5,Simple and clear,The Hands-on: Adding a query did not work as the user ubuntu but had to be done as the user galaxy,,Galaxy Monitoring with gxadmin,Galaxy Server administration,2021-07,2021-07-01
-1253,5,Simple and short and easy THX,,,Galaxy Installation with Ansible,Galaxy Server administration,2021-07,2021-07-01
-1254,5,"Expaination from Dave was Fantastic, and I was able to have the Hands-on without any problem :D",Nothing in my oppinion.,,Introduction to Genomics and Galaxy,Introduction to Galaxy Analyses,2021-07,2021-07-01
-1255,5,,"some tools connect to different tools, like cut that goes to advanced cut",,Reference-based RNA-Seq data analysis,Transcriptomics,2021-07,2021-07-01
-1256,5,Its a quite good tutorial,nothing feld sofar,,Galaxy 101 for everyone,Introduction to Galaxy Analyses,2021-07,2021-07-01
-1257,5,,,,Introduction to Genomics and Galaxy,Introduction to Galaxy Analyses,2021-07,2021-07-01
-1258,5,,,,Extracting Workflows from Histories,Using Galaxy and Managing your Data,2021-07,2021-07-01
-1259,5,,,,Galaxy 101 for everyone,Introduction to Galaxy Analyses,2021-07,2021-07-01
-1260,5,,,,Quality Control,Sequence analysis,2021-07,2021-07-01
-1261,5,,,,Mapping,Sequence analysis,2021-07,2021-07-01
-1262,5,,,,Reference-based RNA-Seq data analysis,Transcriptomics,2021-07,2021-07-01
-1263,5,,,,Visualization of RNA-Seq results with Volcano Plot,Transcriptomics,2021-07,2021-07-01
-1264,5,,,,Visualization of RNA-Seq results with Volcano Plot in R,Transcriptomics,2021-07,2021-07-01
-1265,4,The installation part was very clear and good to follow,The Grafana part was difficult to follow because the version of the tutorial was different from the installed one,,Galaxy Monitoring with Telegraf and Grafana,Galaxy Server administration,2021-07,2021-07-01
-1266,3,,,,De novo transcriptome reconstruction with RNA-Seq,Transcriptomics,2021-07,2021-07-01
-1267,5,,,,Galaxy Tool Management with Ephemeris,Galaxy Server administration,2021-07,2021-07-01
-1268,5,,,,Reference Data with CVMFS,Galaxy Server administration,2021-07,2021-07-01
-1269,5,The explanation was clear and I was able to follow the training without any problems.,the quality of the image was not so good,,Rule Based Uploader,Using Galaxy and Managing your Data,2021-07,2021-07-01
-1270,5,everything,with your YouTube channel guidance it difficult to understand in the beginning so also mention your link here too.,,Quality Control,Sequence analysis,2021-07,2021-07-01
-1271,4,nice talk and gives a rly good overview of apollo/galaxy interface. thank you!,"explain what are all the data you add as input inthefirst step, do u rly need that much? in the tutorial we only use some of them",,Refining Genome Annotations with Apollo (prokaryotes),Genome Annotation,2021-07,2021-07-02
-1272,5,Clear explanation of the subject,"object_store_config_file: ""{{ galaxy_config_dir }}/object_store_conf.xml.j2"" should be object_store_config_file: ""{{ galaxy_config_dir }}/object_store_conf.xml""",,Distributed Object Storage,Galaxy Server administration,2021-07,2021-07-02
-1273,4,,,,Visualisation with Circos,Visualisation,2021-07,2021-07-02
-1274,5,,,,NGS data logistics,Introduction to Galaxy Analyses,2021-07,2021-07-02
-1275,5,The step-by-step description help a lot!. Thank you,,,M. tuberculosis Variant Analysis,Variant Analysis,2021-07,2021-07-02
-1276,1,,Provide a simple example of visualizing a genome with annotation,,Visualisation with Circos,Visualisation,2021-07,2021-07-02
-1277,3,,Speak a bit slower and explain each file before moving on. Relate the theoretical apresentation with this part. ,,Generating a single cell matrix using Alevin,Single Cell,2021-07,2021-07-02
-1278,2,,"From find markers on I couldn't produce the desired output. If a folow the link in galaxy to Scanpy findMarkers it produces an empty table; if a seach this tool in galaxy, it produces complete tables but in the end I can't produce the plots with scanpy plot embebed (gives error). The video is to quick and does not explain what is being doing, it is just a lot of clicks. Taking in consideration the international audience, jargon should not be used. This is a shame, because it is such an interesting topic.",,"Filter, Plot and Explore Single-cell RNA-seq Data",Single Cell,2021-07,2021-07-05
-1279,4,very clear steps and hands-on instruction,"some tools used in the tutorial have namesake with different function, for example, tool ""cut"" have two versions, but function is different. ",,Reference-based RNA-Seq data analysis,Transcriptomics,2021-07,2021-07-06
-1280,5,"All the instruction provided were user friendly, even students without the knowledge of computer can easily learn the tool just by follwing instructions",,,A short introduction to Galaxy,Introduction to Galaxy Analyses,2021-07,2021-07-06
-1281,4,,,,From peaks to genes,Introduction to Galaxy Analyses,2021-07,2021-07-06
-1282,5,The detailed steps were very useful to get started and this would help me do advance analysis as well.,,,Identification of somatic and germline variants from tumor and normal sample pairs,Variant Analysis,2021-07,2021-07-06
-1283,4,The data processing pipeline,"The tutorial should have each module version to avoid errors, GEMINIS is only available in the european server and the final exercises should contain the results from each GEMINIS query (atleast a number)",,Calling variants in diploid systems,Variant Analysis,2021-07,2021-07-07
-1284,5,step by step explanation for each task ,,,A short introduction to Galaxy,Introduction to Galaxy Analyses,2021-07,2021-07-08
-1285,5,"The simple to follow tutorial and best of all, the description given at each step. It's concise and extremely helpful.","Not all of the parameters in the report generated by MultiQC are discussed. I think, a few lines about each of them will do great.",,Quality Control,Sequence analysis,2021-07,2021-07-08
-1286,4,Explaination and discussions on quizes,,,Reference-based RNA-Seq data analysis,Transcriptomics,2021-07,2021-07-08
-1287,5,"Very complete, sufficiently detailed to allow non-computer-science people to go through this with all the questions we could have being answered. ",The video from GCC2021 training week corresponding to this topic is also very well. Maybe a link to this video for people who need to see things in movement to be reassured would be nice :),,Running the GTN website online using GitPod,Contributing to the Galaxy Training Material,2021-07,2021-07-08
-1288,5,,,,A short introduction to Galaxy,Introduction to Galaxy Analyses,2021-07,2021-07-08
-1289,4,protocol,Analysis part can be explained a bit detailed,,NGS data logistics,Introduction to Galaxy Analyses,2021-07,2021-07-08
-1290,5,good and clear explanation of formats and data,-,,NGS data logistics,Introduction to Galaxy Analyses,2021-07,2021-07-08
-1291,5,the lessons,not sure,,Genome Assembly of MRSA using Illumina MiSeq Data,Assembly,2021-07,2021-07-08
-1292,4,Easy to follow with concise description at each step. ,"The IGV browser to browse the alignment was just out of the understanding. I personally didn't understand anything how to read it, how to visualize it and extract useful data, why only visualized chr2 and not the others? What info did we get from visualizing it.",,Mapping,Sequence analysis,2021-07,2021-07-09
-1293,4,,,,NGS data logistics,Introduction to Galaxy Analyses,2021-07,2021-07-09
-1294,5,,,,Infinium Human Methylation BeadChip,Epigenetics,2021-07,2021-07-09
-1295,5,,,,Reference-based RNA-Seq data analysis,Transcriptomics,2021-07,2021-07-09
-1296,5,The overall training session was really nice. ,"However, some more information regarding the viewing in Jbrowse should be discussed like what to analyse in Jbrowse, how to spot irregularities and how to spot meaningful data? What kind of useful data can be visualized or can we get from the visualization in the Jbrowse.",,Chloroplast genome assembly,Assembly,2021-07,2021-07-10
-1297,4,,,,Mapping,Sequence analysis,2021-07,2021-07-10
-1298,5,,,,Reference-based RNA-Seq data analysis,Transcriptomics,2021-07,2021-07-11
-1299,5,Thanks for the detail explanation.,,,From small to large-scale genome comparison,Genome Annotation,2021-07,2021-07-11
-1300,5,clarity and simple,,,A short introduction to Galaxy,Introduction to Galaxy Analyses,2021-07,2021-07-11
-1301,5,,,,Reference Data with CVMFS,Galaxy Server administration,2021-07,2021-07-12
-1302,5,very clear and straightforward. ,,,Data Libraries,Galaxy Server administration,2021-07,2021-07-12
-1303,5,,,,Mapping Jobs to Destinations,Galaxy Server administration,2021-07,2021-07-13
-1304,1,,"Hi, unfortunately, this tutorial will only be useful to those who already know the method. As non-bioinformatician, I have no clue what this is good for. Can I do GWAS with that and how do I implement it? Such tutorials should be cross-checked by biologists, bioinformaticians can solve such problems anyway themselves.",,Interval-Wise Testing for omics data,Statistics and machine learning,2021-07,2021-07-14
-1305,4,,,,RNA Seq Counts to Viz in R,Transcriptomics,2021-07,2021-07-14
-1306,4,Easy to go through and explanations help to understand the results better.,Too many abbreviations,,High Throughput Molecular Dynamics and Analysis,Computational chemistry,2021-07,2021-07-15
-1307,4,,Update to the newer version of Galaxy (new style),,Introduction to Genomics and Galaxy,Introduction to Galaxy Analyses,2021-07,2021-07-15
-1308,5,very good explanation,nothing,,Quality Control,Sequence analysis,2021-07,2021-07-16
-1309,3,Had a bit of information on how to use trinity,"needs way more content, i dont know what i am doing or why when performing the steps. very unfinished tutorial and i felt like i learned nothing because it was so empty and confusing",,"De novo transcriptome assembly, annotation, and differential expression analysis",Transcriptomics,2021-07,2021-07-16
-1310,5,Awesome! Thanks a lot,,,16S Microbial Analysis with mothur (extended),Metagenomics,2021-07,2021-07-17
-1311,5,,,,Metatranscriptomics analysis using microbiome RNA-seq data,Metagenomics,2021-07,2021-07-17
-1312,1,,,,Use Jupyter notebooks in Galaxy,Using Galaxy and Managing your Data,2021-07,2021-07-17
-1313,5,,,,Machine Learning Modeling of Anticancer Peptides,Proteomics,2021-07,2021-07-18
-1314,4,,How can we use/apply this successful models to our real cases/samples?,,Machine Learning Modeling of Anticancer Peptides,Proteomics,2021-07,2021-07-18
-1315,4,,,,Galaxy 101 for everyone,Introduction to Galaxy Analyses,2021-07,2021-07-18
-1316,5,,,,Mapping,Sequence analysis,2021-07,2021-07-19
-1317,5,The step by step procedure,"If you have time, please add further analysis of the SNP  (when we search snippy in galaxy, it shows two snippy programs, only of the them is showing right result) please try to correct it (if m not mistaken)",,Microbial Variant Calling,Variant Analysis,2021-07,2021-07-20
-1318,4,The step By step guide.,adding videos for all the tuitorials as well,,1: RNA-Seq reads to counts,Transcriptomics,2021-07,2021-07-20
-1319,5,,,,A short introduction to Galaxy,Introduction to Galaxy Analyses,2021-07,2021-07-21
-1320,5,Detail explanation of process from A to Z. ,"Maybe adding some more of data interpretation/graph interpretation. Even without this, Tutorial is great. Thank you so much for your hard work and the dedication you put on this tutorial.",,Reference-based RNA-Seq data analysis,Transcriptomics,2021-07,2021-07-21
-1321,4,Lots of detail and a selection of realistic examples,"The directories ""./templates/galaxy/dynamic_job_rules/"" and ""./templates/galaxy/tools/"" should actually be under another directory ""./files/galaxy/ ... "" for the latest Ansible roles to work!",,Mapping Jobs to Destinations,Galaxy Server administration,2021-07,2021-07-22
-1322,5,Very hands-on! And the qc-report workflow can be directly used in furture,,,1: RNA-Seq reads to counts,Transcriptomics,2021-07,2021-07-23
-1323,3,,,,Galaxy 101,Introduction to Galaxy Analyses,2021-07,2021-07-23
-1324,4,the interactive tools,the tools were difficult to find. please mention the tools very specifically in the tutorial,,MaxQuant and MSstats for the analysis of label-free data,Proteomics,2021-07,2021-07-26
-1325,1,,"There is no code. For instance, how do you search your clusters for the marker genes?",,Clustering 3K PBMCs with Scanpy,Single Cell,2021-07,2021-07-27
-1326,5,"Simple, straight-forward, focused",benchmarking (or at least a comparison) to Cell Ranger,,Pre-processing of 10X Single-Cell RNA Datasets,Single Cell,2021-07,2021-07-27
-1327,5,,,,Quality Control,Sequence analysis,2021-07,2021-07-28
-1328,2,It was fairly clear,"Did not discuss removing duplicates from raw reads. Also the formatting of the options in a line of code was not super easy to read. Maybe after explaining each parameter, also show an example of it all in the same line together.",,Quality Control,Sequence analysis,2021-07,2021-07-29
-1329,4,clear explanation of the barcodes/UMI and where/how to find that info in reads,the 'plain' tabular file was a bit confusing and took a while to get in the right format,,Understanding Barcodes,Single Cell,2021-07,2021-07-29
-1330,5,Really easy to follow and understand what I was doing. Very up to date also. Better than many online tutorials that I have done.,More explanation of what the outputs mean.,,A short introduction to Galaxy,Introduction to Galaxy Analyses,2021-07,2021-07-30
-1331,5,The clarity of the instructions.,Great as it is.,,1: RNA-Seq reads to counts,Transcriptomics,2021-07,2021-07-30
-1332,5,very clear and to the point introduction to volcano plots,links to what is Galaxy or galaxy introduction (I still have no idea what it is),,Visualization of RNA-Seq results with Volcano Plot,Transcriptomics,2021-07,2021-07-31
-1333,5,AWWWWWWWWWWWWSOME,,,Protein-ligand docking,Computational chemistry,2021-07,2021-07-31
-1334,5,detailed explanation of the steps for analysis,Also provide information of other tools for the same type of analysis,,NGS data logistics,Introduction to Galaxy Analyses,2021-08,2021-08-03
-1335,5,Tools Detailed Explanation: how to use and details about the tool.,Nill,,Introduction to Genomics and Galaxy,Introduction to Galaxy Analyses,2021-08,2021-08-03
-1336,4,The variety of tools used. ,A clearer explanation about barcodes and batches. ,,Pre-processing of Single-Cell RNA Data,Single Cell,2021-08,2021-08-04
-1337,5,,,,Visualization of RNA-Seq results with Volcano Plot,Transcriptomics,2021-08,2021-08-04
-1338,5,very clear,r code,,Essential genes detection with Transposon insertion sequencing,Genome Annotation,2021-08,2021-08-04
-1339,4,The explanation was clear,The example file does not work,,A short introduction to Galaxy,Introduction to Galaxy Analyses,2021-08,2021-08-05
-1340,5,"It was very clearly explained. So even  someone without experience, as myself, could go through this very easily.",No suggestions,,Galaxy 101,Introduction to Galaxy Analyses,2021-08,2021-08-09
-1341,5,The hands-on manual is very interactive,More pictures on how to carry out the steps,,Galaxy 101,Introduction to Galaxy Analyses,2021-08,2021-08-09
-1342,2,,"There was so much info about FLAG and CIGAR which was not relevant for the exercise. I would have rather learn more about VCF which was important as well as all the meanings behind the headers of the final dataset like DP, AF, SB, DP4, EFF.IMPACT etc. How was read group information relevant for this exercise? I did not understand this. Please state it more clearly in the process if it is relevant.   The search did not often find the specific tools but gave 100 options if the name was not specific. Sometimes the full description of the tool was added at the end of instruction but in some cases it was absent which made it more difficult to find the correct tool.   The info about duplicates is messy and confusing. Either leave it our or explain/link the info about duplicates more clearly and more in relevance to the excercise.   State the point of the final outputs. What can we do with this data, how can this information be used in relation to the covid pandemic? What are the downstream analysis options after this etc. ",,NGS data logistics,Introduction to Galaxy Analyses,2021-08,2021-08-09
-1343,1,terrible,instructions,,From NCBI's Sequence Read Archive (SRA) to Galaxy: SARS-CoV-2 variant analysis,Variant Analysis,2021-08,2021-08-10
-1344,5,It was very clear,It is perfect!,,Galaxy 101,Introduction to Galaxy Analyses,2021-08,2021-08-10
-1345,5,"clarity, information packed",,,Galaxy 101,Introduction to Galaxy Analyses,2021-08,2021-08-10
-1346,4,great organizing and illustrations,more practice ,,Galaxy 101,Introduction to Galaxy Analyses,2021-08,2021-08-10
-1347,5,training format,,,Galaxy 101,Introduction to Galaxy Analyses,2021-08,2021-08-10
-1348,3,"Easy to read instructions, easy to find tools","The IGV output information. What the colours mean actually, what info can  I extract from there. More step-by-step guide what and how can i visualize for the most info. Maybe some tasks what to search for. ",,Mapping,Sequence analysis,2021-08,2021-08-10
-1349,5,It presents both the theoretical concept and practical aspects simultaneously,,,Quality Control,Sequence analysis,2021-08,2021-08-10
-1350,5,The combination of both theoretical concepts and practicals.,,,Mapping,Sequence analysis,2021-08,2021-08-10
-1351,5,Easy to follow,"Not much, overall superb",,Quality Control,Sequence analysis,2021-08,2021-08-10
-1352,5,Easy to follow. To the point!,,,Galaxy 101,Introduction to Galaxy Analyses,2021-08,2021-08-10
-1353,5,Automating workflows,Add more analysis,,Galaxy 101,Introduction to Galaxy Analyses,2021-08,2021-08-11
-1354,4,The activity was interactive but some steps were not explit enough for a beginner,The steps should be made more explicit for beginners to easily grasp,,Using dataset collections,Using Galaxy and Managing your Data,2021-08,2021-08-11
-1355,5,The activity is very interactive.,,,Removal of human reads from SARS-CoV-2 sequencing data,Sequence analysis,2021-08,2021-08-11
-1356,5,Simple steps and result interpretation/ detailing in each steps. ,Frequently asked questions inclusion would help. Link doesnot work,,Quality Control,Sequence analysis,2021-08,2021-08-11
-1357,5,Explanation of the steps,Nothing,,Mapping,Sequence analysis,2021-08,2021-08-11
-1358,4,Systematic,Excellent,,Galaxy 101,Introduction to Galaxy Analyses,2021-08,2021-08-11
-1359,5,Great interactive learning combining both theory and practice,,,"Mutation calling, viral genome reconstruction and lineage/clade assignment from SARS-CoV-2 sequencing data",Variant Analysis,2021-08,2021-08-11
-1360,5,,,,"Mutation calling, viral genome reconstruction and lineage/clade assignment from SARS-CoV-2 sequencing data",Variant Analysis,2021-08,2021-08-11
-1361,5,The mapping part was very interesting.,More examples to explain the concept would do better.,,Removal of human reads from SARS-CoV-2 sequencing data,Sequence analysis,2021-08,2021-08-11
-1362,5,,,,Galaxy 101,Introduction to Galaxy Analyses,2021-08,2021-08-11
-1363,5,The way Galaxy is able to bring all these bioinformatics data possible to the public.,,,NGS data logistics,Introduction to Galaxy Analyses,2021-08,2021-08-11
-1364,5,,,,NGS data logistics,Introduction to Galaxy Analyses,2021-08,2021-08-11
-1365,5,The tutorial is very helpful,,,Mapping,Sequence analysis,2021-08,2021-08-11
-1366,5,The way one can understand the relation between different organism through the clades.,,,"Mutation calling, viral genome reconstruction and lineage/clade assignment from SARS-CoV-2 sequencing data",Variant Analysis,2021-08,2021-08-11
-1367,5,I liked how detailed every steps were taught !,,,"Mutation calling, viral genome reconstruction and lineage/clade assignment from SARS-CoV-2 sequencing data",Variant Analysis,2021-08,2021-08-11
-1368,3,,,,Virtual screening of the SARS-CoV-2 main protease with rxDock and pose scoring,Computational chemistry,2021-08,2021-08-11
-1369,3,,,,Submitting sequence data to ENA,Using Galaxy and Managing your Data,2021-08,2021-08-12
-1370,5,Great flow of tutorial,Not much,,"Mutation calling, viral genome reconstruction and lineage/clade assignment from SARS-CoV-2 sequencing data",Variant Analysis,2021-08,2021-08-12
-1371,5,The tutorial is very detailed,,,"Mutation calling, viral genome reconstruction and lineage/clade assignment from SARS-CoV-2 sequencing data",Variant Analysis,2021-08,2021-08-12
-1372,4,Clear and systematic,Instructions can be more specific (e.g. names of tools),,NGS data logistics,Introduction to Galaxy Analyses,2021-08,2021-08-12
-1373,5,Everything,None,,Quality Control,Sequence analysis,2021-08,2021-08-12
-1374,4,The step-by-step analysis,Clear sound/tone of presenter,,NGS data logistics,Introduction to Galaxy Analyses,2021-08,2021-08-12
-1375,5,,,,Mapping,Sequence analysis,2021-08,2021-08-12
-1376,5,The details,,,Quality Control,Sequence analysis,2021-08,2021-08-12
+1039,5,,,,Quality Control,Sequence analysis,2021-02,2021-02-16
+1040,4,,,,RStudio in Galaxy,Using Galaxy and Managing your Data,2021-02,2021-02-16
+1041,5,Everything about the lesson was crisp in explanation and content,I believe the tutorial is next to perfect,,Quality Control,Sequence analysis,2021-02,2021-02-16
+1042,5,,,,Introduction to Genomics and Galaxy,Introduction to Galaxy Analyses,2021-02,2021-02-16
+1043,4,,,,Chloroplast genome assembly,Assembly,2021-02,2021-02-16
+1044,5,,,,Introduction to Genomics and Galaxy,Introduction to Galaxy Analyses,2021-02,2021-02-16
+1045,4,,,,Reference-based RNA-Seq data analysis,Transcriptomics,2021-02,2021-02-16
+1046,0,The tutorial was easy to follow.,There are very many different choices to make  - a fold-out in the tutorial of just some of themwould be nice.   ,,Mapping,Sequence analysis,2021-02,2021-02-16
+1047,5,,,,Reference-based RNA-Seq data analysis,Transcriptomics,2021-02,2021-02-17
+1048,3,,,,Reference-based RNA-Seq data analysis,Transcriptomics,2021-02,2021-02-17
+1049,0,"I like the examples,being related to genomics .",I am not sure if I would grasp it without previous knowledge. ,,R basics in Galaxy,Foundations of Data Science,2021-02,2021-02-17
+1050,5,very concise and helpful !,,,RNA Seq Counts to Viz in R,Transcriptomics,2021-02,2021-02-17
+1051,5,,,,R basics in Galaxy,Foundations of Data Science,2021-02,2021-02-17
+1052,4,,,,Advanced R in Galaxy,Foundations of Data Science,2021-02,2021-02-17
+1053,5,well explained ,I would include some links with more options such as color palettes... shapes... ,,RNA Seq Counts to Viz in R,Transcriptomics,2021-02,2021-02-17
+1054,5,Complete pipeline to analyse nanopore data. Easy tutorial and results are very clear with a visualisation with krona,,,16S Microbial analysis with Nanopore data,Microbiome,2021-02,2021-02-17
+1055,5,,,,R basics in Galaxy,Foundations of Data Science,2021-02,2021-02-17
+1056,0,I've never done a single cell analysis before!,It was a little bit fast.,,Understanding Barcodes,Single Cell,2021-02,2021-02-17
+1057,5,Very good level of detail. Just appropriate. ,,,Reference-based RNA-Seq data analysis,Transcriptomics,2021-02,2021-02-17
+1058,3,,,,Understanding Barcodes,Single Cell,2021-02,2021-02-17
+1059,5,Easy to follow,"We use FastQC.  it would be nice to have some information about ""Contaminant list "", ""Adapter list"", ""Submodule and Limit specifing file"" etc",,A short introduction to Galaxy,Introduction to Galaxy Analyses,2021-02,2021-02-17
+1060,5,"very clear instructions, step by step to go back and repeat if need to do","not sure, but also following the video to complement the instructions was great",,Quality Control,Sequence analysis,2021-02,2021-02-17
+1061,1,,what will the preprocessing be useful for - perhaps this should be explained?,,Understanding Barcodes,Single Cell,2021-02,2021-02-17
+1062,5,It was very straight forward with clear language and explanations. I found it both very detailed and somehow concise and palatable. ,nothing at all at the moment. ,,Quality Control,Sequence analysis,2021-02,2021-02-17
+1063,4,,,,Understanding Barcodes,Single Cell,2021-02,2021-02-18
+1064,3,,,,Pre-processing of 10X Single-Cell RNA Datasets,Single Cell,2021-02,2021-02-18
+1065,5,Easy to follow tutorial. I learnt about so many tools used for data analysis.,,,Clustering 3K PBMCs with Scanpy,Single Cell,2021-02,2021-02-18
+1066,5,Simple and easy to demonstrate gene annotation using contigs,,,Genome annotation with Prokka,Genome Annotation,2021-02,2021-02-18
+1067,5,Very easy and simple to understand,,,Introduction to deep learning,Statistics and machine learning,2021-02,2021-02-18
+1068,4,Very illustrative,The link to the full pipeline 'A full pipeline which produces both an AnnData and tabular file for inspection is provided here.' directs to a file scrna_tenx.ga - what are .ga files and what program should be used for these?,,Pre-processing of 10X Single-Cell RNA Datasets,Single Cell,2021-02,2021-02-18
+1069,4,,,,Chloroplast genome assembly,Assembly,2021-02,2021-02-18
+1070,5,How easy and friendly is the tutorial ,Nothing,,A short introduction to Galaxy,Introduction to Galaxy Analyses,2021-02,2021-02-18
+1071,5,very clear descriptions of all steps,,,Proteogenomics 1: Database Creation,Proteomics,2021-02,2021-02-18
+1072,5,clear and concise descriptions of each step,provide all necessary input files from tutorial 1 on zenodo,,Proteogenomics 2: Database Search,Proteomics,2021-02,2021-02-18
+1073,5,,,,Reference-based RNA-Seq data analysis,Transcriptomics,2021-02,2021-02-18
+1074,5,Very clear and helpful for first time users,,,Quality Control,Sequence analysis,2021-02,2021-02-18
+1075,4,,,,Proteogenomics 2: Database Search,Proteomics,2021-02,2021-02-18
+1076,5,,,,Understanding Barcodes,Single Cell,2021-02,2021-02-18
+1077,5,,,,Pre-processing of 10X Single-Cell RNA Datasets,Single Cell,2021-02,2021-02-18
+1078,3,that there were several examples,,,Visualisation with Circos,Visualisation,2021-02,2021-02-18
+1079,5,,,,Clustering 3K PBMCs with Scanpy,Single Cell,2021-02,2021-02-19
+1080,5,it was very helpful.,,,Unicycler assembly of SARS-CoV-2 genome with preprocessing to remove human genome reads,Assembly,2021-02,2021-02-19
+1081,5,Very informative yet concise. Did an excellent job of walking through the parameters needed for each step. Also appreciated the walking through of visualization and statistical significance rather than ending at the OTU clustering. ,,,16S Microbial Analysis with mothur (extended),Microbiome,2021-02,2021-02-19
+1082,5,How in depth and clear it was.,,,Unicycler assembly of SARS-CoV-2 genome with preprocessing to remove human genome reads,Assembly,2021-02,2021-02-19
+1083,4,,,,RNA Seq Counts to Viz in R,Transcriptomics,2021-02,2021-02-19
+1084,4,,,,Visualisation with Circos,Visualisation,2021-02,2021-02-19
+1085,5,,,,Proteogenomics 3: Novel peptide analysis,Proteomics,2021-02,2021-02-19
+1086,5,"The presentation was great: first the explanantion what we will do and why, and then tutorial.",,,Proteogenomics 2: Database Search,Proteomics,2021-02,2021-02-19
+1087,5,The clarity and order of the explanation,,,Reference-based RNA-Seq data analysis,Transcriptomics,2021-02,2021-02-19
+1088,3,,,,Proteogenomics 1: Database Creation,Proteomics,2021-02,2021-02-19
+1089,5,Concentration on the essential aspects with the possibility to further deepen the knowledge about the individual tools,,,Exome sequencing data analysis for diagnosing a genetic disease,Variant Analysis,2021-02,2021-02-19
+1090,5,The steps were very clear,Make a tutorial for miRNAs in humans,,Reference-based RNA-Seq data analysis,Transcriptomics,2021-02,2021-02-19
+1091,5,"I like that it has a clear relation to the NGS topic, this helped to keep me motivated","Actually it was very well developed, maybe one for heatmaps would be a great addition",,RNA Seq Counts to Viz in R,Transcriptomics,2021-02,2021-02-19
+1092,5,,,,Antibiotic resistance detection,Microbiome,2021-02,2021-02-20
+1093,5,"I´d like to know how I can get a unique assemble using more than one pair of Illumina reads for the same DNA, for example the same bacterial strain. It is possible? ",,,Chloroplast genome assembly,Assembly,2021-02,2021-02-20
+1094,5,,,,Galaxy 101 for everyone,Introduction to Galaxy Analyses,2021-02,2021-02-20
+1095,5,So useful from getting the data to pathway analysis!!,,,Reference-based RNA-Seq data analysis,Transcriptomics,2021-02,2021-02-21
+1096,3,Handy,Tutorial video went too fast with no much explanation.,,Understanding Barcodes,Single Cell,2021-02,2021-02-21
+1097,3,,Tutorial video went too fast with no much explanation.,,Pre-processing of 10X Single-Cell RNA Datasets,Single Cell,2021-02,2021-02-21
+1098,5,Very good material ,,,NGS data logistics,Introduction to Galaxy Analyses,2021-02,2021-02-22
+1099,5,,,,Identification of somatic and germline variants from tumor and normal sample pairs,Variant Analysis,2021-02,2021-02-22
+1100,5,Easy to follow and clear,,,A short introduction to Galaxy,Introduction to Galaxy Analyses,2021-02,2021-02-23
+1101,5,,,,Quality Control,Sequence analysis,2021-02,2021-02-23
+1102,3,,,,From peaks to genes,Introduction to Galaxy Analyses,2021-02,2021-02-24
+1103,4,,,,Chloroplast genome assembly,Assembly,2021-02,2021-02-25
+1104,5,"the work flow and associated explanations. Perfect for my students to get acquainted with the workflow, inputs and outputs, and then move to HPC learning","incorporate UMI-based workflows (e.g., duplex consensus)",,Identification of somatic and germline variants from tumor and normal sample pairs,Variant Analysis,2021-02,2021-02-25
+1105,5,The hands-on tutorial which is straight forward and easy to follow,,,Introduction to Genomics and Galaxy,Introduction to Galaxy Analyses,2021-02,2021-02-26
+1106,5,"The tutorial is hands-on, straight forward and easy to follow",,,Introduction to Genomics and Galaxy,Introduction to Galaxy Analyses,2021-02,2021-02-26
+1107,5,"Clear and easy to follow, and tones of additional information.",More images perhaps,,Quality Control,Sequence analysis,2021-02,2021-02-27
+1108,5,Explanations and step by by procedure explained,,,High Throughput Molecular Dynamics and Analysis,Computational chemistry,2021-02,2021-02-28
+1109,3,,,,Pre-processing of 10X Single-Cell RNA Datasets,Single Cell,2021-03,2021-03-01
+1110,5,Very good guiding,cant think of something..,,Galaxy 101 for everyone,Introduction to Galaxy Analyses,2021-03,2021-03-02
+1111,5,,,,A short introduction to Galaxy,Introduction to Galaxy Analyses,2021-03,2021-03-03
+1112,5,The instructions are very detailed and clearly presented. ,Some pictures in the tutorial are not up-to-date.,,Galaxy 101 for everyone,Introduction to Galaxy Analyses,2021-03,2021-03-04
+1113,5,It is so clear to show the process step by step.,,,1: RNA-Seq reads to counts,Transcriptomics,2021-03,2021-03-04
+1114,5,,,,Galaxy 101,Introduction to Galaxy Analyses,2021-03,2021-03-05
+1115,5,,,,Galaxy 101,Introduction to Galaxy Analyses,2021-03,2021-03-05
+1116,1,,It doesn't show you where to begin. It gives you steps but doesn't show you how to get to each step. Very frustrating ,,Genome annotation with Prokka,Genome Annotation,2021-03,2021-03-10
+1117,5,It's very precise and explain the most important characteristics of how to use the platform,,,A short introduction to Galaxy,Introduction to Galaxy Analyses,2021-03,2021-03-11
+1118,5,It was clear and well structured.,Nothing! Galaxy is awesome,,Introduction to Genomics and Galaxy,Introduction to Galaxy Analyses,2021-03,2021-03-11
+1119,0,All steps were clearly described and easily understood. ,"I could not find the tool""filter bam dataset on a variety of attributes"" in tool panel of Galaxy-human cell atlas , so I could not follow.",,Pre-processing of Single-Cell RNA Data,Single Cell,2021-03,2021-03-11
+1120,0,,"I wanted to follow ""Hands-on: Remove genes found in less than 3 cells"" with tool ""filter with scanpy"", had given the every parameter correctly, but could not be successful every time.   ",,Clustering 3K PBMCs with Scanpy,Single Cell,2021-03,2021-03-12
+1121,4,Thorough engagement with complex process of this analysis,"Some specifics:  * No BAM to FastQ (used SamToFastq) * not clear what ""the reference mRNA and TE fasta file"" is * In ""siRNA differential abundance testing"" surely it should be Symp vs Blank? * Visualization section is missing * the miRNA reads are ""removed for separate analysis"" - what analysis is this? * Add some hats (this is hard!)  I also resorted to writing some mini-workflows to make it easier to do some of the repetitive parts of the tutorial ",,Differential abundance testing of small RNAs,Transcriptomics,2021-03,2021-03-12
+1122,2,"Part1, the Repeat workflow is not working. The manual is different from for actual workflow in galaxy.",,,From peaks to genes,Introduction to Galaxy Analyses,2021-03,2021-03-12
+1123,5,,,,A short introduction to Galaxy,Introduction to Galaxy Analyses,2021-03,2021-03-19
+1124,5,easy to follow,,,A short introduction to Galaxy,Introduction to Galaxy Analyses,2021-03,2021-03-22
+1125,5,Easy to follow steps,"""Where to go next"" button to jump into another training session",,Galaxy 101,Introduction to Galaxy Analyses,2021-03,2021-03-22
+1126,5,,,,Microbial Variant Calling,Variant Analysis,2021-03,2021-03-23
+1127,5,Brief description of key issues,,,Label-free versus Labelled - How to Choose Your Quantitation Method,Proteomics,2021-03,2021-03-26
+1128,5,,,,2: RNA-seq counts to genes,Transcriptomics,2021-03,2021-03-28
+1129,5,"Simple languange, hands-on example and exercises with answers hidden.","I know it is a lot to ask, but adding matrices would be helpful",,R basics in Galaxy,Foundations of Data Science,2021-03,2021-03-28
+1130,5,Going to use this in Australia soon (late May 2021)- excited about it. More feedback to come afterwards no doubt!,"I can see in the intro that this tutorial is set up for raw (fastq) and BAM data entry points. This is great but I was hoping you could include a workflow for fastq to BAM. I realise it is in the full workflow so I took the liberty of comparing the two offered workflows and trimmed down to a QC to BAM workflow (https://usegalaxy.org.au/u/gareth-qfab/w/copy-of-exome-seq-training-full-w-cached-ref-imported-from-uploaded-file ). I understand we can do this elsewhere but good to have it consistent within this tutorial. Tested on Zenodo data and works fine. Thanks, Gareth",,Exome sequencing data analysis for diagnosing a genetic disease,Variant Analysis,2021-03,2021-03-30
+1131,5,,,,Exome sequencing data analysis for diagnosing a genetic disease,Variant Analysis,2021-03,2021-03-30
+1132,5,very friendly people and very informative.,nothing,,1: RNA-Seq reads to counts,Transcriptomics,2021-03,2021-03-31
+1133,5,It was really clear and easy to follow. ,,,2: RNA-seq counts to genes,Transcriptomics,2021-03,2021-03-31
+1134,5,,,,Reference-based RNAseq data analysis (long),Transcriptomics,2021-03,2021-03-31
+1135,0,"clearly described, can be followed step by step, idea for new-users.",,,Clustering 3K PBMCs with Scanpy,Single Cell,2021-03,2021-03-31
+1136,2,It seemed clear - just didn't work.,I read the tutorial as I tried to duplicate it in Galaxy with a phage genome sequence. The tutorial did not correspond with what was in Galaxy. JBrowse did not work - no indication why.,,Genome annotation with Prokka,Genome Annotation,2021-04,2021-04-03
+1137,0,"clearly described, can be followed step by step, super tutorial for new users.",,,Clustering 3K PBMCs with Scanpy,Single Cell,2021-04,2021-04-03
+1138,5,,,,Quality Control,Sequence analysis,2021-04,2021-04-05
+1139,5,really detailed and clear!,"some tools have different names (e.g. it's now 'Pathway enrichment analysis [Reactome]' instead of 'Query pathway database [Reactome]', I think; in other words I couldn't find 'Query pathway database [Reactome]' so I improvised with 'Pathway enrichment analysis [Reactome]'). Also it would be good to include some tools to analise data other than these 3 species.",,Annotating a protein list identified by LC-MS/MS experiments,Proteomics,2021-04,2021-04-06
+1140,3,,"This tutorial works with the input files. However, working with non-model organisms is a problem. Download the genbank entry is nice, but which one - on BioSample or else? What should it look like? Any requirements? Only the easy way is shown. How can a reference genome fasta be used along with a gff3 file? That does not work at all with files other than built in or sample files. The tutorial is meant well, but it should be improved to enable also people not working with yeast, mouse or human to use it and prevent problems. Thanks a lot!",,Microbial Variant Calling,Variant Analysis,2021-04,2021-04-07
+1141,5,"All aspects: clear, step by step illustration. ",,,A short introduction to Galaxy,Introduction to Galaxy Analyses,2021-04,2021-04-09
+1142,4,,,,Galaxy 101 for everyone,Introduction to Galaxy Analyses,2021-04,2021-04-11
+1143,5,Very detailed walk-through the tutorial!,,,Using dataset collections,Using Galaxy and Managing your Data,2021-04,2021-04-11
+1144,1,,the code,,Visualization of RNA-Seq results with Volcano Plot,Transcriptomics,2021-04,2021-04-12
+1145,5,"I very much enjoy this tutorial! coming back from extensive R experience using limma, DEseq, still find this Galaxy thing makes things easier",,,2: RNA-seq counts to genes,Transcriptomics,2021-04,2021-04-14
+1146,5,It was easy and great with visuals as well,,,A short introduction to Galaxy,Introduction to Galaxy Analyses,2021-04,2021-04-14
+1147,4,I liked that it is possible to use real data and explore multiple tools. It was relatively easy to follow all the way to the final step. I could also take the Structure output and run it through Structure in Galaxy or in my own PC to further demonstrate that the SNP data can be analysed with population genomic software.,"Some of the instructions need to be updated to the latest versions of the tools available in Galaxy. I could not tell which population (1 or 2) was the freshwater and which one was the oceanic, so I assumed 1=freshwater, 2=oceanic. It would also be good to see some of the ""expected"" results, just to verify that what has been done is working fine and that students are on the right track.",,RAD-Seq Reference-based data analysis,Ecology,2021-04,2021-04-14
+1148,5,,,,Quality Control,Sequence analysis,2021-04,2021-04-19
+1149,5,Good for a beginner,,,A short introduction to Galaxy,Introduction to Galaxy Analyses,2021-04,2021-04-20
+1150,5,,,,Peptide and Protein ID using OpenMS tools,Proteomics,2021-04,2021-04-21
+1151,5,Easy to follow,,,ATAC-Seq data analysis,Epigenetics,2021-04,2021-04-21
+1152,3,The solutions after each question,Te previous tutorial (quality control) was more easy to follow the different steps,,Mapping,Sequence analysis,2021-04,2021-04-22
+1153,4,,,,Whole transcriptome analysis of Arabidopsis thaliana,Transcriptomics,2021-04,2021-04-22
+1154,4,,,,Whole transcriptome analysis of Arabidopsis thaliana,Transcriptomics,2021-04,2021-04-22
+1155,5,,,,Understanding Barcodes,Single Cell,2021-04,2021-04-22
+1156,4,I like all the indications step by step. Very clear. I would like to have some information about others parameters that are setted by default. ,"I only correct one part where there are 2 mistakes. In ""Filter significantly differentially expressed mRNAs"" section, Hands-on: Extract significantly DE genes in point 3) Filter “Filter”: Differentially expressed miRNAs (replace by mRNAs)  And in point 5) Filter “Filter”: Differentially expressed miRNAs (replace by mRNAs). This is about the text. ",,Whole transcriptome analysis of Arabidopsis thaliana,Transcriptomics,2021-04,2021-04-23
+1157,5,"the detail in the explanations, the examples included",,,Quality Control,Sequence analysis,2021-04,2021-04-24
+1158,5,,,,Genome Assembly of a bacterial genome (MRSA) sequenced using Illumina MiSeq Data,Assembly,2021-04,2021-04-26
+1159,4,Clear and well explained,Another example to work through. ,,Name tags for following complex histories,Using Galaxy and Managing your Data,2021-04,2021-04-26
+1160,5,,,,Name tags for following complex histories,Using Galaxy and Managing your Data,2021-04,2021-04-26
+1161,5,,,,Name tags for following complex histories,Using Galaxy and Managing your Data,2021-04,2021-04-26
+1162,4,easy to follow,interactive plots could not be opened https://usegalaxy.org/datasets/bbd44e69cb8906b52089f52da217dea4/display/glimma_basalpregnant-basallactate/MD-Plot.html,,2: RNA-seq counts to genes,Transcriptomics,2021-04,2021-04-28
+1163,5,,,,3: RNA-seq genes to pathways,Transcriptomics,2021-04,2021-04-30
+1164,5,,,,A short introduction to Galaxy,Introduction to Galaxy Analyses,2021-05,2021-05-03
+1165,4,,Sometimes it is hard to find a specific thing that we need to click on when we don't know where it is located on the screen.,,Functionally Assembled Terrestrial Ecosystem Simulator (FATES),Climate,2021-05,2021-05-05
+1166,5,TESTING,TESTING,,A short introduction to Galaxy,Introduction to Galaxy Analyses,2021-05,2021-05-06
+1167,2,,"It is not clear which files to choose, because ""C2C12"" clearly isnt available.",,IGV Introduction,Introduction to Galaxy Analyses,2021-05,2021-05-07
+1168,5,"The depth of the tutorial, the examples of bad quality data, the explanation why these tools are used and sometimes alternatives, and the overview figure in the conclusion.",,,ATAC-Seq data analysis,Epigenetics,2021-05,2021-05-10
+1169,5,"It is a very clear step by step, well defined tutorial. ",The difference between method 1 and 2. The peak summit concept may need more explanation.,,From peaks to genes,Introduction to Galaxy Analyses,2021-05,2021-05-11
+1170,5,"The trimming and filtering part is the most important stage of RNA-seq data analysis. Generally, adapter sequences are not given with SRA data in NCBI . Therefore, I was shot in the dark while using the trimmomatic, cuadapt and other tools whose results are not that much satisfactory. The information given in the tutorial seems to work for one of the messiest data.",I think it would be great to see usage of filtering and trimming tools on one or two messy data. It will give us insights about how to deal with such data,,A short introduction to Galaxy,Introduction to Galaxy Analyses,2021-05,2021-05-12
+1171,5,The basics of each step explained very clearly.,Maybe the names of the files which need to be put in the field for the tool. Took a bit of time to understand in few places.,,Unicycler assembly of SARS-CoV-2 genome with preprocessing to remove human genome reads,Assembly,2021-05,2021-05-18
+1172,5,That it is a step by step <3 ,The master branch on my side is called main,,Contributing with GitHub via command-line,Contributing to the Galaxy Training Material,2021-05,2021-05-19
+1173,5,,,,A short introduction to Galaxy,Introduction to Galaxy Analyses,2021-05,2021-05-19
+1174,5,Everything :) ,"""topics/introduction/tutorials/galaxy-intro-peaks2genes/tutorial.md"" is no longer found, example can be changed to ""topics/introduction/tutorials/r-basics/r_introduction.md"" instead  ",,Running the GTN website locally,Contributing to the Galaxy Training Material,2021-05,2021-05-19
+1175,5,,,,An Introduction to Genome Assembly,Assembly,2021-05,2021-05-20
+1176,5,,,,ATAC-Seq data analysis,Epigenetics,2021-05,2021-05-20
+1177,5,It was clear and easy to follow,,,A short introduction to Galaxy,Introduction to Galaxy Analyses,2021-05,2021-05-21
+1178,5,,,,From peaks to genes,Introduction to Galaxy Analyses,2021-05,2021-05-21
+1179,5,The graphs and Q&A,Additional examples,,Visualization of RNA-Seq results with Volcano Plot,Transcriptomics,2021-05,2021-05-21
+1180,4,,,,Reference-based RNAseq data analysis (long),Transcriptomics,2021-05,2021-05-22
+1181,5,well explained!,,,A short introduction to Galaxy,Introduction to Galaxy Analyses,2021-05,2021-05-22
+1182,5,,,,Galaxy 101,Introduction to Galaxy Analyses,2021-05,2021-05-22
+1183,5,,,,NGS data logistics,Introduction to Galaxy Analyses,2021-05,2021-05-23
+1184,5,clear and to the point,,,Galaxy 101,Introduction to Galaxy Analyses,2021-05,2021-05-23
+1185,5,Very informative and clear,Nothing,,Using Workflow Parameters,Using Galaxy and Managing your Data,2021-05,2021-05-24
+1186,5,Very clear,Nothing,,Downloading and Deleting Data in Galaxy,Using Galaxy and Managing your Data,2021-05,2021-05-24
+1187,5,"Gareth, Melissa and Khalid (I was in breakout room 3) were all incredibly helpful and it went at a good pace. It was VERY helpful getting the course material ahead of the workshop, which allowed time to familiarise myself with the content. ",I think it was on the mark for me. ,,Exome sequencing data analysis for diagnosing a genetic disease,Variant Analysis,2021-05,2021-05-25
+1188,4,,,,Galaxy 101,Introduction to Galaxy Analyses,2021-05,2021-05-25
+1189,5,all of it,nothing - it's perfect,,Exome sequencing data analysis for diagnosing a genetic disease,Variant Analysis,2021-05,2021-05-26
+1190,5,,,,Galaxy 101 for everyone,Introduction to Galaxy Analyses,2021-05,2021-05-27
+1191,4,,,,Introduction to Genomics and Galaxy,Introduction to Galaxy Analyses,2021-05,2021-05-27
+1192,5,,,,Calling variants in diploid systems,Variant Analysis,2021-05,2021-05-28
+1193,5,Step by step process and questions to think about,Maybe screenshots of selections ,,Quality Control,Sequence analysis,2021-05,2021-05-31
+1194,3,Quite clear overall,"There is no way to find out the p-values corresponding to the different colors, the meaning of the dotted and solid arrows, etc. Please add those information if you want to make your plots more comprehensible! ",,GO Enrichment Analysis,Transcriptomics,2021-06,2021-06-02
+1195,5,very clear and complete,,,A short introduction to Galaxy,Introduction to Galaxy Analyses,2021-06,2021-06-02
+1196,5,,,,Exome sequencing data analysis for diagnosing a genetic disease,Variant Analysis,2021-06,2021-06-02
+1197,5,The details that were explained are hard to get elsewhere and they were explained in a very lucid and uncomplicated manner that made it a pleasure to read on,Perhaps a more detailed conclusion about the final results obtained in a paragraph style will be the best way to end the discussion.,,Reference-based RNA-Seq data analysis,Transcriptomics,2021-06,2021-06-05
+1198,5,,,,Visualization of RNA-Seq results with heatmap2,Transcriptomics,2021-06,2021-06-05
+1199,5,,,,From peaks to genes,Introduction to Galaxy Analyses,2021-06,2021-06-09
+1200,5,,,,High Throughput Molecular Dynamics and Analysis,Computational chemistry,2021-06,2021-06-09
+1201,5,,,,Clustering 3K PBMCs with Scanpy,Single Cell,2021-06,2021-06-10
+1202,5,Easy to follow for the most part.,"You forgot to describe how to create an hmm database for the hmmscan step. I think hmmbuild can be used for this, but more detail would be needed about what input to feed hmmbuild so it can generate a model that can be effectively used with hmmscan.",,"De novo transcriptome assembly, annotation, and differential expression analysis",Transcriptomics,2021-06,2021-06-11
+1203,5,very simple ,,,"Creating, Editing and Importing Galaxy Workflows",Using Galaxy and Managing your Data,2021-06,2021-06-11
+1204,4,,,,A short introduction to Galaxy,Introduction to Galaxy Analyses,2021-06,2021-06-12
+1205,5,,,,Quality Control,Sequence analysis,2021-06,2021-06-12
+1206,3,,,,Mapping,Sequence analysis,2021-06,2021-06-12
+1207,4,,,,Reference-based RNA-Seq data analysis,Transcriptomics,2021-06,2021-06-13
+1208,5,The explanation to implement each step,nothing,,Galaxy 101,Introduction to Galaxy Analyses,2021-06,2021-06-17
+1209,5,"Everything was explained in detail, easy to follow",,,ATAC-Seq data analysis,Epigenetics,2021-06,2021-06-18
+1210,5,very intuitive,everything is great,,Clustering in Machine Learning,Statistics and machine learning,2021-06,2021-06-18
+1211,5,It helps me to understand about the basic of data type,-,,A short introduction to Galaxy,Introduction to Galaxy Analyses,2021-06,2021-06-19
+1212,5,,,,Identification of somatic and germline variants from tumor and normal sample pairs,Variant Analysis,2021-06,2021-06-21
+1213,5,Clear explanation about QC reports,Adaptor trimming,,Quality Control,Sequence analysis,2021-06,2021-06-22
+1214,5,,,,A short introduction to Galaxy,Introduction to Galaxy Analyses,2021-06,2021-06-22
+1215,5,,,,Galaxy 101 for everyone,Introduction to Galaxy Analyses,2021-06,2021-06-23
+1216,4,,,,NGS data logistics,Introduction to Galaxy Analyses,2021-06,2021-06-24
+1217,3,realistc examples,More details regarding used scripts and templates,,Deploying a compute cluster in OpenStack via Terraform,Galaxy Server administration,2021-06,2021-06-24
+1218,5,,,,Quality Control,Sequence analysis,2021-06,2021-06-25
+1219,5,All,Nothing,,Galaxy 101,Introduction to Galaxy Analyses,2021-06,2021-06-25
+1220,5,Clear and concise; had images to show where things are;,"I got a little confused at the end where it said to click on Analyze Data in the top panel (step 3 in the ""Look at all your histories"") and could not find a way back without clicking the home button again.",,A short introduction to Galaxy,Introduction to Galaxy Analyses,2021-06,2021-06-25
+1221,5,Simple and Elegant,,,A short introduction to Galaxy,Introduction to Galaxy Analyses,2021-06,2021-06-26
+1222,5,The explanations were easy to understand while explaining the intuition behind the graphs and the quality of the data.,The sound has sudden drops and highs making it hard to follow at specific points.,,Quality Control,Sequence analysis,2021-06,2021-06-27
+1223,5,All points were very well explained,,,Galaxy Installation with Ansible,Galaxy Server administration,2021-06,2021-06-28
+1224,5,,,,Introduction to Genomics and Galaxy,Introduction to Galaxy Analyses,2021-06,2021-06-28
+1225,4,,,,Rule Based Uploader,Using Galaxy and Managing your Data,2021-06,2021-06-28
+1226,4,,,,Rule Based Uploader,Using Galaxy and Managing your Data,2021-06,2021-06-29
+1227,5,"Very interesting, the step by step approach is very clear",,,Use Apptainer containers for running Galaxy jobs,Galaxy Server administration,2021-06,2021-06-29
+1228,5,The practical approach,,,Galaxy Tool Management with Ephemeris,Galaxy Server administration,2021-06,2021-06-29
+1229,5,Completness,,,Galaxy 101,Introduction to Galaxy Analyses,2021-06,2021-06-29
+1230,5,Very clear explanation,,,Reference Data with CVMFS,Galaxy Server administration,2021-06,2021-06-29
+1231,5,Very clear step by step,,,Data Libraries,Galaxy Server administration,2021-06,2021-06-29
+1232,5,,,,Reference Data with CVMFS,Galaxy Server administration,2021-06,2021-06-29
+1233,5,,,,Ansible,Galaxy Server administration,2021-06,2021-06-29
+1234,5,,,,Use Apptainer containers for running Galaxy jobs,Galaxy Server administration,2021-06,2021-06-29
+1235,5,,,,Galaxy Tool Management with Ephemeris,Galaxy Server administration,2021-06,2021-06-29
+1236,5,,,,Quality Control,Sequence analysis,2021-06,2021-06-29
+1237,5,,,,Quality Control,Sequence analysis,2021-06,2021-06-29
+1238,4,,,,Mapping,Sequence analysis,2021-06,2021-06-29
+1239,5,,,,Mapping,Sequence analysis,2021-06,2021-06-29
+1240,4,,,,Chloroplast genome assembly,Assembly,2021-06,2021-06-29
+1241,4,,,,Chloroplast genome assembly,Assembly,2021-06,2021-06-29
+1242,5,,,,Quality Control,Sequence analysis,2021-06,2021-06-30
+1243,5,Very clear explanations,,,Connecting Galaxy to a compute cluster,Galaxy Server administration,2021-06,2021-06-30
+1244,5,Great introduction and very useful starting point for beginning to apply these features,,,Mapping Jobs to Destinations using TPV,Galaxy Server administration,2021-06,2021-06-30
+1245,5,Oustanding material!,Nothing!,,Exome sequencing data analysis for diagnosing a genetic disease,Variant Analysis,2021-06,2021-06-30
+1246,4,,,,From peaks to genes,Introduction to Galaxy Analyses,2021-06,2021-06-30
+1247,5,,,,Mapping Jobs to Destinations using TPV,Galaxy Server administration,2021-06,2021-06-30
+1248,4,The idea of comparing long and short reads and how to use short reads to polish the results,It would be great if there was a little explanation of how the tools work,,Chloroplast genome assembly,Assembly,2021-06,2021-06-30
+1249,5,,,,Reference-based RNA-Seq data analysis,Transcriptomics,2021-06,2021-06-30
+1250,5,"Plenty of detail, teaching by example, and context provided","> Written in markdown  ### General - Should I be working in a clone of `galaxyproject/galaxy`? - Where are all the galaxy tools? They don't seem to be in the galaxy/tools/ dir? This is covered well in the ""contributing"" video at the end but could have mentioned briefly at the start. More generally, it would be good to explain that `galaxy-core` has built-in tools (with no `.shed.yml` file) and that all contributed tools (like we're building) are installed from an available toolshed. - I'm not sure if I should actually be following along with all of this... should I actually make a PR for a new Bioconda package in a tutorial? It would be great to clarify what the participant should be doing NOW versus what they would do in a genuine tool wrap. Also, presumably the package sometimes exists already in Bioconda? (I used an existing conda package in my 'practice' tool wrap). - At the end of the ""Toolshed file"" section:   ""In the case where the directory represents a group of tools or a ‘suite’, there are additional overarching sections into which the above tags fall""   ... seems to imply that parent dirs can/should have a `.shed.yml` file too? Or is it only in `suite` and `suite/tool` dirs? Would be great to clarify or provide a link to a toolshed on GitHub as an example. - ""Macros"" section: should note that whitespace inside `<token>` tags matters, and it will not be trimmed by the XML parser! (Should be picked up by the `planemo lint`)   ### Typos - `bellerophon.xml` typo under ""discover datasets"":   `directory=""outputs""/>>` - And ""Outputs section"" (should have closing `/>` on `<data>` according to planemo):   `<data name=""outfile"" label=""${tool.name} on ${on_string}"" format=""bam"">` - ""crate an ad-hoc Galaxy""   ### Planemo - Didn't work when `pip` installed into `conda` env (dependancy errors). `pip` install into a `virtualenv` env worked. - `pip` installing `planemo` into virtualenv requires `apt install python3-venv` as a dependancy  **Some small issues with Planemo** - `tool_test_output.html` output is a bit weird to navigate - buttons don't look like buttons (no hover effect) so most of the content is hidden until you realise there are clickable elements - `planemo serve` doesn't print the local address at the end of output (had to scroll up a few pages to find `http://127.0.0.1:9090`)",,Creating Galaxy tools from Conda Through Deployment,Development in Galaxy,2021-07,2021-07-01
+1251,5,"explanations which were easy to understand, explaining concepts well without going into overwhelming amounts of detail; defined any foreign terms clearly",,,Introduction to Genomics and Galaxy,Introduction to Galaxy Analyses,2021-07,2021-07-01
+1252,1,,update is required,,Infinium Human Methylation BeadChip,Epigenetics,2021-07,2021-07-01
+1253,5,"Very clear, even though the material is complex",,,Running Jobs on Remote Resources with Pulsar,Galaxy Server administration,2021-07,2021-07-01
+1254,5,Simple and clear,The Hands-on: Adding a query did not work as the user ubuntu but had to be done as the user galaxy,,Galaxy Monitoring with gxadmin,Galaxy Server administration,2021-07,2021-07-01
+1255,5,Simple and short and easy THX,,,Galaxy Installation with Ansible,Galaxy Server administration,2021-07,2021-07-01
+1256,5,"Expaination from Dave was Fantastic, and I was able to have the Hands-on without any problem :D",Nothing in my oppinion.,,Introduction to Genomics and Galaxy,Introduction to Galaxy Analyses,2021-07,2021-07-01
+1257,5,,"some tools connect to different tools, like cut that goes to advanced cut",,Reference-based RNA-Seq data analysis,Transcriptomics,2021-07,2021-07-01
+1258,5,Its a quite good tutorial,nothing feld sofar,,Galaxy 101 for everyone,Introduction to Galaxy Analyses,2021-07,2021-07-01
+1259,5,,,,Introduction to Genomics and Galaxy,Introduction to Galaxy Analyses,2021-07,2021-07-01
+1260,5,,,,Extracting Workflows from Histories,Using Galaxy and Managing your Data,2021-07,2021-07-01
+1261,5,,,,Galaxy 101 for everyone,Introduction to Galaxy Analyses,2021-07,2021-07-01
+1262,5,,,,Quality Control,Sequence analysis,2021-07,2021-07-01
+1263,5,,,,Mapping,Sequence analysis,2021-07,2021-07-01
+1264,5,,,,Reference-based RNA-Seq data analysis,Transcriptomics,2021-07,2021-07-01
+1265,5,,,,Visualization of RNA-Seq results with Volcano Plot,Transcriptomics,2021-07,2021-07-01
+1266,5,,,,Visualization of RNA-Seq results with Volcano Plot in R,Transcriptomics,2021-07,2021-07-01
+1267,4,The installation part was very clear and good to follow,The Grafana part was difficult to follow because the version of the tutorial was different from the installed one,,Galaxy Monitoring with Telegraf and Grafana,Galaxy Server administration,2021-07,2021-07-01
+1268,3,,,,De novo transcriptome reconstruction with RNA-Seq,Transcriptomics,2021-07,2021-07-01
+1269,5,,,,Galaxy Tool Management with Ephemeris,Galaxy Server administration,2021-07,2021-07-01
+1270,5,,,,Reference Data with CVMFS,Galaxy Server administration,2021-07,2021-07-01
+1271,5,The explanation was clear and I was able to follow the training without any problems.,the quality of the image was not so good,,Rule Based Uploader,Using Galaxy and Managing your Data,2021-07,2021-07-01
+1272,5,everything,with your YouTube channel guidance it difficult to understand in the beginning so also mention your link here too.,,Quality Control,Sequence analysis,2021-07,2021-07-01
+1273,4,nice talk and gives a rly good overview of apollo/galaxy interface. thank you!,"explain what are all the data you add as input inthefirst step, do u rly need that much? in the tutorial we only use some of them",,Refining Genome Annotations with Apollo (prokaryotes),Genome Annotation,2021-07,2021-07-02
+1274,5,Clear explanation of the subject,"object_store_config_file: ""{{ galaxy_config_dir }}/object_store_conf.xml.j2"" should be object_store_config_file: ""{{ galaxy_config_dir }}/object_store_conf.xml""",,Distributed Object Storage,Galaxy Server administration,2021-07,2021-07-02
+1275,4,,,,Visualisation with Circos,Visualisation,2021-07,2021-07-02
+1276,5,,,,NGS data logistics,Introduction to Galaxy Analyses,2021-07,2021-07-02
+1277,5,The step-by-step description help a lot!. Thank you,,,M. tuberculosis Variant Analysis,Variant Analysis,2021-07,2021-07-02
+1278,1,,Provide a simple example of visualizing a genome with annotation,,Visualisation with Circos,Visualisation,2021-07,2021-07-02
+1279,3,,Speak a bit slower and explain each file before moving on. Relate the theoretical apresentation with this part. ,,Generating a single cell matrix using Alevin,Single Cell,2021-07,2021-07-02
+1280,2,,"From find markers on I couldn't produce the desired output. If a folow the link in galaxy to Scanpy findMarkers it produces an empty table; if a seach this tool in galaxy, it produces complete tables but in the end I can't produce the plots with scanpy plot embebed (gives error). The video is to quick and does not explain what is being doing, it is just a lot of clicks. Taking in consideration the international audience, jargon should not be used. This is a shame, because it is such an interesting topic.",,"Filter, plot and explore single-cell RNA-seq data (Scanpy)",Single Cell,2021-07,2021-07-05
+1281,4,very clear steps and hands-on instruction,"some tools used in the tutorial have namesake with different function, for example, tool ""cut"" have two versions, but function is different. ",,Reference-based RNA-Seq data analysis,Transcriptomics,2021-07,2021-07-06
+1282,5,"All the instruction provided were user friendly, even students without the knowledge of computer can easily learn the tool just by follwing instructions",,,A short introduction to Galaxy,Introduction to Galaxy Analyses,2021-07,2021-07-06
+1283,4,,,,From peaks to genes,Introduction to Galaxy Analyses,2021-07,2021-07-06
+1284,5,The detailed steps were very useful to get started and this would help me do advance analysis as well.,,,Identification of somatic and germline variants from tumor and normal sample pairs,Variant Analysis,2021-07,2021-07-06
+1285,4,The data processing pipeline,"The tutorial should have each module version to avoid errors, GEMINIS is only available in the european server and the final exercises should contain the results from each GEMINIS query (atleast a number)",,Calling variants in diploid systems,Variant Analysis,2021-07,2021-07-07
+1286,5,step by step explanation for each task ,,,A short introduction to Galaxy,Introduction to Galaxy Analyses,2021-07,2021-07-08
+1287,5,"The simple to follow tutorial and best of all, the description given at each step. It's concise and extremely helpful.","Not all of the parameters in the report generated by MultiQC are discussed. I think, a few lines about each of them will do great.",,Quality Control,Sequence analysis,2021-07,2021-07-08
+1288,4,Explaination and discussions on quizes,,,Reference-based RNA-Seq data analysis,Transcriptomics,2021-07,2021-07-08
+1289,5,"Very complete, sufficiently detailed to allow non-computer-science people to go through this with all the questions we could have being answered. ",The video from GCC2021 training week corresponding to this topic is also very well. Maybe a link to this video for people who need to see things in movement to be reassured would be nice :),,Running the GTN website online using GitPod,Contributing to the Galaxy Training Material,2021-07,2021-07-08
+1290,5,,,,A short introduction to Galaxy,Introduction to Galaxy Analyses,2021-07,2021-07-08
+1291,4,protocol,Analysis part can be explained a bit detailed,,NGS data logistics,Introduction to Galaxy Analyses,2021-07,2021-07-08
+1292,5,good and clear explanation of formats and data,-,,NGS data logistics,Introduction to Galaxy Analyses,2021-07,2021-07-08
+1293,5,the lessons,not sure,,Genome Assembly of a bacterial genome (MRSA) sequenced using Illumina MiSeq Data,Assembly,2021-07,2021-07-08
+1294,4,Easy to follow with concise description at each step. ,"The IGV browser to browse the alignment was just out of the understanding. I personally didn't understand anything how to read it, how to visualize it and extract useful data, why only visualized chr2 and not the others? What info did we get from visualizing it.",,Mapping,Sequence analysis,2021-07,2021-07-09
+1295,4,,,,NGS data logistics,Introduction to Galaxy Analyses,2021-07,2021-07-09
+1296,5,,,,Infinium Human Methylation BeadChip,Epigenetics,2021-07,2021-07-09
+1297,5,,,,Reference-based RNA-Seq data analysis,Transcriptomics,2021-07,2021-07-09
+1298,5,The overall training session was really nice. ,"However, some more information regarding the viewing in Jbrowse should be discussed like what to analyse in Jbrowse, how to spot irregularities and how to spot meaningful data? What kind of useful data can be visualized or can we get from the visualization in the Jbrowse.",,Chloroplast genome assembly,Assembly,2021-07,2021-07-10
+1299,4,,,,Mapping,Sequence analysis,2021-07,2021-07-10
+1300,5,,,,Reference-based RNA-Seq data analysis,Transcriptomics,2021-07,2021-07-11
+1301,5,Thanks for the detail explanation.,,,From small to large-scale genome comparison,Genome Annotation,2021-07,2021-07-11
+1302,5,clarity and simple,,,A short introduction to Galaxy,Introduction to Galaxy Analyses,2021-07,2021-07-11
+1303,5,,,,Reference Data with CVMFS,Galaxy Server administration,2021-07,2021-07-12
+1304,5,very clear and straightforward. ,,,Data Libraries,Galaxy Server administration,2021-07,2021-07-12
+1305,5,,,,Mapping Jobs to Destinations using TPV,Galaxy Server administration,2021-07,2021-07-13
+1306,1,,"Hi, unfortunately, this tutorial will only be useful to those who already know the method. As non-bioinformatician, I have no clue what this is good for. Can I do GWAS with that and how do I implement it? Such tutorials should be cross-checked by biologists, bioinformaticians can solve such problems anyway themselves.",,Interval-Wise Testing for omics data,Statistics and machine learning,2021-07,2021-07-14
+1307,4,,,,RNA Seq Counts to Viz in R,Transcriptomics,2021-07,2021-07-14
+1308,4,Easy to go through and explanations help to understand the results better.,Too many abbreviations,,High Throughput Molecular Dynamics and Analysis,Computational chemistry,2021-07,2021-07-15
+1309,4,,Update to the newer version of Galaxy (new style),,Introduction to Genomics and Galaxy,Introduction to Galaxy Analyses,2021-07,2021-07-15
+1310,5,very good explanation,nothing,,Quality Control,Sequence analysis,2021-07,2021-07-16
+1311,3,Had a bit of information on how to use trinity,"needs way more content, i dont know what i am doing or why when performing the steps. very unfinished tutorial and i felt like i learned nothing because it was so empty and confusing",,"De novo transcriptome assembly, annotation, and differential expression analysis",Transcriptomics,2021-07,2021-07-16
+1312,5,Awesome! Thanks a lot,,,16S Microbial Analysis with mothur (extended),Microbiome,2021-07,2021-07-17
+1313,5,,,,Metatranscriptomics analysis using microbiome RNA-seq data,Microbiome,2021-07,2021-07-17
+1314,1,,,,Use Jupyter notebooks in Galaxy,Using Galaxy and Managing your Data,2021-07,2021-07-17
+1315,5,,,,Machine Learning Modeling of Anticancer Peptides,Proteomics,2021-07,2021-07-18
+1316,4,,How can we use/apply this successful models to our real cases/samples?,,Machine Learning Modeling of Anticancer Peptides,Proteomics,2021-07,2021-07-18
+1317,4,,,,Galaxy 101 for everyone,Introduction to Galaxy Analyses,2021-07,2021-07-18
+1318,5,,,,Mapping,Sequence analysis,2021-07,2021-07-19
+1319,5,The step by step procedure,"If you have time, please add further analysis of the SNP  (when we search snippy in galaxy, it shows two snippy programs, only of the them is showing right result) please try to correct it (if m not mistaken)",,Microbial Variant Calling,Variant Analysis,2021-07,2021-07-20
+1320,4,The step By step guide.,adding videos for all the tuitorials as well,,1: RNA-Seq reads to counts,Transcriptomics,2021-07,2021-07-20
+1321,5,,,,A short introduction to Galaxy,Introduction to Galaxy Analyses,2021-07,2021-07-21
+1322,5,Detail explanation of process from A to Z. ,"Maybe adding some more of data interpretation/graph interpretation. Even without this, Tutorial is great. Thank you so much for your hard work and the dedication you put on this tutorial.",,Reference-based RNA-Seq data analysis,Transcriptomics,2021-07,2021-07-21
+1323,4,Lots of detail and a selection of realistic examples,"The directories ""./templates/galaxy/dynamic_job_rules/"" and ""./templates/galaxy/tools/"" should actually be under another directory ""./files/galaxy/ ... "" for the latest Ansible roles to work!",,Mapping Jobs to Destinations using TPV,Galaxy Server administration,2021-07,2021-07-22
+1324,5,Very hands-on! And the qc-report workflow can be directly used in furture,,,1: RNA-Seq reads to counts,Transcriptomics,2021-07,2021-07-23
+1325,3,,,,Galaxy 101,Introduction to Galaxy Analyses,2021-07,2021-07-23
+1326,4,the interactive tools,the tools were difficult to find. please mention the tools very specifically in the tutorial,,MaxQuant and MSstats for the analysis of label-free data,Proteomics,2021-07,2021-07-26
+1327,1,,"There is no code. For instance, how do you search your clusters for the marker genes?",,Clustering 3K PBMCs with Scanpy,Single Cell,2021-07,2021-07-27
+1328,5,"Simple, straight-forward, focused",benchmarking (or at least a comparison) to Cell Ranger,,Pre-processing of 10X Single-Cell RNA Datasets,Single Cell,2021-07,2021-07-27
+1329,5,,,,Quality Control,Sequence analysis,2021-07,2021-07-28
+1330,2,It was fairly clear,"Did not discuss removing duplicates from raw reads. Also the formatting of the options in a line of code was not super easy to read. Maybe after explaining each parameter, also show an example of it all in the same line together.",,Quality Control,Sequence analysis,2021-07,2021-07-29
+1331,4,clear explanation of the barcodes/UMI and where/how to find that info in reads,the 'plain' tabular file was a bit confusing and took a while to get in the right format,,Understanding Barcodes,Single Cell,2021-07,2021-07-29
+1332,5,Really easy to follow and understand what I was doing. Very up to date also. Better than many online tutorials that I have done.,More explanation of what the outputs mean.,,A short introduction to Galaxy,Introduction to Galaxy Analyses,2021-07,2021-07-30
+1333,5,The clarity of the instructions.,Great as it is.,,1: RNA-Seq reads to counts,Transcriptomics,2021-07,2021-07-30
+1334,5,very clear and to the point introduction to volcano plots,links to what is Galaxy or galaxy introduction (I still have no idea what it is),,Visualization of RNA-Seq results with Volcano Plot,Transcriptomics,2021-07,2021-07-31
+1335,5,AWWWWWWWWWWWWSOME,,,Protein-ligand docking,Computational chemistry,2021-07,2021-07-31
+1336,5,detailed explanation of the steps for analysis,Also provide information of other tools for the same type of analysis,,NGS data logistics,Introduction to Galaxy Analyses,2021-08,2021-08-03
+1337,5,Tools Detailed Explanation: how to use and details about the tool.,Nill,,Introduction to Genomics and Galaxy,Introduction to Galaxy Analyses,2021-08,2021-08-03
+1338,4,The variety of tools used. ,A clearer explanation about barcodes and batches. ,,Pre-processing of Single-Cell RNA Data,Single Cell,2021-08,2021-08-04
+1339,5,,,,Visualization of RNA-Seq results with Volcano Plot,Transcriptomics,2021-08,2021-08-04
+1340,5,very clear,r code,,Essential genes detection with Transposon insertion sequencing,Genome Annotation,2021-08,2021-08-04
+1341,4,The explanation was clear,The example file does not work,,A short introduction to Galaxy,Introduction to Galaxy Analyses,2021-08,2021-08-05
+1342,5,"It was very clearly explained. So even  someone without experience, as myself, could go through this very easily.",No suggestions,,Galaxy 101,Introduction to Galaxy Analyses,2021-08,2021-08-09
+1343,5,The hands-on manual is very interactive,More pictures on how to carry out the steps,,Galaxy 101,Introduction to Galaxy Analyses,2021-08,2021-08-09
+1344,2,,"There was so much info about FLAG and CIGAR which was not relevant for the exercise. I would have rather learn more about VCF which was important as well as all the meanings behind the headers of the final dataset like DP, AF, SB, DP4, EFF.IMPACT etc. How was read group information relevant for this exercise? I did not understand this. Please state it more clearly in the process if it is relevant.   The search did not often find the specific tools but gave 100 options if the name was not specific. Sometimes the full description of the tool was added at the end of instruction but in some cases it was absent which made it more difficult to find the correct tool.   The info about duplicates is messy and confusing. Either leave it our or explain/link the info about duplicates more clearly and more in relevance to the excercise.   State the point of the final outputs. What can we do with this data, how can this information be used in relation to the covid pandemic? What are the downstream analysis options after this etc. ",,NGS data logistics,Introduction to Galaxy Analyses,2021-08,2021-08-09
+1345,1,terrible,instructions,,From NCBI's Sequence Read Archive (SRA) to Galaxy: SARS-CoV-2 variant analysis,Variant Analysis,2021-08,2021-08-10
+1346,5,It was very clear,It is perfect!,,Galaxy 101,Introduction to Galaxy Analyses,2021-08,2021-08-10
+1347,5,"clarity, information packed",,,Galaxy 101,Introduction to Galaxy Analyses,2021-08,2021-08-10
+1348,4,great organizing and illustrations,more practice ,,Galaxy 101,Introduction to Galaxy Analyses,2021-08,2021-08-10
+1349,5,training format,,,Galaxy 101,Introduction to Galaxy Analyses,2021-08,2021-08-10
+1350,3,"Easy to read instructions, easy to find tools","The IGV output information. What the colours mean actually, what info can  I extract from there. More step-by-step guide what and how can i visualize for the most info. Maybe some tasks what to search for. ",,Mapping,Sequence analysis,2021-08,2021-08-10
+1351,5,It presents both the theoretical concept and practical aspects simultaneously,,,Quality Control,Sequence analysis,2021-08,2021-08-10
+1352,5,The combination of both theoretical concepts and practicals.,,,Mapping,Sequence analysis,2021-08,2021-08-10
+1353,5,Easy to follow,"Not much, overall superb",,Quality Control,Sequence analysis,2021-08,2021-08-10
+1354,5,Easy to follow. To the point!,,,Galaxy 101,Introduction to Galaxy Analyses,2021-08,2021-08-10
+1355,5,Automating workflows,Add more analysis,,Galaxy 101,Introduction to Galaxy Analyses,2021-08,2021-08-11
+1356,4,The activity was interactive but some steps were not explit enough for a beginner,The steps should be made more explicit for beginners to easily grasp,,Using dataset collections,Using Galaxy and Managing your Data,2021-08,2021-08-11
+1357,5,The activity is very interactive.,,,Removal of human reads from SARS-CoV-2 sequencing data,Sequence analysis,2021-08,2021-08-11
+1358,5,Simple steps and result interpretation/ detailing in each steps. ,Frequently asked questions inclusion would help. Link doesnot work,,Quality Control,Sequence analysis,2021-08,2021-08-11
+1359,5,Explanation of the steps,Nothing,,Mapping,Sequence analysis,2021-08,2021-08-11
+1360,4,Systematic,Excellent,,Galaxy 101,Introduction to Galaxy Analyses,2021-08,2021-08-11
+1361,5,Great interactive learning combining both theory and practice,,,"Mutation calling, viral genome reconstruction and lineage/clade assignment from SARS-CoV-2 sequencing data",Variant Analysis,2021-08,2021-08-11
+1362,5,,,,"Mutation calling, viral genome reconstruction and lineage/clade assignment from SARS-CoV-2 sequencing data",Variant Analysis,2021-08,2021-08-11
+1363,5,The mapping part was very interesting.,More examples to explain the concept would do better.,,Removal of human reads from SARS-CoV-2 sequencing data,Sequence analysis,2021-08,2021-08-11
+1364,5,,,,Galaxy 101,Introduction to Galaxy Analyses,2021-08,2021-08-11
+1365,5,The way Galaxy is able to bring all these bioinformatics data possible to the public.,,,NGS data logistics,Introduction to Galaxy Analyses,2021-08,2021-08-11
+1366,5,,,,NGS data logistics,Introduction to Galaxy Analyses,2021-08,2021-08-11
+1367,5,The tutorial is very helpful,,,Mapping,Sequence analysis,2021-08,2021-08-11
+1368,5,The way one can understand the relation between different organism through the clades.,,,"Mutation calling, viral genome reconstruction and lineage/clade assignment from SARS-CoV-2 sequencing data",Variant Analysis,2021-08,2021-08-11
+1369,5,I liked how detailed every steps were taught !,,,"Mutation calling, viral genome reconstruction and lineage/clade assignment from SARS-CoV-2 sequencing data",Variant Analysis,2021-08,2021-08-11
+1370,3,,,,Virtual screening of the SARS-CoV-2 main protease with rxDock and pose scoring,Computational chemistry,2021-08,2021-08-11
+1371,3,,,,Sequence data submission to ENA,"FAIR Data, Workflows, and Research",2021-08,2021-08-12
+1372,5,Great flow of tutorial,Not much,,"Mutation calling, viral genome reconstruction and lineage/clade assignment from SARS-CoV-2 sequencing data",Variant Analysis,2021-08,2021-08-12
+1373,5,The tutorial is very detailed,,,"Mutation calling, viral genome reconstruction and lineage/clade assignment from SARS-CoV-2 sequencing data",Variant Analysis,2021-08,2021-08-12
+1374,4,Clear and systematic,Instructions can be more specific (e.g. names of tools),,NGS data logistics,Introduction to Galaxy Analyses,2021-08,2021-08-12
+1375,5,Everything,None,,Quality Control,Sequence analysis,2021-08,2021-08-12
+1376,4,The step-by-step analysis,Clear sound/tone of presenter,,NGS data logistics,Introduction to Galaxy Analyses,2021-08,2021-08-12
 1377,5,,,,Mapping,Sequence analysis,2021-08,2021-08-12
-1378,5,,,,Using dataset collections,Using Galaxy and Managing your Data,2021-08,2021-08-12
-1379,4,,,,Submitting sequence data to ENA,Using Galaxy and Managing your Data,2021-08,2021-08-12
-1380,5,the easy step by step guide ,nothing,,Galaxy 101,Introduction to Galaxy Analyses,2021-08,2021-08-12
-1381,5,your explanation of each plaot,,,Quality Control,Sequence analysis,2021-08,2021-08-12
-1382,3,,,,NGS data logistics,Introduction to Galaxy Analyses,2021-08,2021-08-12
-1383,5,,,,Removal of human reads from SARS-CoV-2 sequencing data,Sequence analysis,2021-08,2021-08-13
-1384,5,,,,Submitting sequence data to ENA,Using Galaxy and Managing your Data,2021-08,2021-08-13
-1385,5,,,,Visualization of RNA-Seq results with Volcano Plot,Transcriptomics,2021-08,2021-08-13
-1386,5,The activity was very interactive with a good combination of theory and practical,The last step on NCBI BLAST search was not clear enough to a biginner like me,,Unicycler assembly of SARS-CoV-2 genome with preprocessing to remove human genome reads,Assembly,2021-08,2021-08-13
-1387,4,short but precise information about technique,little bit more information about difference in data analysis part of labelled vs label-free methods.,,Label-free versus Labelled - How to Choose Your Quantitation Method,Proteomics,2021-08,2021-08-14
-1388,4,training is great,,,Quality Control,Sequence analysis,2021-08,2021-08-14
-1389,5,,"Maybe some more ""solutions"" along the way to help users check themselves for mistakes",,De novo transcriptome reconstruction with RNA-Seq,Transcriptomics,2021-08,2021-08-15
-1390,5,The simplicity of the step by step guide,If the tool needed for each step is clearly listed,,NGS data logistics,Introduction to Galaxy Analyses,2021-08,2021-08-17
-1391,5,It is reproducable,,,A short introduction to Galaxy,Introduction to Galaxy Analyses,2021-08,2021-08-17
-1392,5,The way you collect all the necessary info including the definition of each step and the examples of errors ,Optional document for other examples of the bad quality data with more clear explanation ,,Quality Control,Sequence analysis,2021-08,2021-08-18
-1393,4,,,,Understanding Galaxy history system,Using Galaxy and Managing your Data,2021-08,2021-08-18
-1394,4,,,,Age prediction using machine learning,Statistics and machine learning,2021-08,2021-08-19
-1395,5,the brief explanation of each step,,,Quality Control,Sequence analysis,2021-08,2021-08-19
-1396,5,,"nothing, I loved it very clear and well explained!",,Visualisation with Circos,Visualisation,2021-08,2021-08-19
-1397,5,,,,Breve introducción a Galaxy - en español,Introduction to Galaxy Analyses,2021-08,2021-08-19
-1398,5,,,,Setting up molecular systems,Computational chemistry,2021-08,2021-08-21
-1399,5,Good for beginners,More explanation and examples,,NGS data logistics,Introduction to Galaxy Analyses,2021-08,2021-08-21
-1400,5,Well described steps for analysis of proteomic data,Include statistical analysis methods,,Label-free data analysis using MaxQuant,Proteomics,2021-08,2021-08-23
-1401,5,,,,Exome sequencing data analysis for diagnosing a genetic disease,Variant Analysis,2021-08,2021-08-24
-1402,5,,,,Advanced R in Galaxy,Foundations of Data Science,2021-08,2021-08-25
-1403,5,It is clear and answered my questions,I am new to Galaxy so it work worked for my needs as is...,,Downloading and Deleting Data in Galaxy,Using Galaxy and Managing your Data,2021-08,2021-08-27
-1404,5,the instructions were detailed and precise,i think it was fine ,,A short introduction to Galaxy,Introduction to Galaxy Analyses,2021-08,2021-08-27
-1405,5,,,,Basics of machine learning,Statistics and machine learning,2021-08,2021-08-27
-1406,5,,,,Chloroplast genome assembly,Assembly,2021-08,2021-08-31
-1407,5,,,,Quality Control,Sequence analysis,2021-08,2021-08-31
-1408,5,Steps were clear and friendly ,,,A short introduction to Galaxy,Introduction to Galaxy Analyses,2021-09,2021-09-01
-1409,4,how to work on my on data,,,From NCBI's Sequence Read Archive (SRA) to Galaxy: SARS-CoV-2 variant analysis,Variant Analysis,2021-09,2021-09-01
-1410,5,good explaination,difficult to say,,Galaxy 101,Introduction to Galaxy Analyses,2021-09,2021-09-01
-1411,5,,,,ATAC-Seq data analysis,Epigenetics,2021-09,2021-09-02
-1412,5,,,,Visualisation with Circos,Visualisation,2021-09,2021-09-02
-1413,5,,,,Quality Control,Sequence analysis,2021-09,2021-09-03
-1414,4,,,,Analyses of metagenomics data - The global picture,Metagenomics,2021-09,2021-09-06
-1415,4,"Great introduction to Galaxy, simple, easy to follow","Clearer explanation of why something is done. Perhaps similar to the 'tips', added detail for those that want to delve deeper. Also more up-to-date visuals of the steps involved The final output is a little lack-lustre. maybe a nicer visualisation option to cap off the tutorial (kind of like a nice 'reward' for effort)",,From peaks to genes,Introduction to Galaxy Analyses,2021-09,2021-09-07
-1416,5,,"Instructions about finding tutorial data in a Data Library need to be updated. In this tutorial and probably others. Tutorial data is now nested at usegalaxy.* servers -- and that change is confusing some learners. I've been telling people to search data libraries with the keyword ""GTN"" then to navigate down through the topic to the specific tutorial. Not all public servers will host the data in Data Libs, so even that advice needs a tune up to be consistent/accurate across tutorials. (@jennaj)",,DNA Methylation data analysis,Epigenetics,2021-09,2021-09-08
-1417,5,Very well explained,,,Protein FASTA Database Handling,Proteomics,2021-09,2021-09-08
-1418,4,"Hands on tutorial, that makes learning easier ",Can probably expand the training to involved more complicated thing. Maybe saperate training,,Galaxy 101 for everyone,Introduction to Galaxy Analyses,2021-09,2021-09-09
-1419,5,Easy to follow step-by-step instructions,,,Galaxy 101 for everyone,Introduction to Galaxy Analyses,2021-09,2021-09-09
-1420,1,"none of the essentials is working gx_put(), gx_get(), and gx_save()","none of the essentials is working gx_put(), gx_get(), and gx_save()",,R basics in Galaxy,Foundations of Data Science,2021-09,2021-09-09
-1421,5,All of it,"My understanding now is that GEMINI is human only, so I followed this intending to do other species, but have to now find an alternative. Perhaps the title should be ""Variant calling in humans"" rather than ""diploid systems""?  Certainly would be useful to clarify the specificity of GEMINI in that step.  But, thanks so much for doing this brilliant tutorial!",,Calling variants in diploid systems,Variant Analysis,2021-09,2021-09-10
-1422,5,Really clear,,,Annotating a protein list identified by LC-MS/MS experiments,Proteomics,2021-09,2021-09-11
-1423,5,,,,A short introduction to Galaxy,Introduction to Galaxy Analyses,2021-09,2021-09-13
-1424,5,,,,A short introduction to Galaxy,Introduction to Galaxy Analyses,2021-09,2021-09-14
-1425,4,,"I think there is an error in the instructions around which galaxy release to use.  https://training.galaxyproject.org/archive/2021-08-01/topics/admin/tutorials/ansible-galaxy/tutorial.html#galaxy      step 9.   Fails with a pip install error for attmap at galaxy dependency installation:  FAILED! => {""changed"": false, ""cmd"": [""/srv/galaxy/venv/bin/pip3"", ""install"", ""--index-url"", ""https://wheels.galaxyproject.org/simple/"", ""--extra-index-url"", ""https://pypi.python.org/simple"", ""-r"", ""/srv/galaxy/server/lib/galaxy/dependencies/pinned-requirements.txt""], ""msg"": ""stdout: Looking in indexes: https://wheels.galaxyproject.org/simple, https://pypi.python.org/simple\nIgnoring importlib-metadata: markers 'python_version < \""3.8\""' don't match your environment\nIgnoring importlib-resources: markers 'python_version < \""3.7\""' don't match your environment\nIgnoring pathlib2: markers 'python_version < \""3.6\""' don't match your environment\nIgnoring ruamel.yaml.clib: markers 'platform_python_implementation == \""CPython\"" and python_version < \""3.8\""' don't match your environment\nIgnoring typing: markers 'python_version < \""3.5\""' don't match your environment\nIgnoring zipp: markers 'python_version < \""3.8\""' don't match your environment\nCollecting adal==1.2.4\n  Using cached adal-1.2.4-py2.py3-none-any.whl (55 kB)\nCollecting amqp==2.6.0\n  Using cached amqp-2.6.0-py2.py3-none-any.whl (47 kB)\nCollecting appdirs==1.4.4\n  Using cached appdirs-1.4.4-py2.py3-none-any.whl (9.6 kB)\nCollecting attmap==0.12.11\n  Using cached attmap-0.12.11.tar.gz (9.9 kB)\n\n:stderr:     ERROR: Command errored out with exit status 1:\n     command: /srv/galaxy/venv/bin/python -c 'import io, os, sys, setuptools, tokenize; sys.argv[0] = '\""'\""'/tmp/pip-install-rswp62oy/attmap_d1e6f1f187954e539109df4d7760fde7/setup.py'\""'\""'; __file__='\""'\""'/tmp/pip-install-rswp62oy/attmap_d1e6f1f187954e539109df4d7760fde7/setup.py'\""'\""';f = getattr(tokenize, '\""'\""'open'\""'\""', open)(__file__) if os.path.exists(__file__) else io.StringIO('\""'\""'from setuptools import setup; setup()'\""'\""');code = f.read().replace('\""'\""'\\r\\n'\""'\""', '\""'\""'\\n'\""'\""');f.close();exec(compile(code, __file__, '\""'\""'exec'\""'\""'))' egg_info --egg-base /tmp/pip-pip-egg-info-2gc_ov_9\n         cwd: /tmp/pip-install-rswp62oy/attmap_d1e6f1f187954e539109df4d7760fde7/\n    Complete output (1 lines):\n    error in attmap setup command: use_2to3 is invalid.\n    ----------------------------------------\nWARNING: Discarding https://files.pythonhosted.org/packages/d0/d4/8b8fca155270a6675bac9a1e49b7c616ae763f66af7b836042ecfc805552/attmap-0.12.11.tar.gz#sha256=95b1f7dbcdad7278a3702fa921be6271046c96e1c9ed9feb10e0d4c13092b0a0 (from https://pypi.org/simple/attmap/). Command errored out with exit status 1: python setup.py egg_info Check the logs for full command output.\nERROR: Could not find a version that satisfies the requirement attmap==0.12.11 (from versions: 0.1, 0.1.1, 0.1.2, 0.1.4, 0.1.5, 0.1.6, 0.1.7, 0.1.8, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 0.10, 0.11, 0.12, 0.12.1, 0.12.2, 0.12.3, 0.12.4, 0.12.5, 0.12.6, 0.12.7, 0.12.8, 0.12.9, 0.12.10, 0.12.11, 0.13.0)\nERROR: No matching distribution found for attmap==0.12.11\n""}   This occurs with galaxy_commit_id: release_20.09 (as per the instructions), but changing to  release_21.05 makes the error go away.  ",,Galaxy Installation with Ansible,Galaxy Server administration,2021-09,2021-09-14
-1426,4,Good explanation!,Explanation on how to understand the figures in depth,,2: RNA-seq counts to genes,Transcriptomics,2021-09,2021-09-17
-1427,5,,,,From peaks to genes,Introduction to Galaxy Analyses,2021-09,2021-09-17
-1428,5,,It would be great if this can be updated based on the newest version of the packages used in the tutorial. Some of the parameters cannot be set as shown in this tutorial or should be set in a different way.,,DNA Methylation data analysis,Epigenetics,2021-09,2021-09-20
-1429,5,,,,Introduction to Genomics and Galaxy,Introduction to Galaxy Analyses,2021-09,2021-09-21
-1430,5,,,,16S Microbial analysis with Nanopore data,Metagenomics,2021-09,2021-09-26
-1431,5,,,,Reference-based RNA-Seq data analysis,Transcriptomics,2021-09,2021-09-27
-1432,5,,,,Extracting Workflows from Histories,Using Galaxy and Managing your Data,2021-09,2021-09-28
-1433,5,,,,Introduction to Genomics and Galaxy,Introduction to Galaxy Analyses,2021-09,2021-09-28
-1434,3,The short list of ways to add group tags.,How to add different group tags via workflow to members of a collection.,,Group tags for complex experimental designs,Using Galaxy and Managing your Data,2021-09,2021-09-29
-1435,5,great,including other QC parameters as well,,Quality Control,Sequence analysis,2021-10,2021-10-01
-1436,3,,,,"Tools, Data, and Workflows for tutorials",Contributing to the Galaxy Training Material,2021-10,2021-10-08
-1437,5,,,,Genome annotation with Maker (short),Genome Annotation,2021-10,2021-10-08
-1438,4,Clear introduction in using galaxy to explore/map climate data. ,More detailed explanation of the inputs @map plot gridded (lat/lon) netCDF data. Did not understand the R as input “variable name as given in the netCDF file”. For other Essential Climate Variables I guess Ill have to change that input?  ,,Getting your hands-on climate data,Climate,2021-10,2021-10-08
-1439,4,simple enough to follow,It would be nice if a bit more background of machine learning is described. ,,Basics of machine learning,Statistics and machine learning,2021-10,2021-10-09
-1440,5,quick and simple,none,,Genome annotation with Prokka,Genome Annotation,2021-10,2021-10-10
-1441,5,"The tutorial is so detailed that even a preschooler would get it by simply following the steps! I found it so useful, I'm going to make my first contribution right away!","I'd suggest each of the topics under the ""objectives"" in the overview box be made clickable, so each topic can be reached right from the top without having to scroll all the way down the page.",,Contributing with GitHub via its interface,Contributing to the Galaxy Training Material,2021-10,2021-10-11
-1442,5,"I especially loved how simplified the tutorial was, even as a beginner I was able to run my analysis and publish it. Thank You!",It is fine as it is...maybe extra datasets to practice with.,,Galaxy 101,Introduction to Galaxy Analyses,2021-10,2021-10-11
-1443,5,How it shows you that you to make adaptable workflows,,,Galaxy 101,Introduction to Galaxy Analyses,2021-10,2021-10-11
-1444,3,,,,Introduction to Genomics and Galaxy,Introduction to Galaxy Analyses,2021-10,2021-10-11
-1445,5,It like the different tools and the much they can do. it makes analysis easy,"If the ""Tools"" on click or hover and give a little info on what the tool does, it would be nice.",,A short introduction to Galaxy,Introduction to Galaxy Analyses,2021-10,2021-10-12
-1446,5,Very detailed,"It would help if the sites name and the drop-down  button at the top is static. So even when I scroll to to end of this page, I can easily click on the drop-down button and access other files without having to scroll all the way back up",,Running the GTN website online using GitPod,Contributing to the Galaxy Training Material,2021-10,2021-10-12
-1447,4,I love that h training material was straight forward and essay to understand and comprehend,"I had a major challenge, as while using the platform to learn step by step, on the material provided,  I created a Galaxy account, I got handily with the platform , it was said after uploading a file, go to tools to search for FastQC and execute, but it was not bringing out parameters as seen on the project training material, likewise Filter by quality. There by preventing me from going further with the short introduction to Galaxy. In a Nutshell what was listed in the training material is not popping up when I search for this tools. I do not know what I may be doing wrong",,A short introduction to Galaxy,Introduction to Galaxy Analyses,2021-10,2021-10-13
-1448,3,"I liked that the tutorial was very informative, I learnt a lot of new and exciting things. It was short but had a lot of examples packed in it. I also enjoyed trying trying different analysis on the platform.","1. In the ""Upload a file"" section. I suggest that the disclaimer should be added so a user knows that they would not be able to upload a file if their email is not verified.  2. I appreciate that a lot of information was included in this tutorial, however I believe that the page could be improved to engage a reader more. The spacing between the sections and the fonts and colours are quite confusing. 3. The ""Use a tool"" could be more descriptive. No 3 : No change in the other parameters could be changed to "" No changes should be made on the other parameters"" . I believe thie would be easier for a user to understand. 4. I am also not sure why we have a ""Questions"" section. It deviates from teaching a user how to navigate the platform to explaining the analysis of the result. I suggest this is moved to a follow up section. 5. The icons in ""Hands-on: Re-run the tool""  section should be updated to tally with what is currently in use. 6. I believe the tutorial should be more descriptive. More pictures should be used as seen in ""Look at all your histories"" section. Thank you.",,A short introduction to Galaxy,Introduction to Galaxy Analyses,2021-10,2021-10-13
-1449,5, It was well detailed only a few to crack about.,some illustration needs to be more detailed,,From peaks to genes,Introduction to Galaxy Analyses,2021-10,2021-10-13
-1450,5,Very nice intro. Learned about the difference between climate and weather!,,,Getting your hands-on climate data,Climate,2021-10,2021-10-14
-1451,5,I love that you have to pay close to every little details, for now  nothing,,Galaxy 101,Introduction to Galaxy Analyses,2021-10,2021-10-14
-1452,5,Basically the fact that you can always get your way around,None for now,,Introduction to Genomics and Galaxy,Introduction to Galaxy Analyses,2021-10,2021-10-15
-1453,5,Clarity,Please add Bracken,,16S Microbial analysis with Nanopore data,Metagenomics,2021-10,2021-10-16
-1454,4,learning of workflows ,,,From peaks to genes,Introduction to Galaxy Analyses,2021-10,2021-10-18
-1455,5,,,,A short introduction to Galaxy,Introduction to Galaxy Analyses,2021-10,2021-10-19
-1456,2,,,,NGS data logistics,Introduction to Galaxy Analyses,2021-10,2021-10-19
-1457,5,This tutorial is very helpful,After the functional annotation  how to recognise genes related ,,Genome annotation with Maker,Genome Annotation,2021-10,2021-10-20
-1458,3,,,,Mapping,Sequence analysis,2021-10,2021-10-20
-1459,5,"Re-usability, Usages and all are awesome","Wokflow creating, checking , unchecking while editing are little bit confusing to me",,Galaxy 101 for everyone,Introduction to Galaxy Analyses,2021-10,2021-10-21
-1460,5,,,,Visualize Climate data with Panoply netCDF viewer,Climate,2021-10,2021-10-21
-1461,4,Explanation is naïve ,Importing the iris workflow is generating error while making plot. Have a look on it.,,How to reproduce published Galaxy analyses,Introduction to Galaxy Analyses,2021-10,2021-10-22
-1462,4,,,,Ansible,Galaxy Server administration,2021-10,2021-10-22
-1463,5,,,,A short introduction to Galaxy,Introduction to Galaxy Analyses,2021-10,2021-10-22
-1464,1,,"I have got the following error. The tutorial did not work for me.  training-material$ make serve find: ‘_site/training-material’: No such file or directory find: ‘_site/training-material/*/*/slides/*’: No such file or directory find: ‘_site/training-material’: No such file or directory Tip: Want faster builds? Use 'serve-quick' in place of 'serve'. Tip: to serve in incremental mode (faster rebuilds), use the command: make serve FLAGS=--incremental  mv: cannot stat 'Gemfile': No such file or directory mv: cannot stat 'Gemfile.lock': No such file or directory Configuration file: /home/alice/scchoi/downloads/training-material/_config.yml   Dependency Error: Yikes! It looks like you don't have /home/alice/scchoi/downloads/training-material/_plugins/jekyll-environment_variables.rb or one of its dependencies installed. In order to use Jekyll as currently configured, you'll need to install this gem. If you've run Jekyll with `bundle exec`, ensure that you have included the /home/alice/scchoi/downloads/training-material/_plugins/jekyll-environment_variables.rb gem in your Gemfile as well. The full error message from Ruby is: 'cannot load such file -- bibtex' If you run into trouble, you can find helpful resources at https://jekyllrb.com/help/!                     ------------------------------------------------       Jekyll 4.2.1   Please append `--trace` to the `serve` command                      for any additional information or backtrace.                     ----------------------------",,Running the GTN website locally,Contributing to the Galaxy Training Material,2021-10,2021-10-23
-1465,3,,,,Running the GTN website online using GitPod,Contributing to the Galaxy Training Material,2021-10,2021-10-23
-1466,1,,,,Regression in Machine Learning,Statistics and machine learning,2021-10,2021-10-25
-1467,5,"Clarity, granularity, hands-on","Could have a similar tutorial for long read assembly (Nanopore, PB) , and I suppose 'hybrid assembly' , but this one is probably adequate for all these  purposes.",,An Introduction to Genome Assembly,Assembly,2021-10,2021-10-26
-1468,1,,,,Connecting Galaxy to a compute cluster,Galaxy Server administration,2021-10,2021-10-27
-1469,4,,,,A short introduction to Galaxy,Introduction to Galaxy Analyses,2021-10,2021-10-27
-1470,5,"it was really great and very informative tutorial, documintation and blasting over represnted sequences , made me feel getting on more with the tools and the data",the part which talks about the best alingment algorithm for adapters was not very clear for me,,Quality Control,Sequence analysis,2021-10,2021-10-27
-1471,5,,,,Galaxy 101 for everyone,Introduction to Galaxy Analyses,2021-10,2021-10-27
-1472,1,yes,yes,,Analysis of molecular dynamics simulations,Computational chemistry,2021-10,2021-10-28
-1473,5,,,,A short introduction to Galaxy,Introduction to Galaxy Analyses,2021-10,2021-10-28
-1474,5,The hands on part,Add a video ,,Quality Control,Sequence analysis,2021-10,2021-10-31
-1475,4,"Simple, makes the user understand how to use Galaxy ",More user friendly data examples for any kind of student who is not from biology background to experiment with and analyze,,A short introduction to Galaxy,Introduction to Galaxy Analyses,2021-10,2021-10-31
-1476,5,,,,A short introduction to Galaxy,Introduction to Galaxy Analyses,2021-10,2021-10-31
-1477,1,The overall design,"The fact that only one gene was differentially expressed means that there is a major problem with the data or analysis, and could not be used. ",,Reference-based RNAseq data analysis (long),Transcriptomics,2021-11,2021-11-01
-1478,5,"La facilidad de interfaz que tiene la pagina, se entiende muy rápido y claramente los pasos que se deben realizar para cargar un documento, y el como se visualizan, analizan e interpretación de los diferentes datos. ",Aun me toca explorar la pagina por el momento este tutorial introductorio es bastante útil y fácil para quien apenas esta escudriñando con el programa. ,,A short introduction to Galaxy,Introduction to Galaxy Analyses,2021-11,2021-11-01
-1479,5,  All the steps are fully documented and they always suggest further readings for important topics related to the tutorial.,"It is great to me, exactly how it is. ",,De novo transcriptome reconstruction with RNA-Seq,Transcriptomics,2021-11,2021-11-01
-1480,5,Everything,More Videos ,,A short introduction to Galaxy,Introduction to Galaxy Analyses,2021-11,2021-11-02
-1481,5,Explications,More videos ,,Quality Control,Sequence analysis,2021-11,2021-11-02
-1482,4,,,,Pre-processing of 10X Single-Cell RNA Datasets,Single Cell,2021-11,2021-11-04
-1483,5,"Really clearly written and well explained, including details that can go wrong or be confusing (the cowsay bit gave me a chuckle). Not overwhelming, unlike some other tutorials I tried. ",,,Ansible,Galaxy Server administration,2021-11,2021-11-04
-1484,4,,This doesn't tell me what library or package heatmap2 function is in - i can't seem to find it elsewhere.,,Visualization of RNA-Seq results with heatmap2,Transcriptomics,2021-11,2021-11-04
-1485,5,Ease of explanation,Nothing I think,,A short introduction to Galaxy,Introduction to Galaxy Analyses,2021-11,2021-11-06
-1486,5,i understand better quality control of the data,more examples or more quiz examples,,Quality Control,Sequence analysis,2021-11,2021-11-07
-1487,5,the qs and answers and clear explanation of each step,refer to which CLI tool commands can be used for each step,,Understanding Barcodes,Single Cell,2021-11,2021-11-08
-1488,5,"easy tasks, everything worked",,,Quality Control,Sequence analysis,2021-11,2021-11-08
-1489,5,,,,Reference-based RNA-Seq data analysis,Transcriptomics,2021-11,2021-11-09
-1490,4,,,,Pre-processing of Single-Cell RNA Data,Single Cell,2021-11,2021-11-09
-1491,4,Graphics,Putting animations and explanatory videos,,Quality Control,Sequence analysis,2021-11,2021-11-10
-1492,5,Easy to follow and provides good grounding in Galaxy use,"Could the tutorial please be updated to avoid a common ""error"". The tool Group isn't recognised on usegalaxy.* services in the Tool Search as the search ID is tagged as ""grouping"". This is a fix in Galaxy core code but maybe a short work-around is to make mention in this tutorial that this tool can be searched for by the term ""grouping""",,Galaxy 101 for everyone,Introduction to Galaxy Analyses,2021-11,2021-11-10
-1493,5,Yes,,,Metatranscriptomics analysis using microbiome RNA-seq data,Metagenomics,2021-11,2021-11-10
-1494,5,,,,A short introduction to Galaxy,Introduction to Galaxy Analyses,2021-11,2021-11-10
-1495,5,,,,A short introduction to Galaxy,Introduction to Galaxy Analyses,2021-11,2021-11-11
-1496,4,,Some steps and pictures need to be updated for the current version of usegalaxy.,,Extracting Workflows from Histories,Using Galaxy and Managing your Data,2021-11,2021-11-12
-1497,5,,,,2: RNA-seq counts to genes,Transcriptomics,2021-11,2021-11-15
-1498,5,,,,From peaks to genes,Introduction to Galaxy Analyses,2021-11,2021-11-15
-1499,5,Detailed Explanation,,,Introduction to Genomics and Galaxy,Introduction to Galaxy Analyses,2021-11,2021-11-15
-1500,5,,,,Introduction to Genomics and Galaxy,Introduction to Galaxy Analyses,2021-11,2021-11-16
-1501,5,,,,Galaxy 101,Introduction to Galaxy Analyses,2021-11,2021-11-16
-1502,1,The programs were not available at Galaxy,,,DNA Methylation data analysis,Epigenetics,2021-11,2021-11-17
-1503,5,super,nothing,,Galaxy 101 for everyone,Introduction to Galaxy Analyses,2021-11,2021-11-17
-1504,3,Nice features and understandable handling for beginners,"Some data and tools are not at the described places; specifically genome annotation fasta and snpTools... snpEff is not existing, so I used snpEff eff; snpSift Annotate exists twice with different features. Description on how to create the pedigree file.",,Exome sequencing data analysis for diagnosing a genetic disease,Variant Analysis,2021-11,2021-11-17
-1505,4,,,,Galaxy 101,Introduction to Galaxy Analyses,2021-11,2021-11-18
-1506,5,,,,Metaproteomics tutorial,Proteomics,2021-11,2021-11-18
-1507,5,It is structured well and well explained.,It might be helpful to mention the alternative tools and solutions,,Identification of somatic and germline variants from tumor and normal sample pairs,Variant Analysis,2021-11,2021-11-19
-1508,5,,,,A short introduction to Galaxy,Introduction to Galaxy Analyses,2021-11,2021-11-19
-1509,5,"That goes step by step, shows and explains each section ",Give an example of where we can obtain the sequences or which links are the ones that can be used.,,Breve introducción a Galaxy - en español,Introduction to Galaxy Analyses,2021-11,2021-11-21
-1510,5,The webpage is friendly ,"This is my first time on platform, so I need to explore more",,Breve introducción a Galaxy - en español,Introduction to Galaxy Analyses,2021-11,2021-11-21
-1511,5,Lo amigable del programa,Incluir la aplicación de cada herramienta usada,,Breve introducción a Galaxy - en español,Introduction to Galaxy Analyses,2021-11,2021-11-22
-1512,5,,,,Pre-processing of 10X Single-Cell RNA Datasets,Single Cell,2021-11,2021-11-22
-1513,5,It is very simple and understandable,"add an image of where to locate ""See all histories""",,Breve introducción a Galaxy - en español,Introduction to Galaxy Analyses,2021-11,2021-11-22
-1514,5,Very easy,Other practical tools.,,Breve introducción a Galaxy - en español,Introduction to Galaxy Analyses,2021-11,2021-11-22
-1515,5,,,,A short introduction to Galaxy,Introduction to Galaxy Analyses,2021-11,2021-11-23
-1516,1,the concept.,"multiple issues with platform - loosing (they are not on the screen) history buttons, tag buttons, Once I brought the UCSC file in, I no longer can find the gz file - maybe it is supposed to be merged, but that is not what the tutorial showed.  There was a disclaimer that said 'results might be different' but there were no Chr 21 to rename on the file.  A little video showing what to expect might be more helpful than the icons in the description.  I see it was updated in early November, but as a real beginner,  this isn't any fun at all and very frustrating.",,From peaks to genes,Introduction to Galaxy Analyses,2021-11,2021-11-24
-1517,5,It is very clear and easy to follow,"anything, it is what it states: a short introduction :) ",,A short introduction to Galaxy,Introduction to Galaxy Analyses,2021-11,2021-11-28
-1518,5,"Very well explained, very visual",Maybe add some more information about the type of analysis we're running,,A short introduction to Galaxy,Introduction to Galaxy Analyses,2021-11,2021-11-29
-1519,4,,,,Quality Control,Sequence analysis,2021-11,2021-11-29
-1520,5,,,,1: RNA-Seq reads to counts,Transcriptomics,2021-11,2021-11-29
-1521,4,,,,Breve introducción a Galaxy - en español,Introduction to Galaxy Analyses,2021-11,2021-11-29
-1522,5,,,,A short introduction to Galaxy,Introduction to Galaxy Analyses,2021-11,2021-11-29
-1523,5,,,,A short introduction to Galaxy,Introduction to Galaxy Analyses,2021-11,2021-11-30
-1524,5,How easy is to follow the instructions ,"Probably adding more languages, but the english it's totally understandable",,A short introduction to Galaxy,Introduction to Galaxy Analyses,2021-11,2021-11-30
-1525,5,Very assertive and good guidance,More intuitive guidance,,Chloroplast genome assembly,Assembly,2021-11,2021-11-30
-1526,5," The instructions are clear, I really enjoyed it thank you!",Notes for the versions of the tools so you can select them and go a little bit faster with the course. ,,Generating a single cell matrix using Alevin,Single Cell,2021-11,2021-11-30
-1527,5,Everything! Very well organized and practical.,,,Downstream Single-cell RNA analysis with RaceID,Single Cell,2021-12,2021-12-01
-1528,1,,,,Visualization of RNA-Seq results with Volcano Plot in R,Transcriptomics,2021-12,2021-12-02
-1529,5,"La secuencia, además es sencillo y permite experimentar los ejercicios o comprobar y aprender la información teórica.","Quizás algunas indicaciones son susceptibles de mejorar, en virtud de mejorar el desarrollo del ejercicio directamente en los escritos; en los tutoriales quizás la unificacion de ellos, hay autores que son muy especificos y llevan de la mano al estudiante.",,Using dataset collections,Using Galaxy and Managing your Data,2021-12,2021-12-02
-1530,1,,,,Visualization of RNA-Seq results with Volcano Plot,Transcriptomics,2021-12,2021-12-04
-1531,5,"Stepwise, just in time learning and great links to additional information","(Having the video helped), but the steps were all included.",,16S Microbial Analysis with mothur (short),Metagenomics,2021-12,2021-12-05
-1532,5,,,,Galaxy 101,Introduction to Galaxy Analyses,2021-12,2021-12-05
-1533,5,"Easy to follow, good reasoning for each step, mostly successful results","For some reason, I can't get this to work with NMR-derived pdb files",,Running molecular dynamics simulations using GROMACS,Computational chemistry,2021-12,2021-12-07
-1534,5,this tutorial explains CNN for image analysis completely and simply.,,,Image classification in Galaxy with fruit 360 dataset,Statistics and machine learning,2021-12,2021-12-08
-1535,5,,,,A short introduction to Galaxy,Introduction to Galaxy Analyses,2021-12,2021-12-08
-1536,5,The course is elaborated with proper hands on  help and graphical representation. Its gives proper details for each and every concept.,,,Quality Control,Sequence analysis,2021-12,2021-12-08
-1537,5,,,,Mapping,Sequence analysis,2021-12,2021-12-08
-1538,5,You iluustrated the principles of each analysis step.,I am not sure where I can find the codes for practice.,,Visualization of RNA-Seq results with heatmap2,Transcriptomics,2021-12,2021-12-10
-1539,5,,,,Mapping,Sequence analysis,2021-12,2021-12-13
-1540,2,was well explained. ,The tutorial looks nothing like what is one my galaxy web instance. Jupiter notebooks are not listed under visualizations but rather are under tools. The dialog that comes up when I launch Jupyter also does not look like what is in this tutorial. I can't figure it out based on what you have shown.,,Use Jupyter notebooks in Galaxy,Using Galaxy and Managing your Data,2021-12,2021-12-15
-1541,5,Well detailed method of ChIPseq and associated explanations,"The title in itself doesn't really reflect the final results of the tutorial, with the data used one do not really identify TAD on the inactive X chromosome... ",,Formation of the Super-Structures on the Inactive X,Epigenetics,2021-12,2021-12-16
-1542,4,,,,Formation of the Super-Structures on the Inactive X,Epigenetics,2021-12,2021-12-17
-1543,5,,,,Metatranscriptomics analysis using microbiome RNA-seq data,Metagenomics,2021-12,2021-12-20
-1544,1,,,,High Throughput Molecular Dynamics and Analysis,Computational chemistry,2021-12,2021-12-20
-1545,5,Muy claras las explicaciones,Todo está bien en este tutorial,,A short introduction to Galaxy,Introduction to Galaxy Analyses,2021-12,2021-12-20
-1546,5,,Circos plot of the data should also be included.,,Chloroplast genome assembly,Assembly,2021-12,2021-12-23
-1547,5,Step by step nature ,More explanation of what i am actually doing at each step,,NGS data logistics,Introduction to Galaxy Analyses,2021-12,2021-12-23
-1548,5,,,,A short introduction to Galaxy,Introduction to Galaxy Analyses,2021-12,2021-12-24
-1549,5,,,,Mapping,Sequence analysis,2021-12,2021-12-26
-1550,5,,,,RNA Seq Counts to Viz in R,Transcriptomics,2021-12,2021-12-28
-1551,5,,,,A short introduction to Galaxy,Introduction to Galaxy Analyses,2021-12,2021-12-29
-1552,5,,,,A short introduction to Galaxy,Introduction to Galaxy Analyses,2021-12,2021-12-31
-1553,2,Not yet completed,This is how the output of get flanks are stated in the tutorial: For regions on the negative strand e.g. chr1 8349819 9289958 this gives chr1 9279958 9291958. However what I am getting is similar to the results of the + strand; the promoter regions lies between 8347819 and 8359819; it seems to me that get flanks did not recognize between the + and - strands,,From peaks to genes,Introduction to Galaxy Analyses,2022-01,2022-01-03
-1554,5,The simplicity,The tool is pretty solid,,Visualisation with Circos,Visualisation,2022-01,2022-01-04
-1555,5,guidelines are clear / no questions are left unanswered ,,,From peaks to genes,Introduction to Galaxy Analyses,2022-01,2022-01-05
-1556,3,,"I am getting an error : Warning unsupported media type (415) while trying to upload the reference genome using the link ""https://ftp.ncbi.nlm.nih.gov/genomes/all/GCF/009/858/895/GCF_009858895.2_ASM985889v3/GCF_009858895.2_ASM985889v3_genomic.fna.gz"". And I am not sure which file type to pick when trying to download from NCBI using the accession number ""NC_045512.2"" provided.",,NGS data logistics,Introduction to Galaxy Analyses,2022-01,2022-01-06
-1557,5,,,,Reference-based RNA-Seq data analysis,Transcriptomics,2022-01,2022-01-07
-1558,1,,Data set can not be found ,,DNA Methylation data analysis,Epigenetics,2022-01,2022-01-13
-1559,5,Clear instructions,,,Visualization of RNA-Seq results with Volcano Plot,Transcriptomics,2022-01,2022-01-13
-1560,5,The way they teached us.,"Very Short tutorial, needs to add some other tools alo. ",,A short introduction to Galaxy,Introduction to Galaxy Analyses,2022-01,2022-01-14
-1561,4,In-depth explanations and side bars of what the various commands are doing so you can easily troubleshoot and customize.,"There is an ""error"" in the example code for the Galaxy/FTP portion of galaxyservers.yml.  if you intend to use separate upload directories (with email addresses as the folder name) for each user - as the tutorial indicates will happen - then the current code (below) will result in the uploads going into the parent directory ""/uploads"" instead of ""uploads/user_email"" .    # FTP     ftp_upload_dir: /data/uploads     ftp_upload_site: ""{{ inventory_hostname }}""  Instead the code should be (add a ""/""):  # FTP     ftp_upload_dir: /data/uploads/     ftp_upload_site: ""{{ inventory_hostname }}""  Took me a while to work out why it was going into the wrong directory.  Also - it should be stated that there may be a newer version of the playbook that could solve errors/conflicts with newer operating system versions than those used in the tutorial.    Also suggest highlighting parts in the code examples which should be customized to your server environment if you are using this as a guide to setup your own installation (primarily directories where stuff is located).   ",,Enable upload via FTP,Galaxy Server administration,2022-01,2022-01-15
-1562,5,Code examples that you customize to your server set-up; hints and sidebars are very helpful; as is the in-depth explanation of what the code is doing.,"One solution to errors that arise would be to try newer playbook versions.  Although the tutorial cautioned that newer versions could create problems - in my case it solved problems.  I found that the version of galaxyproject.galaxy used in the tutorial-- version: 0.9.16 was incompatible with Ubuntu 20.04 LTS - resulting in a failure to install ""futures"".  When I changed to the newest galaxyproject.galaxy version the problem was solved. ",,Galaxy Installation with Ansible,Galaxy Server administration,2022-01,2022-01-15
-1563,5,,,,An Introduction to Genome Assembly,Assembly,2022-01,2022-01-15
-1564,5,,,,Quality Control,Sequence analysis,2022-01,2022-01-19
-1565,4,,,,1: RNA-Seq reads to counts,Transcriptomics,2022-01,2022-01-19
-1566,5,How the each and every step is shwon with the screenshots. Just what an beginner needs. :),,,From peaks to genes,Introduction to Galaxy Analyses,2022-01,2022-01-20
-1567,1,nothing,"Does not tell me how to get FreeBayes data from Galaxy into IGV.  IGV states that it cannot recognize the file.   I have used these programs before, but something is different now.",,IGV Introduction,Introduction to Galaxy Analyses,2022-01,2022-01-20
-1568,2,,"The examples are still very buggy.  Many of them do not work with the instructions as supplied.  For example, the SalmonKallistoMtxTo10x instructions fails, most  likely because the program is looking for a gz file when the tutorial example makes an unzipped file.  The Droplet barcode rank plot exercise also crashes.",,Generating a single cell matrix using Alevin,Single Cell,2022-01,2022-01-24
-1569,5,,,,Pre-processing of 10X Single-Cell RNA Datasets,Single Cell,2022-01,2022-01-25
-1570,1,,This tutorial is impossible to do with the standard memory allotment of usegalaxy.org.  RNA StarSolo requires too much memory to run for a data set of this size.  I brought my file storage down to 8% of the standard allotment and it did not start for over a day.  You should pick tools that people can use with the standard package or say so up front.  It also makes it impossible to keep anything to re-run later.,,Pre-processing of 10X Single-Cell RNA Datasets,Single Cell,2022-01,2022-01-25
-1571,5,,,,Reference-based RNA-Seq data analysis,Transcriptomics,2022-01,2022-01-26
-1572,1,nothing,nothing,,Genome annotation with Maker,Genome Annotation,2022-01,2022-01-26
-1573,5,An example full of information,no,,Introduction to Genomics and Galaxy,Introduction to Galaxy Analyses,2022-01,2022-01-27
-1574,5,The educational aspect and questions asked,The last question has no answer,,Galaxy 101,Introduction to Galaxy Analyses,2022-02,2022-02-02
-1575,5,,,,Visualization of RNA-Seq results with Volcano Plot,Transcriptomics,2022-02,2022-02-03
-1576,5,,,,Inferring Trajectories using Python (Jupyter Notebook) in Galaxy,Single Cell,2022-02,2022-02-04
-1577,4,,,,Galaxy 101,Introduction to Galaxy Analyses,2022-02,2022-02-04
-1578,5,the simple and easy demonstration,,,Galaxy 101,Introduction to Galaxy Analyses,2022-02,2022-02-07
-1579,4,I liked the step by step follow up of results while doing the analysis,,,Galaxy 101,Introduction to Galaxy Analyses,2022-02,2022-02-07
-1580,5,,,,Quality Control,Sequence analysis,2022-02,2022-02-07
-1581,5,,,,Mapping,Sequence analysis,2022-02,2022-02-07
-1582,3,easy workflow,The metaMS.plot does not work,,Mass spectrometry : GC-MS analysis with metaMS package,Metabolomics,2022-02,2022-02-08
-1583,5,It is very didactical,a better explanation of cross-contamination plots,,Pre-processing of Single-Cell RNA Data,Single Cell,2022-02,2022-02-08
-1584,5,very clear tutorial!,,,Galaxy 101,Introduction to Galaxy Analyses,2022-02,2022-02-09
-1585,4,,,,Genome annotation with Prokka,Genome Annotation,2022-02,2022-02-10
-1586,5,,,,1: RNA-Seq reads to counts,Transcriptomics,2022-02,2022-02-10
-1587,5,,,,16S Microbial analysis with Nanopore data,Metagenomics,2022-02,2022-02-10
-1588,5,,,,ATAC-Seq data analysis,Epigenetics,2022-02,2022-02-12
-1589,5,step by step explanation,IT would be very useful to indicate that a tools used in the exercise are not accessible from all galaxy sites.,,Galaxy 101 for everyone,Introduction to Galaxy Analyses,2022-02,2022-02-13
-1590,4,"Pretty simple step-by-step; A couple of syntax errors are included to make things ""interesting"" when trying to deploy.","Found another syntax error in the referenced tutorial:  In the galaxy.j2 file, ""location /_x_accel_redirect"" should be ""location /_x_accel_redirect/""",,Galaxy Installation with Ansible,Galaxy Server administration,2022-02,2022-02-15
-1591,1,,literally where is the volcano plot code? you give every code except for the actual plot! so unhelpful ,,Visualization of RNA-Seq results with Volcano Plot in R,Transcriptomics,2022-02,2022-02-16
-1592,3,The clear steps and explanation attached,Some tools have not been found in Galaxy such as antiSMASH. ,,Genome Annotation,Genome Annotation,2022-02,2022-02-17
-1593,4,very clear referencing of input files,,,Pre-processing of 10X Single-Cell RNA Datasets,Single Cell,2022-02,2022-02-18
-1594,4,,,,GO Enrichment Analysis,Transcriptomics,2022-02,2022-02-18
-1595,5,,,,Reference-based RNA-Seq data analysis,Transcriptomics,2022-02,2022-02-18
-1596,5,It was very precise and easy to follow.,I think it's excellent as it is.,,A short introduction to Galaxy,Introduction to Galaxy Analyses,2022-02,2022-02-18
-1597,5,every step was clear to follow,follow-up video for people who have network issues so that they can watch and catch-up fast,,A short introduction to Galaxy,Introduction to Galaxy Analyses,2022-02,2022-02-21
-1598,5,A clean flowchart of methods with an explanation for the purpose of each step.,"As a case study, a bad genome assembly or an assembly with incorrect parameters in various steps could be shown",,VGP assembly pipeline,Assembly,2022-02,2022-02-21
-1599,5,"As usal, the step by step procedures.",It is not clear that we have to set up the test-data folder and collect the bam files by our own for passing the test in the planemo section.,,Creating Galaxy tools from Conda Through Deployment,Development in Galaxy,2022-02,2022-02-21
-1600,4,,,,Introduction to Genomics and Galaxy,Introduction to Galaxy Analyses,2022-02,2022-02-22
-1601,5,"Very detailed explained steps, which made the analysis very easy",,,Introduction to Genomics and Galaxy,Introduction to Galaxy Analyses,2022-02,2022-02-22
-1602,5,It's clear and that take us by the hand to learn how to use galaxy. ,maybe make a youtube video to show all this tutorial ,,Galaxy 101 for everyone,Introduction to Galaxy Analyses,2022-02,2022-02-22
-1603,5,,,,Galaxy 101,Introduction to Galaxy Analyses,2022-02,2022-02-22
-1604,5,,,,Genome Assembly of MRSA using Illumina MiSeq Data,Assembly,2022-02,2022-02-23
-1605,5,,,,Galaxy 101,Introduction to Galaxy Analyses,2022-02,2022-02-23
-1606,4,,,,Extracting Workflows from Histories,Using Galaxy and Managing your Data,2022-02,2022-02-24
-1607,4,Nice Step by Step Tutorial,Finding the tools was a bit difficult with the search bar. Somethings are a bit outdated.,,Introduction to Genomics and Galaxy,Introduction to Galaxy Analyses,2022-02,2022-02-24
-1608,5,The clear explanation of the tools,,,Mapping,Sequence analysis,2022-02,2022-02-25
-1609,4,Easy to follow and execute.,The order of selecting parameters can be sequential as it appears on the galaxy platform,,Running molecular dynamics simulations using GROMACS,Computational chemistry,2022-02,2022-02-26
-1610,4,,The further analysis links seems to be broken/unavailable: https://github.com/galaxyproject/training-material/tree/main/topics/computational-chemistry/tutorials/analysis-md-simulations/workflows/advanced_workflow.ga,,Analysis of molecular dynamics simulations,Computational chemistry,2022-02,2022-02-26
-1611,4,Easy to follow and focused on the basics,,,A short introduction to Galaxy,Introduction to Galaxy Analyses,2022-03,2022-03-07
-1612,5,Step wise instruction,It was perfect for me.,,A short introduction to Galaxy,Introduction to Galaxy Analyses,2022-03,2022-03-07
-1613,4,It is very detailed tutorial and easy to follow also for beginners like me,,,A short introduction to Galaxy,Introduction to Galaxy Analyses,2022-03,2022-03-07
-1614,5,It is really hands on,,,A short introduction to Galaxy,Introduction to Galaxy Analyses,2022-03,2022-03-07
-1615,5,,,,Name tags for following complex histories,Using Galaxy and Managing your Data,2022-03,2022-03-07
-1616,5,,,,A short introduction to Galaxy,Introduction to Galaxy Analyses,2022-03,2022-03-07
-1617,5,"Easy to follow, user friendly for someone without background",,,Galaxy 101,Introduction to Galaxy Analyses,2022-03,2022-03-08
-1618,4,easy to understand with easy steps,,,From peaks to genes,Introduction to Galaxy Analyses,2022-03,2022-03-10
-1619,4,,,,Inferring Trajectories using Python (Jupyter Notebook) in Galaxy,Single Cell,2022-03,2022-03-11
-1620,5,The tutorial was very informative and steps were defined clearly to perform the analysis...,"Overall, it was quite informative. However, it would be preferable to include a video tutorial for performing the analysis, where results can be thoroughly explained and the steps would be more easier to follow to perform the analysis for new users.",,Bulk RNA Deconvolution with MuSiC,Single Cell,2022-03,2022-03-12
-1621,4,,,,Galaxy 101,Introduction to Galaxy Analyses,2022-03,2022-03-12
-1622,5,Simplicity. ,"Considering this is an introduction to assembly, it would be helpful if the steps are complete as some steps may have been skipped. It would also be useful if pictures can be added for some steps.   When ran, the results stated in this tutorial doesnt match with the output even if the instructions is strictly followed",,An Introduction to Genome Assembly,Assembly,2022-03,2022-03-12
-1623,4,simplicity,,,Deep Learning (Part 1) - Feedforward neural networks (FNN),Statistics and machine learning,2022-03,2022-03-12
-1624,5,"A single tutorial teaches to get information from UCSC, analyze them, view it in genome browser and asks us to use the pipeline to work on similar biological problems.",,,Introduction to Genomics and Galaxy,Introduction to Galaxy Analyses,2022-03,2022-03-14
-1625,5,,"There is a typo as :""M117-ch_1 - family 117, mother, reverse (R) reads from cheek"" under the section ""About these datasets"". It should have been ""M117-ch_2""",,Using dataset collections,Using Galaxy and Managing your Data,2022-03,2022-03-14
-1626,5,Very informative and in depth without being boring!,,,Galaxy 101 for everyone,Introduction to Galaxy Analyses,2022-03,2022-03-14
-1627,5,Clear explanation and utility of the tool/process,Excellent,,Rule Based Uploader,Using Galaxy and Managing your Data,2022-03,2022-03-14
-1628,5,"Clear explanation, useful content, thanks",clear and useful enough,,Using dataset collections,Using Galaxy and Managing your Data,2022-03,2022-03-14
-1629,5,intuitive,nothing,,Introduction to Genomics and Galaxy,Introduction to Galaxy Analyses,2022-03,2022-03-14
-1630,5,very useful for paired-end datasets for sequencing analysis,nothing,,Rule Based Uploader,Using Galaxy and Managing your Data,2022-03,2022-03-14
-1631,5,,,,Introduction to Genomics and Galaxy,Introduction to Galaxy Analyses,2022-03,2022-03-14
-1632,5,Good information on how to use the rule based uploader,-,,Rule Based Uploader,Using Galaxy and Managing your Data,2022-03,2022-03-14
-1633,5,The slides gave a really useful overview of toolsheds and how to configure them. ,It would be useful if the links to ephemeris commands would open in a new tab (I would prefer this for links in general but especially in this case as you have to do it in the middle of a task and it's not just further reading)  ,,Galaxy Tool Management with Ephemeris,Galaxy Server administration,2022-03,2022-03-14
-1634,5,,,,Introduction to Genomics and Galaxy,Introduction to Galaxy Analyses,2022-03,2022-03-14
-1635,5,saving and re using the workflow,more hand on activities ,,Introduction to Genomics and Galaxy,Introduction to Galaxy Analyses,2022-03,2022-03-14
-1636,5,,,,Quality Control,Sequence analysis,2022-03,2022-03-14
-1637,5,the pace,,,Galaxy 101 for everyone,Introduction to Galaxy Analyses,2022-03,2022-03-14
-1638,4,,,,A short introduction to Galaxy,Introduction to Galaxy Analyses,2022-03,2022-03-15
-1639,5,really loved the simplicity of the processes,,,Galaxy 101 for everyone,Introduction to Galaxy Analyses,2022-03,2022-03-15
-1640,5,the brief exxplanation,more explicit practical experience,,Understanding Barcodes,Single Cell,2022-03,2022-03-15
-1641,5, ,,,Quality Control,Sequence analysis,2022-03,2022-03-15
-1642,5,,,,Mapping,Sequence analysis,2022-03,2022-03-15
-1643,3,that the work can be excecated at the same time the class is on,if we could question the instructor,,Quality Control,Sequence analysis,2022-03,2022-03-15
-1644,5,,,,Introduction to Genomics and Galaxy,Introduction to Galaxy Analyses,2022-03,2022-03-15
-1645,3,that we could do things side by side to the instructor ,it could be more interactive,,Mapping,Sequence analysis,2022-03,2022-03-15
-1646,5,The hands-on material is really well thought and it really gives us confidence in doing this type of analysis. It is very easy to follow through.,"There were two steps where I fumbled, one was when I tried importing the genes from UCSC browser it opened in the new history, I feel one link to paste that to current history tab would be beneficial, secondly, I was literally searching for Group tool under the workflow, then when I expanded the list then I could find it. ",,From peaks to genes,Introduction to Galaxy Analyses,2022-03,2022-03-15
-1647,5,great tutorial on the basics !,nothing,,Quality Control,Sequence analysis,2022-03,2022-03-15
-1648,5,All aspect,Not much improvement,,Chloroplast genome assembly,Assembly,2022-03,2022-03-15
-1649,5,Clear explanation of what CVMFS is for and how it works,,,Reference Data with CVMFS,Galaxy Server administration,2022-03,2022-03-15
-1650,5,,,,Quality Control,Sequence analysis,2022-03,2022-03-15
-1651,5,very informative,,,Mapping,Sequence analysis,2022-03,2022-03-15
-1652,4,,,,Quality Control,Sequence analysis,2022-03,2022-03-15
-1653,4,clear for a beginner,"maybe planemo could be the first step, because needed in the wrapper section",,Creating Galaxy tools from Conda Through Deployment,Development in Galaxy,2022-03,2022-03-15
-1654,4,Explanations on how to create a galaxy tool,Put planemo install first,,Creating Galaxy tools from Conda Through Deployment,Development in Galaxy,2022-03,2022-03-15
-1655,5,good intro course on assembly,some more theory about polishing and why,,Chloroplast genome assembly,Assembly,2022-03,2022-03-15
-1656,5,,,,Data Libraries,Galaxy Server administration,2022-03,2022-03-15
-1657,5,,,,Genome annotation with Prokka,Genome Annotation,2022-03,2022-03-15
-1658,3,,I struggled to access the built-in reference genome and ended up giving up on the tutorial,,Mapping,Sequence analysis,2022-03,2022-03-15
-1659,5,Really liked the given details about each quality parameter,,,Quality Control,Sequence analysis,2022-03,2022-03-15
-1660,5,,,,Mapping,Sequence analysis,2022-03,2022-03-15
-1661,5,The IGV tutorial was great,,,Mapping,Sequence analysis,2022-03,2022-03-15
-1662,5,super interesting ! especially the sharing part !,,,Refining Genome Annotations with Apollo (prokaryotes),Genome Annotation,2022-03,2022-03-15
-1663,5,,,,Refining Genome Annotations with Apollo (prokaryotes),Genome Annotation,2022-03,2022-03-15
-1664,5,The options are pretty  intuitive.,,,Rule Based Uploader,Using Galaxy and Managing your Data,2022-03,2022-03-15
-1665,5,,,,Classification in Machine Learning,Statistics and machine learning,2022-03,2022-03-15
-1666,4,,For me it is not clear wether the apikey example use of vaults is the best. Might it be better to set an example about ssh passwords to connect remote servers?,,Ansible,Galaxy Server administration,2022-03,2022-03-15
-1667,5,Very easy to use and effective,,,Chloroplast genome assembly,Assembly,2022-03,2022-03-15
-1668,5,"I was already familiar with fastqc, but learning about Nanoplot and PycoQC for long read quality control was great",,,Quality Control,Sequence analysis,2022-03,2022-03-15
-1669,5,Ease of understanding and depth of explanation,The videos are old and out of sync of the tutorial material in some cases. There is need for new videos to be developed,,Introduction to Genomics and Galaxy,Introduction to Galaxy Analyses,2022-03,2022-03-15
-1670,4,,,,Mapping,Sequence analysis,2022-03,2022-03-15
-1671,5,"learned new QC checking tools, I only knew fastQC",great tutorial,,Quality Control,Sequence analysis,2022-03,2022-03-15
-1672,5,"It was super clear, and combine nice tools","For me was not ""intuitive"" to have a test with two p-values (for negative/positive selection). That I do not know if it is pretty common in transcriptomic (and I missed it) or if it is non so commonly used and it was speciffically developed on MAGeCK test. If it is not commonly use I think that can be nice to include a brief description of the statistical test in the tutorial of the course. ",,CRISPR screen analysis,Genome Annotation,2022-03,2022-03-15
-1673,5,,"great tutorial, very well explained",,16S Microbial Analysis with mothur (short),Metagenomics,2022-03,2022-03-16
-1674,5,"As someone working on AMR, it was really interesting",,,Antibiotic resistance detection,Metagenomics,2022-03,2022-03-16
-1675,5,"everything was so interesting, but workflow part is more fascinating. ",I think there is no need of the improvement every thing is so perfectly fine and easily understandable.,,Introduction to Genomics and Galaxy,Introduction to Galaxy Analyses,2022-03,2022-03-16
-1676,5,,,,Regression in Machine Learning,Statistics and machine learning,2022-03,2022-03-16
-1677,5,The practical easy-to-use guide,,,Introduction to Genomics and Galaxy,Introduction to Galaxy Analyses,2022-03,2022-03-16
-1678,5,how to do read mapping and understanding the statistics,,,Mapping,Sequence analysis,2022-03,2022-03-16
-1679,5,,,,Visualization of RNA-Seq results with Volcano Plot,Transcriptomics,2022-03,2022-03-16
-1680,4,,The final percentage overlap could be provided so students can compare to make sure the results are the same,,Introduction to Genomics and Galaxy,Introduction to Galaxy Analyses,2022-03,2022-03-16
-1681,5,great tutorial,,,16S Microbial analysis with Nanopore data,Metagenomics,2022-03,2022-03-16
-1682,4,good explanation why masking is done,,,Masking repeats with RepeatMasker,Genome Annotation,2022-03,2022-03-16
-1683,4,Easy to follow,,,Mapping,Sequence analysis,2022-03,2022-03-16
-1684,5,The hand one are very easy and clear. ,Allow students to answer the questions whithin the hand on then they can compare with the available answers,,A short introduction to Galaxy,Introduction to Galaxy Analyses,2022-03,2022-03-16
-1685,5,"the structure, it was very well organized",,,Galaxy Installation with Ansible,Galaxy Server administration,2022-03,2022-03-16
-1686,5,Very simple to understand easy to do,"Nothing,  it is very complete",,High Throughput Molecular Dynamics and Analysis,Computational chemistry,2022-03,2022-03-16
-1687,5,The graphical data presentation and workflow set up,,,Galaxy 101 for everyone,Introduction to Galaxy Analyses,2022-03,2022-03-16
-1688,5,Clear and structured - everything ran without issues on my machines,,,Galaxy Installation with Ansible,Galaxy Server administration,2022-03,2022-03-16
-1689,5,,,,Use Singularity containers for running Galaxy jobs,Galaxy Server administration,2022-03,2022-03-16
-1690,5,It was my first time analyzing the quality of a sequencing experiment and I easily followed the tutorial. This mean to me that it was nicely prepare taking care of the details.,,,Quality Control,Sequence analysis,2022-03,2022-03-16
-1691,5,Great introduction to proteomics tools,,,MaxQuant and MSstats for the analysis of label-free data,Proteomics,2022-03,2022-03-16
-1692,5,Explanations,,,Introduction to Genomics and Galaxy,Introduction to Galaxy Analyses,2022-03,2022-03-17
-1693,4,,I would be great if it could explain how to run ephemeris from a different machine (for example my local machine) but deploying galaxy on the vm,,Galaxy Tool Management with Ephemeris,Galaxy Server administration,2022-03,2022-03-17
-1694,5,"the pace, simon explains everything really well and understandable",,,Reference Data with CVMFS,Galaxy Server administration,2022-03,2022-03-17
-1695,5,Step by Step learning,,,A short introduction to Galaxy,Introduction to Galaxy Analyses,2022-03,2022-03-17
-1696,5,The tutorial was informative. Visualizing the reads in IGV (as a WSL user) was great.,,,Mapping,Sequence analysis,2022-03,2022-03-17
-1697,5,"clearly and easily explained. very good, many thanks","Maybe more details in the video for the advanced, but all is mostly available on this web site. thanks.",,Mapping,Sequence analysis,2022-03,2022-03-17
-1698,5,"compact and fully covering the matter, thanks",n/a,,Mapping,Sequence analysis,2022-03,2022-03-17
-1699,5,very complex biological/ bioinfo problem solved thanks to this great workflow. available and accessible to the whole of the scientific community. Great! Thanks for all contributors and participants.,n/a,,Proteogenomics 1: Database Creation,Proteomics,2022-03,2022-03-17
-1700,5,very complex biological/ bioinfo problem solved thanks to this great workflow. available and accessible to the whole of the scientific community. Great! Thanks for all contributors and participants.,n/a,,Proteogenomics 2: Database Search,Proteomics,2022-03,2022-03-17
-1701,5,very complex biological/ bioinfo problem solved thanks to this great workflow. available and accessible to the whole of the scientific community. Great! Thanks for all contributors and participants of the GalaxyP,n/a,,Proteogenomics 3: Novel peptide analysis,Proteomics,2022-03,2022-03-17
-1702,5,Dataset manipulation,,,Using dataset collections,Using Galaxy and Managing your Data,2022-03,2022-03-17
-1703,5,,,,Connecting Galaxy to a compute cluster,Galaxy Server administration,2022-03,2022-03-17
-1704,4,,,,Reference-based RNA-Seq data analysis,Transcriptomics,2022-03,2022-03-17
-1705,4,,,,Pangeo ecosystem 101 for everyone - Introduction to Xarray Galaxy Tools,Climate,2022-03,2022-03-17
-1706,5,i liked on how to polish nano-pore reads,,,Chloroplast genome assembly,Assembly,2022-03,2022-03-17
-1707,4,The existence of the dynamic job destinations,,,Mapping Jobs to Destinations,Galaxy Server administration,2022-03,2022-03-17
-1708,4,,,,Visualization of RNA-Seq results with Volcano Plot,Transcriptomics,2022-03,2022-03-18
-1709,5,The tutorial is super clear and easy to follow,,,Reference-based RNA-Seq data analysis,Transcriptomics,2022-03,2022-03-18
-1710,5,The straightforward pedagogical approach,I think it is perfect as is ,,Ansible,Galaxy Server administration,2022-03,2022-03-18
-1711,5,how seamless it was to deploy it,,,Galaxy Installation with Ansible,Galaxy Server administration,2022-03,2022-03-18
-1712,5,,,,Quality Control,Sequence analysis,2022-03,2022-03-18
-1713,5,Great workflow ! I have done this on the CLI... only installing humann took a while! It's great that this workflow can be used by biologists,,,Metatranscriptomics analysis using microbiome RNA-seq data (short),Metagenomics,2022-03,2022-03-18
-1714,5,The step-by-step approach and the additional explanations for some input fields,Perhaps an additional indication of which patch of the hg19 is recognised as the database of the SNPeff eff output of GEMINI load. It took me several attempts to realise that it must be the unpatched version.,,Exome sequencing data analysis for diagnosing a genetic disease,Variant Analysis,2022-03,2022-03-18
-1715,5,Very simple and clear,,,Use Singularity containers for running Galaxy jobs,Galaxy Server administration,2022-03,2022-03-18
-1716,5,Is really cool to see lots of different admins pooling their knowledge and effort in this way,"From a voice control perspective, it would be useful if the hands-on gxadmin commands were in a copiable code block like they are in other tutorials – it really helps to be able to copy them with the single click. Also, the 'admin favourites' section could include the arguments for the functions listed, e.g. <job_id>, for a bit more clarity",,Galaxy Monitoring with gxadmin,Galaxy Server administration,2022-03,2022-03-18
-1717,5,,,,Use Singularity containers for running Galaxy jobs,Galaxy Server administration,2022-03,2022-03-18
-1718,5,I never have even coded before! so easy to use,,,Galaxy 101,Introduction to Galaxy Analyses,2022-03,2022-03-18
-1719,5,"Basics explained and accessible, which can be improved to acquire advanced skills and knowledge. thanks.",n/a,,Annotating a protein list identified by LC-MS/MS experiments,Proteomics,2022-03,2022-03-18
-1720,5,Very clear! It's simple and very important to know,,,Reference Data with CVMFS,Galaxy Server administration,2022-03,2022-03-18
-1721,5,"The additional explanations of the individual configuration options within the tools, especially the SQLite Syntax.",,,Identification of somatic and germline variants from tumor and normal sample pairs,Variant Analysis,2022-03,2022-03-18
-1722,5,very interesting tutorial,,,Proteogenomics 1: Database Creation,Proteomics,2022-03,2022-03-19
-1723,5,,,,Mapping,Sequence analysis,2022-03,2022-03-19
-1724,5,very useful and easy to understand workflows,,,Extracting Workflows from Histories,Using Galaxy and Managing your Data,2022-03,2022-03-19
-1725,5,User friendly and really hepful for novices like me,,,Introduction to Genomics and Galaxy,Introduction to Galaxy Analyses,2022-03,2022-03-19
-1726,5,very simple and basics mode of explanation ,,,Introduction to Genomics and Galaxy,Introduction to Galaxy Analyses,2022-03,2022-03-19
-1727,4,All over the presentation is nice and each steps are clearly explained.,Sometimes the tools are not appeared during performing a search and sometimes other tools are also appeared. It will be better if only relevant tools can be found with the keywords for a specific type of data analysis.,,Reference-based RNA-Seq data analysis,Transcriptomics,2022-03,2022-03-19
-1728,5,,An annotation part such as GO and KEGG pathway analysis should be included.,,De novo transcriptome reconstruction with RNA-Seq,Transcriptomics,2022-03,2022-03-19
-1729,4,The way the instructor explained the plot and significance of it.,It will be helpful if the steps to generate the input file limma-voome format using Galaxy tool is explained.,,Visualization of RNA-Seq results with Volcano Plot,Transcriptomics,2022-03,2022-03-19
-1730,5,The detailed description ,I think that all are perfect,,Introduction to Genomics and Galaxy,Introduction to Galaxy Analyses,2022-03,2022-03-19
-1731,5,very useful pipeline,,,Proteogenomics 2: Database Search,Proteomics,2022-03,2022-03-20
-1732,5,it was understandable,,,A short introduction to Galaxy,Introduction to Galaxy Analyses,2022-03,2022-03-20
-1733,5,,,,Reference-based RNA-Seq data analysis,Transcriptomics,2022-03,2022-03-21
-1734,5,nothing,everything,,16S Microbial Analysis with mothur (extended),Metagenomics,2022-03,2022-03-21
-1735,3,nothing,nothing,,16S Microbial Analysis with mothur (extended),Metagenomics,2022-03,2022-03-21
-1736,5,,,,Reference-based RNA-Seq data analysis,Transcriptomics,2022-03,2022-03-21
-1737,5,easy to understand and the tips are really usefull,no idea,,Galaxy 101,Introduction to Galaxy Analyses,2022-03,2022-03-21
-1738,5,the training used different tools and explained how each works as compared to other tolls,,,Antibiotic resistance detection,Metagenomics,2022-03,2022-03-21
-1739,5,Amazing tutorial overall,,,Classification in Machine Learning,Statistics and machine learning,2022-03,2022-03-22
-1740,5,,,,Antibiotic resistance detection,Metagenomics,2022-03,2022-03-22
-1741,5,Sequence analysis,,,M. tuberculosis Variant Analysis,Variant Analysis,2022-03,2022-03-22
-1742,4,I learnt new tools that i haven't used before,,,Chloroplast genome assembly,Assembly,2022-03,2022-03-22
-1743,5,overall the tutorial was easy to go through,sometimes it was unclear where some of the errors came from and how they can be fixed,,M. tuberculosis Variant Analysis,Variant Analysis,2022-03,2022-03-22
-1744,4,I like the step by step instructions on what to do ,It would be better if the tutorials should also be in video form for easy understanding,,M. tuberculosis Variant Analysis,Variant Analysis,2022-03,2022-03-22
-1745,5,The fact that there are explanations for all steps.,All were perfect!!!,,ATAC-Seq data analysis,Epigenetics,2022-03,2022-03-22
-1746,5,Detailed description,All are ecxellent,,Introduction to Genomics and Galaxy,Introduction to Galaxy Analyses,2022-03,2022-03-22
-1747,5,The fact that for the majority of the steps there are pictures that show you what you expect.,All good,,Extracting Workflows from Histories,Using Galaxy and Managing your Data,2022-03,2022-03-22
-1748,5,excellent content overall loved it,,,Regression in Machine Learning,Statistics and machine learning,2022-03,2022-03-22
-1749,4,the hands on helped with grasping tasks,Requires much more time ,,M. tuberculosis Variant Analysis,Variant Analysis,2022-03,2022-03-23
-1750,5,Easy to follow and grasp concept ,Not sure,,A short introduction to Galaxy,Introduction to Galaxy Analyses,2022-03,2022-03-23
-1751,4,"I like that even though we do not have to type in commands, we still have steps to follow. I have made errors but still were able to use tools to rectify. One can play around till the correct output!",Specification of version to use as we ended up getting different answers due to using default version,,M. tuberculosis Variant Analysis,Variant Analysis,2022-03,2022-03-23
-1752,3,hands on run ,everything is perfect,,A short introduction to Galaxy,Introduction to Galaxy Analyses,2022-03,2022-03-24
-1753,5,,,,NGS data logistics,Introduction to Galaxy Analyses,2022-03,2022-03-24
-1754,4,practicality,,,"Creating, Editing and Importing Galaxy Workflows",Using Galaxy and Managing your Data,2022-03,2022-03-25
-1755,5,,,,Quality Control,Sequence analysis,2022-03,2022-03-25
-1756,5,everything because all was new for me,Add more information in the lecture (describe more meticulously the CRISPR analysis),,CRISPR screen analysis,Genome Annotation,2022-03,2022-03-25
-1757,5,,,,Quality Control,Sequence analysis,2022-03,2022-03-26
-1758,5,,,,Galaxy 101,Introduction to Galaxy Analyses,2022-03,2022-03-26
-1759,5,It is very easy to follow,Its great for a beginner and don't think there is anything to improve.,,Galaxy 101 for everyone,Introduction to Galaxy Analyses,2022-03,2022-03-26
-1760,4,It was written clearly,"One place I think it could be improved would be on Create a reusable workflow from a history, under the Test Workflow part 2 (Examine the workflow run form) wasn't clear as the others and found it to be confusing.",,Introduction to Genomics and Galaxy,Introduction to Galaxy Analyses,2022-03,2022-03-26
-1761,5,,,,Removal of human reads from SARS-CoV-2 sequencing data,Sequence analysis,2022-03,2022-03-26
-1762,5,Tutorials easy to follow,This is great model of learning,,M. tuberculosis Variant Analysis,Variant Analysis,2022-03,2022-03-26
-1763,5,"All the steps were clear and precise. Somewhere I found video demonstrations too, which was unexpected. The concept of collapse and expand features were eyecatching.","Yes, at the end if we have a video covering the entire steps, it could be used as a quick revision of the steps we did above.",,A short introduction to Galaxy,Introduction to Galaxy Analyses,2022-03,2022-03-27
-1764,5,"This is the most extensive and instructive tutorial I've ever taken on Galaxy. My understanding of RNA-seq and DGE analysis has been improved greatly. I made some mistakes along the way which prevented certain analyses from working, but I learnt from them.",,,Reference-based RNA-Seq data analysis,Transcriptomics,2022-03,2022-03-27
-1765,5,The extensive description,I think that it is helpful to be conducted by the instructors and the extra practice which there are in the solutions for the questions because in some parts there is confusion.,,Reference-based RNA-Seq data analysis,Transcriptomics,2022-03,2022-03-27
-1766,5,The tutorial was easy to follow,,,Visualization of RNA-Seq results with Volcano Plot,Transcriptomics,2022-03,2022-03-27
-1767,5,The ability to add labels on the volcano plot,"I think that this tutorial was very detailed, so it is not needed any improvement.",,Visualization of RNA-Seq results with Volcano Plot,Transcriptomics,2022-03,2022-03-27
-1768,5,,,,An Introduction to Genome Assembly,Assembly,2022-03,2022-03-27
-1769,5,The fact that there are pictures which helps more the understanding fro each step.,Nothing,,Understanding Barcodes,Single Cell,2022-03,2022-03-27
-1770,4,I loved the workflow aspect of the platform. ,,,A short introduction to Galaxy,Introduction to Galaxy Analyses,2022-03,2022-03-28
-1771,5,The directions on how to create a pull request,i think a video could me made.,,Contributing with GitHub via its interface,Contributing to the Galaxy Training Material,2022-03,2022-03-28
-1772,5,i like the fact that it took me from a newbie to having some level of knowledge on how the galaxy interface works.,"As much as i really enjoyed this article, i actually struggled with understanding the ""Convert your analysis history into a workflow"" part, as it needed more pictures or more specific descriptions at number 4 and 5 guide steps.  i had to read it over and over, and do some brain work to figure out what the author meant.  if this could be improved for upcoming readers like me, it would be much appreciated and will lead to more productivity on our end.",,A short introduction to Galaxy,Introduction to Galaxy Analyses,2022-03,2022-03-28
-1773,5,The tutorial was instructive and easy to follow. I loved the variant calling and annotation.,,,NGS data logistics,Introduction to Galaxy Analyses,2022-03,2022-03-28
-1774,4,,,,De Bruijn Graph Assembly,Assembly,2022-03,2022-03-28
-1775,5,"The best thing about this tutorial is how clearly all the steps have been laid out. As a new user, it makes it very easy follow along and get familiar with this platform. ",I didn't face any issues following this tutorial. One can follow it verbatim. ,,Galaxy 101 for everyone,Introduction to Galaxy Analyses,2022-03,2022-03-29
-1776,5,"the pace and amount of information was just right, very clear and understandable :)",,,16S Microbial Analysis with mothur (short),Metagenomics,2022-03,2022-03-29
-1777,5,Steps were so systematic and to the point ,i think it needs so much clicks but the good point is that you dont need to right that much,,Galaxy 101 for everyone,Introduction to Galaxy Analyses,2022-03,2022-03-29
-1778,2,it was okay,everything is perfect,,Quality Control,Sequence analysis,2022-03,2022-03-29
-1779,4,optimization  ,everything is perfect!,,High Throughput Molecular Dynamics and Analysis,Computational chemistry,2022-03,2022-03-29
-1780,4,It was simple and easy to follow,It would be great to have some real examples of how this can be applied to your data,,A short introduction to Galaxy,Introduction to Galaxy Analyses,2022-03,2022-03-29
-1781,4,Getting to run data through Galaxy,Maybe more schemes to describe the reads for the relevant platform,,Quality Control,Sequence analysis,2022-03,2022-03-29
-1782,5,Everything because all were new for me,"To be given the ability to conduct all parts of the tutorial, because some tools (in my condition) were not worked and I had to create a new account on another server in order to fulfill the tutorial.",,Generating a single cell matrix using Alevin,Single Cell,2022-03,2022-03-29
-1783,5,,,,Using dataset collections,Using Galaxy and Managing your Data,2022-03,2022-03-30
-1784,5,,,,M. tuberculosis Variant Analysis,Variant Analysis,2022-03,2022-03-30
-1785,3,it  was engaging ,to use of terms and examples so a first time contributor could follow along,,From peaks to genes,Introduction to Galaxy Analyses,2022-03,2022-03-30
-1786,5,Simple explanation with helpful images to provide guidance,,,A short introduction to Galaxy,Introduction to Galaxy Analyses,2022-03,2022-03-30
-1787,5,,,,Removal of human reads from SARS-CoV-2 sequencing data,Sequence analysis,2022-03,2022-03-30
-1788,5,Imaging and locating the capscicin,,,Mass spectrometry imaging: Examining the spatial distribution of analytes,Metabolomics,2022-03,2022-03-30
-1789,5,,,,Visualization of RNA-Seq results with Volcano Plot,Transcriptomics,2022-03,2022-03-30
-1790,4,"I WAS NOT AWARE THE OPTION WHERE YOU CAN GROUP YOUR DATA AND ANALYZE IT AS A COLLECTION, THANKS A LOT ",,,16S Microbial Analysis with mothur (short),Metagenomics,2022-03,2022-03-30
-1791,4,the presentation was staight to point,"there is an important feature that differs in the tutorial, the analyze data button is no longer accessible after the doing a workflow editing",,Galaxy 101 for everyone,Introduction to Galaxy Analyses,2022-03,2022-03-30
-1792,5,Great tutorial for intoducing the computational chemistry,,,High Throughput Molecular Dynamics and Analysis,Computational chemistry,2022-03,2022-03-30
-1793,5,very interesting tutorial overall,,,Deep Learning (Part 1) - Feedforward neural networks (FNN),Statistics and machine learning,2022-03,2022-03-30
-1794,5,Simple and concise,,,Deep Learning (Part 2) - Recurrent neural networks (RNN),Statistics and machine learning,2022-03,2022-03-31
-1795,3,a little bit challenging to ordinary first time user,do more videos,,Extracting Workflows from Histories,Using Galaxy and Managing your Data,2022-03,2022-03-31
-1796,5,,give pictures like other tutorial,,Quality Control,Sequence analysis,2022-03,2022-03-31
-1797,5,,,,Mapping,Sequence analysis,2022-03,2022-03-31
-1798,4,,,,CRISPR screen analysis,Genome Annotation,2022-03,2022-03-31
-1799,5,,pictures - screenshots can be added,,Chloroplast genome assembly,Assembly,2022-03,2022-03-31
-1800,5,,,,Antibiotic resistance detection,Metagenomics,2022-03,2022-03-31
-1801,5,great tutorial overall,,,Image classification in Galaxy with fruit 360 dataset,Statistics and machine learning,2022-03,2022-03-31
-1802,4,,"Maybe if you in ""Convert your analysis history into a workflow"" change the photo for how it should looks - where you write what, I was bit confused. This could be better for me.",,A short introduction to Galaxy,Introduction to Galaxy Analyses,2022-03,2022-03-31
-1803,2,not that much,reduce unnecessary details from the page ,,How to reproduce published Galaxy analyses,Introduction to Galaxy Analyses,2022-03,2022-03-31
-1804,5,,,,Genome annotation with Maker,Genome Annotation,2022-03,2022-03-31
-1805,5,Everything because all was new for me,The tutorial video would be more detailed in some parts.,,"Filter, Plot and Explore Single-cell RNA-seq Data",Single Cell,2022-03,2022-03-31
-1806,4,,"the sharing link is not working, so i couldnt share and create the group ",,Refining Genome Annotations with Apollo (prokaryotes),Genome Annotation,2022-03,2022-03-31
-1807,4,,,,Reference-based RNA-Seq data analysis,Transcriptomics,2022-03,2022-03-31
-1808,5,,,,Visualization of RNA-Seq results with Volcano Plot,Transcriptomics,2022-03,2022-03-31
-1809,5,,,,Quality Control,Sequence analysis,2022-03,2022-03-31
-1810,5,,,,Removal of human reads from SARS-CoV-2 sequencing data,Sequence analysis,2022-03,2022-03-31
-1811,5,the creation of plots and after the process of visualization and the try of understanding what I saw,i think nothing,,Bulk RNA Deconvolution with MuSiC,Single Cell,2022-03,2022-03-31
-1812,5,,,,Advanced Python,Foundations of Data Science,2022-03,2022-03-31
-1813,5,great overall,,,Deep Learning (Part 3) - Convolutional neural networks (CNN),Statistics and machine learning,2022-03,2022-03-31
-1814,5,,,,Plotting in Python,Foundations of Data Science,2022-03,2022-03-31
-1815,5,,,,Antibiotic resistance detection,Metagenomics,2022-04,2022-04-01
-1816,4,,,,16S Microbial Analysis with mothur (short),Metagenomics,2022-04,2022-04-01
-1817,4,detailing,make an upgrage to server and do a video if possible,,From peaks to genes,Introduction to Galaxy Analyses,2022-04,2022-04-01
-1818,4,it's was more clear and more relating than others,i think a pdf explaining some notes would be ok,,Galaxy 101,Introduction to Galaxy Analyses,2022-04,2022-04-01
-1819,5,,,,Reference-based RNA-Seq data analysis,Transcriptomics,2022-04,2022-04-01
-1820,5,,,,M. tuberculosis Variant Analysis,Variant Analysis,2022-04,2022-04-01
-1821,5,,,,1: RNA-Seq reads to counts,Transcriptomics,2022-04,2022-04-02
-1822,4,"A demo with a cripsr pool set who works (so many online pool screen CRIPSR tools do not work). so many command based installation do not work.  Simply starting with MAGECK installation on python is just a nightmare, it does not install smoothly, and it seems thatthe original authors move on and do not care at deploying this smoothly to the community(only expert can use these code lines). I really appreciate the work here. It seems more applicable from any machine without all the dependancies, environments, expertise in coding  and languages bug...... ",Should make mageck available in  global galaxy and not just australia one. Could provide other datasets such as cripsrI or cripsA pool set to extend the range of trial for users to get accustomed with the pipeline.  ,,CRISPR screen analysis,Genome Annotation,2022-04,2022-04-03
-1823,5,It was straigthforward and had animations to guide you.,I think it's missing some basics of Galaxy.,,A short introduction to Galaxy,Introduction to Galaxy Analyses,2022-04,2022-04-04
-1824,5,EVERYTHING,NOTHING,,Quality Control,Sequence analysis,2022-04,2022-04-04
-1825,5,,,,Galaxy 101 for everyone,Introduction to Galaxy Analyses,2022-04,2022-04-05
-1826,5,the fact that it gave definitions for things that could be unknown,not really much. maybe make similar tutorials but for larger jobs,,Introduction to Genomics and Galaxy,Introduction to Galaxy Analyses,2022-04,2022-04-06
-1827,5,clear directions. screen shots help,,,A short introduction to Galaxy,Introduction to Galaxy Analyses,2022-04,2022-04-07
-1828,5,"It's easy, indexing and saving history is great tool","Maybe, in this tutorial, using colors for different strand genes would be more easy to see in genome browser later",,Introduction to Genomics and Galaxy,Introduction to Galaxy Analyses,2022-04,2022-04-07
-1829,5,"The tutorial was instructive and easy to follow. As a WSL user, I really loved this session. I got to learn about Planemo. ",,,Automating Galaxy workflows using the command line,Using Galaxy and Managing your Data,2022-04,2022-04-07
-1830,5,Detailed and accurate.,I have no suggestions ,,A short introduction to Galaxy,Introduction to Galaxy Analyses,2022-04,2022-04-08
-1831,5,,,,Galaxy 101,Introduction to Galaxy Analyses,2022-04,2022-04-10
-1832,5,,,,A short introduction to Galaxy,Introduction to Galaxy Analyses,2022-04,2022-04-10
-1833,5,,,,3: RNA-seq genes to pathways,Transcriptomics,2022-04,2022-04-11
-1834,4,great explanation ,,,Reference-based RNA-Seq data analysis,Transcriptomics,2022-04,2022-04-11
-1835,5,Each step of the analysis is very well explained and I could use this tutorial to help student understand 16S microbiome analysis. ,"The trainsets need updating. I tried to do this myself but it did not work. Also, could you do a version for ITS analysis?",,16S Microbial Analysis with mothur (extended),Metagenomics,2022-04,2022-04-13
-1836,5,,,,Running molecular dynamics simulations using GROMACS,Computational chemistry,2022-04,2022-04-13
-1837,5,,,,High Throughput Molecular Dynamics and Analysis,Computational chemistry,2022-04,2022-04-13
-1838,5,,,,Ansible,Galaxy Server administration,2022-04,2022-04-14
-1839,5,,,,Understanding Barcodes,Single Cell,2022-04,2022-04-17
-1840,4,It was good and simple.,More indications on how to read the visualization with IGV and JBrowse. ,,Mapping,Sequence analysis,2022-04,2022-04-17
-1841,5,,,,Quality Control,Sequence analysis,2022-04,2022-04-18
-1842,5,,,,A short introduction to Galaxy,Introduction to Galaxy Analyses,2022-04,2022-04-18
-1843,5,,,,A short introduction to Galaxy,Introduction to Galaxy Analyses,2022-04,2022-04-20
-1844,5,,,,16S Microbial Analysis with mothur (short),Metagenomics,2022-04,2022-04-22
-1845,5,The tutorial is Practical and easy to understand,I think in will be usefull to include another ways to upload files,,A short introduction to Galaxy,Introduction to Galaxy Analyses,2022-04,2022-04-25
-1846,1,,,,De Bruijn Graph Assembly,Assembly,2022-04,2022-04-26
-1847,5,It is easy to follow up as you practice.,More examples to practice with.,,An Introduction to Genome Assembly,Assembly,2022-04,2022-04-26
-1848,4,,,,Genome Annotation,Genome Annotation,2022-04,2022-04-26
-1849,4,The tutorial is very comprehensive.,"The link for the Ensembl gene annotation for Drosophila melanogaster from Zenodo doesn't work. I think there are mistakes regarding the datasets and tools to be used in the ""Gene Ontology analysis"" section, more precisely in the ""Hands on: Get the gene length from previous history"" and ""Hands on: Adapt the gene length to goseq"" parts. ",,Reference-based RNA-Seq data analysis,Transcriptomics,2022-04,2022-04-26
-1850,5,"It was simple (great for the first aproach), really clear and usefull",,,A short introduction to Galaxy,Introduction to Galaxy Analyses,2022-04,2022-04-27
-1851,5,It was easy to follow but learn usefull things,,,Galaxy 101 for everyone,Introduction to Galaxy Analyses,2022-04,2022-04-27
-1852,4,,,,Deep Learning (Part 3) - Convolutional neural networks (CNN),Statistics and machine learning,2022-04,2022-04-28
-1853,5,,,,A short introduction to Galaxy,Introduction to Galaxy Analyses,2022-04,2022-04-28
-1854,5,,,,CRISPR screen analysis,Genome Annotation,2022-04,2022-04-28
-1855,5,The stages of preparing a workshop is very explicit on . Thanks.,The processes  are clear.and direct.,,Organizing a workshop,Teaching and Hosting Galaxy training,2022-04,2022-04-29
-1856,5,hands on,,,Galaxy 101 for everyone,Introduction to Galaxy Analyses,2022-04,2022-04-29
-1857,5,interactive,,,Introduction to Genomics and Galaxy,Introduction to Galaxy Analyses,2022-04,2022-04-29
-1858,5,easy explanations,,,A short introduction to Galaxy,Introduction to Galaxy Analyses,2022-04,2022-04-30
-1859,5,,,,From peaks to genes,Introduction to Galaxy Analyses,2022-05,2022-05-03
-1860,4,,,,A short introduction to Galaxy,Introduction to Galaxy Analyses,2022-05,2022-05-03
-1861,5,Its simplicity. It was easy to follow and didn't make me stressed.,,,Quality Control,Sequence analysis,2022-05,2022-05-04
-1862,5,,,,Reference-based RNA-Seq data analysis,Transcriptomics,2022-05,2022-05-06
-1863,1,topic is very important,"some steps are not cleared explained, workflow for this specific task and visualization tool is not working showing loading error",,From peaks to genes,Introduction to Galaxy Analyses,2022-05,2022-05-07
-1864,5,,,,A short introduction to Galaxy,Introduction to Galaxy Analyses,2022-05,2022-05-09
-1865,4,,,,Quality Control,Sequence analysis,2022-05,2022-05-10
-1866,4,Easy to understand,Pls provide dataset so that we can practice alongside,,Introduction to Machine Learning using R,Statistics and machine learning,2022-05,2022-05-11
-1867,1,,,,Proteogenomics 3: Novel peptide analysis,Proteomics,2022-05,2022-05-13
-1868,4,,,,How to reproduce published Galaxy analyses,Introduction to Galaxy Analyses,2022-05,2022-05-15
-1869,5,yes,,,Mapping,Sequence analysis,2022-05,2022-05-15
-1870,5,I like the clarity of the pictures used in describing the different steps,There is nothing needed to be improved. The tutorial is excellent,,A short introduction to Galaxy,Introduction to Galaxy Analyses,2022-05,2022-05-16
-1871,5,Simplicity of explaining complicate issue (-;,n.a.,,Analyses of metagenomics data - The global picture,Metagenomics,2022-05,2022-05-17
-1872,4,Easy to follow. Helpful examples. ,,,Galaxy 101,Introduction to Galaxy Analyses,2022-05,2022-05-18
-1873,5,The explanations,,,Visualization of RNA-Seq results with Volcano Plot,Transcriptomics,2022-05,2022-05-18
-1874,3,,,,Reference-based RNA-Seq data analysis,Transcriptomics,2022-05,2022-05-18
-1875,5,Platform is simple enough to follow and the steps are well-explained.,"When I run the tutorial with Windows as an OS everything ran smoothly, but when I was on Ubuntu linux I had issues with the window that I had to load the dataset. The options for pasting the data, etc. were not visible at all and I could not do anything for it. ",,A short introduction to Galaxy,Introduction to Galaxy Analyses,2022-05,2022-05-21
-1876,5,,,,Reference-based RNA-Seq data analysis,Transcriptomics,2022-05,2022-05-22
-1877,5,proper description and arrangement.,Results,,Genome Annotation,Genome Annotation,2022-05,2022-05-23
-1878,5,the details,,,A short introduction to Galaxy,Introduction to Galaxy Analyses,2022-05,2022-05-24
-1879,5,,,,Galaxy 101,Introduction to Galaxy Analyses,2022-05,2022-05-25
-1880,5,It explained everything in simple language!!,,,Introduction to Genomics and Galaxy,Introduction to Galaxy Analyses,2022-05,2022-05-25
-1881,4,,,,Mass spectrometry imaging: Examining the spatial distribution of analytes,Metabolomics,2022-05,2022-05-25
-1882,5,,,,A short introduction to Galaxy,Introduction to Galaxy Analyses,2022-05,2022-05-27
-1883,5,hashtags!,,,Understanding Galaxy history system,Using Galaxy and Managing your Data,2022-05,2022-05-28
-1884,5,,,,Pangeo Notebook in Galaxy - Introduction to Xarray,Climate,2022-05,2022-05-29
-1885,4,Good balance between some slightly more 'in depth topics' and simple and to the point hand-on instructions.,"The 'Available on these Galaxies' information should be updates. For exmple, the tutorial can not be completed as it is in the Australian server (for example, there are not locally installed snpEff databases, so a previous step with snpEff Download is needed and then use the option 'Downloaded snpEff database in your history'. Can be done but is confusing specially for novices). On the other hand, as far as I know, it can be conducted exactly as it is in the European server, but that one is not listed in the 'Available on these Galaxies' drop down menu.",,Calling variants in diploid systems,Variant Analysis,2022-05,2022-05-30
-1886,5,"I liked the real world data set, and the real world steps of exploration followed by the analysis. I thought the step wise progression made a lot of sense to me. I like having both predicting a categorical variable and the linear regression. It was great having both as many tutorials concentrate on predicting dichotomous outcomes and skip linear. I also like the exposure to handy R libraries, I am aware of quite a few (this isn't my first rodeo) but I learned of some more from this tutorial which was great.","Perhaps be explicit about the goals for the data analysis of the breast cancer dataset, that way the reader gets emotionally engaged in the analysis. I didn't realise till after looking at the source link that the measurements were from fine-needle biopsies of breast lesions, and the measurements were of cell nucleus radius, (I thought originally it might have been referring to tumour radius in mm). And that the goals were from the cell data from the fine needle aspiration we need to predict whether the patient has breast cancer or not. I appreciate you don't want the tutorial to be too long but perhaps using the cross table to show the positive predictive value or sensitivity and specificity and how increasing the number of clusters could improve the diagnostic accuracy.",,Introduction to Machine Learning using R,Statistics and machine learning,2022-06,2022-06-02
-1887,5,Well organized. Appreciated how the authors explained each QC graph. ,,,Quality Control,Sequence analysis,2022-06,2022-06-07
-1888,4,,,,Masking repeats with RepeatMasker,Genome Annotation,2022-06,2022-06-07
-1889,5,The questions that helped you look for the most relevant information in each Galaxy output in the history really made the tutorial engaging.,,,Library Generation for DIA Analysis,Proteomics,2022-06,2022-06-07
-1890,3,The interactive tools perspective,"The requirement for wildcard SSL certificate and the poor support for fulfilling this requirement. This is a major issue for the deployment of Galaxy servers. From a historical perspective, before 2019, there were IEs. Not super easy to deploy, but doable with motivation and investment in Docker knowledge. After launching the new ITs, IEs became progressively useless and ITs stay either nice demos or running on very few big public servers. Even the latter is not so clear: for instance, usegalaxy.org.au is not really providing ITs, usegalaxy.org (!) seems providing it at first glance, but the Rstudio interface - for instance - remains full blank forever. Only usegalaxy.eu to my knowledge provides effectively running and usable generalist ITs (Rstudio, Jupyter,). Thus, on that matter, where is the initial slogan ""data intensive analysis for everyone"" ? Of course, I am not blaming the trainers and contributors to this tutorial in any way ! But I really think that the technical strategy relying on wildcard SSL certificate to get the ITs running should be discussed with the community as a serious limitation to their use and thereby their active development. As it stands since 3 years now, ITs are out of the possibilities of a majority of Galaxy server instances because too complicated to install.",,Galaxy Interactive Tools,Galaxy Server administration,2022-06,2022-06-08
-1891,4,straightforward,"would have liked to have some practice viewing the assembly graphs and with visual methods for comparing genomes (e.g. dot, synteny plots)",,Genome assembly using PacBio data,Assembly,2022-06,2022-06-08
-1892,5,The explanation of every step which provide understanding even to beginners.,The different methods used in different steps of simulation should be explain in a such a way that the person can understand which method he should apply to his experiment.,,Running molecular dynamics simulations using GROMACS,Computational chemistry,2022-06,2022-06-08
-1893,5,,,,Galaxy 101,Introduction to Galaxy Analyses,2022-06,2022-06-08
-1894,1,nothing,everything,,DNA Methylation data analysis,Epigenetics,2022-06,2022-06-09
-1895,5,,,,Visualization of RNA-Seq results with Volcano Plot,Transcriptomics,2022-06,2022-06-10
-1896,4,it was clear ,maybe you could explain the file formats and what the tools do in a more clean way ,,Formation of the Super-Structures on the Inactive X,Epigenetics,2022-06,2022-06-13
-1897,5,,,,A short introduction to Galaxy,Introduction to Galaxy Analyses,2022-06,2022-06-15
-1898,5,,,,Formation of the Super-Structures on the Inactive X,Epigenetics,2022-06,2022-06-15
-1899,5,"Nice and understandable! I'm a software engineer tasked with setting up and administrating a Galaxy server, so I don't have a bioinformatics background. However, I was able to understand this tutorial and now know why Galaxy is such a powerful tool!",,,Galaxy 101 for everyone,Introduction to Galaxy Analyses,2022-06,2022-06-15
-1900,5,Ease of use,,,Galaxy 101 for everyone,Introduction to Galaxy Analyses,2022-06,2022-06-17
-1901,1,,it can be more better how do you get the end result was not clearly explained,,NGS data logistics,Introduction to Galaxy Analyses,2022-06,2022-06-18
-1902,5,,,,Introduction to Genomics and Galaxy,Introduction to Galaxy Analyses,2022-06,2022-06-20
-1903,3,,,,Quality Control,Sequence analysis,2022-06,2022-06-20
-1904,5,Well-detailed ,Alphadiversity,,16S Microbial Analysis with mothur (extended),Metagenomics,2022-06,2022-06-24
-1905,5,The clarity and flow of topics guidelines,so far so good,,16S Microbial Analysis with mothur (extended),Metagenomics,2022-06,2022-06-24
-1906,5,easy to follow & explained well,,,Quality Control,Sequence analysis,2022-06,2022-06-28
-1907,1,tree -l 2 was helpful as otherwise unclear which file goes where,"Current version of the tutorial is broken, consider rolling back to archive. Ansible errors very hard to troubleshoot - ideally add more tips where things can go wrong, for ex ansible vault seems to enter an unfixable state if you mess up the secret yml file and have to make it again",,Galaxy Installation with Ansible,Galaxy Server administration,2022-06,2022-06-29
-1908,5,,,,A short introduction to Galaxy,Introduction to Galaxy Analyses,2022-06,2022-06-29
-1909,5,"Very detailed, self explanatory",More examples maybe good,,Quality Control,Sequence analysis,2022-06,2022-06-29
-1910,5,learning how to use a workflow on a different dataset,,,Galaxy 101 for everyone,Introduction to Galaxy Analyses,2022-06,2022-06-30
-1911,1,most of the functionsare different what is given here,"please insert screen shorts of the results, how the output look like ",,An Introduction to Genome Assembly,Assembly,2022-06,2022-06-30
-1912,4,The way of presentation to make the tutorial easily understandable.,More numerical examples could be added.,,Deep Learning (Part 2) - Recurrent neural networks (RNN),Statistics and machine learning,2022-07,2022-07-01
-1913,4,The clear instructions on how to use the tools ,allowing learners to supply the solution and evaluating the answers,,M. tuberculosis Variant Analysis,Variant Analysis,2022-07,2022-07-02
-1914,2,It is a useful feature.,"The syntax of the ""Replace text"" tool is not explained. Thus, it is only useful with the data collection of the tutorial, but it does not teach how to aply it to other collections with different element identifiers. It would be great if it explained why the ""Find pattern"" and ""Replace with"" boxes are filled that way.",,Group tags for complex experimental designs,Using Galaxy and Managing your Data,2022-07,2022-07-05
-1915,4,This hands on tutorial made me understands some of the concepts raised in the webnar,"A note on the estimated run time of the on the provided data, this will help to know if i have done something wrong.",,Identifying tuberculosis transmission links: from SNPs to transmission clusters,Evolution,2022-07,2022-07-05
-1916,5,Clear example of a great use case,What to do if pulling from an FTP server that requires credentials,,Rule Based Uploader,Using Galaxy and Managing your Data,2022-07,2022-07-08
-1917,5,Thorough guide with plenty of time for users to try. ,"To me it's simple enough to follow all the instructions, no improvement needed.",,A short introduction to Galaxy,Introduction to Galaxy Analyses,2022-07,2022-07-09
-1918,1,more detailed form example was not explained clearly,,,IGV Introduction,Introduction to Galaxy Analyses,2022-07,2022-07-09
-1919,4,it was information packed and tried to explain in details. ,"well , idk if i'm dumb but i couldn't find the gear icon to start the ctul tutorial. maybe the boxes in the instruction could be direct links instead?",,Quality Control,Sequence analysis,2022-07,2022-07-11
-1920,5,,,,A short introduction to Galaxy,Introduction to Galaxy Analyses,2022-07,2022-07-12
-1921,5,Easy to follow steps ,,,A short introduction to Galaxy,Introduction to Galaxy Analyses,2022-07,2022-07-14
-1922,5,,,,Galaxy 101,Introduction to Galaxy Analyses,2022-07,2022-07-19
-1923,4,The step by step guide and easy to operate,I facet some trouble with Database/Build section and I would like to info about them even it was not necessary for the analyse.,,Label-free data analysis using MaxQuant,Proteomics,2022-07,2022-07-19
-1924,5,It was easy to follow and very useful ,,,Reference-based RNA-Seq data analysis,Transcriptomics,2022-07,2022-07-19
-1925,5,clarity of each step,a short video can easy to complete this workflow and help peopless to learn it in much less time,,A short introduction to Galaxy,Introduction to Galaxy Analyses,2022-07,2022-07-20
-1926,5,,,,A short introduction to Galaxy,Introduction to Galaxy Analyses,2022-07,2022-07-20
-1927,5,,,,Clustering 3K PBMCs with Scanpy,Single Cell,2022-07,2022-07-21
-1928,4,,,,Peptide Library Data Analysis,Proteomics,2022-07,2022-07-24
-1929,5,,,,Machine Learning Modeling of Anticancer Peptides,Proteomics,2022-07,2022-07-24
-1930,5,,,,Microbial Variant Calling,Variant Analysis,2022-07,2022-07-26
-1931,5,the interaction of images and descriptions, more images of the interface step y step,,Galaxy 101 for everyone,Introduction to Galaxy Analyses,2022-07,2022-07-27
-1932,5,"relatively easy to follow, concept explanations are great ",,,Galaxy Installation with Ansible,Galaxy Server administration,2022-07,2022-07-28
-1933,5,,,,Visualization of RNA-Seq results with heatmap2,Transcriptomics,2022-07,2022-07-30
-1934,3,Great overview of ML and the basic models to start.,Many questions still lack solutions and there are some typos within the text.,,Introduction to Machine Learning using R,Statistics and machine learning,2022-08,2022-08-04
-1935,5,"I loved the fact that although this is not in-person, it was more interactive and practical. ",,,A short introduction to Galaxy,Introduction to Galaxy Analyses,2022-08,2022-08-04
-1936,5,Everything,Not much at all,,A short introduction to Galaxy,Introduction to Galaxy Analyses,2022-08,2022-08-04
-1937,5,It was explained in really easy to understand language for a novice like me with great diagrams. I've looked at a number of explanations about alpha and beta diversity and this was the most useful so far.,,,16S Microbial Analysis with mothur (extended),Metagenomics,2022-08,2022-08-04
-1938,3,List  elements identified during the process of genome annotation.,,,Genome Annotation,Genome Annotation,2022-08,2022-08-05
-1939,4,,,,A short introduction to Galaxy,Introduction to Galaxy Analyses,2022-08,2022-08-09
-1940,5,Things are explained in a simple and intuitive way,,,Quality Control,Sequence analysis,2022-08,2022-08-11
-1941,5,,,,16S Microbial analysis with Nanopore data,Metagenomics,2022-08,2022-08-12
-1942,1,,merge gromacs topologies doesn't exist in https://cheminformatics.usegalaxy.eu It was not possible to complete the tutorial without this tool,,High Throughput Molecular Dynamics and Analysis,Computational chemistry,2022-08,2022-08-14
-1943,5,,,,Quality Control,Sequence analysis,2022-08,2022-08-15
-1944,1,,,,Virtual screening of the SARS-CoV-2 main protease with rxDock and pose scoring,Computational chemistry,2022-08,2022-08-18
-1945,5,,Small typo at https://bit.ly/3dG17Er - tedious,,Reference-based RNA-Seq data analysis,Transcriptomics,2022-08,2022-08-18
-1946,5,,,,Reference-based RNA-Seq data analysis,Transcriptomics,2022-08,2022-08-18
-1947,5,The flow and easeness of usage and details.,,,Biomarker candidate identification,Proteomics,2022-08,2022-08-22
-1948,5,,,,Understanding Barcodes,Single Cell,2022-08,2022-08-22
-1949,5,everything.. thanks for this,"i cant find bowtie tools.. only bowtie 2, but the parameters described here are for bowtie.",,Essential genes detection with Transposon insertion sequencing,Genome Annotation,2022-08,2022-08-23
-1950,5,,,,Visualization of RNA-Seq results with heatmap2,Transcriptomics,2022-08,2022-08-23
-1951,4,,,,Mass spectrometry imaging: Loading and exploring MSI data,Proteomics,2022-08,2022-08-24
-1952,4,"Most of the explanations and step were explained well but many icons in Galaxy have changed .  An update will be appreciated.  If USC browser is the main source , please have a detailed tutorial what all that stuff means .  Thanks",,,Introduction to Genomics and Galaxy,Introduction to Galaxy Analyses,2022-08,2022-08-25
-1953,4,,,,A short introduction to Galaxy,Introduction to Galaxy Analyses,2022-08,2022-08-30
-1954,5,Biological explanations after a command. ,"I think its great, but one improviment is add more image from Galaxy. ",,Introduction to Genomics and Galaxy,Introduction to Galaxy Analyses,2022-08,2022-08-30
-1955,5,The instructions were clear and helpful (especially with the video alongside),"It would be super helpful if there were more subsection links! I set followed this tutorial to setup a server for my team, and when they had questions or wanted more info on why or how I did certain things it would have been nice to be able to link them more specifically to the step I wanted instead of the bigger section and then giving them key words to search for",,Galaxy Installation with Ansible,Galaxy Server administration,2022-08,2022-08-30
-1956,5,,,,Visualization of RNA-Seq results with heatmap2,Transcriptomics,2022-09,2022-09-01
-1957,4,"Learn about other tools to asses quality, it is often on software that we use, the one that is showed by the person that initiates us to galaxy. Here, we could see a panel of tools. ","I think maybe it is more pertinent to show one example of good and one of a bad data instead of a panel that increase the information a blur the message. Two images are easier to remember. I'd like that you showed us a panel of tools, but it is maybe too much information, too quickly within a short amount of time. Knowing that we have almost two weeks formations non stop, it could be valuable to synthesis more the message to slow down and make it more digestible. The specifics could be prospected by each user when they contact you. A fact that you could also remember people at the end of the presentation. ",,Quality Control,Sequence analysis,2022-09,2022-09-01
-1958,4,To test the tools of assembly in a control dataset,I think it could be valable to understand the tools and the parameters of the tools while using them: to not do it without thinking it through. I think it is better to understand to remember. ,,Genome assembly using PacBio data,Assembly,2022-09,2022-09-01
-1959,5,I really liked the amount of details,"Its perfect to me, but if you could add short videos in each topic, it can be complementary. ",,Quality Control,Sequence analysis,2022-09,2022-09-05
-1960,4,,,,A short introduction to Galaxy,Introduction to Galaxy Analyses,2022-09,2022-09-06
-1961,5,"Simple, clear",,,A short introduction to Galaxy,Introduction to Galaxy Analyses,2022-09,2022-09-12
-1962,5,It was doable by a wet lab scientist without prior experience in analysis!,,,A short introduction to Galaxy,Introduction to Galaxy Analyses,2022-09,2022-09-12
-1963,5,Easy to follow,"Couple of things out of date: view all histories is now in the menu and ""Click on galaxy-gear (History options) at the top of your history panel and select Extract workflow."" no longer a galaxy-gear icon but a drop down?",,A short introduction to Galaxy,Introduction to Galaxy Analyses,2022-09,2022-09-12
-1964,5,Simple and clear,,,Name tags for following complex histories,Using Galaxy and Managing your Data,2022-09,2022-09-12
-1965,5,Didn't know this feature!,tag=paired is incorrect - should be tag:paired ???,,Name tags for following complex histories,Using Galaxy and Managing your Data,2022-09,2022-09-12
-1966,5,,,,Extracting Workflows from Histories,Using Galaxy and Managing your Data,2022-09,2022-09-12
-1967,4,,,,Name tags for following complex histories,Using Galaxy and Managing your Data,2022-09,2022-09-12
-1968,5,,,,16S Microbial Analysis with mothur (extended),Metagenomics,2022-09,2022-09-14
-1969,5,,,,Quality Control,Sequence analysis,2022-09,2022-09-14
-1970,2,its step by step,"steps are not explained - for example: why do i need align left, why do i need to refilter quality levels...? Way to hard to understand. More Explanation why things are done a certain way. Its not explained why certain values are set and how to choose the right values. This tutorial is way to complicated.",,Identification of somatic and germline variants from tumor and normal sample pairs,Variant Analysis,2022-09,2022-09-14
-1971,5,"Clear, straight forward, but also information rich.",,,"Filter, Plot and Explore Single-cell RNA-seq Data",Single Cell,2022-09,2022-09-15
-1972,5,,,,"Filter, Plot and Explore Single-cell RNA-seq Data",Single Cell,2022-09,2022-09-15
-1973,5,"Easy to follow, encouraging to continue exploring","First time I run the QC analysis it took more than 1 hour, it would be great to have a time tracker so we can estimate the duration of each analysis (Second time I did the analysis it run in about 2 min)",,A short introduction to Galaxy,Introduction to Galaxy Analyses,2022-09,2022-09-15
-1974,5,,,,Inferring Trajectories using Python (Jupyter Notebook) in Galaxy,Single Cell,2022-09,2022-09-16
-1975,5,,,,Galaxy 101,Introduction to Galaxy Analyses,2022-09,2022-09-19
-1976,5,,,,Species distribution modeling,Ecology,2022-09,2022-09-21
-1977,5,,,,Quality Control,Sequence analysis,2022-09,2022-09-21
-1978,4,Data made small enough to process it together in class,"Could you please correct the following typos: ""Differentially expressed miRNAs"" into ""Differentially expressed mRNAs"" in the section ""mRNA data analysis > Filter.. Thanks!",,Whole transcriptome analysis of Arabidopsis thaliana,Transcriptomics,2022-09,2022-09-24
-1979,4,"I appreciated the descriptions and the format of it, like bullet points, etc.","I think more pictures would be valueable since it is a bit hard to navigate at first, especially during the 'workflow' i got a bit confused",,A short introduction to Galaxy,Introduction to Galaxy Analyses,2022-09,2022-09-25
-1980,5,"very comprehensive, needed for the data that doesn’t have annotation file (GTF)",please make a video with it. and a real data using in this tutorial from ncbi or else.,,"De novo transcriptome assembly, annotation, and differential expression analysis",Transcriptomics,2022-09,2022-09-25
-1981,5,,,,1: RNA-Seq reads to counts,Transcriptomics,2022-09,2022-09-26
-1982,5,"I really liked, that I could actually try it out.",,,A short introduction to Galaxy,Introduction to Galaxy Analyses,2022-09,2022-09-28
-1983,5,,,,A short introduction to Galaxy,Introduction to Galaxy Analyses,2022-10,2022-10-01
-1984,5,,,,16S Microbial analysis with Nanopore data,Metagenomics,2022-10,2022-10-07
-1985,5,,,,Visualization of RNA-Seq results with heatmap2,Transcriptomics,2022-10,2022-10-07
-1986,5,,,,A short introduction to Galaxy,Introduction to Galaxy Analyses,2022-10,2022-10-11
-1987,4,,"The wheel symbol in the history menu has changed to an arrow down. Also, the way to see the histories side by side has changed.",,A short introduction to Galaxy,Introduction to Galaxy Analyses,2022-10,2022-10-11
-1988,3,What I liked most about this tutorial was the existence of explanations that helped in the interpretation of the various outputs produced by the software.,"The tutorial could be updated because I found that there are discrepancies between the tutorial and the Galaxy platform. Namely, the name of some of the tools and their location on the website differ between the tutorial and the current platform.",,Genome annotation with Maker (short),Genome Annotation,2022-10,2022-10-11
-1989,5,"simple and easy to follow, although some of the icons have changed in the updated version",Just updated screen shots,,A short introduction to Galaxy,Introduction to Galaxy Analyses,2022-10,2022-10-12
-1990,5,,que explicara mas a fondo el uso de las demas herramientas con ejercicios,,A short introduction to Galaxy,Introduction to Galaxy Analyses,2022-10,2022-10-14
-1991,5,,,,1: RNA-Seq reads to counts,Transcriptomics,2022-10,2022-10-14
-1992,5,,,,A short introduction to Galaxy,Introduction to Galaxy Analyses,2022-10,2022-10-15
-1993,5,,,,Breve introducción a Galaxy - en español,Introduction to Galaxy Analyses,2022-10,2022-10-19
-1994,5,Ease of steps and explanation of file formats,More explanation of the potential pitfalls and essential QC,,Visualization of RNA-Seq results with Volcano Plot,Transcriptomics,2022-10,2022-10-21
-1995,5,"The simplicity and the start level, you can start in a very basic level.","There is sth you have toke take in mind, when you copy the dataset a space is coppied at the beggining of the link. With this space the dataset is not ridden. ",,Breve introducción a Galaxy - en español,Introduction to Galaxy Analyses,2022-10,2022-10-23
-1996,5,The tutorial is simple and easy to understand. The instructions are clear and the images help the student to know what to do. ,One thing that could be improved is the location of some filters due to is a little bit confusing. ,,A short introduction to Galaxy,Introduction to Galaxy Analyses,2022-10,2022-10-24
-1997,5,,,,2: RNA-seq counts to genes,Transcriptomics,2022-10,2022-10-24
-1998,5,images make it easy to undestand,maybe you could add videos to help undestand the steps ,,A short introduction to Galaxy,Introduction to Galaxy Analyses,2022-10,2022-10-25
-1999,5,The complete explanation,,,A short introduction to Galaxy,Introduction to Galaxy Analyses,2022-10,2022-10-25
-2000,4,It was easy to follow the steps and the functions ran in a good amount of time (relatively fast) ,"- I got stuck in staramr. there was a recurrent error due to ERROR: 'Predicted Phenotype'. This error was reported. it appears to be due to a problem of compatibility with the pandas version (https://github.com/phac-nml/staramr/issues/115) - Genome annotation using Prokka, step 2 (Select lines that match an expression) has changed names to Search in Textfiles (grep)  - Table to GFF3 function: I was unable to find this function under the Galaxy tools. downstream commands could not be ran.",,Genome Assembly of MRSA using Oxford Nanopore MinION Data,Assembly,2022-10,2022-10-25
-2001,4,,"Table to gff3 tool does not exist anymore. When I use the tutorial mode on galaxy and click on the table to gff3 hyperlink button, i get this message: Loading tool toolshed.g2.bx.psu.edu/repos/iuc/tbl2gff3/tbl2gff3/1.2 failed: Could not find tool with id 'toolshed.g2.bx.psu.edu/repos/iuc/tbl2gff3/tbl2gff3/1.2'.  Do you have any advice on which other tool to use?  Also, in a prior feedback I mentioned that I could not find select the lines, but it is actually there I found it in the end. sorry for the mistake.",,Genome Assembly of MRSA using Oxford Nanopore MinION Data,Assembly,2022-10,2022-10-25
-2002,5,La manera que explica,Me parece que estuvo bien ,,A short introduction to Galaxy,Introduction to Galaxy Analyses,2022-10,2022-10-25
-2003,5,everything,nothing,,A short introduction to Galaxy,Introduction to Galaxy Analyses,2022-10,2022-10-25
-2004,5,,,,A short introduction to Galaxy,Introduction to Galaxy Analyses,2022-10,2022-10-26
-2005,5,method present and images,,,Running molecular dynamics simulations using GROMACS,Computational chemistry,2022-10,2022-10-31
-2006,4,"The video walkthrough of how to use tools was good. Breakdown of sections with a Table of Contents to jump around was good. I like that extra detail was included, but it's so far above my head I didn't understand those at all. Thanks for the wonderful visuals, it really helps explain the relevance of each section. The beginning of the webpage and the tutorial video was actually very clear and easy to understand, it gets a bit more convoluted about halfway through and really by the end before the Nanoplot stuff (video ends before that).","I would have preferred if additional visual aids were used instead of just a plain screen grab. Some of the text was hard to read even on a large TV screen. Highlighting or circling or arrows, anything would help to focus the viewer's attention towards the relevant topic area. Some written aids which could be directly taken from the written webpage might be handy to sync up reading the webpage and following along with the tutorial would be nice for newbie readers who don't actually understand what's going on. An example would be just titling the section with big obvious words that match the webpage's Table of Content. And useful on screen aids like showing the buttons for pressing and holding Control OR Command with the symbols would be helpful for those following along. That's not a thing that can be demonstrated on the screen itself and can easily be overlooked as it's only mentioned for a few seconds. Then the important changes from FASTQC to MULTIQC where you must change the file input from a single file to multiple files, that right there would benefit from circling or highlighting or drawing a box around that button, maybe zooming in too. It doesn't need to be fancy Hollywood graphics here. The same video can still be used but for those few seconds that he's saying what button to press, you could use a screenshot, recorded in Powerpoint in Presentation mode with nice transitions, use the Zoom effect for each area like typing into the Upload Data section, draw a box around that button, then the Zoom back out transition to the MULTIQC options, draw a box on the button for multiple file uploads, Zoom in or out, up to you there, then return to the original video footage. I know it's simplistic, but it helps alot for new users instead of overwhelming them with a 3 panel screen with a billion options.   It would be nice if this page could easily have a printout to save as PDF and have an option for all the solution and detail boxes to either by opened or closed (useful for writing notes and testing myself before seeing the answers. It would also be nice to have details be a separate option from solutions).    I think the presenter needs to name his files better. By the end of this, he was just referring to them as ""the FASTQC file from step 17"", by this point, as a newbie, I've screwed up so much, my order doesn't match his at all, I've deleted some steps, and re-run them, and the order continues incrementing, so nothing matches his and I have no idea if I'm selecting the right files or not.   This video was really long. And I see sections that aren't included in the original for the Nanopore and long read stuff. Perhaps this would benefit from splitting the video into multiple different videos? Or adding chapters to the current one at least? Chapters corresponding to the Table of Contents names of course. This way it would improve your Youtube video's SEO and usability for users who are probably having multiple sessions watching this spread out over hours anyway. Although I think the better approach for easy future re-recording would be to split it into smaller video sections based on each Table of Contents entry. I don't see why the videos can't be directly embedded on this Training Galaxy page either, right at the top of each titled section.   I think there are too many assumptions that people should know why something should be good or bad or high or low. Even as someone with a Biology background, I haven't delved deeply into sequencing reads before and don't know how to interpret this. It would be helpful to add something like what Phoronix does for benchmarking charts with a directional arrow indicating which way is better: https://www.phoronix.com/review/amd-ryzen7-6850u/8 and I suppose it could be added as video tutorial visuals or as just a labelled screenshot.   My Nanoplot attempt had an error. It would be nice if you had a built-in automated bug reporting button, either in Galaxy, or in your tutorial or just the link or wherever. Just put it somewhere and make it 100% automated so that the user doesn't need to try to figure it out. Make it somehow able to click at the step of the tutorial or report the link as broken or the results as broken. I don't get an HTML page, and I don't know why. It's a bunch of HTML code so I can tell it SHOULD BE an HTML page and the History says so, but trying to download it to read and trying to open it in Galaxy doesn't work.   On a related note, some of the buttons have changed, I think even the datasets have changed and don't match what the tutorial video shows. It would be nice if you had an updated one that matched. ",,Quality Control,Sequence analysis,2022-10,2022-10-31
-2007,5,Hands in,Videos might help us more,,Analyses of metagenomics data - The global picture,Metagenomics,2022-11,2022-11-02
-2008,3,This tutorial gives a comprehensive overview about all analysis steps and important parameters involved.,"Where is the actual hands-on command code, which is generated after all parameter boxes have been checked, and the 'submit button' is clicked? Where are the actual tool commands for each step, a user would need to perform these analysis steps on the command line? I know these can be displayed in Galaxy, but it would be helpful to show them in the tutorials as well. ",,Exome sequencing data analysis for diagnosing a genetic disease,Variant Analysis,2022-11,2022-11-02
-2009,2,,"The instructions may not be up to date. I tried following them but what was described did not appear when I tried to follow. For example, there is no jupyter icon that comes up under visualizations. ",,Use Jupyter notebooks in Galaxy,Using Galaxy and Managing your Data,2022-11,2022-11-04
-2010,4,the flow of presentation,,,Galaxy 101 for everyone,Introduction to Galaxy Analyses,2022-11,2022-11-04
-2011,4,,,,M. tuberculosis Variant Analysis,Variant Analysis,2022-11,2022-11-04
-2012,5,,,,A short introduction to Galaxy,Introduction to Galaxy Analyses,2022-11,2022-11-05
-2013,5,"Hands on data analysis, problem solving",maybe notification of different tools with similar names? but really I guess it was fun problem solving,,3: RNA-seq genes to pathways,Transcriptomics,2022-11,2022-11-07
-2014,4,Flow of information,Add videos and demonstrations,,R basics in Galaxy,Foundations of Data Science,2022-11,2022-11-09
-2015,5,Very comprehensive and detailed,This is already so awesome but If possible could you please add along with this tutorial the pipeline/command line that could be run on MacOS terminal? We would be very appreciate that. Many Thanks!!!,,Reference-based RNA-Seq data analysis,Transcriptomics,2022-11,2022-11-09
-2016,5,Detailed explanations/tips/examples.,,,Breve introducción a Galaxy - en español,Introduction to Galaxy Analyses,2022-11,2022-11-12
-2017,3,,,,Somatic Variant Discovery from WES Data Using Control-FREEC,Variant Analysis,2022-11,2022-11-15
-2018,5,,,,NGS data logistics,Introduction to Galaxy Analyses,2022-11,2022-11-15
-2019,4,detailed explanation of variant calling and genotype calling,,,Exome sequencing data analysis for diagnosing a genetic disease,Variant Analysis,2022-11,2022-11-16
-2020,5,Easy to follow for the most part. ,Needs to be updated to the current galaxy settings. ,,A short introduction to Galaxy,Introduction to Galaxy Analyses,2022-11,2022-11-17
-2021,5,,add the code of volcano plot,,Visualization of RNA-Seq results with Volcano Plot,Transcriptomics,2022-11,2022-11-18
-2022,5,,,,Introduction to Genomics and Galaxy,Introduction to Galaxy Analyses,2022-11,2022-11-19
-2023,3,"Everything, except the Velvet choice.","Use another software besides Velvet, since it's deprecated and it's not working.",,An Introduction to Genome Assembly,Assembly,2022-11,2022-11-20
-2024,5,The fact that from nothing i can do RNA sequencing from start to bottom,Maybe tutorials with other tools from galaxy ,,3: RNA-seq genes to pathways,Transcriptomics,2022-11,2022-11-20
-2025,4,,,,A short introduction to Galaxy,Introduction to Galaxy Analyses,2022-11,2022-11-21
-2026,5,,,,Mapping,Sequence analysis,2022-11,2022-11-21
-2027,5,,,,NGS data logistics,Introduction to Galaxy Analyses,2022-11,2022-11-22
-2028,5,"Short and precise, not more or less than what the title promises","One setting in the JBrowse step isn't congruent with the most recent Prokka version anymore: can't configure ""Produce Standalone Instance”: ""Yes"" maybe you can update this :)",,Genome annotation with Prokka,Genome Annotation,2022-11,2022-11-24
-2029,4,,,,Avian influenza viral strain analysis from gene segment sequencing data,Variant Analysis,2022-11,2022-11-25
-2030,3,,,,Generating theoretical possible pathways for the production of Lycopene in E.Coli using Retrosynthesis tools,Synthetic Biology,2022-11,2022-11-26
-2031,5,all of this tutorial,"nothing, everything is so cool",,Galaxy 101,Introduction to Galaxy Analyses,2022-11,2022-11-29
-2032,4,"step by step, screenshots, global structure of the training content, indications when things seem to get wrong when in fact it is not, good job!","Difficult to know what to do when GitPod sends back an error after the ""make serve-gitpod"" command instead of serving a preview of GTN. I can guess it is a GitPod problem and not a GTN tutorial problem, still I feel helpless not knowing what to do to solve this problem. ",,Running the GTN website online using GitPod,Contributing to the Galaxy Training Material,2022-11,2022-11-29
-2033,4,"The tutorial is broken up into sections, and it's in a step-by-step format.","Some of the tools, like the ""compare two datasets"" tool, were hard to find even with the search bar. Some of the tutorials need an update because the instructions are unclear, or the method of doing something has changed.",,Galaxy 101,Introduction to Galaxy Analyses,2022-11,2022-11-30
-2034,4,,For the areas where they mention that other analysis options or functions are available please link to other website containing information about those options,,ATAC-Seq data analysis,Epigenetics,2022-11,2022-11-30
-2035,5,Clear and straightforward instructions,Clear the potential trouble implementation of the own researcher data,,Pre-processing of 10X Single-Cell RNA Datasets,Single Cell,2022-12,2022-12-02
-2036,5,The tips and answers were very useful,,,A short introduction to Galaxy,Introduction to Galaxy Analyses,2022-12,2022-12-02
-2037,4,UMI was described in detail and examples were great.,One example with 4 reads were given. What happens to the R2 file when one of the reads is indeed a duplicate? Would there be only 4 reads instead? It would be nice if there are a couple of more examples like that. ,,Understanding Barcodes,Single Cell,2022-12,2022-12-06
-2038,5,dat het easy was,geen idee,,A short introduction to Galaxy,Introduction to Galaxy Analyses,2022-12,2022-12-07
-2039,4,dat alles vrij duidelijk was,waar je de workflow kan vinden,,A short introduction to Galaxy,Introduction to Galaxy Analyses,2022-12,2022-12-08
-2040,3,generally excellent,the file used is different from the tutorial,,Advanced R in Galaxy,Foundations of Data Science,2022-12,2022-12-15
-2041,2,,Hard to follow steps as a new user,,Reference-based RNA-Seq data analysis,Transcriptomics,2022-12,2022-12-18
-2042,5,I could follow step by step the directions,I was stacked in the velveth assembly cos I was in the wrong version of the program. Maybe is necessary to add this to the tutorial.,,An Introduction to Genome Assembly,Assembly,2022-12,2022-12-18
-2043,5,Detailed step by step analysis,"the second part of the video, the speaker's voice was a liltte bit softer !",,Reference-based RNA-Seq data analysis,Transcriptomics,2022-12,2022-12-19
-2044,5,Everything was well-annotated. Thank you so much!,I want to see ''How to DESeq2 Results File (DEG List) with Tabular format open in Excel?''.  ,,2: RNA-seq counts to genes,Transcriptomics,2022-12,2022-12-30
-2045,5,I like the detailed instructions of this tool.,When I tred to follow the steps of hicBuildMatrix and ran it on usegalaxy. It showed that I need to provide BED file with all restriction cut places. Could you tell me how to choose to use the bin size or where I can find the BED file?,,Hi-C analysis of Drosophila melanogaster cells using HiCExplorer,Epigenetics,2023-01,2023-01-03
-2046,4,The tutorial was simple to follow and was a great balance between guidance and letting do things myself,Some of the steps seem outdated with some parameter having changed names or being not available anymore. But it doesn't prevent the completion of the tutorial.,,Hi-C analysis of Drosophila melanogaster cells using HiCExplorer,Epigenetics,2023-01,2023-01-05
-2047,4,All except the R studio that is not yet clear,Rstudio,,Identifying tuberculosis transmission links: from SNPs to transmission clusters,Evolution,2023-01,2023-01-07
-2048,4,"In galaxy training,  the tools recommendation are quite good!",1.  The workflow file should be updated.,,Identification of somatic and germline variants from tumor and normal sample pairs,Variant Analysis,2023-01,2023-01-10
-2049,5,,,,M. tuberculosis Variant Analysis,Variant Analysis,2023-01,2023-01-10
-2050,5,"step by step, question and answers for self-checking",,,A short introduction to Galaxy,Introduction to Galaxy Analyses,2023-01,2023-01-10
-2051,5,"The extra examples (2 NGS datasets) at the end of the tutorial are very useful, it gives me a better idea on how to troubleshoot and identify the problem, when encountering a bad NGS data",Perhaps it will be helpful to include more explanation of the results for the different tools after each steps (e.g. a hyperlink to the bioinformatics tool's user manual for more result explanation),,M. tuberculosis Variant Analysis,Variant Analysis,2023-01,2023-01-11
-2052,3,,Not enough information,,Deep Learning (Part 1) - Feedforward neural networks (FNN),Statistics and machine learning,2023-01,2023-01-11
-2053,4,"The interpretation of RMSD, RMSF, and PCA plots.",,,Analysis of molecular dynamics simulations,Computational chemistry,2023-01,2023-01-12
-2054,5,Very well detailed,nothing special,,From peaks to genes,Introduction to Galaxy Analyses,2023-01,2023-01-12
-2055,5,Clear instructions and easy to follow,No suggestions at this stage,,A short introduction to Galaxy,Introduction to Galaxy Analyses,2023-01,2023-01-13
-2056,4,questions along the way ,the questions could be explained better especially the annotation exercise ,,MaxQuant and MSstats for the analysis of TMT data,Proteomics,2023-01,2023-01-14
-2057,5,Adapted for my very first steps in Galaxy. I enjoy using the tools.,,,A short introduction to Galaxy,Introduction to Galaxy Analyses,2023-01,2023-01-16
-2058,5,,,,ATAC-Seq data analysis,Epigenetics,2023-01,2023-01-17
-2059,5,Very clear and each step was explained thoroughly. Really good tutorial.,"There were icons explained in the tutorial that I don't see in my computer (e.g. show histories, I only see it when I open the tab, which again have a different icon than the one in the tutorial), I guess is a difference etween different galaxies (EU, AU, USA) or differences to older version and it confused me a bit. Maybe difficult to fix.",,A short introduction to Galaxy,Introduction to Galaxy Analyses,2023-01,2023-01-18
-2060,5,"I like that you demonstrate several steps to assess the quality of the data, provide ranges of acceptable values, and explain why other values would not be acceptable. You also provide several strategies to attain the same result such as when you explain determining strandedness.  I plan on using this tutorial for my upcoming bacterial transcriptomics course.","I was confused by the explanation of the strandedness, while I understand how transcription work, I did not understand the results of unstranded, same strand and reverse strand, for the same library preparation. i was expecting only one possible result, either unstranded OR same strand OR reverse strand, but MultiQC was providing all the values for the same sample.  I also was confused by the ""Details: The counts obtained in the previous part may be different from the one imported"" as according to https://training.galaxyproject.org/training-material/topics/transcriptomics/tutorials/ref-based/tutorial.html#counting-reads-per-genes, you asked us to set the featureCounts to “""Count fragments instead of reads”: Enabled; fragments (or templates) will be counted instead of reads"". But in the ""Details"" box you state that we used the ""Disabled"" option. I thought we had used the ""Enabled"" option.   Is there a tutorial similar to this one for bacterial RNA-seq analysis? Or which aligner would you recommend that I use for Bacterial transcriptomics, given that there is no splicing involved? Do you have a tutorial for bacterial transcriptomics analysis of Nanopore data?  Thank you again. ",,Reference-based RNA-Seq data analysis,Transcriptomics,2023-01,2023-01-19
-2061,5,My first time working with genomic tools. ,,,Introduction to Genomics and Galaxy,Introduction to Galaxy Analyses,2023-01,2023-01-21
-2062,3,"It got me started on how to use the interactive jupyter tool. However, it issuing python 2 instead of python 3 which is currently used by use galaxy.org .",1. Should use python 3 instead of python 2.  2. distplot in version of seborn in  usegalaxy.org  is deprecated..  3. I cannot find the download button to save notebook to history file. Instead I downloaded it to my composer and can subsequently upload it to use galaxy.org.  4. It would be easier if the code on the webpage was set apart from the text as a code block with the ability to copy it by clicking on copy icon in the code block.,,Use Jupyter notebooks in Galaxy,Using Galaxy and Managing your Data,2023-01,2023-01-21
-2063,1,,does not include how to install packages or set up a local server to install packages to ,,RStudio in Galaxy,Using Galaxy and Managing your Data,2023-01,2023-01-25
-2064,5,,,,Mapping,Sequence analysis,2023-01,2023-01-25
-2065,4,,,,A short introduction to Galaxy,Introduction to Galaxy Analyses,2023-01,2023-01-26
-2066,5,,,,Identification of the binding sites of the T-cell acute lymphocytic leukemia protein 1 (TAL1),Epigenetics,2023-01,2023-01-27
-2067,5,,,,Galaxy 101,Introduction to Galaxy Analyses,2023-01,2023-01-31
-2068,5,,,,A short introduction to Galaxy,Introduction to Galaxy Analyses,2023-01,2023-01-31
-2069,1,,,,Visualization of RNA-Seq results with Volcano Plot,Transcriptomics,2023-02,2023-02-02
-2070,5,,,,A short introduction to Galaxy,Introduction to Galaxy Analyses,2023-02,2023-02-02
-2071,5,,,,A short introduction to Galaxy,Introduction to Galaxy Analyses,2023-02,2023-02-02
-2072,5,It was VERY clear and comprehensive. Thank you so much.,,,Mapping,Sequence analysis,2023-02,2023-02-02
-2073,5,simple and easy to follow,,,16S Microbial analysis with Nanopore data,Metagenomics,2023-02,2023-02-04
-2074,4,,,,A short introduction to Galaxy,Introduction to Galaxy Analyses,2023-02,2023-02-06
-2075,5,,,,16S Microbial Analysis with mothur (extended),Metagenomics,2023-02,2023-02-07
-2076,5,It was easy to follow.,"The command should be updated to the current version. While the tutorial said ""execute"", my version said ""run"". For a novice it may be confusing.",,A short introduction to Galaxy,Introduction to Galaxy Analyses,2023-02,2023-02-12
-2077,5,Very clear and detailed. Great for the first-time user.,A few suggestions to try after 101,,Galaxy 101,Introduction to Galaxy Analyses,2023-02,2023-02-15
-2078,5,,,,How to reproduce published Galaxy analyses,Introduction to Galaxy Analyses,2023-02,2023-02-19
-2079,4,Walkthrough and explanation,Explain some of the more obscure packages used and their functions. Some were explained but other were not.,,Introduction to Machine Learning using R,Statistics and machine learning,2023-02,2023-02-20
-2080,5,Everything is clear and understandable,I was satisfied with everything,,From peaks to genes,Introduction to Galaxy Analyses,2023-02,2023-02-21
-2081,5,It explained every steps in a basic manner!,The result of work flow application (for the student to check whether their workflow work or not),,Galaxy 101,Introduction to Galaxy Analyses,2023-02,2023-02-22
-2082,5,,,,Galaxy 101,Introduction to Galaxy Analyses,2023-02,2023-02-23
-2083,1,,Syntax improved version of Galaxy ,,Galaxy 101,Introduction to Galaxy Analyses,2023-02,2023-02-23
-2084,5,All steps were clearly explained (besides one) and the screenshots and extra info was very helpful! ,With the Hands on: Extract workflow I found the end of step 4 a bit confusing in the sense that I wasn't sure if the tutorial required me to run the workflow. Immediately after it was said the Exon box was named ok. I didn't immediately realize we were to rename the box in the workflow editor.,,Galaxy 101,Introduction to Galaxy Analyses,2023-02,2023-02-23
-2085,5,,,,Understanding Barcodes,Single Cell,2023-02,2023-02-27
-2086,4,,,,A short introduction to Galaxy,Introduction to Galaxy Analyses,2023-03,2023-03-02
-2087,5,the workshop webpage and its specifications,n/a,,Galaxy 101 for everyone,Introduction to Galaxy Analyses,2023-03,2023-03-03
-2088,5,,"One of the initial steps, the one involving getting the RefSeq list of genes from UCSC genome browser is flawed and should be updated. I had to use a different list of genes and make some modifications in the input file.",,From peaks to genes,Introduction to Galaxy Analyses,2023-03,2023-03-03
-2089,5,explanation of operation.,,,Galaxy 101 for everyone,Introduction to Galaxy Analyses,2023-03,2023-03-05
-2090,5,"It included in the end the possibility of using it to analyze repeats instead of SNPs, leading us to realize that it can easily be done.",,,Galaxy 101,Introduction to Galaxy Analyses,2023-03,2023-03-05
-2091,5,Content wise it is good,Provide some video examples ,,Reference-based RNA-Seq data analysis,Transcriptomics,2023-03,2023-03-07
-2092,5,The detailing of steps,Maybe more of short videos of cursor navigating could be helpful,,A short introduction to Galaxy,Introduction to Galaxy Analyses,2023-03,2023-03-07
-2093,5,,,,Galaxy 101 for everyone,Introduction to Galaxy Analyses,2023-03,2023-03-08
-2094,5,the detailed explanation,,,A short introduction to Galaxy,Introduction to Galaxy Analyses,2023-03,2023-03-08
-2095,1,Nothing,"I have never found a question answered that I had. Consult people on what FAQs should be. Like, I have a collection and a couple instances failed. How do I create a new collection without them? This should be easy but is unfindable!!!!!",,Using dataset collections,Using Galaxy and Managing your Data,2023-03,2023-03-09
-2096,5,,,,A short introduction to Galaxy,Introduction to Galaxy Analyses,2023-03,2023-03-10
-2097,5,,,,Introduction to Genomics and Galaxy,Introduction to Galaxy Analyses,2023-03,2023-03-13
-2098,5,"Everything <script>console.log(""Helena Testing"");</script>",,,Galaxy Installation with Ansible,Galaxy Server administration,2023-03,2023-03-14
-2099,5,,,,Quality Control,Sequence analysis,2023-03,2023-03-14
-2100,5,,,,Genome Assembly of MRSA using Illumina MiSeq Data,Assembly,2023-03,2023-03-16
-2101,5,The tutorial try to explain what is doing when selecting params or values.,"Maybe, some animations about the simulation trajectory.",,High Throughput Molecular Dynamics and Analysis,Computational chemistry,2023-03,2023-03-17
-2102,5,,,,Galaxy 101 for everyone,Introduction to Galaxy Analyses,2023-03,2023-03-17
-2103,5,The fact that you provide everything for the hands on experience.,,,A short introduction to Galaxy,Introduction to Galaxy Analyses,2023-03,2023-03-17
-2104,3,,"You should specify that you can't feed GEMINI tool more recent versions of hg19 at the outset. I used a more recent version hg38 throughout my analysis, only to get to the last step and realize that I had to start over using hg19.   Also, GEMINI is not available on usegalaxy.org, only on galaxy.eu, and I am having a lot of difficulty importing my datasets over since the tags for my PED file disappear on transfer.   Extremely frustrating end result for what I originally thought was a great tutorial! ",,Exome sequencing data analysis for diagnosing a genetic disease,Variant Analysis,2023-03,2023-03-19
-2105,5,Order flow of information.,Kindly provide tutorials in video for easy visualization of facts.,,"Mutation calling, viral genome reconstruction and lineage/clade assignment from SARS-CoV-2 sequencing data",Variant Analysis,2023-03,2023-03-19
-2106,1,"There are error when running it. Tools have different versions and some files create with one tool can not be read for another tool. This is the error in Gromacs log for the Production Simulation : ""Attempting to read a checkpoint file of version 22 with code of version 20"". And the same is happening in the other Galaxy history about Molecular Dynamics. ",,,High Throughput Molecular Dynamics and Analysis,Computational chemistry,2023-03,2023-03-19
-2107,5,,,,Breve introducción a Galaxy - en español,Introduction to Galaxy Analyses,2023-03,2023-03-20
-2108,5,,,,Introduction to Genomics and Galaxy,Introduction to Galaxy Analyses,2023-03,2023-03-22
-2109,4,The automation in the process which allows GUI interface ,The response time because it might take some time before it completes the process,,"Mutation calling, viral genome reconstruction and lineage/clade assignment from SARS-CoV-2 sequencing data",Variant Analysis,2023-03,2023-03-23
-2110,5,pipelines workflows,To run all pipelines at once,,"Mutation calling, viral genome reconstruction and lineage/clade assignment from SARS-CoV-2 sequencing data",Variant Analysis,2023-03,2023-03-23
-2111,3,,,,Breve introducción a Galaxy - en español,Introduction to Galaxy Analyses,2023-03,2023-03-25
-2112,5,"Good alternative to local running of GTN, thanks",,,Running the GTN website online using GitPod,Contributing to the Galaxy Training Material,2023-03,2023-03-27
-2113,5,Filter by quality tool is not available on our Galaxy. Used Filter FASTQ instead.,,,A short introduction to Galaxy,Introduction to Galaxy Analyses,2023-03,2023-03-30
-2114,3,,explanation on the different types of barcoding/UMI schemes,,Understanding Barcodes,Single Cell,2023-03,2023-03-31
-2115,5,,,,A short introduction to Galaxy,Introduction to Galaxy Analyses,2023-03,2023-03-31
-2116,5,Easy to followw,,,A short introduction to Galaxy,Introduction to Galaxy Analyses,2023-04,2023-04-03
-2117,4,,,,Quality Control,Sequence analysis,2023-04,2023-04-03
-2118,5,,,,Visualization of RNA-Seq results with heatmap2,Transcriptomics,2023-04,2023-04-03
-2119,5,Most part of the instructions were very clear and detailed.,"There are still some part of the tutorial which can be a little more clear, for example at ""Hands-on: Generating FreeBayes calls"" I was confused and took a while to figure out.",,Exome sequencing data analysis for diagnosing a genetic disease,Variant Analysis,2023-04,2023-04-04
-2120,5,,,,A short introduction to Galaxy,Introduction to Galaxy Analyses,2023-04,2023-04-04
-2121,4,,more screenshots can be added.,,Galaxy 101,Introduction to Galaxy Analyses,2023-04,2023-04-04
-2122,4,How it explained each feature of the model.,"Providing more links to resources for further reading (e.g., on how to select models or various aspects of them) would be nice!",,Introduction to deep learning,Statistics and machine learning,2023-04,2023-04-06
-2123,5,It was easy to follow and really didactic,Maybe a more complex exercise at the end or an explanation of all the potential of the tools in Galaxy,,Breve introducción a Galaxy - en español,Introduction to Galaxy Analyses,2023-04,2023-04-06
-2124,5,Clearness,,,Pre-processing of 10X Single-Cell RNA Datasets,Single Cell,2023-04,2023-04-07
-2125,5,GOOD,,,A short introduction to Galaxy,Introduction to Galaxy Analyses,2023-04,2023-04-11
-2126,5,,,,Mapping and molecular identification of phenotype-causing mutations,Variant Analysis,2023-04,2023-04-12
-2127,5,,,,Metatranscriptomics analysis using microbiome RNA-seq data,Metagenomics,2023-04,2023-04-15
-2128,2,chart explanation,language can be made more simple,,Genome Annotation,Genome Annotation,2023-04,2023-04-17
-2129,5,,,,Ansible,Galaxy Server administration,2023-04,2023-04-17
-2130,5,,,,16S Microbial Analysis with mothur (extended),Metagenomics,2023-04,2023-04-17
-2131,5,,,,A short introduction to Galaxy,Introduction to Galaxy Analyses,2023-04,2023-04-18
-2132,3,,"- (Maybe just me) Too much content, too fast. - Account on a production Galaxy instance is required. I did not have one and it took me a while to get set up - Some familiarity with Jupyter Notebooks seems to be another prerequisite  ",,Scripting Galaxy using the API and BioBlend,Development in Galaxy,2023-04,2023-04-18
-2133,5,,,,Deep Learning (Part 1) - Feedforward neural networks (FNN),Statistics and machine learning,2023-04,2023-04-18
-2134,5,,,,Galaxy Installation with Ansible,Galaxy Server administration,2023-04,2023-04-19
-2135,5,,,,"Server Maintenance: Cleanup, Backup, and Restoration",Galaxy Server administration,2023-04,2023-04-19
-2136,5,,,,Customizing the look of Galaxy,Galaxy Server administration,2023-04,2023-04-19
-2137,5,,,,Performant Uploads with TUS,Galaxy Server administration,2023-04,2023-04-19
-2138,5,,,,Reference Data with CVMFS,Galaxy Server administration,2023-04,2023-04-19
-2139,4,"good and quick overview, no error messages, everything worked","Sometimes the names on the actual webpage are different than what you give in the tutorial, so you have to guess if it is the same",,A short introduction to Galaxy,Introduction to Galaxy Analyses,2023-04,2023-04-19
-2140,5,It is really clearly well explained!,Everything,,A short introduction to Galaxy,Introduction to Galaxy Analyses,2023-04,2023-04-19
-2141,5,,,,16S Microbial analysis with Nanopore data,Metagenomics,2023-04,2023-04-20
-2142,5,,,,A short introduction to Galaxy,Introduction to Galaxy Analyses,2023-04,2023-04-21
-2143,5,,,,Visualization of RNA-Seq results with Volcano Plot,Transcriptomics,2023-04,2023-04-22
-2144,5,,,,A short introduction to Galaxy,Introduction to Galaxy Analyses,2023-04,2023-04-23
-2145,5,,,,Visualization of RNA-Seq results with Volcano Plot,Transcriptomics,2023-04,2023-04-24
-2146,5,,,,A short introduction to Galaxy,Introduction to Galaxy Analyses,2023-04,2023-04-25
-2147,5,,,,From NCBI's Sequence Read Archive (SRA) to Galaxy: SARS-CoV-2 variant analysis,Variant Analysis,2023-04,2023-04-25
-2148,4,,No background information how quality check works,,A short introduction to Galaxy,Introduction to Galaxy Analyses,2023-04,2023-04-26
-2149,5,,,,Chloroplast genome assembly,Assembly,2023-04,2023-04-26
-2150,4,,,,Pre-processing of 10X Single-Cell RNA Datasets,Single Cell,2023-04,2023-04-26
-2151,5,,,,A short introduction to Galaxy,Introduction to Galaxy Analyses,2023-04,2023-04-28
-2152,5,Step by step guide,,,Galaxy 101 for everyone,Introduction to Galaxy Analyses,2023-04,2023-04-30
-2153,5,"The strand used in this tutorial doesn't match the sample inputs (all should be reverse instead). The result doesn't change by much .. but a few people have now brought it up when they run the extra Infer Experiment tool, and it doesn't match assignment used in here.  cc to myself  @jennaj  This has been around for a long time. Not sure of the priority.",,,De novo transcriptome reconstruction with RNA-Seq,Transcriptomics,2023-05,2023-05-02
-2154,5,,,,Quality Control,Sequence analysis,2023-05,2023-05-02
-2155,5,,,,M. tuberculosis Variant Analysis,Variant Analysis,2023-05,2023-05-02
-2156,4,Very clear presentation and rather easy to follow. I really enjoyed it.,The filtering part was a extremely fast.  ;),,MaxQuant and MSstats for the analysis of label-free data,Proteomics,2023-05,2023-05-02
-2157,5,,,,Identifying tuberculosis transmission links: from SNPs to transmission clusters,Evolution,2023-05,2023-05-03
-2158,5,the work flow summary in a diagram format,You could explain the steps in more detail,,Pre-processing of Single-Cell RNA Data,Single Cell,2023-05,2023-05-03
-2159,5,,,,Pre-processing of Single-Cell RNA Data,Single Cell,2023-05,2023-05-03
-2160,3,,Gemini is no longer used,,Exome sequencing data analysis for diagnosing a genetic disease,Variant Analysis,2023-05,2023-05-04
-2161,3,"quite explanatory, understandable terms","update it or make sure the platform possesses the features explained by the tutorial. ""Less"" command was not available. There is no command or instructions to generate dc folder",,Variant Calling Workflow,Foundations of Data Science,2023-05,2023-05-04
-2162,5,,,,A short introduction to Galaxy,Introduction to Galaxy Analyses,2023-05,2023-05-05
-2163,5,,,,Tree thinking for tuberculosis evolution and epidemiology,Evolution,2023-05,2023-05-05
-2164,5,Have a great Job. I am doing my Research on MTB of Bioinformatics Analysis. It was really Helpful.,"sorry to say, but one of my suggestion is on next time need Hands on Session Tutorial vedio.",,M. tuberculosis Variant Analysis,Variant Analysis,2023-05,2023-05-07
-2165,5,Simple and easy-to-understand language of the hands-on-tutorial,"Some of the hyperlinks are not functional; please update those. For example, the hyperlink for alignment tools does not open.",,NGS data logistics,Introduction to Galaxy Analyses,2023-05,2023-05-07
-2166,5,Quite straight forward applications.,This is not applicable t me at the moment ,,A short introduction to Galaxy,Introduction to Galaxy Analyses,2023-05,2023-05-08
-2167,5,,,,1: RNA-Seq reads to counts,Transcriptomics,2023-05,2023-05-08
-2168,5,,,,Chloroplast genome assembly,Assembly,2023-05,2023-05-09
-2169,5,,,,A short introduction to Galaxy,Introduction to Galaxy Analyses,2023-05,2023-05-10
-2170,5,Easy to follow steps,,,A short introduction to Galaxy,Introduction to Galaxy Analyses,2023-05,2023-05-11
-2171,5,very informative and well structured,nothing of note ,,A short introduction to Galaxy,Introduction to Galaxy Analyses,2023-05,2023-05-12
-2172,5,It is very clear and easy to follow. The video also helps sooo much! Thank you. ,,,Galaxy 101,Introduction to Galaxy Analyses,2023-05,2023-05-13
-2173,2,,"Instructions are insufficiently detailed (no definitions for key terms, no explanation of required file structures). The only way to use the tool is by trial and error (wastes a lot of time)",,Group tags for complex experimental designs,Using Galaxy and Managing your Data,2023-05,2023-05-14
-2174,5,,,,From peaks to genes,Introduction to Galaxy Analyses,2023-05,2023-05-14
+1378,5,The details,,,Quality Control,Sequence analysis,2021-08,2021-08-12
+1379,5,,,,Mapping,Sequence analysis,2021-08,2021-08-12
+1380,5,,,,Using dataset collections,Using Galaxy and Managing your Data,2021-08,2021-08-12
+1381,4,,,,Sequence data submission to ENA,"FAIR Data, Workflows, and Research",2021-08,2021-08-12
+1382,5,the easy step by step guide ,nothing,,Galaxy 101,Introduction to Galaxy Analyses,2021-08,2021-08-12
+1383,5,your explanation of each plaot,,,Quality Control,Sequence analysis,2021-08,2021-08-12
+1384,3,,,,NGS data logistics,Introduction to Galaxy Analyses,2021-08,2021-08-12
+1385,5,,,,Removal of human reads from SARS-CoV-2 sequencing data,Sequence analysis,2021-08,2021-08-13
+1386,5,,,,Sequence data submission to ENA,"FAIR Data, Workflows, and Research",2021-08,2021-08-13
+1387,5,,,,Visualization of RNA-Seq results with Volcano Plot,Transcriptomics,2021-08,2021-08-13
+1388,5,The activity was very interactive with a good combination of theory and practical,The last step on NCBI BLAST search was not clear enough to a biginner like me,,Unicycler assembly of SARS-CoV-2 genome with preprocessing to remove human genome reads,Assembly,2021-08,2021-08-13
+1389,4,short but precise information about technique,little bit more information about difference in data analysis part of labelled vs label-free methods.,,Label-free versus Labelled - How to Choose Your Quantitation Method,Proteomics,2021-08,2021-08-14
+1390,4,training is great,,,Quality Control,Sequence analysis,2021-08,2021-08-14
+1391,5,,"Maybe some more ""solutions"" along the way to help users check themselves for mistakes",,De novo transcriptome reconstruction with RNA-Seq,Transcriptomics,2021-08,2021-08-15
+1392,5,The simplicity of the step by step guide,If the tool needed for each step is clearly listed,,NGS data logistics,Introduction to Galaxy Analyses,2021-08,2021-08-17
+1393,5,It is reproducable,,,A short introduction to Galaxy,Introduction to Galaxy Analyses,2021-08,2021-08-17
+1394,5,The way you collect all the necessary info including the definition of each step and the examples of errors ,Optional document for other examples of the bad quality data with more clear explanation ,,Quality Control,Sequence analysis,2021-08,2021-08-18
+1395,4,,,,Understanding Galaxy history system,Using Galaxy and Managing your Data,2021-08,2021-08-18
+1396,4,,,,Age prediction using machine learning,Statistics and machine learning,2021-08,2021-08-19
+1397,5,the brief explanation of each step,,,Quality Control,Sequence analysis,2021-08,2021-08-19
+1398,5,,"nothing, I loved it very clear and well explained!",,Visualisation with Circos,Visualisation,2021-08,2021-08-19
+1399,5,,,,A short introduction to Galaxy,Introduction to Galaxy Analyses,2021-08,2021-08-19
+1400,5,,,,Setting up molecular systems,Computational chemistry,2021-08,2021-08-21
+1401,5,Good for beginners,More explanation and examples,,NGS data logistics,Introduction to Galaxy Analyses,2021-08,2021-08-21
+1402,5,Well described steps for analysis of proteomic data,Include statistical analysis methods,,Label-free data analysis using MaxQuant,Proteomics,2021-08,2021-08-23
+1403,5,,,,Exome sequencing data analysis for diagnosing a genetic disease,Variant Analysis,2021-08,2021-08-24
+1404,5,,,,Advanced R in Galaxy,Foundations of Data Science,2021-08,2021-08-25
+1405,5,It is clear and answered my questions,I am new to Galaxy so it work worked for my needs as is...,,Downloading and Deleting Data in Galaxy,Using Galaxy and Managing your Data,2021-08,2021-08-27
+1406,5,the instructions were detailed and precise,i think it was fine ,,A short introduction to Galaxy,Introduction to Galaxy Analyses,2021-08,2021-08-27
+1407,5,,,,Basics of machine learning,Statistics and machine learning,2021-08,2021-08-27
+1408,5,,,,Chloroplast genome assembly,Assembly,2021-08,2021-08-31
+1409,5,,,,Quality Control,Sequence analysis,2021-08,2021-08-31
+1410,5,Steps were clear and friendly ,,,A short introduction to Galaxy,Introduction to Galaxy Analyses,2021-09,2021-09-01
+1411,4,how to work on my on data,,,From NCBI's Sequence Read Archive (SRA) to Galaxy: SARS-CoV-2 variant analysis,Variant Analysis,2021-09,2021-09-01
+1412,5,good explaination,difficult to say,,Galaxy 101,Introduction to Galaxy Analyses,2021-09,2021-09-01
+1413,5,,,,ATAC-Seq data analysis,Epigenetics,2021-09,2021-09-02
+1414,5,,,,Visualisation with Circos,Visualisation,2021-09,2021-09-02
+1415,5,,,,Quality Control,Sequence analysis,2021-09,2021-09-03
+1416,4,,,,Analyses of metagenomics data - The global picture,Microbiome,2021-09,2021-09-06
+1417,4,"Great introduction to Galaxy, simple, easy to follow","Clearer explanation of why something is done. Perhaps similar to the 'tips', added detail for those that want to delve deeper. Also more up-to-date visuals of the steps involved The final output is a little lack-lustre. maybe a nicer visualisation option to cap off the tutorial (kind of like a nice 'reward' for effort)",,From peaks to genes,Introduction to Galaxy Analyses,2021-09,2021-09-07
+1418,5,,"Instructions about finding tutorial data in a Data Library need to be updated. In this tutorial and probably others. Tutorial data is now nested at usegalaxy.* servers -- and that change is confusing some learners. I've been telling people to search data libraries with the keyword ""GTN"" then to navigate down through the topic to the specific tutorial. Not all public servers will host the data in Data Libs, so even that advice needs a tune up to be consistent/accurate across tutorials. (@jennaj)",,DNA Methylation data analysis,Epigenetics,2021-09,2021-09-08
+1419,5,Very well explained,,,Protein FASTA Database Handling,Proteomics,2021-09,2021-09-08
+1420,4,"Hands on tutorial, that makes learning easier ",Can probably expand the training to involved more complicated thing. Maybe saperate training,,Galaxy 101 for everyone,Introduction to Galaxy Analyses,2021-09,2021-09-09
+1421,5,Easy to follow step-by-step instructions,,,Galaxy 101 for everyone,Introduction to Galaxy Analyses,2021-09,2021-09-09
+1422,1,"none of the essentials is working gx_put(), gx_get(), and gx_save()","none of the essentials is working gx_put(), gx_get(), and gx_save()",,R basics in Galaxy,Foundations of Data Science,2021-09,2021-09-09
+1423,5,All of it,"My understanding now is that GEMINI is human only, so I followed this intending to do other species, but have to now find an alternative. Perhaps the title should be ""Variant calling in humans"" rather than ""diploid systems""?  Certainly would be useful to clarify the specificity of GEMINI in that step.  But, thanks so much for doing this brilliant tutorial!",,Calling variants in diploid systems,Variant Analysis,2021-09,2021-09-10
+1424,5,Really clear,,,Annotating a protein list identified by LC-MS/MS experiments,Proteomics,2021-09,2021-09-11
+1425,5,,,,A short introduction to Galaxy,Introduction to Galaxy Analyses,2021-09,2021-09-13
+1426,5,,,,A short introduction to Galaxy,Introduction to Galaxy Analyses,2021-09,2021-09-14
+1427,4,,"I think there is an error in the instructions around which galaxy release to use.  https://training.galaxyproject.org/archive/2021-08-01/topics/admin/tutorials/ansible-galaxy/tutorial.html#galaxy      step 9.   Fails with a pip install error for attmap at galaxy dependency installation:  FAILED! => {""changed"": false, ""cmd"": [""/srv/galaxy/venv/bin/pip3"", ""install"", ""--index-url"", ""https://wheels.galaxyproject.org/simple/"", ""--extra-index-url"", ""https://pypi.python.org/simple"", ""-r"", ""/srv/galaxy/server/lib/galaxy/dependencies/pinned-requirements.txt""], ""msg"": ""stdout: Looking in indexes: https://wheels.galaxyproject.org/simple, https://pypi.python.org/simple\nIgnoring importlib-metadata: markers 'python_version < \""3.8\""' don't match your environment\nIgnoring importlib-resources: markers 'python_version < \""3.7\""' don't match your environment\nIgnoring pathlib2: markers 'python_version < \""3.6\""' don't match your environment\nIgnoring ruamel.yaml.clib: markers 'platform_python_implementation == \""CPython\"" and python_version < \""3.8\""' don't match your environment\nIgnoring typing: markers 'python_version < \""3.5\""' don't match your environment\nIgnoring zipp: markers 'python_version < \""3.8\""' don't match your environment\nCollecting adal==1.2.4\n  Using cached adal-1.2.4-py2.py3-none-any.whl (55 kB)\nCollecting amqp==2.6.0\n  Using cached amqp-2.6.0-py2.py3-none-any.whl (47 kB)\nCollecting appdirs==1.4.4\n  Using cached appdirs-1.4.4-py2.py3-none-any.whl (9.6 kB)\nCollecting attmap==0.12.11\n  Using cached attmap-0.12.11.tar.gz (9.9 kB)\n\n:stderr:     ERROR: Command errored out with exit status 1:\n     command: /srv/galaxy/venv/bin/python -c 'import io, os, sys, setuptools, tokenize; sys.argv[0] = '\""'\""'/tmp/pip-install-rswp62oy/attmap_d1e6f1f187954e539109df4d7760fde7/setup.py'\""'\""'; __file__='\""'\""'/tmp/pip-install-rswp62oy/attmap_d1e6f1f187954e539109df4d7760fde7/setup.py'\""'\""';f = getattr(tokenize, '\""'\""'open'\""'\""', open)(__file__) if os.path.exists(__file__) else io.StringIO('\""'\""'from setuptools import setup; setup()'\""'\""');code = f.read().replace('\""'\""'\\r\\n'\""'\""', '\""'\""'\\n'\""'\""');f.close();exec(compile(code, __file__, '\""'\""'exec'\""'\""'))' egg_info --egg-base /tmp/pip-pip-egg-info-2gc_ov_9\n         cwd: /tmp/pip-install-rswp62oy/attmap_d1e6f1f187954e539109df4d7760fde7/\n    Complete output (1 lines):\n    error in attmap setup command: use_2to3 is invalid.\n    ----------------------------------------\nWARNING: Discarding https://files.pythonhosted.org/packages/d0/d4/8b8fca155270a6675bac9a1e49b7c616ae763f66af7b836042ecfc805552/attmap-0.12.11.tar.gz#sha256=95b1f7dbcdad7278a3702fa921be6271046c96e1c9ed9feb10e0d4c13092b0a0 (from https://pypi.org/simple/attmap/). Command errored out with exit status 1: python setup.py egg_info Check the logs for full command output.\nERROR: Could not find a version that satisfies the requirement attmap==0.12.11 (from versions: 0.1, 0.1.1, 0.1.2, 0.1.4, 0.1.5, 0.1.6, 0.1.7, 0.1.8, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 0.10, 0.11, 0.12, 0.12.1, 0.12.2, 0.12.3, 0.12.4, 0.12.5, 0.12.6, 0.12.7, 0.12.8, 0.12.9, 0.12.10, 0.12.11, 0.13.0)\nERROR: No matching distribution found for attmap==0.12.11\n""}   This occurs with galaxy_commit_id: release_20.09 (as per the instructions), but changing to  release_21.05 makes the error go away.  ",,Galaxy Installation with Ansible,Galaxy Server administration,2021-09,2021-09-14
+1428,4,Good explanation!,Explanation on how to understand the figures in depth,,2: RNA-seq counts to genes,Transcriptomics,2021-09,2021-09-17
+1429,5,,,,From peaks to genes,Introduction to Galaxy Analyses,2021-09,2021-09-17
+1430,5,,It would be great if this can be updated based on the newest version of the packages used in the tutorial. Some of the parameters cannot be set as shown in this tutorial or should be set in a different way.,,DNA Methylation data analysis,Epigenetics,2021-09,2021-09-20
+1431,5,,,,Introduction to Genomics and Galaxy,Introduction to Galaxy Analyses,2021-09,2021-09-21
+1432,5,,,,16S Microbial analysis with Nanopore data,Microbiome,2021-09,2021-09-26
+1433,5,,,,Reference-based RNA-Seq data analysis,Transcriptomics,2021-09,2021-09-27
+1434,5,,,,Extracting Workflows from Histories,Using Galaxy and Managing your Data,2021-09,2021-09-28
+1435,5,,,,Introduction to Genomics and Galaxy,Introduction to Galaxy Analyses,2021-09,2021-09-28
+1436,3,The short list of ways to add group tags.,How to add different group tags via workflow to members of a collection.,,Group tags for complex experimental designs,Using Galaxy and Managing your Data,2021-09,2021-09-29
+1437,5,great,including other QC parameters as well,,Quality Control,Sequence analysis,2021-10,2021-10-01
+1438,3,,,,"Tools, Data, and Workflows for tutorials",Contributing to the Galaxy Training Material,2021-10,2021-10-08
+1439,5,,,,Genome annotation with Maker (short),Genome Annotation,2021-10,2021-10-08
+1440,4,Clear introduction in using galaxy to explore/map climate data. ,More detailed explanation of the inputs @map plot gridded (lat/lon) netCDF data. Did not understand the R as input “variable name as given in the netCDF file”. For other Essential Climate Variables I guess Ill have to change that input?  ,,Getting your hands-on climate data,Climate,2021-10,2021-10-08
+1441,4,simple enough to follow,It would be nice if a bit more background of machine learning is described. ,,Basics of machine learning,Statistics and machine learning,2021-10,2021-10-09
+1442,5,quick and simple,none,,Genome annotation with Prokka,Genome Annotation,2021-10,2021-10-10
+1443,5,"The tutorial is so detailed that even a preschooler would get it by simply following the steps! I found it so useful, I'm going to make my first contribution right away!","I'd suggest each of the topics under the ""objectives"" in the overview box be made clickable, so each topic can be reached right from the top without having to scroll all the way down the page.",,Contributing with GitHub via its interface,Contributing to the Galaxy Training Material,2021-10,2021-10-11
+1444,5,"I especially loved how simplified the tutorial was, even as a beginner I was able to run my analysis and publish it. Thank You!",It is fine as it is...maybe extra datasets to practice with.,,Galaxy 101,Introduction to Galaxy Analyses,2021-10,2021-10-11
+1445,5,How it shows you that you to make adaptable workflows,,,Galaxy 101,Introduction to Galaxy Analyses,2021-10,2021-10-11
+1446,3,,,,Introduction to Genomics and Galaxy,Introduction to Galaxy Analyses,2021-10,2021-10-11
+1447,5,It like the different tools and the much they can do. it makes analysis easy,"If the ""Tools"" on click or hover and give a little info on what the tool does, it would be nice.",,A short introduction to Galaxy,Introduction to Galaxy Analyses,2021-10,2021-10-12
+1448,5,Very detailed,"It would help if the sites name and the drop-down  button at the top is static. So even when I scroll to to end of this page, I can easily click on the drop-down button and access other files without having to scroll all the way back up",,Running the GTN website online using GitPod,Contributing to the Galaxy Training Material,2021-10,2021-10-12
+1449,4,I love that h training material was straight forward and essay to understand and comprehend,"I had a major challenge, as while using the platform to learn step by step, on the material provided,  I created a Galaxy account, I got handily with the platform , it was said after uploading a file, go to tools to search for FastQC and execute, but it was not bringing out parameters as seen on the project training material, likewise Filter by quality. There by preventing me from going further with the short introduction to Galaxy. In a Nutshell what was listed in the training material is not popping up when I search for this tools. I do not know what I may be doing wrong",,A short introduction to Galaxy,Introduction to Galaxy Analyses,2021-10,2021-10-13
+1450,3,"I liked that the tutorial was very informative, I learnt a lot of new and exciting things. It was short but had a lot of examples packed in it. I also enjoyed trying trying different analysis on the platform.","1. In the ""Upload a file"" section. I suggest that the disclaimer should be added so a user knows that they would not be able to upload a file if their email is not verified.  2. I appreciate that a lot of information was included in this tutorial, however I believe that the page could be improved to engage a reader more. The spacing between the sections and the fonts and colours are quite confusing. 3. The ""Use a tool"" could be more descriptive. No 3 : No change in the other parameters could be changed to "" No changes should be made on the other parameters"" . I believe thie would be easier for a user to understand. 4. I am also not sure why we have a ""Questions"" section. It deviates from teaching a user how to navigate the platform to explaining the analysis of the result. I suggest this is moved to a follow up section. 5. The icons in ""Hands-on: Re-run the tool""  section should be updated to tally with what is currently in use. 6. I believe the tutorial should be more descriptive. More pictures should be used as seen in ""Look at all your histories"" section. Thank you.",,A short introduction to Galaxy,Introduction to Galaxy Analyses,2021-10,2021-10-13
+1451,5, It was well detailed only a few to crack about.,some illustration needs to be more detailed,,From peaks to genes,Introduction to Galaxy Analyses,2021-10,2021-10-13
+1452,5,Very nice intro. Learned about the difference between climate and weather!,,,Getting your hands-on climate data,Climate,2021-10,2021-10-14
+1453,5,I love that you have to pay close to every little details, for now  nothing,,Galaxy 101,Introduction to Galaxy Analyses,2021-10,2021-10-14
+1454,5,Basically the fact that you can always get your way around,None for now,,Introduction to Genomics and Galaxy,Introduction to Galaxy Analyses,2021-10,2021-10-15
+1455,5,"The short introduction to Galaxy was clearly stated  with directions, for real i did not get lost .  i have followed the document well and it was very interesting. ",i suggest you improve on directing new galaxy communities on how to run tools because its very hard to select the provided tool . forexample put a image showing the exact tool.    ,,A short introduction to Galaxy,Introduction to Galaxy Analyses,2021-10,2021-10-15
+1456,5,Clarity,Please add Bracken,,16S Microbial analysis with Nanopore data,Microbiome,2021-10,2021-10-16
+1457,4,learning of workflows ,,,From peaks to genes,Introduction to Galaxy Analyses,2021-10,2021-10-18
+1458,5,,,,A short introduction to Galaxy,Introduction to Galaxy Analyses,2021-10,2021-10-19
+1459,2,,,,NGS data logistics,Introduction to Galaxy Analyses,2021-10,2021-10-19
+1460,5,This tutorial is very helpful,After the functional annotation  how to recognise genes related ,,Genome annotation with Maker,Genome Annotation,2021-10,2021-10-20
+1461,3,,,,Mapping,Sequence analysis,2021-10,2021-10-20
+1462,5,"Re-usability, Usages and all are awesome","Wokflow creating, checking , unchecking while editing are little bit confusing to me",,Galaxy 101 for everyone,Introduction to Galaxy Analyses,2021-10,2021-10-21
+1463,5,"The tutorial had enough clarity ,flow and  cognitive load for me. so thank you for this opportunity.",I think you need to introduce a bit of other languages because some participates do understand English but preferably native languages will make it easier for them to understand. thank you,,From peaks to genes,Introduction to Galaxy Analyses,2021-10,2021-10-21
+1464,5,,,,Visualize Climate data with Panoply netCDF viewer,Climate,2021-10,2021-10-21
+1465,4,Explanation is naïve ,Importing the iris workflow is generating error while making plot. Have a look on it.,,How to reproduce published Galaxy analyses,Introduction to Galaxy Analyses,2021-10,2021-10-22
+1466,4,,,,Ansible,Galaxy Server administration,2021-10,2021-10-22
+1467,5,,,,A short introduction to Galaxy,Introduction to Galaxy Analyses,2021-10,2021-10-22
+1468,1,,"I have got the following error. The tutorial did not work for me.  training-material$ make serve find: ‘_site/training-material’: No such file or directory find: ‘_site/training-material/*/*/slides/*’: No such file or directory find: ‘_site/training-material’: No such file or directory Tip: Want faster builds? Use 'serve-quick' in place of 'serve'. Tip: to serve in incremental mode (faster rebuilds), use the command: make serve FLAGS=--incremental  mv: cannot stat 'Gemfile': No such file or directory mv: cannot stat 'Gemfile.lock': No such file or directory Configuration file: /home/alice/scchoi/downloads/training-material/_config.yml   Dependency Error: Yikes! It looks like you don't have /home/alice/scchoi/downloads/training-material/_plugins/jekyll-environment_variables.rb or one of its dependencies installed. In order to use Jekyll as currently configured, you'll need to install this gem. If you've run Jekyll with `bundle exec`, ensure that you have included the /home/alice/scchoi/downloads/training-material/_plugins/jekyll-environment_variables.rb gem in your Gemfile as well. The full error message from Ruby is: 'cannot load such file -- bibtex' If you run into trouble, you can find helpful resources at https://jekyllrb.com/help/!                     ------------------------------------------------       Jekyll 4.2.1   Please append `--trace` to the `serve` command                      for any additional information or backtrace.                     ----------------------------",,Running the GTN website locally,Contributing to the Galaxy Training Material,2021-10,2021-10-23
+1469,3,,,,Running the GTN website online using GitPod,Contributing to the Galaxy Training Material,2021-10,2021-10-23
+1470,1,,,,Regression in Machine Learning,Statistics and machine learning,2021-10,2021-10-25
+1471,5,"Clarity, granularity, hands-on","Could have a similar tutorial for long read assembly (Nanopore, PB) , and I suppose 'hybrid assembly' , but this one is probably adequate for all these  purposes.",,An Introduction to Genome Assembly,Assembly,2021-10,2021-10-26
+1472,1,,,,Connecting Galaxy to a compute cluster,Galaxy Server administration,2021-10,2021-10-27
+1473,4,,,,A short introduction to Galaxy,Introduction to Galaxy Analyses,2021-10,2021-10-27
+1474,5,"it was really great and very informative tutorial, documintation and blasting over represnted sequences , made me feel getting on more with the tools and the data",the part which talks about the best alingment algorithm for adapters was not very clear for me,,Quality Control,Sequence analysis,2021-10,2021-10-27
+1475,5,,,,Galaxy 101 for everyone,Introduction to Galaxy Analyses,2021-10,2021-10-27
+1476,1,yes,yes,,Analysis of molecular dynamics simulations,Computational chemistry,2021-10,2021-10-28
+1477,5,,,,A short introduction to Galaxy,Introduction to Galaxy Analyses,2021-10,2021-10-28
+1478,5,The hands on part,Add a video ,,Quality Control,Sequence analysis,2021-10,2021-10-31
+1479,4,"Simple, makes the user understand how to use Galaxy ",More user friendly data examples for any kind of student who is not from biology background to experiment with and analyze,,A short introduction to Galaxy,Introduction to Galaxy Analyses,2021-10,2021-10-31
+1480,5,,,,A short introduction to Galaxy,Introduction to Galaxy Analyses,2021-10,2021-10-31
+1481,1,The overall design,"The fact that only one gene was differentially expressed means that there is a major problem with the data or analysis, and could not be used. ",,Reference-based RNAseq data analysis (long),Transcriptomics,2021-11,2021-11-01
+1482,5,"La facilidad de interfaz que tiene la pagina, se entiende muy rápido y claramente los pasos que se deben realizar para cargar un documento, y el como se visualizan, analizan e interpretación de los diferentes datos. ",Aun me toca explorar la pagina por el momento este tutorial introductorio es bastante útil y fácil para quien apenas esta escudriñando con el programa. ,,A short introduction to Galaxy,Introduction to Galaxy Analyses,2021-11,2021-11-01
+1483,5,  All the steps are fully documented and they always suggest further readings for important topics related to the tutorial.,"It is great to me, exactly how it is. ",,De novo transcriptome reconstruction with RNA-Seq,Transcriptomics,2021-11,2021-11-01
+1484,5,Everything,More Videos ,,A short introduction to Galaxy,Introduction to Galaxy Analyses,2021-11,2021-11-02
+1485,5,Explications,More videos ,,Quality Control,Sequence analysis,2021-11,2021-11-02
+1486,4,,,,Pre-processing of 10X Single-Cell RNA Datasets,Single Cell,2021-11,2021-11-04
+1487,5,"Really clearly written and well explained, including details that can go wrong or be confusing (the cowsay bit gave me a chuckle). Not overwhelming, unlike some other tutorials I tried. ",,,Ansible,Galaxy Server administration,2021-11,2021-11-04
+1488,4,,This doesn't tell me what library or package heatmap2 function is in - i can't seem to find it elsewhere.,,Visualization of RNA-Seq results with heatmap2,Transcriptomics,2021-11,2021-11-04
+1489,5,Ease of explanation,Nothing I think,,A short introduction to Galaxy,Introduction to Galaxy Analyses,2021-11,2021-11-06
+1490,5,i understand better quality control of the data,more examples or more quiz examples,,Quality Control,Sequence analysis,2021-11,2021-11-07
+1491,5,the qs and answers and clear explanation of each step,refer to which CLI tool commands can be used for each step,,Understanding Barcodes,Single Cell,2021-11,2021-11-08
+1492,5,"easy tasks, everything worked",,,Quality Control,Sequence analysis,2021-11,2021-11-08
+1493,5,,,,Reference-based RNA-Seq data analysis,Transcriptomics,2021-11,2021-11-09
+1494,4,,,,Pre-processing of Single-Cell RNA Data,Single Cell,2021-11,2021-11-09
+1495,4,Graphics,Putting animations and explanatory videos,,Quality Control,Sequence analysis,2021-11,2021-11-10
+1496,5,Easy to follow and provides good grounding in Galaxy use,"Could the tutorial please be updated to avoid a common ""error"". The tool Group isn't recognised on usegalaxy.* services in the Tool Search as the search ID is tagged as ""grouping"". This is a fix in Galaxy core code but maybe a short work-around is to make mention in this tutorial that this tool can be searched for by the term ""grouping""",,Galaxy 101 for everyone,Introduction to Galaxy Analyses,2021-11,2021-11-10
+1497,5,Yes,,,Metatranscriptomics analysis using microbiome RNA-seq data,Microbiome,2021-11,2021-11-10
+1498,5,,,,A short introduction to Galaxy,Introduction to Galaxy Analyses,2021-11,2021-11-10
+1499,5,,,,A short introduction to Galaxy,Introduction to Galaxy Analyses,2021-11,2021-11-11
+1500,4,,Some steps and pictures need to be updated for the current version of usegalaxy.,,Extracting Workflows from Histories,Using Galaxy and Managing your Data,2021-11,2021-11-12
+1501,5,,,,2: RNA-seq counts to genes,Transcriptomics,2021-11,2021-11-15
+1502,5,,,,From peaks to genes,Introduction to Galaxy Analyses,2021-11,2021-11-15
+1503,5,Detailed Explanation,,,Introduction to Genomics and Galaxy,Introduction to Galaxy Analyses,2021-11,2021-11-15
+1504,5,,,,Introduction to Genomics and Galaxy,Introduction to Galaxy Analyses,2021-11,2021-11-16
+1505,5,,,,Galaxy 101,Introduction to Galaxy Analyses,2021-11,2021-11-16
+1506,1,The programs were not available at Galaxy,,,DNA Methylation data analysis,Epigenetics,2021-11,2021-11-17
+1507,5,super,nothing,,Galaxy 101 for everyone,Introduction to Galaxy Analyses,2021-11,2021-11-17
+1508,3,Nice features and understandable handling for beginners,"Some data and tools are not at the described places; specifically genome annotation fasta and snpTools... snpEff is not existing, so I used snpEff eff; snpSift Annotate exists twice with different features. Description on how to create the pedigree file.",,Exome sequencing data analysis for diagnosing a genetic disease,Variant Analysis,2021-11,2021-11-17
+1509,4,,,,Galaxy 101,Introduction to Galaxy Analyses,2021-11,2021-11-18
+1510,5,,,,Metaproteomics tutorial,Proteomics,2021-11,2021-11-18
+1511,5,It is structured well and well explained.,It might be helpful to mention the alternative tools and solutions,,Identification of somatic and germline variants from tumor and normal sample pairs,Variant Analysis,2021-11,2021-11-19
+1512,5,,,,A short introduction to Galaxy,Introduction to Galaxy Analyses,2021-11,2021-11-19
+1513,5,"That goes step by step, shows and explains each section ",Give an example of where we can obtain the sequences or which links are the ones that can be used.,,A short introduction to Galaxy,Introduction to Galaxy Analyses,2021-11,2021-11-21
+1514,5,The webpage is friendly ,"This is my first time on platform, so I need to explore more",,A short introduction to Galaxy,Introduction to Galaxy Analyses,2021-11,2021-11-21
+1515,5,Lo amigable del programa,Incluir la aplicación de cada herramienta usada,,A short introduction to Galaxy,Introduction to Galaxy Analyses,2021-11,2021-11-22
+1516,5,,,,Pre-processing of 10X Single-Cell RNA Datasets,Single Cell,2021-11,2021-11-22
+1517,5,It is very simple and understandable,"add an image of where to locate ""See all histories""",,A short introduction to Galaxy,Introduction to Galaxy Analyses,2021-11,2021-11-22
+1518,5,Very easy,Other practical tools.,,A short introduction to Galaxy,Introduction to Galaxy Analyses,2021-11,2021-11-22
+1519,5,,,,A short introduction to Galaxy,Introduction to Galaxy Analyses,2021-11,2021-11-23
+1520,1,the concept.,"multiple issues with platform - loosing (they are not on the screen) history buttons, tag buttons, Once I brought the UCSC file in, I no longer can find the gz file - maybe it is supposed to be merged, but that is not what the tutorial showed.  There was a disclaimer that said 'results might be different' but there were no Chr 21 to rename on the file.  A little video showing what to expect might be more helpful than the icons in the description.  I see it was updated in early November, but as a real beginner,  this isn't any fun at all and very frustrating.",,From peaks to genes,Introduction to Galaxy Analyses,2021-11,2021-11-24
+1521,5,It is very clear and easy to follow,"anything, it is what it states: a short introduction :) ",,A short introduction to Galaxy,Introduction to Galaxy Analyses,2021-11,2021-11-28
+1522,5,"Very well explained, very visual",Maybe add some more information about the type of analysis we're running,,A short introduction to Galaxy,Introduction to Galaxy Analyses,2021-11,2021-11-29
+1523,4,,,,Quality Control,Sequence analysis,2021-11,2021-11-29
+1524,5,,,,1: RNA-Seq reads to counts,Transcriptomics,2021-11,2021-11-29
+1525,4,,,,A short introduction to Galaxy,Introduction to Galaxy Analyses,2021-11,2021-11-29
+1526,5,,,,A short introduction to Galaxy,Introduction to Galaxy Analyses,2021-11,2021-11-29
+1527,5,,,,A short introduction to Galaxy,Introduction to Galaxy Analyses,2021-11,2021-11-30
+1528,5,How easy is to follow the instructions ,"Probably adding more languages, but the english it's totally understandable",,A short introduction to Galaxy,Introduction to Galaxy Analyses,2021-11,2021-11-30
+1529,5,Very assertive and good guidance,More intuitive guidance,,Chloroplast genome assembly,Assembly,2021-11,2021-11-30
+1530,5," The instructions are clear, I really enjoyed it thank you!",Notes for the versions of the tools so you can select them and go a little bit faster with the course. ,,Generating a single cell matrix using Alevin,Single Cell,2021-11,2021-11-30
+1531,5,Everything! Very well organized and practical.,,,Downstream Single-cell RNA analysis with RaceID,Single Cell,2021-12,2021-12-01
+1532,1,,,,Visualization of RNA-Seq results with Volcano Plot in R,Transcriptomics,2021-12,2021-12-02
+1533,5,"La secuencia, además es sencillo y permite experimentar los ejercicios o comprobar y aprender la información teórica.","Quizás algunas indicaciones son susceptibles de mejorar, en virtud de mejorar el desarrollo del ejercicio directamente en los escritos; en los tutoriales quizás la unificacion de ellos, hay autores que son muy especificos y llevan de la mano al estudiante.",,Using dataset collections,Using Galaxy and Managing your Data,2021-12,2021-12-02
+1534,1,,,,Visualization of RNA-Seq results with Volcano Plot,Transcriptomics,2021-12,2021-12-04
+1535,5,"Stepwise, just in time learning and great links to additional information","(Having the video helped), but the steps were all included.",,16S Microbial Analysis with mothur (short),Microbiome,2021-12,2021-12-05
+1536,5,,,,Galaxy 101,Introduction to Galaxy Analyses,2021-12,2021-12-05
+1537,5,"Easy to follow, good reasoning for each step, mostly successful results","For some reason, I can't get this to work with NMR-derived pdb files",,Running molecular dynamics simulations using GROMACS,Computational chemistry,2021-12,2021-12-07
+1538,5,this tutorial explains CNN for image analysis completely and simply.,,,Image classification in Galaxy with fruit 360 dataset,Statistics and machine learning,2021-12,2021-12-08
+1539,5,,,,A short introduction to Galaxy,Introduction to Galaxy Analyses,2021-12,2021-12-08
+1540,5,The course is elaborated with proper hands on  help and graphical representation. Its gives proper details for each and every concept.,,,Quality Control,Sequence analysis,2021-12,2021-12-08
+1541,5,,,,Mapping,Sequence analysis,2021-12,2021-12-08
+1542,5,You iluustrated the principles of each analysis step.,I am not sure where I can find the codes for practice.,,Visualization of RNA-Seq results with heatmap2,Transcriptomics,2021-12,2021-12-10
+1543,5,,,,Mapping,Sequence analysis,2021-12,2021-12-13
+1544,2,was well explained. ,The tutorial looks nothing like what is one my galaxy web instance. Jupiter notebooks are not listed under visualizations but rather are under tools. The dialog that comes up when I launch Jupyter also does not look like what is in this tutorial. I can't figure it out based on what you have shown.,,Use Jupyter notebooks in Galaxy,Using Galaxy and Managing your Data,2021-12,2021-12-15
+1545,5,Well detailed method of ChIPseq and associated explanations,"The title in itself doesn't really reflect the final results of the tutorial, with the data used one do not really identify TAD on the inactive X chromosome... ",,Formation of the Super-Structures on the Inactive X,Epigenetics,2021-12,2021-12-16
+1546,4,,,,Formation of the Super-Structures on the Inactive X,Epigenetics,2021-12,2021-12-17
+1547,5,,,,Metatranscriptomics analysis using microbiome RNA-seq data,Microbiome,2021-12,2021-12-20
+1548,1,,,,High Throughput Molecular Dynamics and Analysis,Computational chemistry,2021-12,2021-12-20
+1549,5,Muy claras las explicaciones,Todo está bien en este tutorial,,A short introduction to Galaxy,Introduction to Galaxy Analyses,2021-12,2021-12-20
+1550,5,,Circos plot of the data should also be included.,,Chloroplast genome assembly,Assembly,2021-12,2021-12-23
+1551,5,Step by step nature ,More explanation of what i am actually doing at each step,,NGS data logistics,Introduction to Galaxy Analyses,2021-12,2021-12-23
+1552,5,,,,A short introduction to Galaxy,Introduction to Galaxy Analyses,2021-12,2021-12-24
+1553,5,,,,Mapping,Sequence analysis,2021-12,2021-12-26
+1554,5,,,,RNA Seq Counts to Viz in R,Transcriptomics,2021-12,2021-12-28
+1555,5,,,,A short introduction to Galaxy,Introduction to Galaxy Analyses,2021-12,2021-12-29
+1556,5,,,,A short introduction to Galaxy,Introduction to Galaxy Analyses,2021-12,2021-12-31
+1557,2,Not yet completed,This is how the output of get flanks are stated in the tutorial: For regions on the negative strand e.g. chr1 8349819 9289958 this gives chr1 9279958 9291958. However what I am getting is similar to the results of the + strand; the promoter regions lies between 8347819 and 8359819; it seems to me that get flanks did not recognize between the + and - strands,,From peaks to genes,Introduction to Galaxy Analyses,2022-01,2022-01-03
+1558,5,The simplicity,The tool is pretty solid,,Visualisation with Circos,Visualisation,2022-01,2022-01-04
+1559,5,guidelines are clear / no questions are left unanswered ,,,From peaks to genes,Introduction to Galaxy Analyses,2022-01,2022-01-05
+1560,3,,"I am getting an error : Warning unsupported media type (415) while trying to upload the reference genome using the link ""https://ftp.ncbi.nlm.nih.gov/genomes/all/GCF/009/858/895/GCF_009858895.2_ASM985889v3/GCF_009858895.2_ASM985889v3_genomic.fna.gz"". And I am not sure which file type to pick when trying to download from NCBI using the accession number ""NC_045512.2"" provided.",,NGS data logistics,Introduction to Galaxy Analyses,2022-01,2022-01-06
+1561,5,,,,Reference-based RNA-Seq data analysis,Transcriptomics,2022-01,2022-01-07
+1562,1,,Data set can not be found ,,DNA Methylation data analysis,Epigenetics,2022-01,2022-01-13
+1563,5,Clear instructions,,,Visualization of RNA-Seq results with Volcano Plot,Transcriptomics,2022-01,2022-01-13
+1564,5,The way they teached us.,"Very Short tutorial, needs to add some other tools alo. ",,A short introduction to Galaxy,Introduction to Galaxy Analyses,2022-01,2022-01-14
+1565,4,In-depth explanations and side bars of what the various commands are doing so you can easily troubleshoot and customize.,"There is an ""error"" in the example code for the Galaxy/FTP portion of galaxyservers.yml.  if you intend to use separate upload directories (with email addresses as the folder name) for each user - as the tutorial indicates will happen - then the current code (below) will result in the uploads going into the parent directory ""/uploads"" instead of ""uploads/user_email"" .    # FTP     ftp_upload_dir: /data/uploads     ftp_upload_site: ""{{ inventory_hostname }}""  Instead the code should be (add a ""/""):  # FTP     ftp_upload_dir: /data/uploads/     ftp_upload_site: ""{{ inventory_hostname }}""  Took me a while to work out why it was going into the wrong directory.  Also - it should be stated that there may be a newer version of the playbook that could solve errors/conflicts with newer operating system versions than those used in the tutorial.    Also suggest highlighting parts in the code examples which should be customized to your server environment if you are using this as a guide to setup your own installation (primarily directories where stuff is located).   ",,Enable upload via FTP,Galaxy Server administration,2022-01,2022-01-15
+1566,5,Code examples that you customize to your server set-up; hints and sidebars are very helpful; as is the in-depth explanation of what the code is doing.,"One solution to errors that arise would be to try newer playbook versions.  Although the tutorial cautioned that newer versions could create problems - in my case it solved problems.  I found that the version of galaxyproject.galaxy used in the tutorial-- version: 0.9.16 was incompatible with Ubuntu 20.04 LTS - resulting in a failure to install ""futures"".  When I changed to the newest galaxyproject.galaxy version the problem was solved. ",,Galaxy Installation with Ansible,Galaxy Server administration,2022-01,2022-01-15
+1567,5,,,,An Introduction to Genome Assembly,Assembly,2022-01,2022-01-15
+1568,5,,,,Quality Control,Sequence analysis,2022-01,2022-01-19
+1569,4,,,,1: RNA-Seq reads to counts,Transcriptomics,2022-01,2022-01-19
+1570,5,How the each and every step is shwon with the screenshots. Just what an beginner needs. :),,,From peaks to genes,Introduction to Galaxy Analyses,2022-01,2022-01-20
+1571,1,nothing,"Does not tell me how to get FreeBayes data from Galaxy into IGV.  IGV states that it cannot recognize the file.   I have used these programs before, but something is different now.",,IGV Introduction,Introduction to Galaxy Analyses,2022-01,2022-01-20
+1572,2,,"The examples are still very buggy.  Many of them do not work with the instructions as supplied.  For example, the SalmonKallistoMtxTo10x instructions fails, most  likely because the program is looking for a gz file when the tutorial example makes an unzipped file.  The Droplet barcode rank plot exercise also crashes.",,Generating a single cell matrix using Alevin,Single Cell,2022-01,2022-01-24
+1573,5,,,,Pre-processing of 10X Single-Cell RNA Datasets,Single Cell,2022-01,2022-01-25
+1574,1,,This tutorial is impossible to do with the standard memory allotment of usegalaxy.org.  RNA StarSolo requires too much memory to run for a data set of this size.  I brought my file storage down to 8% of the standard allotment and it did not start for over a day.  You should pick tools that people can use with the standard package or say so up front.  It also makes it impossible to keep anything to re-run later.,,Pre-processing of 10X Single-Cell RNA Datasets,Single Cell,2022-01,2022-01-25
+1575,5,,,,Reference-based RNA-Seq data analysis,Transcriptomics,2022-01,2022-01-26
+1576,1,nothing,nothing,,Genome annotation with Maker,Genome Annotation,2022-01,2022-01-26
+1577,5,An example full of information,no,,Introduction to Genomics and Galaxy,Introduction to Galaxy Analyses,2022-01,2022-01-27
+1578,5,The educational aspect and questions asked,The last question has no answer,,Galaxy 101,Introduction to Galaxy Analyses,2022-02,2022-02-02
+1579,5,,,,Visualization of RNA-Seq results with Volcano Plot,Transcriptomics,2022-02,2022-02-03
+1580,5,,,,"Inferring single cell trajectories (Scanpy, Python)",Single Cell,2022-02,2022-02-04
+1581,4,,,,Galaxy 101,Introduction to Galaxy Analyses,2022-02,2022-02-04
+1582,5,the simple and easy demonstration,,,Galaxy 101,Introduction to Galaxy Analyses,2022-02,2022-02-07
+1583,4,I liked the step by step follow up of results while doing the analysis,,,Galaxy 101,Introduction to Galaxy Analyses,2022-02,2022-02-07
+1584,5,,,,Quality Control,Sequence analysis,2022-02,2022-02-07
+1585,5,,,,Mapping,Sequence analysis,2022-02,2022-02-07
+1586,3,easy workflow,The metaMS.plot does not work,,Mass spectrometry : GC-MS analysis with metaMS package,Metabolomics,2022-02,2022-02-08
+1587,5,It is very didactical,a better explanation of cross-contamination plots,,Pre-processing of Single-Cell RNA Data,Single Cell,2022-02,2022-02-08
+1588,5,very clear tutorial!,,,Galaxy 101,Introduction to Galaxy Analyses,2022-02,2022-02-09
+1589,4,,,,Genome annotation with Prokka,Genome Annotation,2022-02,2022-02-10
+1590,5,,,,1: RNA-Seq reads to counts,Transcriptomics,2022-02,2022-02-10
+1591,5,,,,16S Microbial analysis with Nanopore data,Microbiome,2022-02,2022-02-10
+1592,5,,,,ATAC-Seq data analysis,Epigenetics,2022-02,2022-02-12
+1593,5,step by step explanation,IT would be very useful to indicate that a tools used in the exercise are not accessible from all galaxy sites.,,Galaxy 101 for everyone,Introduction to Galaxy Analyses,2022-02,2022-02-13
+1594,4,"Pretty simple step-by-step; A couple of syntax errors are included to make things ""interesting"" when trying to deploy.","Found another syntax error in the referenced tutorial:  In the galaxy.j2 file, ""location /_x_accel_redirect"" should be ""location /_x_accel_redirect/""",,Galaxy Installation with Ansible,Galaxy Server administration,2022-02,2022-02-15
+1595,1,,literally where is the volcano plot code? you give every code except for the actual plot! so unhelpful ,,Visualization of RNA-Seq results with Volcano Plot in R,Transcriptomics,2022-02,2022-02-16
+1596,3,The clear steps and explanation attached,Some tools have not been found in Galaxy such as antiSMASH. ,,Genome Annotation,Genome Annotation,2022-02,2022-02-17
+1597,4,very clear referencing of input files,,,Pre-processing of 10X Single-Cell RNA Datasets,Single Cell,2022-02,2022-02-18
+1598,4,,,,GO Enrichment Analysis,Transcriptomics,2022-02,2022-02-18
+1599,5,,,,Reference-based RNA-Seq data analysis,Transcriptomics,2022-02,2022-02-18
+1600,5,It was very precise and easy to follow.,I think it's excellent as it is.,,A short introduction to Galaxy,Introduction to Galaxy Analyses,2022-02,2022-02-18
+1601,5,every step was clear to follow,follow-up video for people who have network issues so that they can watch and catch-up fast,,A short introduction to Galaxy,Introduction to Galaxy Analyses,2022-02,2022-02-21
+1602,5,A clean flowchart of methods with an explanation for the purpose of each step.,"As a case study, a bad genome assembly or an assembly with incorrect parameters in various steps could be shown",,VGP assembly pipeline: Step by Step,Assembly,2022-02,2022-02-21
+1603,5,"As usal, the step by step procedures.",It is not clear that we have to set up the test-data folder and collect the bam files by our own for passing the test in the planemo section.,,Creating Galaxy tools from Conda Through Deployment,Development in Galaxy,2022-02,2022-02-21
+1604,4,,,,Introduction to Genomics and Galaxy,Introduction to Galaxy Analyses,2022-02,2022-02-22
+1605,5,"Very detailed explained steps, which made the analysis very easy",,,Introduction to Genomics and Galaxy,Introduction to Galaxy Analyses,2022-02,2022-02-22
+1606,5,It's clear and that take us by the hand to learn how to use galaxy. ,maybe make a youtube video to show all this tutorial ,,Galaxy 101 for everyone,Introduction to Galaxy Analyses,2022-02,2022-02-22
+1607,5,,,,Galaxy 101,Introduction to Galaxy Analyses,2022-02,2022-02-22
+1608,5,,,,Genome Assembly of a bacterial genome (MRSA) sequenced using Illumina MiSeq Data,Assembly,2022-02,2022-02-23
+1609,5,,,,Galaxy 101,Introduction to Galaxy Analyses,2022-02,2022-02-23
+1610,4,,,,Extracting Workflows from Histories,Using Galaxy and Managing your Data,2022-02,2022-02-24
+1611,4,Nice Step by Step Tutorial,Finding the tools was a bit difficult with the search bar. Somethings are a bit outdated.,,Introduction to Genomics and Galaxy,Introduction to Galaxy Analyses,2022-02,2022-02-24
+1612,5,The clear explanation of the tools,,,Mapping,Sequence analysis,2022-02,2022-02-25
+1613,4,Easy to follow and execute.,The order of selecting parameters can be sequential as it appears on the galaxy platform,,Running molecular dynamics simulations using GROMACS,Computational chemistry,2022-02,2022-02-26
+1614,4,,The further analysis links seems to be broken/unavailable: https://github.com/galaxyproject/training-material/tree/main/topics/computational-chemistry/tutorials/analysis-md-simulations/workflows/advanced_workflow.ga,,Analysis of molecular dynamics simulations,Computational chemistry,2022-02,2022-02-26
+1615,4,Easy to follow and focused on the basics,,,A short introduction to Galaxy,Introduction to Galaxy Analyses,2022-03,2022-03-07
+1616,5,Step wise instruction,It was perfect for me.,,A short introduction to Galaxy,Introduction to Galaxy Analyses,2022-03,2022-03-07
+1617,4,It is very detailed tutorial and easy to follow also for beginners like me,,,A short introduction to Galaxy,Introduction to Galaxy Analyses,2022-03,2022-03-07
+1618,5,It is really hands on,,,A short introduction to Galaxy,Introduction to Galaxy Analyses,2022-03,2022-03-07
+1619,5,,,,Name tags for following complex histories,Using Galaxy and Managing your Data,2022-03,2022-03-07
+1620,5,,,,A short introduction to Galaxy,Introduction to Galaxy Analyses,2022-03,2022-03-07
+1621,5,"Easy to follow, user friendly for someone without background",,,Galaxy 101,Introduction to Galaxy Analyses,2022-03,2022-03-08
+1622,4,easy to understand with easy steps,,,From peaks to genes,Introduction to Galaxy Analyses,2022-03,2022-03-10
+1623,4,,,,"Inferring single cell trajectories (Scanpy, Python)",Single Cell,2022-03,2022-03-11
+1624,5,The tutorial was very informative and steps were defined clearly to perform the analysis...,"Overall, it was quite informative. However, it would be preferable to include a video tutorial for performing the analysis, where results can be thoroughly explained and the steps would be more easier to follow to perform the analysis for new users.",,Bulk RNA Deconvolution with MuSiC,Single Cell,2022-03,2022-03-12
+1625,4,,,,Galaxy 101,Introduction to Galaxy Analyses,2022-03,2022-03-12
+1626,5,Simplicity. ,"Considering this is an introduction to assembly, it would be helpful if the steps are complete as some steps may have been skipped. It would also be useful if pictures can be added for some steps.   When ran, the results stated in this tutorial doesnt match with the output even if the instructions is strictly followed",,An Introduction to Genome Assembly,Assembly,2022-03,2022-03-12
+1627,4,simplicity,,,Deep Learning (Part 1) - Feedforward neural networks (FNN),Statistics and machine learning,2022-03,2022-03-12
+1628,5,"A single tutorial teaches to get information from UCSC, analyze them, view it in genome browser and asks us to use the pipeline to work on similar biological problems.",,,Introduction to Genomics and Galaxy,Introduction to Galaxy Analyses,2022-03,2022-03-14
+1629,5,,"There is a typo as :""M117-ch_1 - family 117, mother, reverse (R) reads from cheek"" under the section ""About these datasets"". It should have been ""M117-ch_2""",,Using dataset collections,Using Galaxy and Managing your Data,2022-03,2022-03-14
+1630,5,Very informative and in depth without being boring!,,,Galaxy 101 for everyone,Introduction to Galaxy Analyses,2022-03,2022-03-14
+1631,5,Clear explanation and utility of the tool/process,Excellent,,Rule Based Uploader,Using Galaxy and Managing your Data,2022-03,2022-03-14
+1632,5,"Clear explanation, useful content, thanks",clear and useful enough,,Using dataset collections,Using Galaxy and Managing your Data,2022-03,2022-03-14
+1633,5,intuitive,nothing,,Introduction to Genomics and Galaxy,Introduction to Galaxy Analyses,2022-03,2022-03-14
+1634,5,very useful for paired-end datasets for sequencing analysis,nothing,,Rule Based Uploader,Using Galaxy and Managing your Data,2022-03,2022-03-14
+1635,5,,,,Introduction to Genomics and Galaxy,Introduction to Galaxy Analyses,2022-03,2022-03-14
+1636,5,Good information on how to use the rule based uploader,-,,Rule Based Uploader,Using Galaxy and Managing your Data,2022-03,2022-03-14
+1637,5,The slides gave a really useful overview of toolsheds and how to configure them. ,It would be useful if the links to ephemeris commands would open in a new tab (I would prefer this for links in general but especially in this case as you have to do it in the middle of a task and it's not just further reading)  ,,Galaxy Tool Management with Ephemeris,Galaxy Server administration,2022-03,2022-03-14
+1638,5,,,,Introduction to Genomics and Galaxy,Introduction to Galaxy Analyses,2022-03,2022-03-14
+1639,5,saving and re using the workflow,more hand on activities ,,Introduction to Genomics and Galaxy,Introduction to Galaxy Analyses,2022-03,2022-03-14
+1640,5,,,,Quality Control,Sequence analysis,2022-03,2022-03-14
+1641,5,the pace,,,Galaxy 101 for everyone,Introduction to Galaxy Analyses,2022-03,2022-03-14
+1642,4,,,,A short introduction to Galaxy,Introduction to Galaxy Analyses,2022-03,2022-03-15
+1643,5,really loved the simplicity of the processes,,,Galaxy 101 for everyone,Introduction to Galaxy Analyses,2022-03,2022-03-15
+1644,5,the brief exxplanation,more explicit practical experience,,Understanding Barcodes,Single Cell,2022-03,2022-03-15
+1645,5, ,,,Quality Control,Sequence analysis,2022-03,2022-03-15
+1646,5,,,,Mapping,Sequence analysis,2022-03,2022-03-15
+1647,3,that the work can be excecated at the same time the class is on,if we could question the instructor,,Quality Control,Sequence analysis,2022-03,2022-03-15
+1648,5,,,,Introduction to Genomics and Galaxy,Introduction to Galaxy Analyses,2022-03,2022-03-15
+1649,3,that we could do things side by side to the instructor ,it could be more interactive,,Mapping,Sequence analysis,2022-03,2022-03-15
+1650,5,The hands-on material is really well thought and it really gives us confidence in doing this type of analysis. It is very easy to follow through.,"There were two steps where I fumbled, one was when I tried importing the genes from UCSC browser it opened in the new history, I feel one link to paste that to current history tab would be beneficial, secondly, I was literally searching for Group tool under the workflow, then when I expanded the list then I could find it. ",,From peaks to genes,Introduction to Galaxy Analyses,2022-03,2022-03-15
+1651,5,great tutorial on the basics !,nothing,,Quality Control,Sequence analysis,2022-03,2022-03-15
+1652,5,All aspect,Not much improvement,,Chloroplast genome assembly,Assembly,2022-03,2022-03-15
+1653,5,Clear explanation of what CVMFS is for and how it works,,,Reference Data with CVMFS,Galaxy Server administration,2022-03,2022-03-15
+1654,5,,,,Quality Control,Sequence analysis,2022-03,2022-03-15
+1655,5,very informative,,,Mapping,Sequence analysis,2022-03,2022-03-15
+1656,4,,,,Quality Control,Sequence analysis,2022-03,2022-03-15
+1657,4,clear for a beginner,"maybe planemo could be the first step, because needed in the wrapper section",,Creating Galaxy tools from Conda Through Deployment,Development in Galaxy,2022-03,2022-03-15
+1658,4,Explanations on how to create a galaxy tool,Put planemo install first,,Creating Galaxy tools from Conda Through Deployment,Development in Galaxy,2022-03,2022-03-15
+1659,5,good intro course on assembly,some more theory about polishing and why,,Chloroplast genome assembly,Assembly,2022-03,2022-03-15
+1660,5,,,,Data Libraries,Galaxy Server administration,2022-03,2022-03-15
+1661,5,,,,Genome annotation with Prokka,Genome Annotation,2022-03,2022-03-15
+1662,3,,I struggled to access the built-in reference genome and ended up giving up on the tutorial,,Mapping,Sequence analysis,2022-03,2022-03-15
+1663,5,Really liked the given details about each quality parameter,,,Quality Control,Sequence analysis,2022-03,2022-03-15
+1664,5,,,,Mapping,Sequence analysis,2022-03,2022-03-15
+1665,5,The IGV tutorial was great,,,Mapping,Sequence analysis,2022-03,2022-03-15
+1666,5,super interesting ! especially the sharing part !,,,Refining Genome Annotations with Apollo (prokaryotes),Genome Annotation,2022-03,2022-03-15
+1667,5,,,,Refining Genome Annotations with Apollo (prokaryotes),Genome Annotation,2022-03,2022-03-15
+1668,5,The options are pretty  intuitive.,,,Rule Based Uploader,Using Galaxy and Managing your Data,2022-03,2022-03-15
+1669,5,,,,Classification in Machine Learning,Statistics and machine learning,2022-03,2022-03-15
+1670,4,,For me it is not clear wether the apikey example use of vaults is the best. Might it be better to set an example about ssh passwords to connect remote servers?,,Ansible,Galaxy Server administration,2022-03,2022-03-15
+1671,5,Very easy to use and effective,,,Chloroplast genome assembly,Assembly,2022-03,2022-03-15
+1672,5,"I was already familiar with fastqc, but learning about Nanoplot and PycoQC for long read quality control was great",,,Quality Control,Sequence analysis,2022-03,2022-03-15
+1673,5,Ease of understanding and depth of explanation,The videos are old and out of sync of the tutorial material in some cases. There is need for new videos to be developed,,Introduction to Genomics and Galaxy,Introduction to Galaxy Analyses,2022-03,2022-03-15
+1674,4,,,,Mapping,Sequence analysis,2022-03,2022-03-15
+1675,5,"learned new QC checking tools, I only knew fastQC",great tutorial,,Quality Control,Sequence analysis,2022-03,2022-03-15
+1676,5,"It was super clear, and combine nice tools","For me was not ""intuitive"" to have a test with two p-values (for negative/positive selection). That I do not know if it is pretty common in transcriptomic (and I missed it) or if it is non so commonly used and it was speciffically developed on MAGeCK test. If it is not commonly use I think that can be nice to include a brief description of the statistical test in the tutorial of the course. ",,CRISPR screen analysis,Genome Annotation,2022-03,2022-03-15
+1677,5,,"great tutorial, very well explained",,16S Microbial Analysis with mothur (short),Microbiome,2022-03,2022-03-16
+1678,5,"As someone working on AMR, it was really interesting",,,Antibiotic resistance detection,Microbiome,2022-03,2022-03-16
+1679,5,"everything was so interesting, but workflow part is more fascinating. ",I think there is no need of the improvement every thing is so perfectly fine and easily understandable.,,Introduction to Genomics and Galaxy,Introduction to Galaxy Analyses,2022-03,2022-03-16
+1680,5,,,,Regression in Machine Learning,Statistics and machine learning,2022-03,2022-03-16
+1681,5,The practical easy-to-use guide,,,Introduction to Genomics and Galaxy,Introduction to Galaxy Analyses,2022-03,2022-03-16
+1682,5,how to do read mapping and understanding the statistics,,,Mapping,Sequence analysis,2022-03,2022-03-16
+1683,5,,,,Visualization of RNA-Seq results with Volcano Plot,Transcriptomics,2022-03,2022-03-16
+1684,4,,The final percentage overlap could be provided so students can compare to make sure the results are the same,,Introduction to Genomics and Galaxy,Introduction to Galaxy Analyses,2022-03,2022-03-16
+1685,5,great tutorial,,,16S Microbial analysis with Nanopore data,Microbiome,2022-03,2022-03-16
+1686,4,good explanation why masking is done,,,Masking repeats with RepeatMasker,Genome Annotation,2022-03,2022-03-16
+1687,4,Easy to follow,,,Mapping,Sequence analysis,2022-03,2022-03-16
+1688,5,The hand one are very easy and clear. ,Allow students to answer the questions whithin the hand on then they can compare with the available answers,,A short introduction to Galaxy,Introduction to Galaxy Analyses,2022-03,2022-03-16
+1689,5,"the structure, it was very well organized",,,Galaxy Installation with Ansible,Galaxy Server administration,2022-03,2022-03-16
+1690,5,Very simple to understand easy to do,"Nothing,  it is very complete",,High Throughput Molecular Dynamics and Analysis,Computational chemistry,2022-03,2022-03-16
+1691,5,The graphical data presentation and workflow set up,,,Galaxy 101 for everyone,Introduction to Galaxy Analyses,2022-03,2022-03-16
+1692,5,Clear and structured - everything ran without issues on my machines,,,Galaxy Installation with Ansible,Galaxy Server administration,2022-03,2022-03-16
+1693,5,,,,Use Apptainer containers for running Galaxy jobs,Galaxy Server administration,2022-03,2022-03-16
+1694,5,It was my first time analyzing the quality of a sequencing experiment and I easily followed the tutorial. This mean to me that it was nicely prepare taking care of the details.,,,Quality Control,Sequence analysis,2022-03,2022-03-16
+1695,5,Great introduction to proteomics tools,,,MaxQuant and MSstats for the analysis of label-free data,Proteomics,2022-03,2022-03-16
+1696,5,Explanations,,,Introduction to Genomics and Galaxy,Introduction to Galaxy Analyses,2022-03,2022-03-17
+1697,4,,I would be great if it could explain how to run ephemeris from a different machine (for example my local machine) but deploying galaxy on the vm,,Galaxy Tool Management with Ephemeris,Galaxy Server administration,2022-03,2022-03-17
+1698,5,"the pace, simon explains everything really well and understandable",,,Reference Data with CVMFS,Galaxy Server administration,2022-03,2022-03-17
+1699,5,Step by Step learning,,,A short introduction to Galaxy,Introduction to Galaxy Analyses,2022-03,2022-03-17
+1700,5,The tutorial was informative. Visualizing the reads in IGV (as a WSL user) was great.,,,Mapping,Sequence analysis,2022-03,2022-03-17
+1701,5,"clearly and easily explained. very good, many thanks","Maybe more details in the video for the advanced, but all is mostly available on this web site. thanks.",,Mapping,Sequence analysis,2022-03,2022-03-17
+1702,5,"compact and fully covering the matter, thanks",n/a,,Mapping,Sequence analysis,2022-03,2022-03-17
+1703,5,very complex biological/ bioinfo problem solved thanks to this great workflow. available and accessible to the whole of the scientific community. Great! Thanks for all contributors and participants.,n/a,,Proteogenomics 1: Database Creation,Proteomics,2022-03,2022-03-17
+1704,5,very complex biological/ bioinfo problem solved thanks to this great workflow. available and accessible to the whole of the scientific community. Great! Thanks for all contributors and participants.,n/a,,Proteogenomics 2: Database Search,Proteomics,2022-03,2022-03-17
+1705,5,very complex biological/ bioinfo problem solved thanks to this great workflow. available and accessible to the whole of the scientific community. Great! Thanks for all contributors and participants of the GalaxyP,n/a,,Proteogenomics 3: Novel peptide analysis,Proteomics,2022-03,2022-03-17
+1706,5,Dataset manipulation,,,Using dataset collections,Using Galaxy and Managing your Data,2022-03,2022-03-17
+1707,5,,,,Connecting Galaxy to a compute cluster,Galaxy Server administration,2022-03,2022-03-17
+1708,4,,,,Reference-based RNA-Seq data analysis,Transcriptomics,2022-03,2022-03-17
+1709,4,,,,Pangeo ecosystem 101 for everyone - Introduction to Xarray Galaxy Tools,Climate,2022-03,2022-03-17
+1710,5,i liked on how to polish nano-pore reads,,,Chloroplast genome assembly,Assembly,2022-03,2022-03-17
+1711,4,The existence of the dynamic job destinations,,,Mapping Jobs to Destinations using TPV,Galaxy Server administration,2022-03,2022-03-17
+1712,4,,,,Visualization of RNA-Seq results with Volcano Plot,Transcriptomics,2022-03,2022-03-18
+1713,5,The tutorial is super clear and easy to follow,,,Reference-based RNA-Seq data analysis,Transcriptomics,2022-03,2022-03-18
+1714,5,The straightforward pedagogical approach,I think it is perfect as is ,,Ansible,Galaxy Server administration,2022-03,2022-03-18
+1715,5,how seamless it was to deploy it,,,Galaxy Installation with Ansible,Galaxy Server administration,2022-03,2022-03-18
+1716,5,,,,Quality Control,Sequence analysis,2022-03,2022-03-18
+1717,5,Great workflow ! I have done this on the CLI... only installing humann took a while! It's great that this workflow can be used by biologists,,,Metatranscriptomics analysis using microbiome RNA-seq data (short),Microbiome,2022-03,2022-03-18
+1718,5,The step-by-step approach and the additional explanations for some input fields,Perhaps an additional indication of which patch of the hg19 is recognised as the database of the SNPeff eff output of GEMINI load. It took me several attempts to realise that it must be the unpatched version.,,Exome sequencing data analysis for diagnosing a genetic disease,Variant Analysis,2022-03,2022-03-18
+1719,5,Very simple and clear,,,Use Apptainer containers for running Galaxy jobs,Galaxy Server administration,2022-03,2022-03-18
+1720,5,Is really cool to see lots of different admins pooling their knowledge and effort in this way,"From a voice control perspective, it would be useful if the hands-on gxadmin commands were in a copiable code block like they are in other tutorials – it really helps to be able to copy them with the single click. Also, the 'admin favourites' section could include the arguments for the functions listed, e.g. <job_id>, for a bit more clarity",,Galaxy Monitoring with gxadmin,Galaxy Server administration,2022-03,2022-03-18
+1721,5,,,,Use Apptainer containers for running Galaxy jobs,Galaxy Server administration,2022-03,2022-03-18
+1722,5,I never have even coded before! so easy to use,,,Galaxy 101,Introduction to Galaxy Analyses,2022-03,2022-03-18
+1723,5,"Basics explained and accessible, which can be improved to acquire advanced skills and knowledge. thanks.",n/a,,Annotating a protein list identified by LC-MS/MS experiments,Proteomics,2022-03,2022-03-18
+1724,5,Very clear! It's simple and very important to know,,,Reference Data with CVMFS,Galaxy Server administration,2022-03,2022-03-18
+1725,5,"The additional explanations of the individual configuration options within the tools, especially the SQLite Syntax.",,,Identification of somatic and germline variants from tumor and normal sample pairs,Variant Analysis,2022-03,2022-03-18
+1726,5,very interesting tutorial,,,Proteogenomics 1: Database Creation,Proteomics,2022-03,2022-03-19
+1727,5,,,,Mapping,Sequence analysis,2022-03,2022-03-19
+1728,5,very useful and easy to understand workflows,,,Extracting Workflows from Histories,Using Galaxy and Managing your Data,2022-03,2022-03-19
+1729,5,User friendly and really hepful for novices like me,,,Introduction to Genomics and Galaxy,Introduction to Galaxy Analyses,2022-03,2022-03-19
+1730,5,very simple and basics mode of explanation ,,,Introduction to Genomics and Galaxy,Introduction to Galaxy Analyses,2022-03,2022-03-19
+1731,4,All over the presentation is nice and each steps are clearly explained.,Sometimes the tools are not appeared during performing a search and sometimes other tools are also appeared. It will be better if only relevant tools can be found with the keywords for a specific type of data analysis.,,Reference-based RNA-Seq data analysis,Transcriptomics,2022-03,2022-03-19
+1732,5,,An annotation part such as GO and KEGG pathway analysis should be included.,,De novo transcriptome reconstruction with RNA-Seq,Transcriptomics,2022-03,2022-03-19
+1733,4,The way the instructor explained the plot and significance of it.,It will be helpful if the steps to generate the input file limma-voome format using Galaxy tool is explained.,,Visualization of RNA-Seq results with Volcano Plot,Transcriptomics,2022-03,2022-03-19
+1734,5,The detailed description ,I think that all are perfect,,Introduction to Genomics and Galaxy,Introduction to Galaxy Analyses,2022-03,2022-03-19
+1735,5,very useful pipeline,,,Proteogenomics 2: Database Search,Proteomics,2022-03,2022-03-20
+1736,5,it was understandable,,,A short introduction to Galaxy,Introduction to Galaxy Analyses,2022-03,2022-03-20
+1737,5,,,,Reference-based RNA-Seq data analysis,Transcriptomics,2022-03,2022-03-21
+1738,5,nothing,everything,,16S Microbial Analysis with mothur (extended),Microbiome,2022-03,2022-03-21
+1739,3,nothing,nothing,,16S Microbial Analysis with mothur (extended),Microbiome,2022-03,2022-03-21
+1740,5,,,,Reference-based RNA-Seq data analysis,Transcriptomics,2022-03,2022-03-21
+1741,5,easy to understand and the tips are really usefull,no idea,,Galaxy 101,Introduction to Galaxy Analyses,2022-03,2022-03-21
+1742,5,the training used different tools and explained how each works as compared to other tolls,,,Antibiotic resistance detection,Microbiome,2022-03,2022-03-21
+1743,5,Amazing tutorial overall,,,Classification in Machine Learning,Statistics and machine learning,2022-03,2022-03-22
+1744,5,,,,Antibiotic resistance detection,Microbiome,2022-03,2022-03-22
+1745,5,Sequence analysis,,,M. tuberculosis Variant Analysis,Variant Analysis,2022-03,2022-03-22
+1746,4,I learnt new tools that i haven't used before,,,Chloroplast genome assembly,Assembly,2022-03,2022-03-22
+1747,5,overall the tutorial was easy to go through,sometimes it was unclear where some of the errors came from and how they can be fixed,,M. tuberculosis Variant Analysis,Variant Analysis,2022-03,2022-03-22
+1748,4,I like the step by step instructions on what to do ,It would be better if the tutorials should also be in video form for easy understanding,,M. tuberculosis Variant Analysis,Variant Analysis,2022-03,2022-03-22
+1749,5,The fact that there are explanations for all steps.,All were perfect!!!,,ATAC-Seq data analysis,Epigenetics,2022-03,2022-03-22
+1750,5,Detailed description,All are ecxellent,,Introduction to Genomics and Galaxy,Introduction to Galaxy Analyses,2022-03,2022-03-22
+1751,5,The fact that for the majority of the steps there are pictures that show you what you expect.,All good,,Extracting Workflows from Histories,Using Galaxy and Managing your Data,2022-03,2022-03-22
+1752,5,excellent content overall loved it,,,Regression in Machine Learning,Statistics and machine learning,2022-03,2022-03-22
+1753,4,the hands on helped with grasping tasks,Requires much more time ,,M. tuberculosis Variant Analysis,Variant Analysis,2022-03,2022-03-23
+1754,5,Easy to follow and grasp concept ,Not sure,,A short introduction to Galaxy,Introduction to Galaxy Analyses,2022-03,2022-03-23
+1755,4,"I like that even though we do not have to type in commands, we still have steps to follow. I have made errors but still were able to use tools to rectify. One can play around till the correct output!",Specification of version to use as we ended up getting different answers due to using default version,,M. tuberculosis Variant Analysis,Variant Analysis,2022-03,2022-03-23
+1756,3,hands on run ,everything is perfect,,A short introduction to Galaxy,Introduction to Galaxy Analyses,2022-03,2022-03-24
+1757,5,,,,NGS data logistics,Introduction to Galaxy Analyses,2022-03,2022-03-24
+1758,4,practicality,,,"Creating, Editing and Importing Galaxy Workflows",Using Galaxy and Managing your Data,2022-03,2022-03-25
+1759,5,,,,Quality Control,Sequence analysis,2022-03,2022-03-25
+1760,5,everything because all was new for me,Add more information in the lecture (describe more meticulously the CRISPR analysis),,CRISPR screen analysis,Genome Annotation,2022-03,2022-03-25
+1761,5,,,,Quality Control,Sequence analysis,2022-03,2022-03-26
+1762,5,,,,Galaxy 101,Introduction to Galaxy Analyses,2022-03,2022-03-26
+1763,5,It is very easy to follow,Its great for a beginner and don't think there is anything to improve.,,Galaxy 101 for everyone,Introduction to Galaxy Analyses,2022-03,2022-03-26
+1764,4,It was written clearly,"One place I think it could be improved would be on Create a reusable workflow from a history, under the Test Workflow part 2 (Examine the workflow run form) wasn't clear as the others and found it to be confusing.",,Introduction to Genomics and Galaxy,Introduction to Galaxy Analyses,2022-03,2022-03-26
+1765,5,,,,Removal of human reads from SARS-CoV-2 sequencing data,Sequence analysis,2022-03,2022-03-26
+1766,5,Tutorials easy to follow,This is great model of learning,,M. tuberculosis Variant Analysis,Variant Analysis,2022-03,2022-03-26
+1767,5,"All the steps were clear and precise. Somewhere I found video demonstrations too, which was unexpected. The concept of collapse and expand features were eyecatching.","Yes, at the end if we have a video covering the entire steps, it could be used as a quick revision of the steps we did above.",,A short introduction to Galaxy,Introduction to Galaxy Analyses,2022-03,2022-03-27
+1768,5,"This is the most extensive and instructive tutorial I've ever taken on Galaxy. My understanding of RNA-seq and DGE analysis has been improved greatly. I made some mistakes along the way which prevented certain analyses from working, but I learnt from them.",,,Reference-based RNA-Seq data analysis,Transcriptomics,2022-03,2022-03-27
+1769,5,The extensive description,I think that it is helpful to be conducted by the instructors and the extra practice which there are in the solutions for the questions because in some parts there is confusion.,,Reference-based RNA-Seq data analysis,Transcriptomics,2022-03,2022-03-27
+1770,5,The tutorial was easy to follow,,,Visualization of RNA-Seq results with Volcano Plot,Transcriptomics,2022-03,2022-03-27
+1771,5,The ability to add labels on the volcano plot,"I think that this tutorial was very detailed, so it is not needed any improvement.",,Visualization of RNA-Seq results with Volcano Plot,Transcriptomics,2022-03,2022-03-27
+1772,5,,,,An Introduction to Genome Assembly,Assembly,2022-03,2022-03-27
+1773,5,The fact that there are pictures which helps more the understanding fro each step.,Nothing,,Understanding Barcodes,Single Cell,2022-03,2022-03-27
+1774,4,I loved the workflow aspect of the platform. ,,,A short introduction to Galaxy,Introduction to Galaxy Analyses,2022-03,2022-03-28
+1775,5,The directions on how to create a pull request,i think a video could me made.,,Contributing with GitHub via its interface,Contributing to the Galaxy Training Material,2022-03,2022-03-28
+1776,5,i like the fact that it took me from a newbie to having some level of knowledge on how the galaxy interface works.,"As much as i really enjoyed this article, i actually struggled with understanding the ""Convert your analysis history into a workflow"" part, as it needed more pictures or more specific descriptions at number 4 and 5 guide steps.  i had to read it over and over, and do some brain work to figure out what the author meant.  if this could be improved for upcoming readers like me, it would be much appreciated and will lead to more productivity on our end.",,A short introduction to Galaxy,Introduction to Galaxy Analyses,2022-03,2022-03-28
+1777,5,The tutorial was instructive and easy to follow. I loved the variant calling and annotation.,,,NGS data logistics,Introduction to Galaxy Analyses,2022-03,2022-03-28
+1778,4,,,,De Bruijn Graph Assembly,Assembly,2022-03,2022-03-28
+1779,5,"The best thing about this tutorial is how clearly all the steps have been laid out. As a new user, it makes it very easy follow along and get familiar with this platform. ",I didn't face any issues following this tutorial. One can follow it verbatim. ,,Galaxy 101 for everyone,Introduction to Galaxy Analyses,2022-03,2022-03-29
+1780,5,"the pace and amount of information was just right, very clear and understandable :)",,,16S Microbial Analysis with mothur (short),Microbiome,2022-03,2022-03-29
+1781,5,Steps were so systematic and to the point ,i think it needs so much clicks but the good point is that you dont need to right that much,,Galaxy 101 for everyone,Introduction to Galaxy Analyses,2022-03,2022-03-29
+1782,2,it was okay,everything is perfect,,Quality Control,Sequence analysis,2022-03,2022-03-29
+1783,4,optimization  ,everything is perfect!,,High Throughput Molecular Dynamics and Analysis,Computational chemistry,2022-03,2022-03-29
+1784,4,It was simple and easy to follow,It would be great to have some real examples of how this can be applied to your data,,A short introduction to Galaxy,Introduction to Galaxy Analyses,2022-03,2022-03-29
+1785,4,Getting to run data through Galaxy,Maybe more schemes to describe the reads for the relevant platform,,Quality Control,Sequence analysis,2022-03,2022-03-29
+1786,5,Everything because all were new for me,"To be given the ability to conduct all parts of the tutorial, because some tools (in my condition) were not worked and I had to create a new account on another server in order to fulfill the tutorial.",,Generating a single cell matrix using Alevin,Single Cell,2022-03,2022-03-29
+1787,5,,,,Using dataset collections,Using Galaxy and Managing your Data,2022-03,2022-03-30
+1788,5,,,,M. tuberculosis Variant Analysis,Variant Analysis,2022-03,2022-03-30
+1789,3,it  was engaging ,to use of terms and examples so a first time contributor could follow along,,From peaks to genes,Introduction to Galaxy Analyses,2022-03,2022-03-30
+1790,5,Simple explanation with helpful images to provide guidance,,,A short introduction to Galaxy,Introduction to Galaxy Analyses,2022-03,2022-03-30
+1791,5,,,,Removal of human reads from SARS-CoV-2 sequencing data,Sequence analysis,2022-03,2022-03-30
+1792,5,Imaging and locating the capscicin,,,Mass spectrometry imaging: Examining the spatial distribution of analytes,Metabolomics,2022-03,2022-03-30
+1793,5,,,,Visualization of RNA-Seq results with Volcano Plot,Transcriptomics,2022-03,2022-03-30
+1794,4,"I WAS NOT AWARE THE OPTION WHERE YOU CAN GROUP YOUR DATA AND ANALYZE IT AS A COLLECTION, THANKS A LOT ",,,16S Microbial Analysis with mothur (short),Microbiome,2022-03,2022-03-30
+1795,4,the presentation was staight to point,"there is an important feature that differs in the tutorial, the analyze data button is no longer accessible after the doing a workflow editing",,Galaxy 101 for everyone,Introduction to Galaxy Analyses,2022-03,2022-03-30
+1796,5,Great tutorial for intoducing the computational chemistry,,,High Throughput Molecular Dynamics and Analysis,Computational chemistry,2022-03,2022-03-30
+1797,5,very interesting tutorial overall,,,Deep Learning (Part 1) - Feedforward neural networks (FNN),Statistics and machine learning,2022-03,2022-03-30
+1798,5,Simple and concise,,,Deep Learning (Part 2) - Recurrent neural networks (RNN),Statistics and machine learning,2022-03,2022-03-31
+1799,3,a little bit challenging to ordinary first time user,do more videos,,Extracting Workflows from Histories,Using Galaxy and Managing your Data,2022-03,2022-03-31
+1800,5,,give pictures like other tutorial,,Quality Control,Sequence analysis,2022-03,2022-03-31
+1801,5,,,,Mapping,Sequence analysis,2022-03,2022-03-31
+1802,4,,,,CRISPR screen analysis,Genome Annotation,2022-03,2022-03-31
+1803,5,,pictures - screenshots can be added,,Chloroplast genome assembly,Assembly,2022-03,2022-03-31
+1804,5,,,,Antibiotic resistance detection,Microbiome,2022-03,2022-03-31
+1805,5,great tutorial overall,,,Image classification in Galaxy with fruit 360 dataset,Statistics and machine learning,2022-03,2022-03-31
+1806,4,,"Maybe if you in ""Convert your analysis history into a workflow"" change the photo for how it should looks - where you write what, I was bit confused. This could be better for me.",,A short introduction to Galaxy,Introduction to Galaxy Analyses,2022-03,2022-03-31
+1807,2,not that much,reduce unnecessary details from the page ,,How to reproduce published Galaxy analyses,Introduction to Galaxy Analyses,2022-03,2022-03-31
+1808,5,,,,Genome annotation with Maker,Genome Annotation,2022-03,2022-03-31
+1809,5,Everything because all was new for me,The tutorial video would be more detailed in some parts.,,"Filter, plot and explore single-cell RNA-seq data (Scanpy)",Single Cell,2022-03,2022-03-31
+1810,4,,"the sharing link is not working, so i couldnt share and create the group ",,Refining Genome Annotations with Apollo (prokaryotes),Genome Annotation,2022-03,2022-03-31
+1811,4,,,,Reference-based RNA-Seq data analysis,Transcriptomics,2022-03,2022-03-31
+1812,5,,,,Visualization of RNA-Seq results with Volcano Plot,Transcriptomics,2022-03,2022-03-31
+1813,5,,,,Quality Control,Sequence analysis,2022-03,2022-03-31
+1814,5,,,,Removal of human reads from SARS-CoV-2 sequencing data,Sequence analysis,2022-03,2022-03-31
+1815,5,the creation of plots and after the process of visualization and the try of understanding what I saw,i think nothing,,Bulk RNA Deconvolution with MuSiC,Single Cell,2022-03,2022-03-31
+1816,5,,,,Advanced Python,Foundations of Data Science,2022-03,2022-03-31
+1817,5,great overall,,,Deep Learning (Part 3) - Convolutional neural networks (CNN),Statistics and machine learning,2022-03,2022-03-31
+1818,5,,,,Plotting in Python,Foundations of Data Science,2022-03,2022-03-31
+1819,5,,,,Antibiotic resistance detection,Microbiome,2022-04,2022-04-01
+1820,4,,,,16S Microbial Analysis with mothur (short),Microbiome,2022-04,2022-04-01
+1821,4,detailing,make an upgrage to server and do a video if possible,,From peaks to genes,Introduction to Galaxy Analyses,2022-04,2022-04-01
+1822,4,it's was more clear and more relating than others,i think a pdf explaining some notes would be ok,,Galaxy 101,Introduction to Galaxy Analyses,2022-04,2022-04-01
+1823,5,,,,Reference-based RNA-Seq data analysis,Transcriptomics,2022-04,2022-04-01
+1824,5,,,,M. tuberculosis Variant Analysis,Variant Analysis,2022-04,2022-04-01
+1825,5,,,,1: RNA-Seq reads to counts,Transcriptomics,2022-04,2022-04-02
+1826,4,"A demo with a cripsr pool set who works (so many online pool screen CRIPSR tools do not work). so many command based installation do not work.  Simply starting with MAGECK installation on python is just a nightmare, it does not install smoothly, and it seems thatthe original authors move on and do not care at deploying this smoothly to the community(only expert can use these code lines). I really appreciate the work here. It seems more applicable from any machine without all the dependancies, environments, expertise in coding  and languages bug...... ",Should make mageck available in  global galaxy and not just australia one. Could provide other datasets such as cripsrI or cripsA pool set to extend the range of trial for users to get accustomed with the pipeline.  ,,CRISPR screen analysis,Genome Annotation,2022-04,2022-04-03
+1827,5,It was straigthforward and had animations to guide you.,I think it's missing some basics of Galaxy.,,A short introduction to Galaxy,Introduction to Galaxy Analyses,2022-04,2022-04-04
+1828,5,EVERYTHING,NOTHING,,Quality Control,Sequence analysis,2022-04,2022-04-04
+1829,5,,,,Galaxy 101 for everyone,Introduction to Galaxy Analyses,2022-04,2022-04-05
+1830,5,the fact that it gave definitions for things that could be unknown,not really much. maybe make similar tutorials but for larger jobs,,Introduction to Genomics and Galaxy,Introduction to Galaxy Analyses,2022-04,2022-04-06
+1831,5,clear directions. screen shots help,,,A short introduction to Galaxy,Introduction to Galaxy Analyses,2022-04,2022-04-07
+1832,5,"It's easy, indexing and saving history is great tool","Maybe, in this tutorial, using colors for different strand genes would be more easy to see in genome browser later",,Introduction to Genomics and Galaxy,Introduction to Galaxy Analyses,2022-04,2022-04-07
+1833,5,"The tutorial was instructive and easy to follow. As a WSL user, I really loved this session. I got to learn about Planemo. ",,,Automating Galaxy workflows using the command line,Using Galaxy and Managing your Data,2022-04,2022-04-07
+1834,5,Detailed and accurate.,I have no suggestions ,,A short introduction to Galaxy,Introduction to Galaxy Analyses,2022-04,2022-04-08
+1835,5,,,,Galaxy 101,Introduction to Galaxy Analyses,2022-04,2022-04-10
+1836,5,,,,A short introduction to Galaxy,Introduction to Galaxy Analyses,2022-04,2022-04-10
+1837,5,,,,3: RNA-seq genes to pathways,Transcriptomics,2022-04,2022-04-11
+1838,4,great explanation ,,,Reference-based RNA-Seq data analysis,Transcriptomics,2022-04,2022-04-11
+1839,5,Each step of the analysis is very well explained and I could use this tutorial to help student understand 16S microbiome analysis. ,"The trainsets need updating. I tried to do this myself but it did not work. Also, could you do a version for ITS analysis?",,16S Microbial Analysis with mothur (extended),Microbiome,2022-04,2022-04-13
+1840,5,,,,Running molecular dynamics simulations using GROMACS,Computational chemistry,2022-04,2022-04-13
+1841,5,,,,High Throughput Molecular Dynamics and Analysis,Computational chemistry,2022-04,2022-04-13
+1842,5,,,,Ansible,Galaxy Server administration,2022-04,2022-04-14
+1843,5,,,,Understanding Barcodes,Single Cell,2022-04,2022-04-17
+1844,4,It was good and simple.,More indications on how to read the visualization with IGV and JBrowse. ,,Mapping,Sequence analysis,2022-04,2022-04-17
+1845,5,,,,Quality Control,Sequence analysis,2022-04,2022-04-18
+1846,5,,,,A short introduction to Galaxy,Introduction to Galaxy Analyses,2022-04,2022-04-18
+1847,5,,,,A short introduction to Galaxy,Introduction to Galaxy Analyses,2022-04,2022-04-20
+1848,5,,,,16S Microbial Analysis with mothur (short),Microbiome,2022-04,2022-04-22
+1849,5,The tutorial is Practical and easy to understand,I think in will be usefull to include another ways to upload files,,A short introduction to Galaxy,Introduction to Galaxy Analyses,2022-04,2022-04-25
+1850,1,,,,De Bruijn Graph Assembly,Assembly,2022-04,2022-04-26
+1851,5,It is easy to follow up as you practice.,More examples to practice with.,,An Introduction to Genome Assembly,Assembly,2022-04,2022-04-26
+1852,4,,,,Genome Annotation,Genome Annotation,2022-04,2022-04-26
+1853,4,The tutorial is very comprehensive.,"The link for the Ensembl gene annotation for Drosophila melanogaster from Zenodo doesn't work. I think there are mistakes regarding the datasets and tools to be used in the ""Gene Ontology analysis"" section, more precisely in the ""Hands on: Get the gene length from previous history"" and ""Hands on: Adapt the gene length to goseq"" parts. ",,Reference-based RNA-Seq data analysis,Transcriptomics,2022-04,2022-04-26
+1854,5,"It was simple (great for the first aproach), really clear and usefull",,,A short introduction to Galaxy,Introduction to Galaxy Analyses,2022-04,2022-04-27
+1855,5,It was easy to follow but learn usefull things,,,Galaxy 101 for everyone,Introduction to Galaxy Analyses,2022-04,2022-04-27
+1856,4,,,,Deep Learning (Part 3) - Convolutional neural networks (CNN),Statistics and machine learning,2022-04,2022-04-28
+1857,5,,,,A short introduction to Galaxy,Introduction to Galaxy Analyses,2022-04,2022-04-28
+1858,5,,,,CRISPR screen analysis,Genome Annotation,2022-04,2022-04-28
+1859,5,The stages of preparing a workshop is very explicit on . Thanks.,The processes  are clear.and direct.,,Organizing a workshop,Teaching and Hosting Galaxy training,2022-04,2022-04-29
+1860,5,hands on,,,Galaxy 101 for everyone,Introduction to Galaxy Analyses,2022-04,2022-04-29
+1861,5,interactive,,,Introduction to Genomics and Galaxy,Introduction to Galaxy Analyses,2022-04,2022-04-29
+1862,5,easy explanations,,,A short introduction to Galaxy,Introduction to Galaxy Analyses,2022-04,2022-04-30
+1863,5,,,,From peaks to genes,Introduction to Galaxy Analyses,2022-05,2022-05-03
+1864,4,,,,A short introduction to Galaxy,Introduction to Galaxy Analyses,2022-05,2022-05-03
+1865,5,Its simplicity. It was easy to follow and didn't make me stressed.,,,Quality Control,Sequence analysis,2022-05,2022-05-04
+1866,5,,,,Reference-based RNA-Seq data analysis,Transcriptomics,2022-05,2022-05-06
+1867,1,topic is very important,"some steps are not cleared explained, workflow for this specific task and visualization tool is not working showing loading error",,From peaks to genes,Introduction to Galaxy Analyses,2022-05,2022-05-07
+1868,5,,,,A short introduction to Galaxy,Introduction to Galaxy Analyses,2022-05,2022-05-09
+1869,4,,,,Quality Control,Sequence analysis,2022-05,2022-05-10
+1870,4,Easy to understand,Pls provide dataset so that we can practice alongside,,Introduction to Machine Learning using R,Statistics and machine learning,2022-05,2022-05-11
+1871,1,,,,Proteogenomics 3: Novel peptide analysis,Proteomics,2022-05,2022-05-13
+1872,4,,,,How to reproduce published Galaxy analyses,Introduction to Galaxy Analyses,2022-05,2022-05-15
+1873,5,yes,,,Mapping,Sequence analysis,2022-05,2022-05-15
+1874,5,I like the clarity of the pictures used in describing the different steps,There is nothing needed to be improved. The tutorial is excellent,,A short introduction to Galaxy,Introduction to Galaxy Analyses,2022-05,2022-05-16
+1875,5,Simplicity of explaining complicate issue (-;,n.a.,,Analyses of metagenomics data - The global picture,Microbiome,2022-05,2022-05-17
+1876,4,Easy to follow. Helpful examples. ,,,Galaxy 101,Introduction to Galaxy Analyses,2022-05,2022-05-18
+1877,5,The explanations,,,Visualization of RNA-Seq results with Volcano Plot,Transcriptomics,2022-05,2022-05-18
+1878,3,,,,Reference-based RNA-Seq data analysis,Transcriptomics,2022-05,2022-05-18
+1879,5,Platform is simple enough to follow and the steps are well-explained.,"When I run the tutorial with Windows as an OS everything ran smoothly, but when I was on Ubuntu linux I had issues with the window that I had to load the dataset. The options for pasting the data, etc. were not visible at all and I could not do anything for it. ",,A short introduction to Galaxy,Introduction to Galaxy Analyses,2022-05,2022-05-21
+1880,5,,,,Reference-based RNA-Seq data analysis,Transcriptomics,2022-05,2022-05-22
+1881,5,proper description and arrangement.,Results,,Genome Annotation,Genome Annotation,2022-05,2022-05-23
+1882,5,the details,,,A short introduction to Galaxy,Introduction to Galaxy Analyses,2022-05,2022-05-24
+1883,5,,,,Galaxy 101,Introduction to Galaxy Analyses,2022-05,2022-05-25
+1884,5,It explained everything in simple language!!,,,Introduction to Genomics and Galaxy,Introduction to Galaxy Analyses,2022-05,2022-05-25
+1885,4,,,,Mass spectrometry imaging: Examining the spatial distribution of analytes,Metabolomics,2022-05,2022-05-25
+1886,5,,,,A short introduction to Galaxy,Introduction to Galaxy Analyses,2022-05,2022-05-27
+1887,5,hashtags!,,,Understanding Galaxy history system,Using Galaxy and Managing your Data,2022-05,2022-05-28
+1888,5,,,,Pangeo Notebook in Galaxy - Introduction to Xarray,Climate,2022-05,2022-05-29
+1889,4,Good balance between some slightly more 'in depth topics' and simple and to the point hand-on instructions.,"The 'Available on these Galaxies' information should be updates. For exmple, the tutorial can not be completed as it is in the Australian server (for example, there are not locally installed snpEff databases, so a previous step with snpEff Download is needed and then use the option 'Downloaded snpEff database in your history'. Can be done but is confusing specially for novices). On the other hand, as far as I know, it can be conducted exactly as it is in the European server, but that one is not listed in the 'Available on these Galaxies' drop down menu.",,Calling variants in diploid systems,Variant Analysis,2022-05,2022-05-30
+1890,5,"I liked the real world data set, and the real world steps of exploration followed by the analysis. I thought the step wise progression made a lot of sense to me. I like having both predicting a categorical variable and the linear regression. It was great having both as many tutorials concentrate on predicting dichotomous outcomes and skip linear. I also like the exposure to handy R libraries, I am aware of quite a few (this isn't my first rodeo) but I learned of some more from this tutorial which was great.","Perhaps be explicit about the goals for the data analysis of the breast cancer dataset, that way the reader gets emotionally engaged in the analysis. I didn't realise till after looking at the source link that the measurements were from fine-needle biopsies of breast lesions, and the measurements were of cell nucleus radius, (I thought originally it might have been referring to tumour radius in mm). And that the goals were from the cell data from the fine needle aspiration we need to predict whether the patient has breast cancer or not. I appreciate you don't want the tutorial to be too long but perhaps using the cross table to show the positive predictive value or sensitivity and specificity and how increasing the number of clusters could improve the diagnostic accuracy.",,Introduction to Machine Learning using R,Statistics and machine learning,2022-06,2022-06-02
+1891,5,Well organized. Appreciated how the authors explained each QC graph. ,,,Quality Control,Sequence analysis,2022-06,2022-06-07
+1892,4,,,,Masking repeats with RepeatMasker,Genome Annotation,2022-06,2022-06-07
+1893,5,The questions that helped you look for the most relevant information in each Galaxy output in the history really made the tutorial engaging.,,,Library Generation for DIA Analysis,Proteomics,2022-06,2022-06-07
+1894,3,The interactive tools perspective,"The requirement for wildcard SSL certificate and the poor support for fulfilling this requirement. This is a major issue for the deployment of Galaxy servers. From a historical perspective, before 2019, there were IEs. Not super easy to deploy, but doable with motivation and investment in Docker knowledge. After launching the new ITs, IEs became progressively useless and ITs stay either nice demos or running on very few big public servers. Even the latter is not so clear: for instance, usegalaxy.org.au is not really providing ITs, usegalaxy.org (!) seems providing it at first glance, but the Rstudio interface - for instance - remains full blank forever. Only usegalaxy.eu to my knowledge provides effectively running and usable generalist ITs (Rstudio, Jupyter,). Thus, on that matter, where is the initial slogan ""data intensive analysis for everyone"" ? Of course, I am not blaming the trainers and contributors to this tutorial in any way ! But I really think that the technical strategy relying on wildcard SSL certificate to get the ITs running should be discussed with the community as a serious limitation to their use and thereby their active development. As it stands since 3 years now, ITs are out of the possibilities of a majority of Galaxy server instances because too complicated to install.",,Galaxy Interactive Tools,Galaxy Server administration,2022-06,2022-06-08
+1895,4,straightforward,"would have liked to have some practice viewing the assembly graphs and with visual methods for comparing genomes (e.g. dot, synteny plots)",,Genome assembly using PacBio data,Assembly,2022-06,2022-06-08
+1896,5,The explanation of every step which provide understanding even to beginners.,The different methods used in different steps of simulation should be explain in a such a way that the person can understand which method he should apply to his experiment.,,Running molecular dynamics simulations using GROMACS,Computational chemistry,2022-06,2022-06-08
+1897,5,,,,Galaxy 101,Introduction to Galaxy Analyses,2022-06,2022-06-08
+1898,1,nothing,everything,,DNA Methylation data analysis,Epigenetics,2022-06,2022-06-09
+1899,5,,,,Visualization of RNA-Seq results with Volcano Plot,Transcriptomics,2022-06,2022-06-10
+1900,4,it was clear ,maybe you could explain the file formats and what the tools do in a more clean way ,,Formation of the Super-Structures on the Inactive X,Epigenetics,2022-06,2022-06-13
+1901,5,,,,A short introduction to Galaxy,Introduction to Galaxy Analyses,2022-06,2022-06-15
+1902,5,,,,Formation of the Super-Structures on the Inactive X,Epigenetics,2022-06,2022-06-15
+1903,5,"Nice and understandable! I'm a software engineer tasked with setting up and administrating a Galaxy server, so I don't have a bioinformatics background. However, I was able to understand this tutorial and now know why Galaxy is such a powerful tool!",,,Galaxy 101 for everyone,Introduction to Galaxy Analyses,2022-06,2022-06-15
+1904,5,Ease of use,,,Galaxy 101 for everyone,Introduction to Galaxy Analyses,2022-06,2022-06-17
+1905,1,,it can be more better how do you get the end result was not clearly explained,,NGS data logistics,Introduction to Galaxy Analyses,2022-06,2022-06-18
+1906,5,,,,Introduction to Genomics and Galaxy,Introduction to Galaxy Analyses,2022-06,2022-06-20
+1907,3,,,,Quality Control,Sequence analysis,2022-06,2022-06-20
+1908,5,Well-detailed ,Alphadiversity,,16S Microbial Analysis with mothur (extended),Microbiome,2022-06,2022-06-24
+1909,5,The clarity and flow of topics guidelines,so far so good,,16S Microbial Analysis with mothur (extended),Microbiome,2022-06,2022-06-24
+1910,5,easy to follow & explained well,,,Quality Control,Sequence analysis,2022-06,2022-06-28
+1911,1,tree -l 2 was helpful as otherwise unclear which file goes where,"Current version of the tutorial is broken, consider rolling back to archive. Ansible errors very hard to troubleshoot - ideally add more tips where things can go wrong, for ex ansible vault seems to enter an unfixable state if you mess up the secret yml file and have to make it again",,Galaxy Installation with Ansible,Galaxy Server administration,2022-06,2022-06-29
+1912,5,,,,A short introduction to Galaxy,Introduction to Galaxy Analyses,2022-06,2022-06-29
+1913,5,"Very detailed, self explanatory",More examples maybe good,,Quality Control,Sequence analysis,2022-06,2022-06-29
+1914,5,learning how to use a workflow on a different dataset,,,Galaxy 101 for everyone,Introduction to Galaxy Analyses,2022-06,2022-06-30
+1915,1,most of the functionsare different what is given here,"please insert screen shorts of the results, how the output look like ",,An Introduction to Genome Assembly,Assembly,2022-06,2022-06-30
+1916,4,The way of presentation to make the tutorial easily understandable.,More numerical examples could be added.,,Deep Learning (Part 2) - Recurrent neural networks (RNN),Statistics and machine learning,2022-07,2022-07-01
+1917,4,The clear instructions on how to use the tools ,allowing learners to supply the solution and evaluating the answers,,M. tuberculosis Variant Analysis,Variant Analysis,2022-07,2022-07-02
+1918,2,It is a useful feature.,"The syntax of the ""Replace text"" tool is not explained. Thus, it is only useful with the data collection of the tutorial, but it does not teach how to aply it to other collections with different element identifiers. It would be great if it explained why the ""Find pattern"" and ""Replace with"" boxes are filled that way.",,Group tags for complex experimental designs,Using Galaxy and Managing your Data,2022-07,2022-07-05
+1919,4,This hands on tutorial made me understands some of the concepts raised in the webnar,"A note on the estimated run time of the on the provided data, this will help to know if i have done something wrong.",,Identifying tuberculosis transmission links: from SNPs to transmission clusters,Evolution,2022-07,2022-07-05
+1920,5,Clear example of a great use case,What to do if pulling from an FTP server that requires credentials,,Rule Based Uploader,Using Galaxy and Managing your Data,2022-07,2022-07-08
+1921,5,Thorough guide with plenty of time for users to try. ,"To me it's simple enough to follow all the instructions, no improvement needed.",,A short introduction to Galaxy,Introduction to Galaxy Analyses,2022-07,2022-07-09
+1922,1,more detailed form example was not explained clearly,,,IGV Introduction,Introduction to Galaxy Analyses,2022-07,2022-07-09
+1923,4,it was information packed and tried to explain in details. ,"well , idk if i'm dumb but i couldn't find the gear icon to start the ctul tutorial. maybe the boxes in the instruction could be direct links instead?",,Quality Control,Sequence analysis,2022-07,2022-07-11
+1924,5,,,,A short introduction to Galaxy,Introduction to Galaxy Analyses,2022-07,2022-07-12
+1925,5,Easy to follow steps ,,,A short introduction to Galaxy,Introduction to Galaxy Analyses,2022-07,2022-07-14
+1926,5,,,,Galaxy 101,Introduction to Galaxy Analyses,2022-07,2022-07-19
+1927,4,The step by step guide and easy to operate,I facet some trouble with Database/Build section and I would like to info about them even it was not necessary for the analyse.,,Label-free data analysis using MaxQuant,Proteomics,2022-07,2022-07-19
+1928,5,It was easy to follow and very useful ,,,Reference-based RNA-Seq data analysis,Transcriptomics,2022-07,2022-07-19
+1929,5,clarity of each step,a short video can easy to complete this workflow and help peopless to learn it in much less time,,A short introduction to Galaxy,Introduction to Galaxy Analyses,2022-07,2022-07-20
+1930,5,,,,A short introduction to Galaxy,Introduction to Galaxy Analyses,2022-07,2022-07-20
+1931,5,,,,Clustering 3K PBMCs with Scanpy,Single Cell,2022-07,2022-07-21
+1932,4,,,,Peptide Library Data Analysis,Proteomics,2022-07,2022-07-24
+1933,5,,,,Machine Learning Modeling of Anticancer Peptides,Proteomics,2022-07,2022-07-24
+1934,5,,,,Microbial Variant Calling,Variant Analysis,2022-07,2022-07-26
+1935,5,the interaction of images and descriptions, more images of the interface step y step,,Galaxy 101 for everyone,Introduction to Galaxy Analyses,2022-07,2022-07-27
+1936,5,"relatively easy to follow, concept explanations are great ",,,Galaxy Installation with Ansible,Galaxy Server administration,2022-07,2022-07-28
+1937,5,,,,Visualization of RNA-Seq results with heatmap2,Transcriptomics,2022-07,2022-07-30
+1938,3,Great overview of ML and the basic models to start.,Many questions still lack solutions and there are some typos within the text.,,Introduction to Machine Learning using R,Statistics and machine learning,2022-08,2022-08-04
+1939,5,"I loved the fact that although this is not in-person, it was more interactive and practical. ",,,A short introduction to Galaxy,Introduction to Galaxy Analyses,2022-08,2022-08-04
+1940,5,Everything,Not much at all,,A short introduction to Galaxy,Introduction to Galaxy Analyses,2022-08,2022-08-04
+1941,5,It was explained in really easy to understand language for a novice like me with great diagrams. I've looked at a number of explanations about alpha and beta diversity and this was the most useful so far.,,,16S Microbial Analysis with mothur (extended),Microbiome,2022-08,2022-08-04
+1942,3,List  elements identified during the process of genome annotation.,,,Genome Annotation,Genome Annotation,2022-08,2022-08-05
+1943,4,,,,A short introduction to Galaxy,Introduction to Galaxy Analyses,2022-08,2022-08-09
+1944,5,Things are explained in a simple and intuitive way,,,Quality Control,Sequence analysis,2022-08,2022-08-11
+1945,5,,,,16S Microbial analysis with Nanopore data,Microbiome,2022-08,2022-08-12
+1946,1,,merge gromacs topologies doesn't exist in https://cheminformatics.usegalaxy.eu It was not possible to complete the tutorial without this tool,,High Throughput Molecular Dynamics and Analysis,Computational chemistry,2022-08,2022-08-14
+1947,5,,,,Quality Control,Sequence analysis,2022-08,2022-08-15
+1948,1,,,,Virtual screening of the SARS-CoV-2 main protease with rxDock and pose scoring,Computational chemistry,2022-08,2022-08-18
+1949,5,,Small typo at https://bit.ly/3dG17Er - tedious,,Reference-based RNA-Seq data analysis,Transcriptomics,2022-08,2022-08-18
+1950,5,,,,Reference-based RNA-Seq data analysis,Transcriptomics,2022-08,2022-08-18
+1951,5,The flow and easeness of usage and details.,,,Biomarker candidate identification,Proteomics,2022-08,2022-08-22
+1952,5,,,,Understanding Barcodes,Single Cell,2022-08,2022-08-22
+1953,5,everything.. thanks for this,"i cant find bowtie tools.. only bowtie 2, but the parameters described here are for bowtie.",,Essential genes detection with Transposon insertion sequencing,Genome Annotation,2022-08,2022-08-23
+1954,5,,,,Visualization of RNA-Seq results with heatmap2,Transcriptomics,2022-08,2022-08-23
+1955,4,,,,Mass spectrometry imaging: Loading and exploring MSI data,Proteomics,2022-08,2022-08-24
+1956,4,"Most of the explanations and step were explained well but many icons in Galaxy have changed .  An update will be appreciated.  If USC browser is the main source , please have a detailed tutorial what all that stuff means .  Thanks",,,Introduction to Genomics and Galaxy,Introduction to Galaxy Analyses,2022-08,2022-08-25
+1957,4,,,,A short introduction to Galaxy,Introduction to Galaxy Analyses,2022-08,2022-08-30
+1958,5,Biological explanations after a command. ,"I think its great, but one improviment is add more image from Galaxy. ",,Introduction to Genomics and Galaxy,Introduction to Galaxy Analyses,2022-08,2022-08-30
+1959,5,The instructions were clear and helpful (especially with the video alongside),"It would be super helpful if there were more subsection links! I set followed this tutorial to setup a server for my team, and when they had questions or wanted more info on why or how I did certain things it would have been nice to be able to link them more specifically to the step I wanted instead of the bigger section and then giving them key words to search for",,Galaxy Installation with Ansible,Galaxy Server administration,2022-08,2022-08-30
+1960,5,,,,Visualization of RNA-Seq results with heatmap2,Transcriptomics,2022-09,2022-09-01
+1961,4,"Learn about other tools to asses quality, it is often on software that we use, the one that is showed by the person that initiates us to galaxy. Here, we could see a panel of tools. ","I think maybe it is more pertinent to show one example of good and one of a bad data instead of a panel that increase the information a blur the message. Two images are easier to remember. I'd like that you showed us a panel of tools, but it is maybe too much information, too quickly within a short amount of time. Knowing that we have almost two weeks formations non stop, it could be valuable to synthesis more the message to slow down and make it more digestible. The specifics could be prospected by each user when they contact you. A fact that you could also remember people at the end of the presentation. ",,Quality Control,Sequence analysis,2022-09,2022-09-01
+1962,4,To test the tools of assembly in a control dataset,I think it could be valable to understand the tools and the parameters of the tools while using them: to not do it without thinking it through. I think it is better to understand to remember. ,,Genome assembly using PacBio data,Assembly,2022-09,2022-09-01
+1963,5,I really liked the amount of details,"Its perfect to me, but if you could add short videos in each topic, it can be complementary. ",,Quality Control,Sequence analysis,2022-09,2022-09-05
+1964,4,,,,A short introduction to Galaxy,Introduction to Galaxy Analyses,2022-09,2022-09-06
+1965,5,"Simple, clear",,,A short introduction to Galaxy,Introduction to Galaxy Analyses,2022-09,2022-09-12
+1966,5,It was doable by a wet lab scientist without prior experience in analysis!,,,A short introduction to Galaxy,Introduction to Galaxy Analyses,2022-09,2022-09-12
+1967,5,Easy to follow,"Couple of things out of date: view all histories is now in the menu and ""Click on galaxy-gear (History options) at the top of your history panel and select Extract workflow."" no longer a galaxy-gear icon but a drop down?",,A short introduction to Galaxy,Introduction to Galaxy Analyses,2022-09,2022-09-12
+1968,5,Simple and clear,,,Name tags for following complex histories,Using Galaxy and Managing your Data,2022-09,2022-09-12
+1969,5,Didn't know this feature!,tag=paired is incorrect - should be tag:paired ???,,Name tags for following complex histories,Using Galaxy and Managing your Data,2022-09,2022-09-12
+1970,5,,,,Extracting Workflows from Histories,Using Galaxy and Managing your Data,2022-09,2022-09-12
+1971,4,,,,Name tags for following complex histories,Using Galaxy and Managing your Data,2022-09,2022-09-12
+1972,5,,,,16S Microbial Analysis with mothur (extended),Microbiome,2022-09,2022-09-14
+1973,5,,,,Quality Control,Sequence analysis,2022-09,2022-09-14
+1974,2,its step by step,"steps are not explained - for example: why do i need align left, why do i need to refilter quality levels...? Way to hard to understand. More Explanation why things are done a certain way. Its not explained why certain values are set and how to choose the right values. This tutorial is way to complicated.",,Identification of somatic and germline variants from tumor and normal sample pairs,Variant Analysis,2022-09,2022-09-14
+1975,5,"Clear, straight forward, but also information rich.",,,"Filter, plot and explore single-cell RNA-seq data (Scanpy)",Single Cell,2022-09,2022-09-15
+1976,5,,,,"Filter, plot and explore single-cell RNA-seq data (Scanpy)",Single Cell,2022-09,2022-09-15
+1977,5,"Easy to follow, encouraging to continue exploring","First time I run the QC analysis it took more than 1 hour, it would be great to have a time tracker so we can estimate the duration of each analysis (Second time I did the analysis it run in about 2 min)",,A short introduction to Galaxy,Introduction to Galaxy Analyses,2022-09,2022-09-15
+1978,5,,,,"Inferring single cell trajectories (Scanpy, Python)",Single Cell,2022-09,2022-09-16
+1979,5,,,,Galaxy 101,Introduction to Galaxy Analyses,2022-09,2022-09-19
+1980,5,,,,Species distribution modeling,Ecology,2022-09,2022-09-21
+1981,5,,,,Quality Control,Sequence analysis,2022-09,2022-09-21
+1982,4,Data made small enough to process it together in class,"Could you please correct the following typos: ""Differentially expressed miRNAs"" into ""Differentially expressed mRNAs"" in the section ""mRNA data analysis > Filter.. Thanks!",,Whole transcriptome analysis of Arabidopsis thaliana,Transcriptomics,2022-09,2022-09-24
+1983,4,"I appreciated the descriptions and the format of it, like bullet points, etc.","I think more pictures would be valueable since it is a bit hard to navigate at first, especially during the 'workflow' i got a bit confused",,A short introduction to Galaxy,Introduction to Galaxy Analyses,2022-09,2022-09-25
+1984,5,"very comprehensive, needed for the data that doesn’t have annotation file (GTF)",please make a video with it. and a real data using in this tutorial from ncbi or else.,,"De novo transcriptome assembly, annotation, and differential expression analysis",Transcriptomics,2022-09,2022-09-25
+1985,5,,,,1: RNA-Seq reads to counts,Transcriptomics,2022-09,2022-09-26
+1986,5,"I really liked, that I could actually try it out.",,,A short introduction to Galaxy,Introduction to Galaxy Analyses,2022-09,2022-09-28
+1987,5,,,,A short introduction to Galaxy,Introduction to Galaxy Analyses,2022-10,2022-10-01
+1988,5,,,,16S Microbial analysis with Nanopore data,Microbiome,2022-10,2022-10-07
+1989,5,,,,Visualization of RNA-Seq results with heatmap2,Transcriptomics,2022-10,2022-10-07
+1990,5,,,,A short introduction to Galaxy,Introduction to Galaxy Analyses,2022-10,2022-10-11
+1991,4,,"The wheel symbol in the history menu has changed to an arrow down. Also, the way to see the histories side by side has changed.",,A short introduction to Galaxy,Introduction to Galaxy Analyses,2022-10,2022-10-11
+1992,3,What I liked most about this tutorial was the existence of explanations that helped in the interpretation of the various outputs produced by the software.,"The tutorial could be updated because I found that there are discrepancies between the tutorial and the Galaxy platform. Namely, the name of some of the tools and their location on the website differ between the tutorial and the current platform.",,Genome annotation with Maker (short),Genome Annotation,2022-10,2022-10-11
+1993,5,"simple and easy to follow, although some of the icons have changed in the updated version",Just updated screen shots,,A short introduction to Galaxy,Introduction to Galaxy Analyses,2022-10,2022-10-12
+1994,5,,que explicara mas a fondo el uso de las demas herramientas con ejercicios,,A short introduction to Galaxy,Introduction to Galaxy Analyses,2022-10,2022-10-14
+1995,5,,,,1: RNA-Seq reads to counts,Transcriptomics,2022-10,2022-10-14
+1996,5,,,,A short introduction to Galaxy,Introduction to Galaxy Analyses,2022-10,2022-10-15
+1997,5,,,,A short introduction to Galaxy,Introduction to Galaxy Analyses,2022-10,2022-10-19
+1998,5,Ease of steps and explanation of file formats,More explanation of the potential pitfalls and essential QC,,Visualization of RNA-Seq results with Volcano Plot,Transcriptomics,2022-10,2022-10-21
+1999,5,"The simplicity and the start level, you can start in a very basic level.","There is sth you have toke take in mind, when you copy the dataset a space is coppied at the beggining of the link. With this space the dataset is not ridden. ",,A short introduction to Galaxy,Introduction to Galaxy Analyses,2022-10,2022-10-23
+2000,5,The tutorial is simple and easy to understand. The instructions are clear and the images help the student to know what to do. ,One thing that could be improved is the location of some filters due to is a little bit confusing. ,,A short introduction to Galaxy,Introduction to Galaxy Analyses,2022-10,2022-10-24
+2001,5,,,,2: RNA-seq counts to genes,Transcriptomics,2022-10,2022-10-24
+2002,5,images make it easy to undestand,maybe you could add videos to help undestand the steps ,,A short introduction to Galaxy,Introduction to Galaxy Analyses,2022-10,2022-10-25
+2003,5,The complete explanation,,,A short introduction to Galaxy,Introduction to Galaxy Analyses,2022-10,2022-10-25
+2004,4,It was easy to follow the steps and the functions ran in a good amount of time (relatively fast) ,"- I got stuck in staramr. there was a recurrent error due to ERROR: 'Predicted Phenotype'. This error was reported. it appears to be due to a problem of compatibility with the pandas version (https://github.com/phac-nml/staramr/issues/115) - Genome annotation using Prokka, step 2 (Select lines that match an expression) has changed names to Search in Textfiles (grep)  - Table to GFF3 function: I was unable to find this function under the Galaxy tools. downstream commands could not be ran.",,Genome Assembly of MRSA using Oxford Nanopore MinION Data,Assembly,2022-10,2022-10-25
+2005,4,,"Table to gff3 tool does not exist anymore. When I use the tutorial mode on galaxy and click on the table to gff3 hyperlink button, i get this message: Loading tool toolshed.g2.bx.psu.edu/repos/iuc/tbl2gff3/tbl2gff3/1.2 failed: Could not find tool with id 'toolshed.g2.bx.psu.edu/repos/iuc/tbl2gff3/tbl2gff3/1.2'.  Do you have any advice on which other tool to use?  Also, in a prior feedback I mentioned that I could not find select the lines, but it is actually there I found it in the end. sorry for the mistake.",,Genome Assembly of MRSA using Oxford Nanopore MinION Data,Assembly,2022-10,2022-10-25
+2006,5,La manera que explica,Me parece que estuvo bien ,,A short introduction to Galaxy,Introduction to Galaxy Analyses,2022-10,2022-10-25
+2007,5,everything,nothing,,A short introduction to Galaxy,Introduction to Galaxy Analyses,2022-10,2022-10-25
+2008,5,,,,A short introduction to Galaxy,Introduction to Galaxy Analyses,2022-10,2022-10-26
+2009,5,method present and images,,,Running molecular dynamics simulations using GROMACS,Computational chemistry,2022-10,2022-10-31
+2010,4,"The video walkthrough of how to use tools was good. Breakdown of sections with a Table of Contents to jump around was good. I like that extra detail was included, but it's so far above my head I didn't understand those at all. Thanks for the wonderful visuals, it really helps explain the relevance of each section. The beginning of the webpage and the tutorial video was actually very clear and easy to understand, it gets a bit more convoluted about halfway through and really by the end before the Nanoplot stuff (video ends before that).","I would have preferred if additional visual aids were used instead of just a plain screen grab. Some of the text was hard to read even on a large TV screen. Highlighting or circling or arrows, anything would help to focus the viewer's attention towards the relevant topic area. Some written aids which could be directly taken from the written webpage might be handy to sync up reading the webpage and following along with the tutorial would be nice for newbie readers who don't actually understand what's going on. An example would be just titling the section with big obvious words that match the webpage's Table of Content. And useful on screen aids like showing the buttons for pressing and holding Control OR Command with the symbols would be helpful for those following along. That's not a thing that can be demonstrated on the screen itself and can easily be overlooked as it's only mentioned for a few seconds. Then the important changes from FASTQC to MULTIQC where you must change the file input from a single file to multiple files, that right there would benefit from circling or highlighting or drawing a box around that button, maybe zooming in too. It doesn't need to be fancy Hollywood graphics here. The same video can still be used but for those few seconds that he's saying what button to press, you could use a screenshot, recorded in Powerpoint in Presentation mode with nice transitions, use the Zoom effect for each area like typing into the Upload Data section, draw a box around that button, then the Zoom back out transition to the MULTIQC options, draw a box on the button for multiple file uploads, Zoom in or out, up to you there, then return to the original video footage. I know it's simplistic, but it helps alot for new users instead of overwhelming them with a 3 panel screen with a billion options.   It would be nice if this page could easily have a printout to save as PDF and have an option for all the solution and detail boxes to either by opened or closed (useful for writing notes and testing myself before seeing the answers. It would also be nice to have details be a separate option from solutions).    I think the presenter needs to name his files better. By the end of this, he was just referring to them as ""the FASTQC file from step 17"", by this point, as a newbie, I've screwed up so much, my order doesn't match his at all, I've deleted some steps, and re-run them, and the order continues incrementing, so nothing matches his and I have no idea if I'm selecting the right files or not.   This video was really long. And I see sections that aren't included in the original for the Nanopore and long read stuff. Perhaps this would benefit from splitting the video into multiple different videos? Or adding chapters to the current one at least? Chapters corresponding to the Table of Contents names of course. This way it would improve your Youtube video's SEO and usability for users who are probably having multiple sessions watching this spread out over hours anyway. Although I think the better approach for easy future re-recording would be to split it into smaller video sections based on each Table of Contents entry. I don't see why the videos can't be directly embedded on this Training Galaxy page either, right at the top of each titled section.   I think there are too many assumptions that people should know why something should be good or bad or high or low. Even as someone with a Biology background, I haven't delved deeply into sequencing reads before and don't know how to interpret this. It would be helpful to add something like what Phoronix does for benchmarking charts with a directional arrow indicating which way is better: https://www.phoronix.com/review/amd-ryzen7-6850u/8 and I suppose it could be added as video tutorial visuals or as just a labelled screenshot.   My Nanoplot attempt had an error. It would be nice if you had a built-in automated bug reporting button, either in Galaxy, or in your tutorial or just the link or wherever. Just put it somewhere and make it 100% automated so that the user doesn't need to try to figure it out. Make it somehow able to click at the step of the tutorial or report the link as broken or the results as broken. I don't get an HTML page, and I don't know why. It's a bunch of HTML code so I can tell it SHOULD BE an HTML page and the History says so, but trying to download it to read and trying to open it in Galaxy doesn't work.   On a related note, some of the buttons have changed, I think even the datasets have changed and don't match what the tutorial video shows. It would be nice if you had an updated one that matched. ",,Quality Control,Sequence analysis,2022-10,2022-10-31
+2011,5,Hands in,Videos might help us more,,Analyses of metagenomics data - The global picture,Microbiome,2022-11,2022-11-02
+2012,3,This tutorial gives a comprehensive overview about all analysis steps and important parameters involved.,"Where is the actual hands-on command code, which is generated after all parameter boxes have been checked, and the 'submit button' is clicked? Where are the actual tool commands for each step, a user would need to perform these analysis steps on the command line? I know these can be displayed in Galaxy, but it would be helpful to show them in the tutorials as well. ",,Exome sequencing data analysis for diagnosing a genetic disease,Variant Analysis,2022-11,2022-11-02
+2013,2,,"The instructions may not be up to date. I tried following them but what was described did not appear when I tried to follow. For example, there is no jupyter icon that comes up under visualizations. ",,Use Jupyter notebooks in Galaxy,Using Galaxy and Managing your Data,2022-11,2022-11-04
+2014,4,the flow of presentation,,,Galaxy 101 for everyone,Introduction to Galaxy Analyses,2022-11,2022-11-04
+2015,4,,,,M. tuberculosis Variant Analysis,Variant Analysis,2022-11,2022-11-04
+2016,5,,,,A short introduction to Galaxy,Introduction to Galaxy Analyses,2022-11,2022-11-05
+2017,5,"Hands on data analysis, problem solving",maybe notification of different tools with similar names? but really I guess it was fun problem solving,,3: RNA-seq genes to pathways,Transcriptomics,2022-11,2022-11-07
+2018,4,Flow of information,Add videos and demonstrations,,R basics in Galaxy,Foundations of Data Science,2022-11,2022-11-09
+2019,5,Very comprehensive and detailed,This is already so awesome but If possible could you please add along with this tutorial the pipeline/command line that could be run on MacOS terminal? We would be very appreciate that. Many Thanks!!!,,Reference-based RNA-Seq data analysis,Transcriptomics,2022-11,2022-11-09
+2020,5,Detailed explanations/tips/examples.,,,A short introduction to Galaxy,Introduction to Galaxy Analyses,2022-11,2022-11-12
+2021,3,,,,Somatic Variant Discovery from WES Data Using Control-FREEC,Variant Analysis,2022-11,2022-11-15
+2022,5,,,,NGS data logistics,Introduction to Galaxy Analyses,2022-11,2022-11-15
+2023,4,detailed explanation of variant calling and genotype calling,,,Exome sequencing data analysis for diagnosing a genetic disease,Variant Analysis,2022-11,2022-11-16
+2024,5,Easy to follow for the most part. ,Needs to be updated to the current galaxy settings. ,,A short introduction to Galaxy,Introduction to Galaxy Analyses,2022-11,2022-11-17
+2025,5,,add the code of volcano plot,,Visualization of RNA-Seq results with Volcano Plot,Transcriptomics,2022-11,2022-11-18
+2026,5,,,,Introduction to Genomics and Galaxy,Introduction to Galaxy Analyses,2022-11,2022-11-19
+2027,3,"Everything, except the Velvet choice.","Use another software besides Velvet, since it's deprecated and it's not working.",,An Introduction to Genome Assembly,Assembly,2022-11,2022-11-20
+2028,5,The fact that from nothing i can do RNA sequencing from start to bottom,Maybe tutorials with other tools from galaxy ,,3: RNA-seq genes to pathways,Transcriptomics,2022-11,2022-11-20
+2029,4,,,,A short introduction to Galaxy,Introduction to Galaxy Analyses,2022-11,2022-11-21
+2030,5,,,,Mapping,Sequence analysis,2022-11,2022-11-21
+2031,5,,,,NGS data logistics,Introduction to Galaxy Analyses,2022-11,2022-11-22
+2032,5,"Short and precise, not more or less than what the title promises","One setting in the JBrowse step isn't congruent with the most recent Prokka version anymore: can't configure ""Produce Standalone Instance”: ""Yes"" maybe you can update this :)",,Genome annotation with Prokka,Genome Annotation,2022-11,2022-11-24
+2033,4,,,,Avian influenza viral strain analysis from gene segment sequencing data,Variant Analysis,2022-11,2022-11-25
+2034,3,,,,Generating theoretical possible pathways for the production of Lycopene in E.Coli using Retrosynthesis tools,Synthetic Biology,2022-11,2022-11-26
+2035,5,all of this tutorial,"nothing, everything is so cool",,Galaxy 101,Introduction to Galaxy Analyses,2022-11,2022-11-29
+2036,4,"step by step, screenshots, global structure of the training content, indications when things seem to get wrong when in fact it is not, good job!","Difficult to know what to do when GitPod sends back an error after the ""make serve-gitpod"" command instead of serving a preview of GTN. I can guess it is a GitPod problem and not a GTN tutorial problem, still I feel helpless not knowing what to do to solve this problem. ",,Running the GTN website online using GitPod,Contributing to the Galaxy Training Material,2022-11,2022-11-29
+2037,4,"The tutorial is broken up into sections, and it's in a step-by-step format.","Some of the tools, like the ""compare two datasets"" tool, were hard to find even with the search bar. Some of the tutorials need an update because the instructions are unclear, or the method of doing something has changed.",,Galaxy 101,Introduction to Galaxy Analyses,2022-11,2022-11-30
+2038,4,,For the areas where they mention that other analysis options or functions are available please link to other website containing information about those options,,ATAC-Seq data analysis,Epigenetics,2022-11,2022-11-30
+2039,5,Clear and straightforward instructions,Clear the potential trouble implementation of the own researcher data,,Pre-processing of 10X Single-Cell RNA Datasets,Single Cell,2022-12,2022-12-02
+2040,5,The tips and answers were very useful,,,A short introduction to Galaxy,Introduction to Galaxy Analyses,2022-12,2022-12-02
+2041,4,UMI was described in detail and examples were great.,One example with 4 reads were given. What happens to the R2 file when one of the reads is indeed a duplicate? Would there be only 4 reads instead? It would be nice if there are a couple of more examples like that. ,,Understanding Barcodes,Single Cell,2022-12,2022-12-06
+2042,5,dat het easy was,geen idee,,A short introduction to Galaxy,Introduction to Galaxy Analyses,2022-12,2022-12-07
+2043,4,dat alles vrij duidelijk was,waar je de workflow kan vinden,,A short introduction to Galaxy,Introduction to Galaxy Analyses,2022-12,2022-12-08
+2044,3,generally excellent,the file used is different from the tutorial,,Advanced R in Galaxy,Foundations of Data Science,2022-12,2022-12-15
+2045,2,,Hard to follow steps as a new user,,Reference-based RNA-Seq data analysis,Transcriptomics,2022-12,2022-12-18
+2046,5,I could follow step by step the directions,I was stacked in the velveth assembly cos I was in the wrong version of the program. Maybe is necessary to add this to the tutorial.,,An Introduction to Genome Assembly,Assembly,2022-12,2022-12-18
+2047,5,Detailed step by step analysis,"the second part of the video, the speaker's voice was a liltte bit softer !",,Reference-based RNA-Seq data analysis,Transcriptomics,2022-12,2022-12-19
+2048,5,Everything was well-annotated. Thank you so much!,I want to see ''How to DESeq2 Results File (DEG List) with Tabular format open in Excel?''.  ,,2: RNA-seq counts to genes,Transcriptomics,2022-12,2022-12-30
+2049,5,I like the detailed instructions of this tool.,When I tred to follow the steps of hicBuildMatrix and ran it on usegalaxy. It showed that I need to provide BED file with all restriction cut places. Could you tell me how to choose to use the bin size or where I can find the BED file?,,Hi-C analysis of Drosophila melanogaster cells using HiCExplorer,Epigenetics,2023-01,2023-01-03
+2050,4,The tutorial was simple to follow and was a great balance between guidance and letting do things myself,Some of the steps seem outdated with some parameter having changed names or being not available anymore. But it doesn't prevent the completion of the tutorial.,,Hi-C analysis of Drosophila melanogaster cells using HiCExplorer,Epigenetics,2023-01,2023-01-05
+2051,4,All except the R studio that is not yet clear,Rstudio,,Identifying tuberculosis transmission links: from SNPs to transmission clusters,Evolution,2023-01,2023-01-07
+2052,4,"In galaxy training,  the tools recommendation are quite good!",1.  The workflow file should be updated.,,Identification of somatic and germline variants from tumor and normal sample pairs,Variant Analysis,2023-01,2023-01-10
+2053,5,,,,M. tuberculosis Variant Analysis,Variant Analysis,2023-01,2023-01-10
+2054,5,"step by step, question and answers for self-checking",,,A short introduction to Galaxy,Introduction to Galaxy Analyses,2023-01,2023-01-10
+2055,5,"The extra examples (2 NGS datasets) at the end of the tutorial are very useful, it gives me a better idea on how to troubleshoot and identify the problem, when encountering a bad NGS data",Perhaps it will be helpful to include more explanation of the results for the different tools after each steps (e.g. a hyperlink to the bioinformatics tool's user manual for more result explanation),,M. tuberculosis Variant Analysis,Variant Analysis,2023-01,2023-01-11
+2056,3,,Not enough information,,Deep Learning (Part 1) - Feedforward neural networks (FNN),Statistics and machine learning,2023-01,2023-01-11
+2057,4,"The interpretation of RMSD, RMSF, and PCA plots.",,,Analysis of molecular dynamics simulations,Computational chemistry,2023-01,2023-01-12
+2058,5,Very well detailed,nothing special,,From peaks to genes,Introduction to Galaxy Analyses,2023-01,2023-01-12
+2059,5,Clear instructions and easy to follow,No suggestions at this stage,,A short introduction to Galaxy,Introduction to Galaxy Analyses,2023-01,2023-01-13
+2060,4,questions along the way ,the questions could be explained better especially the annotation exercise ,,MaxQuant and MSstats for the analysis of TMT data,Proteomics,2023-01,2023-01-14
+2061,5,Adapted for my very first steps in Galaxy. I enjoy using the tools.,,,A short introduction to Galaxy,Introduction to Galaxy Analyses,2023-01,2023-01-16
+2062,5,,,,ATAC-Seq data analysis,Epigenetics,2023-01,2023-01-17
+2063,5,Very clear and each step was explained thoroughly. Really good tutorial.,"There were icons explained in the tutorial that I don't see in my computer (e.g. show histories, I only see it when I open the tab, which again have a different icon than the one in the tutorial), I guess is a difference etween different galaxies (EU, AU, USA) or differences to older version and it confused me a bit. Maybe difficult to fix.",,A short introduction to Galaxy,Introduction to Galaxy Analyses,2023-01,2023-01-18
+2064,5,"I like that you demonstrate several steps to assess the quality of the data, provide ranges of acceptable values, and explain why other values would not be acceptable. You also provide several strategies to attain the same result such as when you explain determining strandedness.  I plan on using this tutorial for my upcoming bacterial transcriptomics course.","I was confused by the explanation of the strandedness, while I understand how transcription work, I did not understand the results of unstranded, same strand and reverse strand, for the same library preparation. i was expecting only one possible result, either unstranded OR same strand OR reverse strand, but MultiQC was providing all the values for the same sample.  I also was confused by the ""Details: The counts obtained in the previous part may be different from the one imported"" as according to https://training.galaxyproject.org/training-material/topics/transcriptomics/tutorials/ref-based/tutorial.html#counting-reads-per-genes, you asked us to set the featureCounts to “""Count fragments instead of reads”: Enabled; fragments (or templates) will be counted instead of reads"". But in the ""Details"" box you state that we used the ""Disabled"" option. I thought we had used the ""Enabled"" option.   Is there a tutorial similar to this one for bacterial RNA-seq analysis? Or which aligner would you recommend that I use for Bacterial transcriptomics, given that there is no splicing involved? Do you have a tutorial for bacterial transcriptomics analysis of Nanopore data?  Thank you again. ",,Reference-based RNA-Seq data analysis,Transcriptomics,2023-01,2023-01-19
+2065,5,My first time working with genomic tools. ,,,Introduction to Genomics and Galaxy,Introduction to Galaxy Analyses,2023-01,2023-01-21
+2066,3,"It got me started on how to use the interactive jupyter tool. However, it issuing python 2 instead of python 3 which is currently used by use galaxy.org .",1. Should use python 3 instead of python 2.  2. distplot in version of seborn in  usegalaxy.org  is deprecated..  3. I cannot find the download button to save notebook to history file. Instead I downloaded it to my composer and can subsequently upload it to use galaxy.org.  4. It would be easier if the code on the webpage was set apart from the text as a code block with the ability to copy it by clicking on copy icon in the code block.,,Use Jupyter notebooks in Galaxy,Using Galaxy and Managing your Data,2023-01,2023-01-21
+2067,1,,does not include how to install packages or set up a local server to install packages to ,,RStudio in Galaxy,Using Galaxy and Managing your Data,2023-01,2023-01-25
+2068,5,,,,Mapping,Sequence analysis,2023-01,2023-01-25
+2069,4,,,,A short introduction to Galaxy,Introduction to Galaxy Analyses,2023-01,2023-01-26
+2070,5,,,,Identification of the binding sites of the T-cell acute lymphocytic leukemia protein 1 (TAL1),Epigenetics,2023-01,2023-01-27
+2071,5,,,,Galaxy 101,Introduction to Galaxy Analyses,2023-01,2023-01-31
+2072,5,,,,A short introduction to Galaxy,Introduction to Galaxy Analyses,2023-01,2023-01-31
+2073,1,,,,Visualization of RNA-Seq results with Volcano Plot,Transcriptomics,2023-02,2023-02-02
+2074,5,,,,A short introduction to Galaxy,Introduction to Galaxy Analyses,2023-02,2023-02-02
+2075,5,,,,A short introduction to Galaxy,Introduction to Galaxy Analyses,2023-02,2023-02-02
+2076,5,It was VERY clear and comprehensive. Thank you so much.,,,Mapping,Sequence analysis,2023-02,2023-02-02
+2077,5,simple and easy to follow,,,16S Microbial analysis with Nanopore data,Microbiome,2023-02,2023-02-04
+2078,4,,,,A short introduction to Galaxy,Introduction to Galaxy Analyses,2023-02,2023-02-06
+2079,5,,,,16S Microbial Analysis with mothur (extended),Microbiome,2023-02,2023-02-07
+2080,5,It was easy to follow.,"The command should be updated to the current version. While the tutorial said ""execute"", my version said ""run"". For a novice it may be confusing.",,A short introduction to Galaxy,Introduction to Galaxy Analyses,2023-02,2023-02-12
+2081,5,Very clear and detailed. Great for the first-time user.,A few suggestions to try after 101,,Galaxy 101,Introduction to Galaxy Analyses,2023-02,2023-02-15
+2082,5,,,,How to reproduce published Galaxy analyses,Introduction to Galaxy Analyses,2023-02,2023-02-19
+2083,4,Walkthrough and explanation,Explain some of the more obscure packages used and their functions. Some were explained but other were not.,,Introduction to Machine Learning using R,Statistics and machine learning,2023-02,2023-02-20
+2084,5,Everything is clear and understandable,I was satisfied with everything,,From peaks to genes,Introduction to Galaxy Analyses,2023-02,2023-02-21
+2085,5,It explained every steps in a basic manner!,The result of work flow application (for the student to check whether their workflow work or not),,Galaxy 101,Introduction to Galaxy Analyses,2023-02,2023-02-22
+2086,5,,,,Galaxy 101,Introduction to Galaxy Analyses,2023-02,2023-02-23
+2087,1,,Syntax improved version of Galaxy ,,Galaxy 101,Introduction to Galaxy Analyses,2023-02,2023-02-23
+2088,5,All steps were clearly explained (besides one) and the screenshots and extra info was very helpful! ,With the Hands on: Extract workflow I found the end of step 4 a bit confusing in the sense that I wasn't sure if the tutorial required me to run the workflow. Immediately after it was said the Exon box was named ok. I didn't immediately realize we were to rename the box in the workflow editor.,,Galaxy 101,Introduction to Galaxy Analyses,2023-02,2023-02-23
+2089,5,,,,Understanding Barcodes,Single Cell,2023-02,2023-02-27
+2090,4,,,,A short introduction to Galaxy,Introduction to Galaxy Analyses,2023-03,2023-03-02
+2091,5,the workshop webpage and its specifications,n/a,,Galaxy 101 for everyone,Introduction to Galaxy Analyses,2023-03,2023-03-03
+2092,5,,"One of the initial steps, the one involving getting the RefSeq list of genes from UCSC genome browser is flawed and should be updated. I had to use a different list of genes and make some modifications in the input file.",,From peaks to genes,Introduction to Galaxy Analyses,2023-03,2023-03-03
+2093,5,explanation of operation.,,,Galaxy 101 for everyone,Introduction to Galaxy Analyses,2023-03,2023-03-05
+2094,5,"It included in the end the possibility of using it to analyze repeats instead of SNPs, leading us to realize that it can easily be done.",,,Galaxy 101,Introduction to Galaxy Analyses,2023-03,2023-03-05
+2095,5,Content wise it is good,Provide some video examples ,,Reference-based RNA-Seq data analysis,Transcriptomics,2023-03,2023-03-07
+2096,5,The detailing of steps,Maybe more of short videos of cursor navigating could be helpful,,A short introduction to Galaxy,Introduction to Galaxy Analyses,2023-03,2023-03-07
+2097,5,,,,Galaxy 101 for everyone,Introduction to Galaxy Analyses,2023-03,2023-03-08
+2098,5,the detailed explanation,,,A short introduction to Galaxy,Introduction to Galaxy Analyses,2023-03,2023-03-08
+2099,1,Nothing,"I have never found a question answered that I had. Consult people on what FAQs should be. Like, I have a collection and a couple instances failed. How do I create a new collection without them? This should be easy but is unfindable!!!!!",,Using dataset collections,Using Galaxy and Managing your Data,2023-03,2023-03-09
+2100,5,,,,A short introduction to Galaxy,Introduction to Galaxy Analyses,2023-03,2023-03-10
+2101,5,,,,Introduction to Genomics and Galaxy,Introduction to Galaxy Analyses,2023-03,2023-03-13
+2102,5,"Everything <script>console.log(""Helena Testing"");</script>",,,Galaxy Installation with Ansible,Galaxy Server administration,2023-03,2023-03-14
+2103,5,,,,Quality Control,Sequence analysis,2023-03,2023-03-14
+2104,5,,,,Genome Assembly of a bacterial genome (MRSA) sequenced using Illumina MiSeq Data,Assembly,2023-03,2023-03-16
+2105,5,The tutorial try to explain what is doing when selecting params or values.,"Maybe, some animations about the simulation trajectory.",,High Throughput Molecular Dynamics and Analysis,Computational chemistry,2023-03,2023-03-17
+2106,5,,,,Galaxy 101 for everyone,Introduction to Galaxy Analyses,2023-03,2023-03-17
+2107,5,The fact that you provide everything for the hands on experience.,,,A short introduction to Galaxy,Introduction to Galaxy Analyses,2023-03,2023-03-17
+2108,3,,"You should specify that you can't feed GEMINI tool more recent versions of hg19 at the outset. I used a more recent version hg38 throughout my analysis, only to get to the last step and realize that I had to start over using hg19.   Also, GEMINI is not available on usegalaxy.org, only on galaxy.eu, and I am having a lot of difficulty importing my datasets over since the tags for my PED file disappear on transfer.   Extremely frustrating end result for what I originally thought was a great tutorial! ",,Exome sequencing data analysis for diagnosing a genetic disease,Variant Analysis,2023-03,2023-03-19
+2109,5,Order flow of information.,Kindly provide tutorials in video for easy visualization of facts.,,"Mutation calling, viral genome reconstruction and lineage/clade assignment from SARS-CoV-2 sequencing data",Variant Analysis,2023-03,2023-03-19
+2110,1,"There are error when running it. Tools have different versions and some files create with one tool can not be read for another tool. This is the error in Gromacs log for the Production Simulation : ""Attempting to read a checkpoint file of version 22 with code of version 20"". And the same is happening in the other Galaxy history about Molecular Dynamics. ",,,High Throughput Molecular Dynamics and Analysis,Computational chemistry,2023-03,2023-03-19
+2111,5,,,,A short introduction to Galaxy,Introduction to Galaxy Analyses,2023-03,2023-03-20
+2112,5,,,,Introduction to Genomics and Galaxy,Introduction to Galaxy Analyses,2023-03,2023-03-22
+2113,4,The automation in the process which allows GUI interface ,The response time because it might take some time before it completes the process,,"Mutation calling, viral genome reconstruction and lineage/clade assignment from SARS-CoV-2 sequencing data",Variant Analysis,2023-03,2023-03-23
+2114,5,pipelines workflows,To run all pipelines at once,,"Mutation calling, viral genome reconstruction and lineage/clade assignment from SARS-CoV-2 sequencing data",Variant Analysis,2023-03,2023-03-23
+2115,3,,,,A short introduction to Galaxy,Introduction to Galaxy Analyses,2023-03,2023-03-25
+2116,5,"Good alternative to local running of GTN, thanks",,,Running the GTN website online using GitPod,Contributing to the Galaxy Training Material,2023-03,2023-03-27
+2117,5,Filter by quality tool is not available on our Galaxy. Used Filter FASTQ instead.,,,A short introduction to Galaxy,Introduction to Galaxy Analyses,2023-03,2023-03-30
+2118,3,,explanation on the different types of barcoding/UMI schemes,,Understanding Barcodes,Single Cell,2023-03,2023-03-31
+2119,5,,,,A short introduction to Galaxy,Introduction to Galaxy Analyses,2023-03,2023-03-31
+2120,5,Easy to followw,,,A short introduction to Galaxy,Introduction to Galaxy Analyses,2023-04,2023-04-03
+2121,4,,,,Quality Control,Sequence analysis,2023-04,2023-04-03
+2122,5,,,,Visualization of RNA-Seq results with heatmap2,Transcriptomics,2023-04,2023-04-03
+2123,5,Most part of the instructions were very clear and detailed.,"There are still some part of the tutorial which can be a little more clear, for example at ""Hands-on: Generating FreeBayes calls"" I was confused and took a while to figure out.",,Exome sequencing data analysis for diagnosing a genetic disease,Variant Analysis,2023-04,2023-04-04
+2124,5,,,,A short introduction to Galaxy,Introduction to Galaxy Analyses,2023-04,2023-04-04
+2125,4,,more screenshots can be added.,,Galaxy 101,Introduction to Galaxy Analyses,2023-04,2023-04-04
+2126,4,How it explained each feature of the model.,"Providing more links to resources for further reading (e.g., on how to select models or various aspects of them) would be nice!",,Introduction to deep learning,Statistics and machine learning,2023-04,2023-04-06
+2127,5,It was easy to follow and really didactic,Maybe a more complex exercise at the end or an explanation of all the potential of the tools in Galaxy,,A short introduction to Galaxy,Introduction to Galaxy Analyses,2023-04,2023-04-06
+2128,5,Clearness,,,Pre-processing of 10X Single-Cell RNA Datasets,Single Cell,2023-04,2023-04-07
+2129,5,GOOD,,,A short introduction to Galaxy,Introduction to Galaxy Analyses,2023-04,2023-04-11
+2130,5,,,,Mapping and molecular identification of phenotype-causing mutations,Variant Analysis,2023-04,2023-04-12
+2131,5,,,,Metatranscriptomics analysis using microbiome RNA-seq data,Microbiome,2023-04,2023-04-15
+2132,2,chart explanation,language can be made more simple,,Genome Annotation,Genome Annotation,2023-04,2023-04-17
+2133,5,,,,Ansible,Galaxy Server administration,2023-04,2023-04-17
+2134,5,,,,16S Microbial Analysis with mothur (extended),Microbiome,2023-04,2023-04-17
+2135,5,,,,A short introduction to Galaxy,Introduction to Galaxy Analyses,2023-04,2023-04-18
+2136,3,,"- (Maybe just me) Too much content, too fast. - Account on a production Galaxy instance is required. I did not have one and it took me a while to get set up - Some familiarity with Jupyter Notebooks seems to be another prerequisite  ",,Scripting Galaxy using the API and BioBlend,Development in Galaxy,2023-04,2023-04-18
+2137,5,,,,Deep Learning (Part 1) - Feedforward neural networks (FNN),Statistics and machine learning,2023-04,2023-04-18
+2138,5,,,,Galaxy Installation with Ansible,Galaxy Server administration,2023-04,2023-04-19
+2139,5,,,,"Server Maintenance: Cleanup, Backup, and Restoration",Galaxy Server administration,2023-04,2023-04-19
+2140,5,,,,Customizing the look of Galaxy,Galaxy Server administration,2023-04,2023-04-19
+2141,5,,,,Performant Uploads with TUS,Galaxy Server administration,2023-04,2023-04-19
+2142,5,,,,Reference Data with CVMFS,Galaxy Server administration,2023-04,2023-04-19
+2143,4,"good and quick overview, no error messages, everything worked","Sometimes the names on the actual webpage are different than what you give in the tutorial, so you have to guess if it is the same",,A short introduction to Galaxy,Introduction to Galaxy Analyses,2023-04,2023-04-19
+2144,5,It is really clearly well explained!,Everything,,A short introduction to Galaxy,Introduction to Galaxy Analyses,2023-04,2023-04-19
+2145,5,,,,16S Microbial analysis with Nanopore data,Microbiome,2023-04,2023-04-20
+2146,5,,,,A short introduction to Galaxy,Introduction to Galaxy Analyses,2023-04,2023-04-21
+2147,5,,,,Visualization of RNA-Seq results with Volcano Plot,Transcriptomics,2023-04,2023-04-22
+2148,5,,,,A short introduction to Galaxy,Introduction to Galaxy Analyses,2023-04,2023-04-23
+2149,5,,,,Visualization of RNA-Seq results with Volcano Plot,Transcriptomics,2023-04,2023-04-24
+2150,5,,,,A short introduction to Galaxy,Introduction to Galaxy Analyses,2023-04,2023-04-25
+2151,5,,,,From NCBI's Sequence Read Archive (SRA) to Galaxy: SARS-CoV-2 variant analysis,Variant Analysis,2023-04,2023-04-25
+2152,4,,No background information how quality check works,,A short introduction to Galaxy,Introduction to Galaxy Analyses,2023-04,2023-04-26
+2153,5,,,,Chloroplast genome assembly,Assembly,2023-04,2023-04-26
+2154,4,,,,Pre-processing of 10X Single-Cell RNA Datasets,Single Cell,2023-04,2023-04-26
+2155,5,,,,A short introduction to Galaxy,Introduction to Galaxy Analyses,2023-04,2023-04-28
+2156,5,Step by step guide,,,Galaxy 101 for everyone,Introduction to Galaxy Analyses,2023-04,2023-04-30
+2157,5,"The strand used in this tutorial doesn't match the sample inputs (all should be reverse instead). The result doesn't change by much .. but a few people have now brought it up when they run the extra Infer Experiment tool, and it doesn't match assignment used in here.  cc to myself  @jennaj  This has been around for a long time. Not sure of the priority.",,,De novo transcriptome reconstruction with RNA-Seq,Transcriptomics,2023-05,2023-05-02
+2158,5,,,,Quality Control,Sequence analysis,2023-05,2023-05-02
+2159,5,,,,M. tuberculosis Variant Analysis,Variant Analysis,2023-05,2023-05-02
+2160,4,Very clear presentation and rather easy to follow. I really enjoyed it.,The filtering part was a extremely fast.  ;),,MaxQuant and MSstats for the analysis of label-free data,Proteomics,2023-05,2023-05-02
+2161,5,,,,Identifying tuberculosis transmission links: from SNPs to transmission clusters,Evolution,2023-05,2023-05-03
+2162,5,the work flow summary in a diagram format,You could explain the steps in more detail,,Pre-processing of Single-Cell RNA Data,Single Cell,2023-05,2023-05-03
+2163,5,,,,Pre-processing of Single-Cell RNA Data,Single Cell,2023-05,2023-05-03
+2164,3,,Gemini is no longer used,,Exome sequencing data analysis for diagnosing a genetic disease,Variant Analysis,2023-05,2023-05-04
+2165,3,"quite explanatory, understandable terms","update it or make sure the platform possesses the features explained by the tutorial. ""Less"" command was not available. There is no command or instructions to generate dc folder",,Variant Calling Workflow,Foundations of Data Science,2023-05,2023-05-04
+2166,5,,,,A short introduction to Galaxy,Introduction to Galaxy Analyses,2023-05,2023-05-05
+2167,5,,,,Tree thinking for tuberculosis evolution and epidemiology,Evolution,2023-05,2023-05-05
+2168,5,Have a great Job. I am doing my Research on MTB of Bioinformatics Analysis. It was really Helpful.,"sorry to say, but one of my suggestion is on next time need Hands on Session Tutorial vedio.",,M. tuberculosis Variant Analysis,Variant Analysis,2023-05,2023-05-07
+2169,5,Simple and easy-to-understand language of the hands-on-tutorial,"Some of the hyperlinks are not functional; please update those. For example, the hyperlink for alignment tools does not open.",,NGS data logistics,Introduction to Galaxy Analyses,2023-05,2023-05-07
+2170,5,Quite straight forward applications.,This is not applicable t me at the moment ,,A short introduction to Galaxy,Introduction to Galaxy Analyses,2023-05,2023-05-08
+2171,5,,,,1: RNA-Seq reads to counts,Transcriptomics,2023-05,2023-05-08
+2172,5,,,,Chloroplast genome assembly,Assembly,2023-05,2023-05-09
+2173,5,,,,A short introduction to Galaxy,Introduction to Galaxy Analyses,2023-05,2023-05-10
+2174,5,Easy to follow steps,,,A short introduction to Galaxy,Introduction to Galaxy Analyses,2023-05,2023-05-11
+2175,5,very informative and well structured,nothing of note ,,A short introduction to Galaxy,Introduction to Galaxy Analyses,2023-05,2023-05-12
+2176,5,It is very clear and easy to follow. The video also helps sooo much! Thank you. ,,,Galaxy 101,Introduction to Galaxy Analyses,2023-05,2023-05-13
+2177,2,,"Instructions are insufficiently detailed (no definitions for key terms, no explanation of required file structures). The only way to use the tool is by trial and error (wastes a lot of time)",,Group tags for complex experimental designs,Using Galaxy and Managing your Data,2023-05,2023-05-14
+2178,5,,,,From peaks to genes,Introduction to Galaxy Analyses,2023-05,2023-05-14
+2179,5,"very intuitive and colors of the page helps alot, thank you",,,Variant Calling Workflow,Foundations of Data Science,2023-05,2023-05-16
+2180,5,,,,Genome annotation with Maker,Genome Annotation,2023-05,2023-05-16
+2181,4,It was very straightforward and easy to follow. Instructions were well written.,"In the step, ""2. Copy a dataset into your new history,"" the .gif featured a differently named file than the one used in the tutorial. This was the only point of confusion in the tutorial, so it was very minor.",,A short introduction to Galaxy,Introduction to Galaxy Analyses,2023-05,2023-05-16
+2182,5,"Yes, is incredible.",Add the expected output graphs to compare the results,,Avian influenza viral strain analysis from gene segment sequencing data,Variant Analysis,2023-05,2023-05-17
+2183,5,,,,Identification of the micro-organisms in a beer using Nanopore sequencing,Microbiome,2023-05,2023-05-19
+2184,5,It is very clear and simple. Easy to follow.,,,A short introduction to Galaxy,Introduction to Galaxy Analyses,2023-05,2023-05-19
+2185,4,The tutorial was easy to reproduce.,"Perhaps a video of this tutorial could be generated, explaining in more detail the parameters used.",,Pox virus genome analysis from tiled-amplicon sequencing data,Variant Analysis,2023-05,2023-05-19
+2186,5,,,,Data Manipulation Olympics,Introduction to Galaxy Analyses,2023-05,2023-05-21
+2187,5,Interesting genome for tutorial and explanation of how to do long read assembly with short read polishing. ,,,Chloroplast genome assembly,Assembly,2023-05,2023-05-22
+2188,5,Using kraken for the first time in my scientific journey was a life changing experience,the tutorial is perfect for me,,Taxonomic Profiling and Visualization of Metagenomic Data,Microbiome,2023-05,2023-05-22
+2189,5,,,,Quality Control,Sequence analysis,2023-05,2023-05-22
+2190,4,The ease to follow through,Create a video version of the tutorial.,,"Creating, Editing and Importing Galaxy Workflows",Using Galaxy and Managing your Data,2023-05,2023-05-22
+2191,5,It is Nice ,good,,Rule Based Uploader,Using Galaxy and Managing your Data,2023-05,2023-05-22
+2192,5,,,,Extracting Workflows from Histories,Using Galaxy and Managing your Data,2023-05,2023-05-22
+2193,5,The content was thooroghly presented in a concise manner,,,Quality Control,Sequence analysis,2023-05,2023-05-22
+2194,5,The explanation and details,It's awesome,,Introduction to Genomics and Galaxy,Introduction to Galaxy Analyses,2023-05,2023-05-22
+2195,4,,,,Quality Control,Sequence analysis,2023-05,2023-05-22
+2196,4,the try one and see approach,"a little more time on the USC graphic--juat a little, I know its a whole course alone,but a little more time spent in the different lines available and options would be nice.",,Introduction to Genomics and Galaxy,Introduction to Galaxy Analyses,2023-05,2023-05-22
+2197,5,It is clear and usable,Its fine for me and I understood,,Quality Control,Sequence analysis,2023-05,2023-05-22
+2198,5,it is simple and straight to the point ,was very beginner friendly it didn't mention (i guess) that some things can be done multiple ways,,A short introduction to Galaxy,Introduction to Galaxy Analyses,2023-05,2023-05-22
+2199,5,knowing the different tools for quality control,More time allocation,,Quality Control,Sequence analysis,2023-05,2023-05-22
+2200,5,the steps are very clear ,Hands-on: Embedding a workflow must be more detailled ,,"Creating, Editing and Importing Galaxy Workflows",Using Galaxy and Managing your Data,2023-05,2023-05-23
+2201,5,Quality control ,its ok for me,,Quality Control,Sequence analysis,2023-05,2023-05-23
+2202,5,Very clear and to the point,,,A short introduction to Galaxy,Introduction to Galaxy Analyses,2023-05,2023-05-23
+2203,5,its simplicity ,nothing,,Mapping,Sequence analysis,2023-05,2023-05-23
+2204,5,FastQC ,-,,A short introduction to Galaxy,Introduction to Galaxy Analyses,2023-05,2023-05-23
+2205,4,,,,Rule Based Uploader,Using Galaxy and Managing your Data,2023-05,2023-05-23
+2206,5,,,,Using dataset collections,Using Galaxy and Managing your Data,2023-05,2023-05-23
+2207,4,,,,"Creating, Editing and Importing Galaxy Workflows",Using Galaxy and Managing your Data,2023-05,2023-05-23
+2208,5,,,,Understanding Galaxy history system,Using Galaxy and Managing your Data,2023-05,2023-05-23
+2209,5,,,,A short introduction to Galaxy,Introduction to Galaxy Analyses,2023-05,2023-05-23
+2210,5,,,,Introduction to Genomics and Galaxy,Introduction to Galaxy Analyses,2023-05,2023-05-23
+2211,5,,,,Understanding Galaxy history system,Using Galaxy and Managing your Data,2023-05,2023-05-23
+2212,5,it was easy to follow and understand each step,,,Avian influenza viral strain analysis from gene segment sequencing data,Variant Analysis,2023-05,2023-05-23
+2213,5,,,,16S Microbial Analysis with mothur (short),Microbiome,2023-05,2023-05-23
+2214,5,,,,Introduction to Genomics and Galaxy,Introduction to Galaxy Analyses,2023-05,2023-05-23
+2215,5,Things were clearly explained. It was a comprehensive introduction to Galaxy. I really learnt a lot. ,"I think for an introduction to Galaxy, everything was covered really well. ",,Introduction to Genomics and Galaxy,Introduction to Galaxy Analyses,2023-05,2023-05-23
+2216,4,knowing how JBrowser works in mapping,its all good,,Mapping,Sequence analysis,2023-05,2023-05-23
+2217,5,It was quite explicit,Navigating is quite complex,,A short introduction to Galaxy,Introduction to Galaxy Analyses,2023-05,2023-05-23
+2218,4,,,,Chloroplast genome assembly,Assembly,2023-05,2023-05-23
+2219,5,,,,Quality Control,Sequence analysis,2023-05,2023-05-23
+2220,5,,,,Pre-processing of Single-Cell RNA Data,Single Cell,2023-05,2023-05-23
+2221,5,,,,Pre-processing of 10X Single-Cell RNA Datasets,Single Cell,2023-05,2023-05-23
+2222,4,,,,Introduction to Genomics and Galaxy,Introduction to Galaxy Analyses,2023-05,2023-05-23
+2223,5,,,,Chloroplast genome assembly,Assembly,2023-05,2023-05-23
+2224,5,"included all technologies ireads (llumina, ONT etc), good explanations",no idea,,Quality Control,Sequence analysis,2023-05,2023-05-24
+2225,5,,,,Mapping,Sequence analysis,2023-05,2023-05-24
+2226,5,Good overview of the tools used and why they were used. ,,,Pathogen detection from (direct Nanopore) sequencing data using Galaxy - Foodborne Edition,Microbiome,2023-05,2023-05-24
+2227,5,,,,Quality Control,Sequence analysis,2023-05,2023-05-24
+2228,5,,,,Reference-based RNA-Seq data analysis,Transcriptomics,2023-05,2023-05-24
+2229,5,,,,Mapping,Sequence analysis,2023-05,2023-05-24
+2230,5,"It's very intuitive, with very good explanation. Awesome!",,,Reference-based RNA-Seq data analysis,Transcriptomics,2023-05,2023-05-24
+2231,5,,,,Chloroplast genome assembly,Assembly,2023-05,2023-05-24
+2232,5,,,,Large genome assembly and polishing,Assembly,2023-05,2023-05-24
+2233,5,,,,Visualization of RNA-Seq results with Volcano Plot,Transcriptomics,2023-05,2023-05-24
+2234,5,Everything!,,,Introduction to Genomics and Galaxy,Introduction to Galaxy Analyses,2023-05,2023-05-24
+2235,5,,,,"Creating, Editing and Importing Galaxy Workflows",Using Galaxy and Managing your Data,2023-05,2023-05-24
+2236,5,The explanation and guidance were great.,,,Reference-based RNA-Seq data analysis,Transcriptomics,2023-05,2023-05-24
+2237,5,All the steps and the clarifications,,,R basics in Galaxy,Foundations of Data Science,2023-05,2023-05-24
+2238,5,,,,De novo transcriptome reconstruction with RNA-Seq,Transcriptomics,2023-05,2023-05-24
+2239,5,Great explanations and pace,,,R basics in Galaxy,Foundations of Data Science,2023-05,2023-05-25
+2240,5,,,,Visualization of RNA-Seq results with Volcano Plot in R,Transcriptomics,2023-05,2023-05-25
+2241,5,The tutorial is easy to follow along. ,,,Antibiotic resistance detection,Microbiome,2023-05,2023-05-25
+2242,4,Very informative as I'm new to galaxy and I've never done this sort of analysis before.,"In the tutorial video, the explanation and interpretation of the BAM output and using the genome browser felt a bit rushed. Would have liked the instructor to move a bit more slowly through those sections. ",,Mapping,Sequence analysis,2023-05,2023-05-25
+2243,5,Reapplication of theories as techniques learnt in previous tutorials and transferring them from Galaxy to R,"Issues related to the installation and loading of packages in the Galaxy RStudio environment, ended up using the RStudio Cloud for analyses. Linking the outputs accordingly to the Galaxy History would be greatly beneficial",,Introduction to Machine Learning using R,Statistics and machine learning,2023-05,2023-05-25
+2244,5,,,,Regression in Machine Learning,Statistics and machine learning,2023-05,2023-05-25
+2245,5,,,,Large genome assembly and polishing,Assembly,2023-05,2023-05-26
+2246,5,,,,Visualization of RNA-Seq results with Volcano Plot,Transcriptomics,2023-05,2023-05-26
+2247,5,,,,M. tuberculosis Variant Analysis,Variant Analysis,2023-05,2023-05-26
+2248,5,,,,Genome annotation with Prokka,Genome Annotation,2023-05,2023-05-26
+2249,4,,,,Visualization of RNA-Seq results with Volcano Plot,Transcriptomics,2023-05,2023-05-26
+2250,5,,,,Masking repeats with RepeatMasker,Genome Annotation,2023-05,2023-05-26
+2251,5,"A really comprehensive breakdown of how to do this analysis. All the steps of the analysis were well laid out in a good amount of detail that if you followed closely you should be equipped with the tools to run the same analysis yourself.  The instructor was excellent and covered a lot of material, maintaining good clarity throughout. ","I don't think anything could be improved upon. It is a long tutorial but the length of the tutorial is necessary to cover the content in a thorough way, as was done. Thank you.",,16S Microbial Analysis with mothur (short),Microbiome,2023-05,2023-05-26
+2252,5,,,,ATAC-Seq data analysis,Epigenetics,2023-05,2023-05-26
+2253,5,,,,Visualisation with Circos,Visualisation,2023-05,2023-05-26
+2254,5,,,,CRISPR screen analysis,Genome Annotation,2023-05,2023-05-26
+2255,5,I liked the simplicity of following the methodology rather than having to focus on the coding,I got a bit lost during the hyperparameterization section. It would have helped to have more context on how it leads on from the previous machine learning algorithms and whether it is applied to these or whether it is a completely different approach,,Classification in Machine Learning,Statistics and machine learning,2023-05,2023-05-26
+2256,5,,,,Quality Control,Sequence analysis,2023-05,2023-05-26
+2257,4,,,,Rule Based Uploader,Using Galaxy and Managing your Data,2023-05,2023-05-26
+2258,5,,,,A short introduction to Galaxy,Introduction to Galaxy Analyses,2023-05,2023-05-27
+2259,5,,,,Analyses of metagenomics data - The global picture,Microbiome,2023-05,2023-05-27
+2260,4,It was a great start with fundamentals of using Galaxy and everything was made quite easy to do.,Everything was quite simple but a short video of following procedures woould help any learner to get things easily.,,A short introduction to Galaxy,Introduction to Galaxy Analyses,2023-05,2023-05-27
+2261,5,,,,Using dataset collections,Using Galaxy and Managing your Data,2023-05,2023-05-28
+2262,5,,,,Rule Based Uploader,Using Galaxy and Managing your Data,2023-05,2023-05-28
+2263,5,The explanation and demonstration were very clear.,"Overall, the video was very good to motivate more practice!",,RNA Seq Counts to Viz in R,Transcriptomics,2023-05,2023-05-28
+2264,4,Interesting teaching method,,,A short introduction to Galaxy,Introduction to Galaxy Analyses,2023-05,2023-05-29
+2265,5,application of proteomics in diagnosing heart disease,,,Biomarker candidate identification,Proteomics,2023-05,2023-05-29
+2266,5,Really easy to follow and to understand. The most important points were explained in a clear and concise manner. ,I got everything I needed as an introduction to using Prokka. ,,Genome annotation with Prokka,Genome Annotation,2023-05,2023-05-29
+2267,5,Really great explanations and the video was well-paced,,,Classification in Machine Learning,Statistics and machine learning,2023-05,2023-05-30
+2268,5,,,,A short introduction to Galaxy,Introduction to Galaxy Analyses,2023-05,2023-05-30
+2269,4,Really interesting topic and very helpful to be able to run script in R,The packages do not all install on galaxy.eu and some of the questions do not yet have answers,,Introduction to Machine Learning using R,Statistics and machine learning,2023-05,2023-05-30
+2270,5,was great to laern something new ,,,A short introduction to Galaxy,Introduction to Galaxy Analyses,2023-05,2023-05-30
+2271,5,The module scRNA analysis is really complete and very well explained !!! ,"- In this step: Plot expression difference for the marker genes distinguishing cluster 0 from cluster 1 - There is no the suggested option (even using the same version from Galaxy Training Materials ): “Method used for plotting”: Marker genes: Plot ranking of genes as violin plot, using 'pl.rank_genes_groups_violin'  - The option available is: pl.rank_genes_groups_stacked_violin  - So I don't know if there is another way to plot.",,Clustering 3K PBMCs with Scanpy,Single Cell,2023-05,2023-05-31
+2272,5,,,,Classification in Machine Learning,Statistics and machine learning,2023-05,2023-05-31
+2273,5,,,,Rule Based Uploader,Using Galaxy and Managing your Data,2023-05,2023-05-31
+2274,5,Everything is very well explained ! Love it <3,,,Regression in Machine Learning,Statistics and machine learning,2023-06,2023-06-01
+2275,4,Easy to follow instructions,,,Mapping,Sequence analysis,2023-06,2023-06-02
+2276,5,"I appreciate how the instructor goes through the overview of classification algorithms in Machine Learning, providing essential background information. Moreover, the steps in the tutorial are very clear and yield results that are easy to follow.",,,Classification in Machine Learning,Statistics and machine learning,2023-06,2023-06-02
+2277,3,,,,Introduction to Machine Learning using R,Statistics and machine learning,2023-06,2023-06-02
+2278,5,"I learnt a lot. Another really comprehensive tutorial, with each of the steps clearly outlined and everything explained really well. ",I didn't know what to expect having never done a genome annotation before and I am fully satisfied with the content and how it was presented. ,,Refining Genome Annotations with Apollo (prokaryotes),Genome Annotation,2023-06,2023-06-03
+2279,5,,,,Basics of machine learning,Statistics and machine learning,2023-06,2023-06-04
+2280,5,,,,From peaks to genes,Introduction to Galaxy Analyses,2023-06,2023-06-05
+2281,1,,,,Exome sequencing data analysis for diagnosing a genetic disease,Variant Analysis,2023-06,2023-06-05
+2282,5,,,,An Introduction to Genome Assembly,Assembly,2023-06,2023-06-05
+2283,5,"I had to use galaxy for a project and I didn't have time to follow the tutorials. at that time it was so confusing and I was not getting the difference between a history and a workflow. Now that I started to learn working with it from scratch, everything is becoming clear and understandable. ",,,A short introduction to Galaxy,Introduction to Galaxy Analyses,2023-06,2023-06-07
+2284,5,"Easy to follow, gave me confidence in using the site","updated instructions with the newer format, there were a few inconsistencies in buttons, such as ""execute"" is now ""run tool""",,A short introduction to Galaxy,Introduction to Galaxy Analyses,2023-06,2023-06-07
+2285,5,All the content,So far so good,,A short introduction to Galaxy,Introduction to Galaxy Analyses,2023-06,2023-06-08
+2286,5,,,,A short introduction to Galaxy,Introduction to Galaxy Analyses,2023-06,2023-06-09
+2287,5,,,,A short introduction to Galaxy,Introduction to Galaxy Analyses,2023-06,2023-06-09
+2288,4,put example for single end data  ,,,Reference-based RNA-Seq data analysis,Transcriptomics,2023-06,2023-06-10
+2289,5,Everything,"If the NxN clustering dendrogram uses Tanimoto similarity, shouldn't it be the higher  the the horizontal line, the more similar the data points are to each other?",,Protein-ligand docking,Computational chemistry,2023-06,2023-06-10
+2290,5,In depth explanations and hands on activities.,,,A short introduction to Galaxy,Introduction to Galaxy Analyses,2023-06,2023-06-12
+2291,5,,,,A short introduction to Galaxy,Introduction to Galaxy Analyses,2023-06,2023-06-13
+2292,5,The training is very good. I like the step by step teaching. ,I need more time to follow. ,,"Mass spectrometry: GC-MS data processing (with XCMS, RAMClustR, RIAssigner, and matchms)",Metabolomics,2023-06,2023-06-14
+2293,5,,,,A short introduction to Galaxy,Introduction to Galaxy Analyses,2023-06,2023-06-15
+2294,5,Easy to follow,Nothing to improve,,From NCBI's Sequence Read Archive (SRA) to Galaxy: SARS-CoV-2 variant analysis,Variant Analysis,2023-06,2023-06-15
+2295,5,Well organised and clear!,It would help to have a table of contents or all of the links to the other parts in the overview or somewhere obvious. It wasn't intuitive to move between the sections.,,Assessment and feedback in training and teachings,Teaching and Hosting Galaxy training,2023-06,2023-06-15
+2296,1,Misleading and poor ,,,3: RNA-seq genes to pathways,Transcriptomics,2023-06,2023-06-15
+2297,5,,,,Inferring single cell trajectories (Monocle3),Single Cell,2023-06,2023-06-16
+2298,5,I liked every part of the tutorial,For now everything seems ok,,A short introduction to Galaxy,Introduction to Galaxy Analyses,2023-06,2023-06-16
+2299,5,"semplicity, to-the-point",perhaps more videos? but is ok as it is,,A short introduction to Galaxy,Introduction to Galaxy Analyses,2023-06,2023-06-19
+2300,4,"pretty easy to follow, and I liked the questions that ensure that we are getting the answers we are supposed to","Some of this tutorial is out of date with the new platform, making it a little more confusing. ",,Galaxy 101,Introduction to Galaxy Analyses,2023-06,2023-06-19
+2301,5,very nice progression in the explanation!  I like the practicality of the tasks,"the ""openstack"" provider has been demoted(?) so the source ""terraform-provider-openstack/openstack"" has to be added to the configuration to make this work now.  it would be nice if the cluster example worked with a plain centos7 image.  there does not seem to be a condor package in plain centos7, so I guess it would have to be replaced by some other cluster service, e.g., haproxy and nginx.  still, it was nice to see the NFS setup - although the automounter did not work for me, that's not the point of the tutorial.  thanks!",,Deploying a compute cluster in OpenStack via Terraform,Galaxy Server administration,2023-06,2023-06-19
+2302,5,,,,A short introduction to Galaxy,Introduction to Galaxy Analyses,2023-06,2023-06-21
+2303,5,,,,Annotating a protein list identified by LC-MS/MS experiments,Proteomics,2023-06,2023-06-21
+2304,5,,,,A short introduction to Galaxy,Introduction to Galaxy Analyses,2023-06,2023-06-21
+2305,1,,"There are plenty of R tutorials out there. I was rather hoping to learn someting about the interaction between RStudio/Galaxy, which is an empty chapter.",,RStudio in Galaxy,Using Galaxy and Managing your Data,2023-06,2023-06-22
+2306,5,it is very exact (therefore it requires an exact working style),,,Avian influenza viral strain analysis from gene segment sequencing data,Variant Analysis,2023-06,2023-06-22
+2307,4,the comprehensive nature ,,,Quality Control,Sequence analysis,2023-06,2023-06-23
+2308,5,,,,Visualization of RNA-Seq results with Volcano Plot,Transcriptomics,2023-06,2023-06-23
+2309,5,"The instructions were clear. I can not express how important that is to me, an elementary bioinformatics researcher.",I loved when images were provided. There may have been some points where a simple screenshot would have improved my bioinformatics experience.,,Reference-based RNA-Seq data analysis,Transcriptomics,2023-06,2023-06-23
+2310,5,"Short, simple and straight forward",,,A short introduction to Galaxy,Introduction to Galaxy Analyses,2023-06,2023-06-24
+2311,4,It is easy to follow and explains the relevant background well,The MSstats volcano plot from the tutorial results in two proteins at the extreme ends (top left and right corners). This is seen in other datasets as well. The tutorial does not explain why this artefact occurs or whether these are true protein hits,,MaxQuant and MSstats for the analysis of label-free data,Proteomics,2023-06,2023-06-24
+2312,5,Everything!,It's awesome!,,ERGA post-assembly QC,Assembly,2023-06,2023-06-26
+2313,4,I have a better vision of what to do with my data after using fastqc and how to check some points to analyze. Thank you very much,"the result after using cutadapt is not so good i was expecting to improve the two parameters (per base sequence content and Per sequence GC content) but instead it did not get better...so at the end...i would like to do some more examples to figure out how this process really improve the quality of my reads. Also, i would like to know how to choose the parameters that the tutorial says like ""Filter options: Minimum length”: 20"" to understand better in other situations what to do.",,Quality Control,Sequence analysis,2023-06,2023-06-27
+2314,1,,"there is no analysis of cases, it does not really help a lot to use the IGV, it is needed more options to move, colors etc",,IGV Introduction,Introduction to Galaxy Analyses,2023-06,2023-06-27
+2315,5,,,,A short introduction to Galaxy,Introduction to Galaxy Analyses,2023-06,2023-06-27
+2316,5,Detailed explaination,,,Reference-based RNA-Seq data analysis,Transcriptomics,2023-06,2023-06-30
+2317,5,,,,An Introduction to Genome Assembly,Assembly,2023-07,2023-07-05
+2318,5,,,,A short introduction to Galaxy,Introduction to Galaxy Analyses,2023-07,2023-07-05
+2319,5,,,,A short introduction to Galaxy,Introduction to Galaxy Analyses,2023-07,2023-07-09
+2320,5,,,,ATAC-Seq data analysis,Epigenetics,2023-07,2023-07-10
+2321,2,The step-by-step explanation of the entire pipeline,"Some of the commands are incorrect, and some of the explanations are not clear enough",,Variant Calling Workflow,Foundations of Data Science,2023-07,2023-07-10
+2322,5,Comprehensive,"end data tag is missing in outputs section , xml will fail to lint",,Creating Galaxy tools from Conda Through Deployment,Development in Galaxy,2023-07,2023-07-11
+2323,5,It is a wonderful tutorial. I am extremely thankful for sharing such an informative and detailed tutorial. I wish that for all topics be the same. ,,,Identification of the binding sites of the T-cell acute lymphocytic leukemia protein 1 (TAL1),Epigenetics,2023-07,2023-07-11
+2324,5,,,,A short introduction to Galaxy,Introduction to Galaxy Analyses,2023-07,2023-07-12
+2325,5,"I liked that there was an example dataset to follow along with, and questions to be answered as you went along. It really helped me understand what I was supposed to be looking for, whether something was actually working or not, and what real outputs would look like.","Stacks (not sure about Stacks2) process_radtags doesn't work when the data are converted from fastqsanger.gz to fastqsanger. Data have to be left in the fastqsanger.gz format to properly demultiplex. I spent a lot of time trying to figure out why this step of the tutorial wasn't working. Also, I couldn't find the Charts function, so I ended up skipping this step of the tutorial. ",,RAD-Seq de-novo data analysis,Ecology,2023-07,2023-07-12
+2326,5,,,,Label-free versus Labelled - How to Choose Your Quantitation Method,Proteomics,2023-07,2023-07-13
+2327,5,I learned a lot about a subject new to me. I appreciated that why and how each tool contributed was explained.,"It would be great if the example Galaxy workflow carried over more of the explanatory information; met the best practices, etc..",,Peptide and Protein ID using OpenMS tools,Proteomics,2023-07,2023-07-14
+2328,3,It was detailed,"I've used galaxy a few times, and this is the first time I'm seeing the collections feature. Somewhere in the tutorial, I think after BWA-MEM, the next tool didn't automatically pick an input file as usual, and even when I clicked the drop down, there was no list of the files in my history. Might probably make more sense with a screenshot, but anyway. Now, I feel like the rest of the analysis from that point was on just one of the datasets and not the collection. There's also the fact that some outputs are automatically hidden. I enjoy tinkering around knowing fully well that i won't break anything, so I don't really mind. But a complete newbie would probably get frustrated not knowing where history 16,17,18,19... disappeared to. Since this tutorial is in the introductory section, it might be helpful to acknowledge those peculiarities. Finally, maybe tell us how to visualise the vcf too? What to look for, how to know what's interesting,... I'm still looking for the nonesense mutation, but I'm sure I'll find it.  Thanks to the creators still. I loved the intro part; it set the flow for the rest of the tutorial.",,NGS data logistics,Introduction to Galaxy Analyses,2023-07,2023-07-15
+2329,5,The accurate step by step explanations,"Look at all your histories   I think it would be benefical to mention that you have to create a new history before you can see them side by side. Also i was not able to get my window to look like the one in the tutorial. Couldn't really get the ""proper"" side by side view. ",,A short introduction to Galaxy,Introduction to Galaxy Analyses,2023-07,2023-07-17
+2330,5,Very user friendly,,,Galaxy 101 for everyone,Introduction to Galaxy Analyses,2023-07,2023-07-18
+2331,5,The clarity of the explanation and the easy-to-use slack tutorial,,,Galaxy 101 for everyone,Introduction to Galaxy Analyses,2023-07,2023-07-18
+2332,5,"Using Galaxy is not trivial without initial training, but the initial training is simple enough to get everything you need to follow.  I have found no other way to acquire bioinformatics expertise in such a wide diversity of tools and analyses in a unified and practical way, just by clicking, and with easy access to any amount of data. ",Can't say yet.,,Basics of machine learning,Statistics and machine learning,2023-07,2023-07-18
+2333,4,"Overall this is so good; it introduces a whole lot of tools and there are checkpoints along the way that are extra helpful with making sure I'm on the right track. I'm early career faculty at a small college, so having such a good resource to teach this tool to myself has been invaluable","I had a problem with the tags and found that in the "" Add tags to your collection for each of these factors"" step, when using the regular expression in ""Replace Text in entire line"", it should be: Find pattern: (.*)_(.*)_(.*)_(.*) Replace with: \1_\2_\3_\4\tgroup:\2\tgroup:\3  because the counts files have names like GSM461176_untreat_single_featureCounts.counts, so you want the second and third element.",,Reference-based RNA-Seq data analysis,Transcriptomics,2023-07,2023-07-22
+2334,5,,,,Galaxy 101,Introduction to Galaxy Analyses,2023-07,2023-07-24
+2335,4,Very clear and detailed tutorial,Some more information on the 'display at UCSC' could be provided,,Galaxy 101,Introduction to Galaxy Analyses,2023-07,2023-07-24
+2336,5,"nice step by step description,  could follow pretty easy",,,Galaxy 101,Introduction to Galaxy Analyses,2023-07,2023-07-24
+2337,5,,,,Genome-wide alternative splicing analysis,Transcriptomics,2023-07,2023-07-25
+2338,5,The simplicity,,,A short introduction to Galaxy,Introduction to Galaxy Analyses,2023-07,2023-07-25
+2339,4,"Very helpful tutorial, thank you for posting it!","You should state explicitly what the input file(s) should be at each step. Each function produces multiple outputs; It is not clear what I am supposed to run Stacks: populations ON, for instance.",,RAD-Seq de-novo data analysis,Ecology,2023-07,2023-07-27
+2340,4,,,,Microbial Variant Calling,Variant Analysis,2023-08,2023-08-02
+2341,3,Es interesante conocer un poco más de esta etapa del análisis de secuenciación,Algunos pasos como saber a partir del resporte de samtools stats cuales son los reads con un quality score >20 no sé donde visualizarlo. Faltan imágenes de como se ve el archivo cargado en IGV para la región del cromosoma 2 solicitado,,Mapping,Sequence analysis,2023-08,2023-08-03
+2342,5,,,,Identification of the binding sites of the T-cell acute lymphocytic leukemia protein 1 (TAL1),Epigenetics,2023-08,2023-08-03
+2343,2,Spades tutorial is correct,"Velvet tutorial is not working, I follow the instructions and didn't got a final image it went white all, so think is something up to the tutorial or the tool",,De Bruijn Graph Assembly,Assembly,2023-08,2023-08-11
+2344,5,Detailed explanation,Too complicated in some aspects like explain on theory,,Reference-based RNA-Seq data analysis,Transcriptomics,2023-08,2023-08-15
+2345,5,every thing ,,,Galaxy 101 for everyone,Introduction to Galaxy Analyses,2023-08,2023-08-15
+2346,4,,,,Quality Control,Sequence analysis,2023-08,2023-08-20
+2347,5,it is very perfect ,,,"De novo transcriptome assembly, annotation, and differential expression analysis",Transcriptomics,2023-08,2023-08-21
+2348,5,,,,Quality Control,Sequence analysis,2023-08,2023-08-22
+2349,5,The elegant instructions to follow along,"I would recommend to include the information about APIs and how it works, and some content with automating stuffs on python",,A short introduction to Galaxy,Introduction to Galaxy Analyses,2023-08,2023-08-22
+2350,4,Step by step instructions,"Since my data are Illumina, each sample has two sets of reads and the tutorial didn't seem to address dealing with them as a set. I gather I would do QC, then filter, then pair them, but we didn't cover it. Thanks for doing these! I'm going to try to learn more about how to use Galaxy for Illumina and Nanopore sequencing data.",,A short introduction to Galaxy,Introduction to Galaxy Analyses,2023-08,2023-08-22
+2351,5,,,,Introduction to Genomics and Galaxy,Introduction to Galaxy Analyses,2023-08,2023-08-22
+2352,5,,,,Genome annotation with Prokka,Genome Annotation,2023-08,2023-08-23
+2353,5,the hands-on part works. It is simple and clear,,,Taxonomic Profiling and Visualization of Metagenomic Data,Microbiome,2023-08,2023-08-25
+2354,1,Nothing at all,"Provide explanation of steps that lead to results, not only instructions on how to run a workflow. Person can't learn much from that",,"Mutation calling, viral genome reconstruction and lineage/clade assignment from SARS-CoV-2 sequencing data",Variant Analysis,2023-08,2023-08-26
+2355,5,Such an elegant way for quick sub-typing. Thank you very much!,,,Avian influenza viral strain analysis from gene segment sequencing data,Variant Analysis,2023-08,2023-08-27
+2356,5,,,,A short introduction to Galaxy,Introduction to Galaxy Analyses,2023-08,2023-08-28
+2357,5,easy to follow,please update the tutorial; i think i was working with a newer version and some of the options were different; ,,De novo transcriptome reconstruction with RNA-Seq,Transcriptomics,2023-08,2023-08-29
+2358,5,,,,Reference-based RNA-Seq data analysis,Transcriptomics,2023-08,2023-08-31
+2359,5,"It's so didactic, well thought over and it encompasses all the dark corners of jq usage.",I had a hard finding the dataset used in this tutorial because the url are no longer available. Managed to find the .tsv files that I've converted back to json,,Data Manipulation Olympics - JQ,Foundations of Data Science,2023-09,2023-09-01
+2360,5,,,,Virtual screening of the SARS-CoV-2 main protease with rxDock and pose scoring,Computational chemistry,2023-09,2023-09-01
+2361,4,The ease of flow,,,Introduction to Genomics and Galaxy,Introduction to Galaxy Analyses,2023-09,2023-09-01
+2362,5,"Tutorials like this serve as valuable educational resources for researchers, students, and healthcare professionals interested in cancer biology and genomics. They can enhance the skills and knowledge of individuals in the field, fostering a more informed and capable scientific community.","When I follow the turoial, everything working very well. however, when I put my data, I encounter the problem in gffread: FASTA index file genomeref.fa.fai created. Error (GFaSeqGet): subsequence cannot be larger than 2790 Error getting subseq for STRG.5.1 (5..23254)! Many individuals encounter this issue while conducting online searches, and it would be highly beneficial to include a solution to address this problem if feasible. and till now I still don't know how to solve this problem please feel free to contact me ppm8888200@gmail.com Kind regards ",,Genome-wide alternative splicing analysis,Transcriptomics,2023-09,2023-09-04
+2363,5,,,,Mass spectrometry: LC-MS analysis,Metabolomics,2023-09,2023-09-05
+2364,5,,,,Quality Control,Sequence analysis,2023-09,2023-09-05
+2365,4,Very clear.  Most of it worked. ,"""Pose scoring with TransFS"" crashed for me.  Error message said ""No score found for record xxxx"" for every molecule",,Virtual screening of the SARS-CoV-2 main protease with rxDock and pose scoring,Computational chemistry,2023-09,2023-09-05
+2366,5,,,,A short introduction to Galaxy,Introduction to Galaxy Analyses,2023-09,2023-09-06
+2367,5,,,,A short introduction to Galaxy,Introduction to Galaxy Analyses,2023-09,2023-09-06
+2368,4,,,,Mapping,Sequence analysis,2023-09,2023-09-07
+2369,5,"it was well-structured, rich in details and understandable. Thank you for it!",,,Reference-based RNA-Seq data analysis,Transcriptomics,2023-09,2023-09-07
+2370,5,The step manner it uses and that it does not take into account any previous knowledge from the reader. ,,,A short introduction to Galaxy,Introduction to Galaxy Analyses,2023-09,2023-09-08
+2371,4,,,,A short introduction to Galaxy,Introduction to Galaxy Analyses,2023-09,2023-09-12
+2372,1,,,,RStudio in Galaxy,Using Galaxy and Managing your Data,2023-09,2023-09-12
+2373,5,,,,DNA Methylation data analysis,Epigenetics,2023-09,2023-09-14
+2374,5,Easy to follow with multiple examples,,,Understanding Barcodes,Single Cell,2023-09,2023-09-14
+2375,5,Simple explanations with illustrative screenshots,"The screenshots don't all correspond to what is currently seen, particularly the one in which we select a previous history/dataset and import it into ""New history"" using the drag-and-drop option. Perhaps this particular screenshot could be updated please? Otherwise, a brilliant first tutorial. Thank you.",,A short introduction to Galaxy,Introduction to Galaxy Analyses,2023-09,2023-09-19
+2376,5,Ease of use as well as explaining what the steps were doing in a easy to understand way.,"Perhaps a drop down section giving a deeper/more technical explanation of the step/tool being used, if there is one.",,Galaxy 101,Introduction to Galaxy Analyses,2023-09,2023-09-19
+2377,5,step wise instructions,a screenshot of the output/result would be helpful,,Galaxy 101 for everyone,Introduction to Galaxy Analyses,2023-09,2023-09-20
+2378,5,,,,A short introduction to Galaxy,Introduction to Galaxy Analyses,2023-09,2023-09-20
+2379,5,,,,A short introduction to Galaxy,Introduction to Galaxy Analyses,2023-09,2023-09-21
+2380,5,simplicity,an example of how to save your file to galaxy and how to see it there.,,RStudio in Galaxy,Using Galaxy and Managing your Data,2023-09,2023-09-21
+2381,5,Self-explanatory. Very few bioinformatics platforms have made processing data so easy to follow!!! Great job guys!!!,"I hope that Galaxy can keep up with the updates of all the bioinformatics tools it has curated from various Github pages. For example, for CRISPR screening analysis, MaGeCKflute is the latest version and can be added to the pipeline on top of MaGeCK MLE and MaGeCK RRA. ",,A short introduction to Galaxy,Introduction to Galaxy Analyses,2023-09,2023-09-23
+2382,5,a good way to dip my feet in the water,Update some screenshots,,Galaxy 101,Introduction to Galaxy Analyses,2023-09,2023-09-23
+2383,5,,,,Galaxy 101 for everyone,Introduction to Galaxy Analyses,2023-09,2023-09-23
+2384,5,,,,Reference-based RNA-Seq data analysis,Transcriptomics,2023-09,2023-09-24
+2385,5,workflow process,,,A short introduction to Galaxy,Introduction to Galaxy Analyses,2023-09,2023-09-25
+2386,5,"simple, well rounded in terms of introducing basic features and easy to understand ","It would be great to have a video on what the platform is as a concept, the story behind it and most importantly how it functions (from a compsci POV)",,A short introduction to Galaxy,Introduction to Galaxy Analyses,2023-09,2023-09-26
+2387,5,"Easy to follow, exactly what I was looking to do with my data",,,Visualization of RNA-Seq results with Volcano Plot,Transcriptomics,2023-09,2023-09-26
+2388,5,It is understandable,,,Understanding Barcodes,Single Cell,2023-09,2023-09-27
+2389,5,,,,Understanding Barcodes,Single Cell,2023-09,2023-09-27
+2390,5,A brief guide that is easy to understand when you first come into contact with the galaxy,,,A short introduction to Galaxy,Introduction to Galaxy Analyses,2023-09,2023-09-27
+2391,5,Step by step explanations are very good. ,You can add photos for each steps.,,Galaxy 101,Introduction to Galaxy Analyses,2023-09,2023-09-30
+2392,3,"As a new hand and being not literate at coding, this step-by-step tutorial is what i really needed. Especially the provided data sets. ","Because I am very new, once the results is not what I should see, I was totally lost. E.g. after running the GOEnrichment tool, next is ""Analyze again the table and graph from Biological Process"". Here I was lost. I suppose to do more analysis? I suppose I can visualize the CC, MF, BP graphs through the eye icon, only the top of the graph (100%BP) showed up. The rest of the ontology was invisible. I was lost again.  I posted this question on the Galaxy Help. I realized that it might be a stupid question. I am very new to this, for which I apologize.",,GO Enrichment Analysis,Transcriptomics,2023-10,2023-10-01
+2393,5,,,,A short introduction to Galaxy,Introduction to Galaxy Analyses,2023-10,2023-10-01
+2394,5,,,,A short introduction to Galaxy,Introduction to Galaxy Analyses,2023-10,2023-10-02
+2395,5,,,,Visualisation with Circos,Visualisation,2023-10,2023-10-02
+2396,5,it was easy to follow ,i would like it to be able to follow the tutorial and use the platform at the same. i think a divided screen with the tutorial on one side and the platform on the other would be great ,,A short introduction to Galaxy,Introduction to Galaxy Analyses,2023-10,2023-10-03
+2397,5,,,,A short introduction to Galaxy,Introduction to Galaxy Analyses,2023-10,2023-10-03
+2398,4,,,,M. tuberculosis Variant Analysis,Variant Analysis,2023-10,2023-10-03
+2399,5,"easy to follow, step-by-step explanation",alternative workflows for different situations (for instance workflow w/o mock community removal),,16S Microbial Analysis with mothur (extended),Microbiome,2023-10,2023-10-03
+2400,4,All the steps are very clear,More time to take the session due to complexity for the ones who are not familiar,,Galaxy 101,Introduction to Galaxy Analyses,2023-10,2023-10-04
+2401,5,At the end I see the SNPs in different colours.,The steps should contain more explanatory steps.,,Mapping,Sequence analysis,2023-10,2023-10-04
+2402,5,The pipelines,Time to go through all tutorial.,,Tree thinking for tuberculosis evolution and epidemiology,Evolution,2023-10,2023-10-05
+2403,5,,,,A short introduction to Galaxy,Introduction to Galaxy Analyses,2023-10,2023-10-06
+2404,5,,,,JupyterLab in Galaxy,Using Galaxy and Managing your Data,2023-10,2023-10-06
+2405,5,It was great to see that I achieved results by following the tutorial.,In Part-1 Rstudio step was difficult to understand for me.,,Identifying tuberculosis transmission links: from SNPs to transmission clusters,Evolution,2023-10,2023-10-08
+2406,5,,,,Tree thinking for tuberculosis evolution and epidemiology,Evolution,2023-10,2023-10-08
+2407,3,,"The url for one of the datasets is incorrect. The correct url is ""https://zenodo.org/records/1489208/files/Trimmed_ref_5000_uniprot_cRAP.fasta""",,Proteogenomics 1: Database Creation,Proteomics,2023-10,2023-10-13
+2408,5,,,,A short introduction to Galaxy,Introduction to Galaxy Analyses,2023-10,2023-10-16
+2409,5,,,,Identification of the micro-organisms in a beer using Nanopore sequencing,Microbiome,2023-10,2023-10-16
+2410,5,Extremely easy to follow and I was so impressed that it all works as described. Good maintenance :),"I had the mental model of a Jupyter Notebook coming in, so I was trying to figure out how to open the tutorial in my usegalaxy.org account view.",,Analysis of molecular dynamics simulations,Computational chemistry,2023-10,2023-10-17
+2411,5,,,,A short introduction to Galaxy,Introduction to Galaxy Analyses,2023-10,2023-10-17
+2412,5,The important function of each tool was described clearly. The questions and answers could highlight other practical information.,,,Mapping,Sequence analysis,2023-10,2023-10-18
+2413,5,Easy to follow,-,,2: RNA-seq counts to genes,Transcriptomics,2023-10,2023-10-19
+2414,5,I think it was very straightforward and easy to follow,"This part: Given the following variables: a = 2 b = 1 c = -1 I think the variables should be separated, I was really confused for a bit",,Python - Math,Foundations of Data Science,2023-10,2023-10-19
+2415,3,All steps are very clear and have a great explanation ,all the datasets used in this pipeline are very poor and incomplete and there are a lot of unclassified reads and taxa so really need to improve ,,Taxonomic Profiling and Visualization of Metagenomic Data,Microbiome,2023-10,2023-10-19
+2416,1,,I feel this was too advanced for an introduction. I couldn't follow as outputs were not as described.,,NGS data logistics,Introduction to Galaxy Analyses,2023-10,2023-10-20
+2417,5,,,,A short introduction to Galaxy,Introduction to Galaxy Analyses,2023-10,2023-10-21
+2418,5,Easy and completed,You should try more video clips content but I think tihs tuturial is great,,A short introduction to Galaxy,Introduction to Galaxy Analyses,2023-10,2023-10-21
+2419,5,"I like almost everything, nicely presented and so helpful",maybe more clear at first regarding what site provides what so we dont have to register several rounds,,Library Generation for DIA Analysis,Proteomics,2023-10,2023-10-25
+2420,3,,"I went through the first tutorial, Proteogenomics 1: Database Creation. This resulted in creation of the fasta protein database file, Uniprot_cRAP_SAV_indel_translatedbed.FASTA which is used by this tutorial. When I ran the SearchGUI against this database file and the same downloaded mfg files, an empty SearchGUI archive file was generated. So I could not move onto the next steps of the tutorial. I suppose it is possible that I somehow did something wrong in the first tutorial to create the fasta file although just by looking at it it seemed reasonable and had a fair amount of data in it. I was wondering if anyone has gone through the first tutorial and the second tutorial to verify that they work. Also, it would be helpful if there was a sample input protein database file available on zenodo to complete this tutorial without having to be dependent upon the output of the first tutorial.",,Proteogenomics 2: Database Search,Proteomics,2023-10,2023-10-25
+2421,4,il is well explained and step-by-step guided. ,"It maybe useful to have more details on the special meaning of "" *, ?, ., + etc in a regular expression, maybe i just missed the information.  Regarding the sort-tool based exercise i had a different answer to ""Which athlete comes last by alphabet, in the most recent Olympics?"" : instead of "" Žolt Peto who competed in table tennis at the 2020 Summer Olympics in Tokyo. "" i obtained ""Zuzana Rehák Štefečeková who competed in shooting at the 2020 Summer Olympics in Tokyo"". I do not understand why i get a different result and if Žolt should come last because of the ""Ž"" not being a ""Z"" ?",,Data Manipulation Olympics,Introduction to Galaxy Analyses,2023-10,2023-10-26
+2422,4,,,,NGS data logistics,Introduction to Galaxy Analyses,2023-10,2023-10-27
+2423,5,,,,An Introduction to Genome Assembly,Assembly,2023-10,2023-10-27
+2424,4,Clearly stated with pictures,Trouble shooting pages and video recording,,A short introduction to Galaxy,Introduction to Galaxy Analyses,2023-10,2023-10-28
+2425,4,Very clear and well explain tutorial,Maybe I would suggest to put some figures to easy find some commands on galaxy,,M. tuberculosis Variant Analysis,Variant Analysis,2023-10,2023-10-29
+2426,4,How to develop and analyse a phylogenetic tree,,,Tree thinking for tuberculosis evolution and epidemiology,Evolution,2023-10,2023-10-30
+2427,4,Very clear tutorial,,,Identifying tuberculosis transmission links: from SNPs to transmission clusters,Evolution,2023-10,2023-10-31
+2428,5,,,,A short introduction to Galaxy,Introduction to Galaxy Analyses,2023-10,2023-10-31
+2429,4,It was very clear and detailed,"Some of the options were not updated, or at least they show different in my browser (galaxy.ue). Specifically in the FastQC ""short...""",,A short introduction to Galaxy,Introduction to Galaxy Analyses,2023-10,2023-10-31
+2430,4,,,,A short introduction to Galaxy,Introduction to Galaxy Analyses,2023-11,2023-11-01
+2431,5,,More examples of poor quality reads.,,Quality Control,Sequence analysis,2023-11,2023-11-03
+2432,5,"Very clear, providing a first glance on the main actions with Galaxy.","Maybe the tutorial should be updated according to new versions of web Galaxy. Also, the reason for the second renaming (as ""FASTQ reads"") during the creation of a workflow is not well justified.",,A short introduction to Galaxy,Introduction to Galaxy Analyses,2023-11,2023-11-03
+2433,5,,,,A short introduction to Galaxy,Introduction to Galaxy Analyses,2023-11,2023-11-04
+2434,4,The step by step process is well explained,"I as not able to comple some steps, like converting the resistance gene table to gf3",,Identification of the micro-organisms in a beer using Nanopore sequencing,Microbiome,2023-11,2023-11-07
+2435,5,the coherence,Examples in many ways to analyze,,A short introduction to Galaxy,Introduction to Galaxy Analyses,2023-11,2023-11-08
+2436,5,,,,Identification of the binding sites of the T-cell acute lymphocytic leukemia protein 1 (TAL1),Epigenetics,2023-11,2023-11-09
+2437,5,,,,Identification of somatic and germline variants from tumor and normal sample pairs,Variant Analysis,2023-11,2023-11-09
+2438,5,Thank you for the detailed step by step guide,,,A short introduction to Galaxy,Introduction to Galaxy Analyses,2023-11,2023-11-09
+2439,5,it was easy to follow,,,Identification of somatic and germline variants from tumor and normal sample pairs,Variant Analysis,2023-11,2023-11-12
+2440,5,the details,i think it was perfect,,A short introduction to Galaxy,Introduction to Galaxy Analyses,2023-11,2023-11-13
+2441,4,Clear and progressive,Not up to date ( gear icon is not here anymore for the history sharing part ),,A short introduction to Galaxy,Introduction to Galaxy Analyses,2023-11,2023-11-13
+2442,5,Simple and straightforward instructions,,,A short introduction to Galaxy,Introduction to Galaxy Analyses,2023-11,2023-11-20
+2443,5,Easy to follow ,,,A short introduction to Galaxy,Introduction to Galaxy Analyses,2023-11,2023-11-20
+2444,1,,,,Mapping,Sequence analysis,2023-11,2023-11-23
+2445,5,,,,Galaxy 101,Introduction to Galaxy Analyses,2023-11,2023-11-23
+2446,5,Questions and answers,,,"Filter, plot and explore single-cell RNA-seq data (Scanpy)",Single Cell,2023-11,2023-11-24
+2447,4,,,,Introduction to Genomics and Galaxy,Introduction to Galaxy Analyses,2023-11,2023-11-24
+2448,5,,,,From NCBI's Sequence Read Archive (SRA) to Galaxy: SARS-CoV-2 variant analysis,Variant Analysis,2023-11,2023-11-27
+2449,5,,,,R basics in Galaxy,Foundations of Data Science,2023-11,2023-11-28
+2450,1,,"I'm trying to use data from GEO and there are no tags nor a tag file.  I can't figure out how to make those or obtain them (likely not possible).  Because of this, this tutorial is not useful.",,Group tags for complex experimental designs,Using Galaxy and Managing your Data,2023-11,2023-11-28
+2451,5,,,,A short introduction to Galaxy,Introduction to Galaxy Analyses,2023-11,2023-11-30
+2452,5,,,,A short introduction to Galaxy,Introduction to Galaxy Analyses,2023-12,2023-12-04
+2453,5,It was explicit and clear,Please show wich versions of plugins and software ur using,,3: RNA-seq genes to pathways,Transcriptomics,2023-12,2023-12-05
+2454,4,easy to follow,please add more screenshots for easy localization of the buttons ,,A short introduction to Galaxy,Introduction to Galaxy Analyses,2023-12,2023-12-05
+2455,3,"Good tutorial, but it is outdated. There is no training branch to be found on the galaxy Github (no old training, no new training2022 or the like).  I managed to find the branch here: https://github.com/galaxyproject/galaxy/pull/14339 and cloned https://github.com/jdavcs/galaxy/tree/training2022  which made me able to do the training. But I believe that is the reason there were minor differences furtherdown the tutorial as it is a year old so I think this is the problem that would fix the rest.",Updating to latest changes,,Debugging Galaxy,Development in Galaxy,2023-12,2023-12-07
+2456,5,,,,Pre-processing of 10X Single-Cell RNA Datasets,Single Cell,2023-12,2023-12-11
+2457,5,It is very well explained and it's in a easy way to understand all the commands and what they do.,,,VGP assembly pipeline: Step by Step,Assembly,2023-12,2023-12-13
+2458,5,The screenshots/videos were helpful,,,A short introduction to Galaxy,Introduction to Galaxy Analyses,2023-12,2023-12-13
+2459,3,,,,A short introduction to Galaxy,Introduction to Galaxy Analyses,2023-12,2023-12-14
+2460,5,,,,A short introduction to Galaxy,Introduction to Galaxy Analyses,2023-12,2023-12-18
+2461,4,It was clear,,,A short introduction to Galaxy,Introduction to Galaxy Analyses,2023-12,2023-12-19
+2462,5,,,,A short introduction to Galaxy,Introduction to Galaxy Analyses,2023-12,2023-12-19
+2463,5,explanation of process,more theory,,Label-free data analysis using MaxQuant,Proteomics,2023-12,2023-12-19
+2464,1,,,,Identifying tuberculosis transmission links: from SNPs to transmission clusters,Evolution,2023-12,2023-12-22
+2465,5,,,,Removal of human reads from SARS-CoV-2 sequencing data,Sequence analysis,2023-12,2023-12-23
+2466,5,,,,"Inferring single cell trajectories (Scanpy, Python)",Single Cell,2023-12,2023-12-27
+2467,4,Easy to understand,Please use simple explanation ,,Mapping,Sequence analysis,2023-12,2023-12-29
+2468,5,,,,Exome sequencing data analysis for diagnosing a genetic disease,Variant Analysis,2023-12,2023-12-29
+2469,5,everything worked as described,"double check that terms ""run"" and ""execute"" match up between tutorial and latest software ",,A short introduction to Galaxy,Introduction to Galaxy Analyses,2024-01,2024-01-03
+2470,1,good,.,,Quality Control,Sequence analysis,2024-01,2024-01-09
+2471,5,The 'easy-to-understand' way of explaining the whole process,,,Large genome assembly and polishing,Assembly,2024-01,2024-01-10
+2472,3,I think it clearly explained.,"Thanks for the tutorial it is good. But I would add some info about the interpretation of the output. I don't understand for example this case that is shown in the tutorial: % head -5 mysnps/snps.tab CHROM  POS     TYPE    REF   ALT    EVIDENCE        FTYPE STRAND NT_POS AA_POS LOCUS_TAG GENE PRODUCT EFFECT chr      5958  snp     A     G      G:44 A:0        CDS   +      41/600 13/200 ECO_0001  dnaA replication protein DnaA missense_variant c.548A>C p.Lys183Thr  REF is A and ALT is G, but then the change is c.548A>C",,Microbial Variant Calling,Variant Analysis,2024-01,2024-01-15
+2473,3,Just started but looks good so far,The following links could replace the current ones in the past and fetch data box  https://zenodo.org/records/4406623/files/S_pombe_chrIII.fasta?download=1 https://zenodo.org/records/4406623/files/S_pombe_genome.fasta?download=1 https://zenodo.org/records/4406623/files/S_pombe_trinity_assembly.fasta?download=1 https://zenodo.org/records/4406623/files/Swissprot_no_S_pombe.fasta?download=1 https://zenodo.org/records/4406623/files/augustus_training_1.tar.gz?download=1 https://zenodo.org/records/4406623/files/augustus_training_2.tar.gz?download=1  ,,Genome annotation with Maker,Genome Annotation,2024-01,2024-01-16
+2474,5,The explanations are very clear and the tutorial is very easy to follow,"The Table to GFF3 is no longer available, so I couldn't finish the tutorial. And I didn't find an alternative tool to Table to GFF3.",,Genome Assembly of a bacterial genome (MRSA) sequenced using Illumina MiSeq Data,Assembly,2024-01,2024-01-17
+2475,5,the simplicity of access,a few more screen shots towards the end. I got a tad lost.,,From peaks to genes,Introduction to Galaxy Analyses,2024-01,2024-01-18
+2476,5,,really great session ,,A short introduction to Galaxy,Introduction to Galaxy Analyses,2024-01,2024-01-18
+2477,5,,,,A short introduction to Galaxy,Introduction to Galaxy Analyses,2024-01,2024-01-19
+2478,4,Its easy to understand,Some videos would be more useful,,Python - Math,Foundations of Data Science,2024-01,2024-01-19
+2479,5,step by step demos and the scientifc background behind each step ,,,Protein-ligand docking,Computational chemistry,2024-01,2024-01-19
+2480,5,,,,Introduction to Genomics and Galaxy,Introduction to Galaxy Analyses,2024-01,2024-01-29
+2481,5,simple to be understand,,,A short introduction to Galaxy,Introduction to Galaxy Analyses,2024-01,2024-01-30
+2482,5,,,,VGP assembly pipeline: Step by Step,Assembly,2024-01,2024-01-31
+2483,1,title,is there a video link to this tutorial as i coulnt find,,Running a workshop as instructor,Teaching and Hosting Galaxy training,2024-02,2024-02-01
+2484,1,,you need to add more graphics for step by step guide,,"Creating, Editing and Importing Galaxy Workflows",Using Galaxy and Managing your Data,2024-02,2024-02-02
+2485,4,Details,"For someone trying without support, there are some mandatory fields in hicbuildmatrix that are not explained:   1. Need to add the hicfindrestsite step to generate the compulsory contact bed file   2. Need to add a dangling sequence for the restriction enzyme for hicbuildmatrix",,Hi-C analysis of Drosophila melanogaster cells using HiCExplorer,Epigenetics,2024-02,2024-02-03
+2486,5,"It looks really useful, clearly explained. I still didn`t get it to work with my own data, but I am just learning.","I believe the link to the workflow is incorrect, it links to something else",,Ploting a Microbial Genome with Circos,Visualisation,2024-02,2024-02-05
+2487,5,The structure.,,,A short introduction to Galaxy,Introduction to Galaxy Analyses,2024-02,2024-02-05
+2488,5,,,,A short introduction to Galaxy,Introduction to Galaxy Analyses,2024-02,2024-02-05
+2489,1,,"It`s not working. I have tried the bedtools intersect intervals five times, including with the files provided via Zenodo. Each time a table is returned that lists the SNP twice instead of the intersection with the exon.",,Galaxy 101,Introduction to Galaxy Analyses,2024-02,2024-02-06
+2490,5,,,,Galaxy 101,Introduction to Galaxy Analyses,2024-02,2024-02-11
+2491,5,"Steps are well explained and detailed, tips are very useful in general",,,Mass spectrometry: LC-MS data processing,Metabolomics,2024-02,2024-02-11
+2492,5,Everything. Explanation is great.,"As the field is still evolving, please include the recent changes as well. ",,Pre-processing of 10X Single-Cell RNA Datasets,Single Cell,2024-02,2024-02-12
+2493,1,,"Following the tutorial did not work in my hands. I loaded the data via Paste/Fetch, but already in the FastQC step I get an error for dataset 2: ""An error occurred with this dataset: format txt database ?""",,Genome Assembly of a bacterial genome (MRSA) sequenced using Illumina MiSeq Data,Assembly,2024-02,2024-02-12
+2494,5,Clear instructions. Liked the image and drop down menu's.,,,A short introduction to Galaxy,Introduction to Galaxy Analyses,2024-02,2024-02-12
+2495,5,,,,A short introduction to Galaxy,Introduction to Galaxy Analyses,2024-02,2024-02-13
+2496,4,Detailed step by stepintroduction into the application,"It seems to me like the tutorial was written for an earlier version of Galaxy. In the beginning some buttons were named differently from the current panels, which was a bit confusing at first. ",,A short introduction to Galaxy,Introduction to Galaxy Analyses,2024-02,2024-02-15
+2497,5,,"Hi all -- the reads for this tutorial are incorrect at the zenodo site. Both are interleaved fastq, and the second (labeled as the ""reverse"" file) has a content problem. The tutorial workflow will happily process the data as-is, except for a fastqc failure on that second file (reported as truncated).   > End-User Workaround: use only the first file, de-interlace as a new first step, rename the split files, get rid of the originals (to avoid mixing up data), then proceed with the remainder of the tutorial.   Self-pinging so I can find this later @jennaj",,Genome Assembly of a bacterial genome (MRSA) sequenced using Illumina MiSeq Data,Assembly,2024-02,2024-02-15
+2498,5,the interface an steps are easy to follow,,,From peaks to genes,Introduction to Galaxy Analyses,2024-02,2024-02-16
+2499,5,"step for step explanation supported by fotos and videos, easy language",,,A short introduction to Galaxy,Introduction to Galaxy Analyses,2024-02,2024-02-19

--- a/topics/teaching/tutorials/workshop-intro/slides.html
+++ b/topics/teaching/tutorials/workshop-intro/slides.html
@@ -119,10 +119,9 @@ afterwards. By asking participants to put up the sticky when they are done,
 you will have a sense of when most of your learners are ready to continue.
 
 **Request to instructors:**
- - Collect all sticky notes and add them to [this GitHub issue](https://github.com/galaxyproject/training-material/issues/989)
+ - Collect all sticky notes and add them to [this GitHub issue](https://github.com/galaxyproject/training-material/discussions/1452)
    after the workshop to share the feedback and ideas for improvements with the GTN community.
  - Add any feedback received from yourself, other instructors, and helpers here as well
- - Example feedback posts from other instructors: [here](https://github.com/galaxyproject/training-material/issues/989#issuecomment-493438843) and [here](https://github.com/galaxyproject/training-material/issues/989#issuecomment-493642457)
 
 
 ---


### PR DESCRIPTION
this should be slightly more rewrite safe and we'll need to keep it up a little bit less...

i've converted the ones in the google sheet, we just need to move the replacement column two times left, and it'll be ready (should be done when this is merged to prevent issues.)

the other bonus of course is that the remapping in the future to a new material can be done automatically by looking through `redirect_from` and discovering previous IDs for a material (this is not currently implemented) whereas we don't have historical titles without walking the git history. So we'll never have to update this file again (hopefully.)