### PR TITLE
Conditional loading of mermaid.js library

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -49,14 +49,13 @@ javascript_bundles:
   main:
     preload: true
     resources:
-      - assets/js/jquery.slim.min.js
-      - assets/js/popper.min.js
-      - assets/js/bootstrap.min.js
-      - assets/js/bootstrap-toc.min.js
-      - assets/js/clipboard.min.js
-      - assets/js/list.min.js
-      - assets/js/mermaid@10.6.1.js
+      - assets/js/jquery.slim.min.js   # Mandatory for bootstrap.
+      - assets/js/popper.min.js        # Everywhere, dropdown menu.
+      - assets/js/bootstrap.min.js     # Everywhere
+      - assets/js/bootstrap-toc.min.js # Only tutorials, faqs
+      - assets/js/clipboard.min.js     # Used on anything with a pre
       - assets/js/main.js
+      # - assets/js/list.min.js # Potentially unused?
 
 # Conversion
 markdown: kramdown

--- a/_config.yml
+++ b/_config.yml
@@ -48,6 +48,8 @@ javascript_bundles:
       - assets/js/theme.js
   main:
     preload: true
+    defer: true
+    async: true
     resources:
       - assets/js/jquery.slim.min.js   # Mandatory for bootstrap.
       - assets/js/popper.min.js        # Everywhere, dropdown menu.

--- a/_layouts/base.html
+++ b/_layouts/base.html
@@ -21,7 +21,7 @@
         <link rel="preload" href="{{ site.baseurl }}/assets/fonts/AtkinsonHyperlegible/Atkinson-Hyperlegible-Regular-102a.woff2" as="font" type="font/woff2" crossorigin>
         <link rel="preload" href="{{ site.baseurl }}/assets/fonts/AtkinsonHyperlegible/Atkinson-Hyperlegible-Bold-102a.woff2" as="font" type="font/woff2" crossorigin>
         <link rel="preload" href="{{ site.baseurl }}/assets/fonts/AtkinsonHyperlegible/Atkinson-Hyperlegible-Italic-102a.woff2" as="font" type="font/woff2" crossorigin>
-        {% if page.mathjax %}
+        {% if page.js_requirements.mathjax %}
         <link rel="preload" href="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.1/MathJax.js?config=TeX-AMS-MML_HTMLorMML" as="script" crossorigin>
         {% endif %}
         <link rel="preload" href="{{ site.baseurl }}/assets/css/main.css?v=3" as="style">
@@ -68,8 +68,13 @@
         {% include _includes/default-footer.html %}
 
         {{ 'main' | load_bundle }}
-        {% if page.mathjax %}
-        <script src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.1/MathJax.js?config=TeX-AMS-MML_HTMLorMML"></script>
-        {% endif %}
+
+	{% if page.js_requirements.mathjax %}
+	<script src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.1/MathJax.js?config=TeX-AMS-MML_HTMLorMML"></script>
+	{% endif %}
+	{% if page.js_requirements.mermaid %}
+	<script src="{{ site.baseurl }}/assets/js/mermaid@10.6.1.js" async></script>
+	<link rel="preload" href="{{ site.baseurl }}/assets/js/mermaid@10.6.1.js" as="script" crossorigin>
+	{% endif %}
     </body>
 </html>

--- a/_layouts/home.html
+++ b/_layouts/home.html
@@ -248,7 +248,7 @@ layout: base
             <h2>GTN Toots</h2>
 
 <link rel="stylesheet" type="text/css" href="{{ site.baseurl }}/assets/js/emfed/toots.css">
-		<script type="module" src="{{ site.baseurl }}/assets/js/emfed/emfed.js"></script>
+		<script async defer type="module" src="{{ site.baseurl }}/assets/js/emfed/emfed.js"></script>
 		<a rel="me" class="mastodon-feed"
 		href="https://mstdn.science/@gtn"
 		data-toot-limit="3"

--- a/_plugins/jekyll-bundler.rb
+++ b/_plugins/jekyll-bundler.rb
@@ -13,7 +13,7 @@ Jekyll::Hooks.register :site, :post_read do |site|
     bundle = resources['resources'].map { |f| File.read(f) }.join("\n")
     hash = Digest::MD5.hexdigest(bundle)[0..7]
     site.config['javascript_bundles'][name]['hash'] = hash
