### PR TITLE
Ensure stronger URL persistence

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -101,3 +101,7 @@ jobs:
       - name: Validate notebooks (If this fails, ask @hexylena to look at your notebook)
         run: |
           find _site | grep ipynb | xargs bundle exec ruby bin/check-valid-notebook.rb
+
+      - name: Check URL persistence
+        run: |
+          bash bin/check-url-persistence.sh

--- a/bin/check-url-persistence.sh
+++ b/bin/check-url-persistence.sh
@@ -8,7 +8,13 @@ if [[ ! -f /tmp/2024.txt ]]; then
 fi
 
 # No guarantees of API or data-file persistence
-cat /tmp/202*.txt | grep -v '/api/' | grep -v '/by-tool/'  | grep -v '/hall-of-fame/' | grep -v 'training-material/tags/' | grep -v 'data-library'| sed 's|/$|/index.html|'  | grep '.html$' | sort -u | sed 's|https://training.galaxyproject.org|_site|' > /tmp/gtn-files.txt
+# 1fe4d7d92e5ea5a5794cbe741eadb96a74511261
+cat /tmp/202*.txt | grep -v '/api/' | grep -v '/by-tool/'  | grep -v '/hall-of-fame/' | \
+	grep -v '/badges/' | \
+	grep -v '/transcriptomics/tutorials/ref-based/faqs/rnaseq_data.html' | \
+	grep -v '/topics/data-management/' | \
+	grep -v 'training-material/tags/' | grep -v 'data-library'| \
+	sed 's|/$|/index.html|'  | grep '.html$' | sort -u | sed 's|https://training.galaxyproject.org|_site|' > /tmp/gtn-files.txt
 
 count=0
 while read line; do

--- a/bin/check-url-persistence.sh
+++ b/bin/check-url-persistence.sh
@@ -27,5 +27,6 @@ done < /tmp/gtn-files.txt
 if (( $count > 0 )); then
 	echo "Files in previous versions that are not currently redirected: $count"
 	echo "Please ensure you add redirect_from: entries to each page"
+	echo "If this file is intentionally deleted, with no replacement, please update this script with some exclusions."
 	exit 1
 fi

--- a/bin/check-url-persistence.sh
+++ b/bin/check-url-persistence.sh
@@ -8,7 +8,7 @@ if [[ ! -f /tmp/2024.txt ]]; then
 fi
 
 # No guarantees of API or data-file persistence
-cat /tmp/202*.txt | grep -v '/api/' | grep -v '/by-tool/'  | grep -v '/hall-of-fame/.*/index.html' | grep -v 'training-material/tags/' | grep -v 'data-library'| sed 's|/$|/index.html|'  | grep '.html$' | sort -u | sed 's|https://training.galaxyproject.org|_site|' > /tmp/gtn-files.txt
+cat /tmp/202*.txt | grep -v '/api/' | grep -v '/by-tool/'  | grep -v '/hall-of-fame/' | grep -v 'training-material/tags/' | grep -v 'data-library'| sed 's|/$|/index.html|'  | grep '.html$' | sort -u | sed 's|https://training.galaxyproject.org|_site|' > /tmp/gtn-files.txt
 
 count=0
 while read line; do

--- a/bin/check-url-persistence.sh
+++ b/bin/check-url-persistence.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+if [[ ! -f /tmp/2022.txt ]]; then
+	curl --silent https://training.galaxyproject.org/archive/2022-01-01/sitemap.xml | sed 's|<url>|\n|g' | grep '<loc>[^<]*</loc>' -o | sed 's/<loc>//;s/<\/loc>//' | sed 's|archive/2022-01-01|training-material|g'  > /tmp/2022.txt
+fi
+
+if [[ ! -f /tmp/2024.txt ]]; then
+	curl --silent https://training.galaxyproject.org/archive/2024-01-01/sitemap.xml | sed 's|<url>|\n|g' | grep '<loc>[^<]*</loc>' -o | sed 's/<loc>//;s/<\/loc>//' | sed 's|archive/2024-01-01|training-material|g'  > /tmp/2024.txt
+fi
+
+# No guarantees of API or data-file persistence
+cat /tmp/202*.txt | grep -v '/api/' | grep -v '/by-tool/'  | grep -v '/hall-of-fame/.*/index.html' | grep -v 'training-material/tags/' | grep -v 'data-library'| sed 's|/$|/index.html|'  | grep '.html$' | sort -u | sed 's|https://training.galaxyproject.org|_site|' > /tmp/gtn-files.txt
+
+count=0
+while read line; do
+	if [[ ! -f $line ]]; then
+		echo "Missing: $line"
+		count=$((count+1))
+	fi
+done < /tmp/gtn-files.txt
+
+if (( $count > 0 )); then
+	echo "Files in previous versions that are not currently redirected: $count"
+	exit 1
+fi

