### PR TITLE
Add tutorial mode to short intro to Galaxy

### DIFF
--- a/topics/introduction/tutorials/galaxy-intro-short/tutorial.md
+++ b/topics/introduction/tutorials/galaxy-intro-short/tutorial.md
@@ -181,6 +181,8 @@ Let's look at the quality of the reads in this file.
 
 This tool will run and two new output datasets will appear at the top of your history panel.
 
+{% snippet faqs/galaxy/tutorial_mode.md %}
+
 ## View results
 
 We will now look at the output dataset called *FastQC on data 1: Webpage*.


### PR DESCRIPTION
Just seems like a really important tip to get across early on - then maybe we can remove it from the beginning of literally every tutorial I write...

{% snippet faqs/galaxy/tutorial_mode.md %}