-    site.config['javascript_bundles'][name]['path'] = "/assets/js/bundle.#{hash}.js"
+    site.config['javascript_bundles'][name]['path'] = "/assets/js/bundle.#{name}.#{hash}.js"
 
     Jekyll.logger.info "Analysing JS Bundle #{name} => #{bundle_timestamp} / #{hash}"
   end
@@ -106,7 +106,7 @@ module Jekyll
       attrs = ""
       attrs += " async" if bundle['async']
       attrs += " defer" if bundle['defer']
-      bundle_path = "#{baseurl}#{bundle['path']}?v=#{bundle['timestamp']}"
+      bundle_path = "#{baseurl}#{bundle['path']}"
       "<script #{attrs} src='#{bundle_path}'></script>"
     end
   end

--- a/_plugins/jekyll-bundler.rb
+++ b/_plugins/jekyll-bundler.rb
@@ -89,8 +89,12 @@ module Jekyll
 
       baseurl = @context.registers[:site].config['baseurl']
 
+      attrs = ""
+      attrs += " async" if bundle['async']
+      attrs += " defer" if bundle['defer']
+
       bundle['resources'].map do |f|
-        "<script src='#{baseurl}/#{f}'></script>"
+        "<script #{attrs} src='#{baseurl}/#{f}'></script>"
       end.join("\n")
     end
 
@@ -99,8 +103,11 @@ module Jekyll
       raise "Bundle #{name} not found in site config" if bundle.nil?
 
       baseurl = @context.registers[:site].config['baseurl']
+      attrs = ""
+      attrs += " async" if bundle['async']
+      attrs += " defer" if bundle['defer']
       bundle_path = "#{baseurl}#{bundle['path']}?v=#{bundle['timestamp']}"
-      "<script src='#{bundle_path}'></script>"
+      "<script #{attrs} src='#{bundle_path}'></script>"
     end
   end
 end

--- a/_plugins/jekyll-bundler.rb
+++ b/_plugins/jekyll-bundler.rb
@@ -64,7 +64,7 @@ module Jekyll
       end
 
       bundles.map do |_name, bundle|
-        bundle_path = "#{baseurl}#{bundle['path']}?v=#{bundle['timestamp']}"
+        bundle_path = "#{baseurl}#{bundle['path']}"
         "<link rel='preload' href='#{bundle_path}' as='script'>"
       end.join("\n")
     end

--- a/_plugins/jekyll-mathjax.rb
+++ b/_plugins/jekyll-mathjax.rb
@@ -1,3 +1,6 @@
 Jekyll::Hooks.register :pages, :post_init do |page|
-  page.data['mathjax'] = page.content =~ /\$\$/
+  page.data['js_requirements'] = {
+    'mathjax' => page.content =~ /\$\$/,
+    'mermaid' => page.content =~ /```mermaid/ || page.content =~ /pre class="mermaid"/ || page.data['layout'] == 'workflow-list',
+  }
 end

--- a/bin/commit-cache-update.rb
+++ b/bin/commit-cache-update.rb
@@ -1,5 +1,5 @@
 require 'jekyll'
-require './_plugins/gtn/mod.rb'
+require './_plugins/gtn/mod'
 
 # Write the commit log
 Gtn::ModificationTimes.generate_cache


### PR DESCRIPTION
since it's a chonker. This also deprecates `list.min.js` which I *think* is not used anywhlere but I am not completely sure yet, so we wait to see if Sentry reports any complaints to properly remove it.

(this was pulling our load time metrics down a wee bit.)

```
$ du -h assets/js/* | sort -h
4.0K	assets/js/bootstrap-toc.min.js
4.0K	assets/js/details-element-polyfill.js
8.0K	assets/js/main.js
8.0K	assets/js/theme.js
12K	assets/js/clipboard.min.js
16K	assets/js/chartjs-plugin-datalabels@0.7.0.js
20K	assets/js/emfed
20K	assets/js/list.min.js
20K	assets/js/popper.min.js
52K	assets/js/bootstrap.min.js
60K	assets/js/chartjs-plugin-colorschemes.js
68K	assets/js/jquery.slim.min.js
144K	assets/js/leaflet-1.9.3.js
188K	assets/js/dompurify
568K	assets/js/Chart.bundle.js
652K	assets/js/remark-latest.min.js
2.9M	assets/js/mermaid@10.6.1.js
```