--- a/bin/check-url-persistence.sh
+++ b/bin/check-url-persistence.sh
@@ -20,5 +20,6 @@ done < /tmp/gtn-files.txt
 
 if (( $count > 0 )); then
 	echo "Files in previous versions that are not currently redirected: $count"
+	echo "Please ensure you add redirect_from: entries to each page"
 	exit 1
 fi

--- a/faqs/galaxy/account_create.md
+++ b/faqs/galaxy/account_create.md
@@ -1,5 +1,7 @@
 ---
-redirect_from: [/faqs/galaxy/galaxy_creating_an_account]
+redirect_from:
+- /faqs/galaxy/galaxy_creating_an_account
+- /faqs/galaxy/creating_account
 title: How do I create an account on a public Galaxy instance?
 area: account
 layout: faq

--- a/topics/assembly/tutorials/vgp_genome_assembly/faqs/dataset_upload_fastqsanger_via_urls.md
+++ b/topics/assembly/tutorials/vgp_genome_assembly/faqs/dataset_upload_fastqsanger_via_urls.md
@@ -4,6 +4,8 @@ area: data upload
 box_type: tip
 layout: faq
 contributors: [nekrut]
+redirect_from:
+ - /faqs/galaxy/dataset_upload_fastqsanger_via_urls
 ---
 
 Uploading `fastqsanger` or `fastqsanger.gz` datasets via URL.

--- a/topics/contributing/tutorials/create-new-tutorial-content/faqs/tutorial_from_workflows.md
+++ b/topics/contributing/tutorials/create-new-tutorial-content/faqs/tutorial_from_workflows.md
@@ -4,6 +4,8 @@ area: markdown
 box_type: tip
 layout: faq
 contributors: [shiltemann]
+redirect_from:
+- /topics/contributing/faqs/tutorial_from_workflows
 ---
 
 There are two ways to do this:

--- a/topics/epigenetics/tutorials/introduction-chip-seq/slides.html
+++ b/topics/epigenetics/tutorials/introduction-chip-seq/slides.html
@@ -5,6 +5,8 @@ priority: 1
 title: "Introduction to ChIP-Seq data analysis"
 contributors:
   - bebatut
+redirect_from:
+  - /topics/epigenetics/slides/introduction-chip-seq
 ---
 
 # What is ChIP sequencing?

--- a/topics/epigenetics/tutorials/introduction-dna-methylation/slides.html
+++ b/topics/epigenetics/tutorials/introduction-dna-methylation/slides.html
@@ -6,6 +6,8 @@ title: "Introduction to DNA Methylation data analysis"
 contributors:
   - joachimwolff
   - yvanlebras
+redirect_from:
+- /topics/epigenetics/slides/introduction-dna-methylation
 ---
 
 ## DNA Methylation data analysis

--- a/topics/genome-annotation/faqs/index.md
+++ b/topics/genome-annotation/faqs/index.md
@@ -1,3 +1,5 @@
 ---
 layout: faq-page
+redirect_from:
+ - /topics/genome-editing/faqs/index
 ---

--- a/topics/genome-annotation/index.md
+++ b/topics/genome-annotation/index.md
@@ -1,4 +1,6 @@
 ---
 layout: topic
 topic_name: genome-annotation
+redirect_from:
+ - /topics/genome-editing/index
 ---

--- a/topics/genome-annotation/tutorials/crispr-screen/tutorial.md
+++ b/topics/genome-annotation/tutorials/crispr-screen/tutorial.md
@@ -39,6 +39,8 @@ abbreviations:
   MAGeCK: Model-based Analysis of Genome-wide CRISPR-Cas9 Knockout
 subtopic: eukaryote
 priority: 8
+redirect_from:
+ - /topics/genome-editing/tutorials/crispr-screen/tutorial
 ---
 
 

--- a/topics/genome-annotation/tutorials/crispr-screen/tutorial.md
+++ b/topics/genome-annotation/tutorials/crispr-screen/tutorial.md
@@ -405,7 +405,7 @@ If we want to compare the drug treatment (T8-APR-246) to the vehicle control (T8
 * a sgRNA Summary file
 * a PDF report
 
-**Gene Summary file**
+### Gene Summary file
 
 The Gene Summary file contains the columns described below and a row for each gene targeted by sgRNAs. We have >20,000 genes in the file for this dataset.
 We get values for both negative and positive selection. The dataset here is from a negative selection screen so we are most interested in the negative values.
@@ -429,7 +429,7 @@ pos\|goodsgrna | The number of "good" sgRNAs, i.e., sgRNAs whose ranking is belo
 pos\|lfc | The log fold change of this gene in positive selection
 
 
-**sgRNA summary file**
+### sgRNA summary file
 
 The sgRNA Summary file contains the columns described below. We can use the sgRNA file to check how the individual guides for genes of interest performed.
 
@@ -452,7 +452,7 @@ FDR | false discovery rate
 high_in_treatment | Whether the abundance is higher in treatment samples
 
 
-**PDF report**
+### PDF report
 
 The PDF shows plots of the top 10 negatively and positively selected genes.
 We can see the top genes ranked by RRA scores or p value. These values come from the gene summary file.

--- a/topics/genome-annotation/tutorials/crispr-screen/workflows/index.md
+++ b/topics/genome-annotation/tutorials/crispr-screen/workflows/index.md
@@ -1,3 +1,5 @@
 ---
 layout: workflow-list
+redirect_from:
+ - /topics/genome-editing/tutorials/crispr-screen/workflows/index
 ---

--- a/topics/microbiome/faqs/index.md
+++ b/topics/microbiome/faqs/index.md
@@ -1,5 +1,5 @@
 ---
 layout: faq-page
 redirect_from:
-- /topics/metagenomics/faqs
+- /topics/metagenomics/faqs/index
 ---

--- a/topics/microbiome/index.md
+++ b/topics/microbiome/index.md
@@ -2,5 +2,5 @@
 layout: topic
 topic_name: microbiome
 redirect_from:
-- /topics/metagenomics
+- /topics/metagenomics/index
 ---

--- a/topics/microbiome/tutorials/beer-data-analysis/workflows/index.md
+++ b/topics/microbiome/tutorials/beer-data-analysis/workflows/index.md
@@ -1,5 +1,5 @@
 ---
 layout: workflow-list
 redirect_from:
-- /topics/metagenomics/tutorials/beer-data-analysis/workflows
+- /topics/metagenomics/tutorials/beer-data-analysis/workflows/index
 ---

--- a/topics/microbiome/tutorials/general-tutorial/faqs/index.md
+++ b/topics/microbiome/tutorials/general-tutorial/faqs/index.md
@@ -1,5 +1,6 @@
 ---
 layout: faq-page
 redirect_from:
-- /topics/metagenomics/tutorials/beer-data-analysis/faqs
+- /topics/metagenomics/tutorials/beer-data-analysis/faqs/index
+- /topics/metagenomics/tutorials/general-tutorial/faqs/index
 ---

--- a/topics/microbiome/tutorials/general-tutorial/workflows/index.md
+++ b/topics/microbiome/tutorials/general-tutorial/workflows/index.md
@@ -1,5 +1,5 @@
 ---
 layout: workflow-list
 redirect_from:
-- /topics/metagenomics/tutorials/beer-data-analysis/workflows
+- /topics/metagenomics/tutorials/beer-data-analysis/workflows/index
 ---

--- a/topics/microbiome/tutorials/general-tutorial/workflows/index.md
+++ b/topics/microbiome/tutorials/general-tutorial/workflows/index.md
@@ -2,4 +2,5 @@
 layout: workflow-list
 redirect_from:
 - /topics/metagenomics/tutorials/beer-data-analysis/workflows/index
+- /topics/metagenomics/tutorials/general-tutorial/workflows/index
 ---

--- a/topics/microbiome/tutorials/metagenomics-assembly/workflows/index.md
+++ b/topics/microbiome/tutorials/metagenomics-assembly/workflows/index.md
@@ -1,5 +1,5 @@
 ---
 layout: workflow-list
 redirect_from:
-- /topics/metagenomics/tutorials/metagenomics-assembly/workflows
+- /topics/metagenomics/tutorials/metagenomics-assembly/workflows/index
 ---

--- a/topics/microbiome/tutorials/metatranscriptomics-short/faqs/index.md
+++ b/topics/microbiome/tutorials/metatranscriptomics-short/faqs/index.md
@@ -1,5 +1,5 @@
 ---
 layout: faq-page
 redirect_from:
-- /topics/metagenomics/tutorials/metatranscriptomics-short/faqs
+- /topics/metagenomics/tutorials/metatranscriptomics-short/faqs/index
 ---

--- a/topics/microbiome/tutorials/metatranscriptomics-short/workflows/index.md
+++ b/topics/microbiome/tutorials/metatranscriptomics-short/workflows/index.md
@@ -1,5 +1,5 @@
 ---
 layout: workflow-list
 redirect_from:
-- /topics/metagenomics/tutorials/metatranscriptomics-short/workflows
+- /topics/metagenomics/tutorials/metatranscriptomics-short/workflows/index
 ---

--- a/topics/microbiome/tutorials/metatranscriptomics/faqs/index.md
+++ b/topics/microbiome/tutorials/metatranscriptomics/faqs/index.md
@@ -1,5 +1,5 @@
 ---
 layout: faq-page
 redirect_from:
-- /topics/metagenomics/tutorials/metatranscriptomics/faqs
+- /topics/metagenomics/tutorials/metatranscriptomics/faqs/index
 ---

--- a/topics/microbiome/tutorials/metatranscriptomics/workflows/index.md
+++ b/topics/microbiome/tutorials/metatranscriptomics/workflows/index.md
@@ -1,5 +1,5 @@
 ---
 layout: workflow-list
 redirect_from:
-- /topics/metagenomics/tutorials/metatranscriptomics/workflows
+- /topics/metagenomics/tutorials/metatranscriptomics/workflows/index
 ---

--- a/topics/microbiome/tutorials/mothur-miseq-sop-short/workflows/index.md
+++ b/topics/microbiome/tutorials/mothur-miseq-sop-short/workflows/index.md
@@ -1,5 +1,5 @@
 ---
 layout: workflow-list
 redirect_from:
-  - /topics/metagenomics/tutorials/mothur-miseq-sop-short/workflows
+  - /topics/metagenomics/tutorials/mothur-miseq-sop-short/workflows/index
 ---

--- a/topics/microbiome/tutorials/mothur-miseq-sop/faqs/index.md
+++ b/topics/microbiome/tutorials/mothur-miseq-sop/faqs/index.md
@@ -1,7 +1,7 @@
 ---
 layout: faq-page
 redirect_from:
-  - /topics/metagenomics/tutorials/mothur-miseq-sop/faqs
-  - /topics/metagenomics/tutorials/mothur-miseq-sop-short/faqs
+  - /topics/metagenomics/tutorials/mothur-miseq-sop/faqs/index
+  - /topics/metagenomics/tutorials/mothur-miseq-sop-short/faqs/index
 
 ---

--- a/topics/microbiome/tutorials/mothur-miseq-sop/workflows/index.md
+++ b/topics/microbiome/tutorials/mothur-miseq-sop/workflows/index.md
@@ -1,5 +1,5 @@
 ---
 layout: workflow-list
 redirect_from:
-  - /topics/metagenomics/tutorials/mothur-miseq-sop/workflows
+  - /topics/metagenomics/tutorials/mothur-miseq-sop/workflows/index
 ---

--- a/topics/microbiome/tutorials/nanopore-16S-metagenomics/faqs/index.md
+++ b/topics/microbiome/tutorials/nanopore-16S-metagenomics/faqs/index.md
@@ -1,5 +1,5 @@
 ---
 layout: faq-page
 redirect_from:
-  - /topics/metagenomics/tutorials/nanopore-16S-metagenomics/faqs
+  - /topics/metagenomics/tutorials/nanopore-16S-metagenomics/faqs/index
 ---

--- a/topics/microbiome/tutorials/nanopore-16S-metagenomics/workflows/index.md
+++ b/topics/microbiome/tutorials/nanopore-16S-metagenomics/workflows/index.md
@@ -1,5 +1,5 @@
 ---
 layout: workflow-list
 redirect_from:
-  - /topics/metagenomics/tutorials/nanopore-16S-metagenomics/workflows
+  - /topics/metagenomics/tutorials/nanopore-16S-metagenomics/workflows/index
 ---

--- a/topics/microbiome/tutorials/pathogen-detection-from-nanopore-foodborne-data/faqs/index.md
+++ b/topics/microbiome/tutorials/pathogen-detection-from-nanopore-foodborne-data/faqs/index.md
@@ -1,5 +1,5 @@
 ---
 layout: faq-page
 redirect_from:
-- /topics/metagenomics/tutorials/pathogen-detection-from-nanopore-foodborne-data/faqs
+- /topics/metagenomics/tutorials/pathogen-detection-from-nanopore-foodborne-data/faqs/index
 ---

--- a/topics/microbiome/tutorials/pathogen-detection-from-nanopore-foodborne-data/workflows/index.md
+++ b/topics/microbiome/tutorials/pathogen-detection-from-nanopore-foodborne-data/workflows/index.md
@@ -1,5 +1,5 @@
 ---
 layout: workflow-list
 redirect_from:
-- /topics/metagenomics/tutorials/pathogen-detection-from-nanopore-foodborne-data/workflows
+- /topics/metagenomics/tutorials/pathogen-detection-from-nanopore-foodborne-data/workflows/index
 ---

--- a/topics/microbiome/tutorials/plasmid-metagenomics-nanopore/faqs/index.md
+++ b/topics/microbiome/tutorials/plasmid-metagenomics-nanopore/faqs/index.md
@@ -1,5 +1,5 @@
 ---
 layout: faq-page
 redirect_from:
-- /topics/metagenomics/tutorials/plasmid-metagenomics-nanopore/faqs
+- /topics/metagenomics/tutorials/plasmid-metagenomics-nanopore/faqs/index
 ---

--- a/topics/microbiome/tutorials/plasmid-metagenomics-nanopore/workflows/index.md
+++ b/topics/microbiome/tutorials/plasmid-metagenomics-nanopore/workflows/index.md
@@ -1,5 +1,5 @@
 ---
 layout: workflow-list
 redirect_from:
-- /topics/metagenomics/tutorials/plasmid-metagenomics-nanopore/workflows
+- /topics/metagenomics/tutorials/plasmid-metagenomics-nanopore/workflows/index
 ---

--- a/topics/microbiome/tutorials/taxonomic-profiling/workflows/index.md
+++ b/topics/microbiome/tutorials/taxonomic-profiling/workflows/index.md
@@ -1,5 +1,5 @@
 ---
 layout: workflow-list
 redirect_from:
-- /topics/metagenomics/tutorials/taxonomic-profiling/workflows
+- /topics/metagenomics/tutorials/taxonomic-profiling/workflows/index
 ---

--- a/topics/proteomics/tutorials/metaproteomics/faqs/comparing_measurement.md
+++ b/topics/proteomics/tutorials/metaproteomics/faqs/comparing_measurement.md
@@ -3,6 +3,8 @@ title: How does one compare metaproteomics measurements from two experimental co
 box_type: tip
 layout: faq
 contributors: [millen2223]
+redirect_from:
+ - /topics/proteomics/faqs/comparing_measurement
 ---
 
 For comparing taxonomy composition or functional content of two conditions in metaproteomics or metatranscriptomics studies, users are recommended to use metaQuantome. GTN tutorials for metaQuantome are available [in the proteomics topic.]({% link topics/proteomics/index.md %})

--- a/topics/proteomics/tutorials/metaproteomics/faqs/convert_to_MGF.md
+++ b/topics/proteomics/tutorials/metaproteomics/faqs/convert_to_MGF.md
@@ -3,6 +3,8 @@ title: How does one convert RAW files to MGF peak lists within Galaxy?
 box_type: tip
 layout: faq
 contributors: [millen2223]
+redirect_from:
+ - /topics/proteomics/faqs/convert_to_MGF
 ---
 
 Galaxy has implemented msconvert tool so that RAW files from Thermo instruments can be converted into MGF or mzML formats.

--- a/topics/proteomics/tutorials/metaproteomics/faqs/converting_FASTA.md
+++ b/topics/proteomics/tutorials/metaproteomics/faqs/converting_FASTA.md
@@ -3,6 +3,8 @@ title: I have FASTQ files from metagenomics or metatranscriptomics datasets? How
 box_type: tip
 layout: faq
 contributors: [millen2223]
+redirect_from:
+ - /topics/proteomics/faqs/converting_FASTA
 ---
 
 Galaxy has a tool named Sixgill that can be used to convert the nucleic acid sequences to ‘metapeptide’ sequences. There are other options available within Galaxy such as the GalaxyGraph approach and Metagenome Binning, Assembly and Annotation Workflow. Please [contact us](https://help.galaxyproject.org/), if you need assistance.

--- a/topics/proteomics/tutorials/metaproteomics/faqs/determine_taxonomic_composition.md
+++ b/topics/proteomics/tutorials/metaproteomics/faqs/determine_taxonomic_composition.md
@@ -3,6 +3,8 @@ title: What software tools are available to determine taxonomic composition from
 box_type: tip
 layout: faq
 contributors: [millen2223]
+redirect_from:
+ - /topics/proteomics/faqs/determine_taxonomic_composition
 ---
 
 Within the Galaxy framework we recommend the use of Unipept software that uses NCBI taxonomy and UniProt databases to detect unique peptides for taxonomy. Other software tools such as MetaTryp 2.0 (PMID: 32897080) can also be used to determine the taxonomic composition of the metaproteomics datasets.

--- a/topics/proteomics/tutorials/metaproteomics/faqs/functional_analysis_tools.md
+++ b/topics/proteomics/tutorials/metaproteomics/faqs/functional_analysis_tools.md
@@ -5,6 +5,7 @@ layout: faq
 contributors: [millen2223]
 redirect_from:
  - /topics/proteomics/faqs/function_analysis_tools
+ - /topics/proteomics/faqs/functional_analysis_tools
 ---
 
 Within the Galaxy framework we recommend the use of Unipept software that uses UniProt databases and annotation to detect proteins (EC terms) and functional groups such as GO Ontology and InterPro terms. Other software tools such as [EggNOG Mapper](https://journals.plos.org/plosone/article?id=10.1371/journal.pone.0241503) are also available within the Galaxy platform. Other software such as MEGAN5, MetaGOmics, MetaProteomeAnalyzer (MPA), ProPHAnE also generate functional outputs.

--- a/topics/proteomics/tutorials/metaproteomics/faqs/functional_analysis_tools.md
+++ b/topics/proteomics/tutorials/metaproteomics/faqs/functional_analysis_tools.md
@@ -3,6 +3,8 @@ title: Why do we do dimension reduction and then clustering? Why not just cluste
 box_type: tip
 layout: faq
 contributors: [millen2223]
+redirect_from:
+ - /topics/proteomics/faqs/function_analysis_tools
 ---
 
 Within the Galaxy framework we recommend the use of Unipept software that uses UniProt databases and annotation to detect proteins (EC terms) and functional groups such as GO Ontology and InterPro terms. Other software tools such as [EggNOG Mapper](https://journals.plos.org/plosone/article?id=10.1371/journal.pone.0241503) are also available within the Galaxy platform. Other software such as MEGAN5, MetaGOmics, MetaProteomeAnalyzer (MPA), ProPHAnE also generate functional outputs.

--- a/topics/proteomics/tutorials/metaproteomics/faqs/reusing_workflows.md
+++ b/topics/proteomics/tutorials/metaproteomics/faqs/reusing_workflows.md
@@ -3,6 +3,8 @@ title: Can I use these workflows on datasets generated from our laboratory?
 box_type: tip
 layout: faq
 contributors: [millen2223]
+redirect_from:
+ - /topics/proteomics/faqs/reusing_workflows
 ---
 
 Yes, the workflows can be used on other datasets as well. However, you will need to consider data acquisition and sample preparation methods so that the tool parameters can be adjusted accordingly.

--- a/topics/proteomics/tutorials/metaproteomics/faqs/search_algorithms.md
+++ b/topics/proteomics/tutorials/metaproteomics/faqs/search_algorithms.md
@@ -3,6 +3,8 @@ title: Which search algorithms are recommended for searching the metaproteomics 
 box_type: tip
 layout: faq
 contributors: [millen2223]
+redirect_from:
+ - /topics/proteomics/faqs/search_algorithms
 ---
 
 SearchGUI supports search using nine search algorithms (X! Tandem. MS-GF+. OMSSA, Comet, Tide, MyriMatch, MS_Amanda, DirecTag and Novor). For this tutorial, we have used the first two search algorithms in the list. In our hands, the first four search algorithms have given us the most optimal results.

--- a/topics/proteomics/tutorials/metaproteomics/faqs/search_strategies.md
+++ b/topics/proteomics/tutorials/metaproteomics/faqs/search_strategies.md
@@ -3,6 +3,8 @@ title: I have a really large search database, what search strategies do you reco
 box_type: tip
 layout: faq
 contributors: [millen2223]
+redirect_from:
+ - /topics/proteomics/faqs/search_strategies
 ---
 
 Readers are encouraged to use the database sectioning approach described by [Praveen Kumar et al](https://pubmed.ncbi.nlm.nih.gov/32396365/) and available within Galaxy. Readers are also encouraged to consider other approaches such as MetaNovo (not yet available in Galaxy). In absence of any database or taxonomic information about the microbiome dataset, other methods such as COMPIL 2.0  and De novo search methods can also be considered.

--- a/topics/proteomics/tutorials/metaproteomics/faqs/studying_microbiome_state.md
+++ b/topics/proteomics/tutorials/metaproteomics/faqs/studying_microbiome_state.md
@@ -3,6 +3,8 @@ title: What other methods are available to study the functional state of the mic
 box_type: tip
 layout: faq
 contributors: [millen2223]
+redirect_from:
+ - /topics/proteomics/faqs/studying_microbiome_state
 ---
 
 Other software such as EggNOG Mapper, MEGAN5, MetaGOmics, MetaProteomeAnalyzer (MPA) and  ProPHAnE also generate [functional outputs](https://journals.plos.org/plosone/article?id=10.1371/journal.pone.0241503).

--- a/topics/proteomics/tutorials/metaproteomics/faqs/tools_versions.md
+++ b/topics/proteomics/tutorials/metaproteomics/faqs/tools_versions.md
@@ -3,6 +3,8 @@ title: Which version of SearchGUI and PeptideShaker shall I use for this tutoria
 box_type: tip
 layout: faq
 contributors: [millen2223]
+redirect_from:
+ - /topics/proteomics/faqs/tools_versions
 ---
 
 We highly recommend the usage of SearchGUI Galaxy version 3.3.10.1 and PeptideShaker version Galaxy Version 1.16.36.3. The newer versions of SearchGUI and PeptideShaker have not yet been tested for this workflow.

--- a/topics/single-cell/tutorials/scrna-case_alevin/workflows/index.md
+++ b/topics/single-cell/tutorials/scrna-case_alevin/workflows/index.md
@@ -1,3 +1,5 @@
 ---
 layout: workflow-list
+redirect_from:
+  - /topics/transcriptomics/tutorials/droplet-quantification-preprocessing/workflows/index
 ---

--- a/topics/single-cell/tutorials/scrna-case_basic-pipeline/workflows/index.md
+++ b/topics/single-cell/tutorials/scrna-case_basic-pipeline/workflows/index.md
@@ -1,3 +1,6 @@
 ---
 layout: workflow-list
+redirect_from:
+- /topics/transcriptomics/tutorials/scrna-seq-basic-pipeline/workflows/index
+- /topics/transcriptomics/tutorials/scrna-case_basic-pipeline/workflows/index
 ---

--- a/topics/single-cell/tutorials/scrna-plant/workflows/index.md
+++ b/topics/single-cell/tutorials/scrna-plant/workflows/index.md
@@ -1,3 +1,5 @@
 ---
 layout: workflow-list
+redirect_from:
+  - /topics/transcriptomics/tutorials/scrna-plant/workflows/index
 ---

--- a/topics/single-cell/tutorials/scrna-preprocessing-tenx/workflows/index.md
+++ b/topics/single-cell/tutorials/scrna-preprocessing-tenx/workflows/index.md
@@ -1,3 +1,5 @@
 ---
 layout: workflow-list
+redirect_from:
+  - /topics/transcriptomics/tutorials/scrna-preprocessing-tenx/workflows/index
 ---

--- a/topics/single-cell/tutorials/scrna-preprocessing/workflows/index.md
+++ b/topics/single-cell/tutorials/scrna-preprocessing/workflows/index.md
@@ -1,3 +1,5 @@
 ---
 layout: workflow-list
+redirect_from:
+  - /topics/transcriptomics/tutorials/scrna-preprocessing/workflows/index
 ---

--- a/topics/single-cell/tutorials/scrna-raceid/workflows/index.md
+++ b/topics/single-cell/tutorials/scrna-raceid/workflows/index.md
@@ -1,3 +1,5 @@
 ---
 layout: workflow-list
+redirect_from:
+  - /topics/transcriptomics/tutorials/scrna-raceid/workflows/index
 ---

--- a/topics/single-cell/tutorials/scrna-scanpy-pbmc3k/workflows/index.md
+++ b/topics/single-cell/tutorials/scrna-scanpy-pbmc3k/workflows/index.md
@@ -1,3 +1,5 @@
 ---
 layout: workflow-list
+redirect_from:
+- /topics/transcriptomics/tutorials/scrna-scanpy-pbmc3k/workflows/index
 ---

--- a/topics/single-cell/tutorials/scrna-scater-qc/workflows/index.md
+++ b/topics/single-cell/tutorials/scrna-scater-qc/workflows/index.md
@@ -1,3 +1,5 @@
 ---
 layout: workflow-list
+redirect_from:
+ - /topics/transcriptomics/tutorials/scrna-scater-qc/workflows/index
 ---

--- a/topics/transcriptomics/tutorials/de-novo/faqs/transcript.md
+++ b/topics/transcriptomics/tutorials/de-novo/faqs/transcript.md
@@ -4,6 +4,8 @@ area: De novo transcriptome reconstruction with RNA-Seq
 box_type: tip
 layout: faq
 contributors: [rahmot]
+redirect_from:
+- /topics/transcriptomics/faqs/transcript
 ---
 
 This is okay! Many aspects of the tutorial can potentially affect the exact results you obtain. For example, the reference genome version used and versions of tools. It’s less important to get the exact results shown in the tutorial, and more important to understand the concepts so you can apply them to your own data.

--- a/topics/transcriptomics/tutorials/mirna-target-finder/faqs/different_padj_value.md
+++ b/topics/transcriptomics/tutorials/mirna-target-finder/faqs/different_padj_value.md
@@ -4,7 +4,7 @@ box_type: question
 layout: faq
 contributors: [gallardoalba]
 redirect_from:
-- /training-material/topics/transcriptomics/faqs/p_adj
+- /topics/transcriptomics/faqs/p_adj
 ---
 
 Yes, you can modify this value, to perform a more rigorous analysis, or extend the range of genes selected. A higher p-value will significantly increase the number of genes selected, at the expense of including possible false positives.

--- a/topics/transcriptomics/tutorials/mirna-target-finder/faqs/different_padj_value.md
+++ b/topics/transcriptomics/tutorials/mirna-target-finder/faqs/different_padj_value.md
@@ -3,6 +3,8 @@ title: Could I use a different p-adj value for filtering differentially expresse
 box_type: question
 layout: faq
 contributors: [gallardoalba]
+redirect_from:
+- /training-material/topics/transcriptomics/faqs/p_adj
 ---
 
 Yes, you can modify this value, to perform a more rigorous analysis, or extend the range of genes selected. A higher p-value will significantly increase the number of genes selected, at the expense of including possible false positives.

--- a/topics/transcriptomics/tutorials/mirna-target-finder/faqs/quantification_alternatives.md
+++ b/topics/transcriptomics/tutorials/mirna-target-finder/faqs/quantification_alternatives.md
@@ -3,6 +3,8 @@ title: Can I use alternative tools for the Quantification step?
 layout: faq
 box_type: question
 contributors: [gallardoalba]
+redirect_from:
+  - /topics/transcriptomics/faqs/quantification
 ---
 
 There are some alternatives to Salmon for reference transcriptome-based RNA quantification. **Kallisto** and **Sailfish** use a similar approach, known as pseudoalignment.


### PR DESCRIPTION
This adds a script which checks the current site build against a couple previous sitemaps, to ensure everything is 100% properly redirected in case of renames.

For every URL acknowledged in the previous sitemaps, we ensure there is a file on disk matching that. As we use [`jekyll-redirect-from`](https://github.com/jekyll/jekyll-redirect-from), it generates an html file on disk for any 'redirect_from' entries (which is why they generally shouldn't conflict.)

Thus, on every PR, we can be **very** certain that we aren't at risk of losing any URLs (un)intentionally.

If we delete a file, it'll have to be added to the script (it mentions that in its output.)

Fixes https://github.com/galaxyproject/training-material/issues/4642