### PR TITLE
New learning pathway: Intermediate single cell analysis

### DIFF
--- a/learning-pathways/beyond_single_cell.md
+++ b/learning-pathways/beyond_single_cell.md
@@ -1,6 +1,6 @@
 ---
 layout: learning-pathway
-tags: [beginner]
+tags: [intermediate]
 cover-image: assets/images/wab-annotatedcells-2.png
 cover-image-alt: "Image of cells in different coloured clusters"
 type: use
@@ -9,26 +9,23 @@ editorial_board:
 - nomadscientist
 - pavanvidem
 
-title: Introduction to Galaxy and Single Cell RNA Sequence analysis
+title: Applying single-cell RNA-seq analysis
 description: |
-  These tutorials take you from raw scRNA sequencing reads to inferred trajectories to replicate a published analysis. The data is messy. The decisions are tough. The interpretation is meaningful. Come here to advance your single cell skills! Note that you get two options for inferring trajectories.
+  Gone is the pre-annotated, high quality tutorial data - now you have real, messy data to deal with. You have decisions to make and parameters to decide. This learning pathway challenges you to replicate a published analysis as if this were your own dataset. You will be introduced to a few more tools available for scRNA-seq in Galaxy. Finally, if our tool offerings are not enough for you, you will be directed towards how to use coding notebooks within Galaxy, setting you up to analyse scRNA-seq in R or python notebooks.
 
-  This learning path aims to teach you the basics of Galaxy and analysis of Single Cell RNA-seq data.
-  You will learn how to use Galaxy for analysis, and an important Galaxy feature for iterative single cell analysis. You'll tbe guided through the general theory of single analysis and then perform a basic analysis of 10X chromium data. For support throughout these tutorials, join our Galaxy [single cell chat group on Matrix](https://matrix.to/#/#Galaxy-Training-Network_galaxy-single-cell:gitter.im) to ask questions!
+  The data is messy. The decisions are tough. The interpretation is meaningful. Come here to advance your single cell skills! Note that you get two options for inferring trajectories.
 
-priority: 9
+  For support throughout these tutorials, join our Galaxy [single cell chat group on Matrix](https://matrix.to/#/#Galaxy-Training-Network_galaxy-single-cell:gitter.im) to ask questions!
 
 pathway:
-  - section: "Module 1: Introduction to Galaxy"
+  - section: "Module 1: Case study"
     description: |
-      Get a first look at the Galaxy platform for data analysis. We start with a
-      short introduction (video slides & practical) to familiarize you with the Galaxy
-      interface, and then proceed with a short tutorial of how to tag - and organise! - your history.
+      These tutorials take you from raw scRNA sequencing reads to inferred trajectories to replicate a published analysis. Note that you get two options for inferring trajectories.
     tutorials:
-      - name: galaxy-intro-short
-        topic: introduction
+      - name: scrna-case_alevin
+        topic: single-cell
       - name: name-tags
-        topic: galaxy-interface
+        topic: single-cell
 
   - section: "Module 2: Theory of Single-Cell RNA-seq"
     description: |

--- a/learning-pathways/beyond_single_cell.md
+++ b/learning-pathways/beyond_single_cell.md
@@ -52,7 +52,7 @@ pathway:
 
   - section: "The End!"
     description: |
-      And now you're done! If you are interested in trying out the case study analyses in a coding environment, try out our []"Case study: Reloaded" series](/training-material/topics/single-cell#single-cell-CS) next! Otherwise, you will find more features, tips and tricks in our general [Galaxy Single-cell Training page](/training-material/topics/single-cell/index.html).
+      And now you're done! If you are interested in trying out the case study analyses in a coding environment, try out our ["Case study: Reloaded" series](/training-material/topics/single-cell#single-cell-CS) next! Otherwise, you will find more features, tips and tricks in our general [Galaxy Single-cell Training page](/training-material/topics/single-cell/index.html).
 ---
 
 New to Galaxy and/or the field of scRNA-seq? Follow this learning path to get familiar with the basics!

--- a/learning-pathways/beyond_single_cell.md
+++ b/learning-pathways/beyond_single_cell.md
@@ -41,7 +41,7 @@ pathway:
 
   - section: "Module 3: Moving into coding environments"
     description: |
-      Did you know Galaxy can host coding environments? They don't have the same level of computational power as are allocated our tools, but you can still learn how to use these environments to analyse your data. Sometimes, there will be a tool you want to use that's not available in Galaxy, and ([after requesting it!](https://docs.google.com/spreadsheets/d/15hqgqA-RMDhXR-ylKhRF-Dab9Ij2arYSKiEVoPl2df4/edit?usp=sharing)) you can export your data into a coding environment and run the tool there. Let's start with the basics of running these environments in Galaxy.
+      Did you know Galaxy can host coding environments? They don't have the same level of computational power as the easy-to-use Galaxy tools, but you can unlock the full freedom in your data analysis. You can install your favourite single-cell tool suite that is not available on Galaxy, export your data into these coding environments and run your analysis there. If you want your favourite tool suite as a Galaxy tool, you can always request [here](https://docs.google.com/spreadsheets/d/15hqgqA-RMDhXR-ylKhRF-Dab9Ij2arYSKiEVoPl2df4/edit?usp=sharing). Let's start with the basics of running these environments in Galaxy.
     tutorials:
       - name: jupyterlab
         topic: galaxy-interface

--- a/learning-pathways/beyond_single_cell.md
+++ b/learning-pathways/beyond_single_cell.md
@@ -8,6 +8,7 @@ type: use
 editorial_board:
 - nomadscientist
 - pavanvidem
+- pcm32
 
 title: Applying single-cell RNA-seq analysis
 description: |
@@ -20,32 +21,38 @@ description: |
 pathway:
   - section: "Module 1: Case study"
     description: |
-      These tutorials take you from raw scRNA sequencing reads to inferred trajectories to replicate a published analysis. Note that you get two options for inferring trajectories.
+      These tutorials take you from raw scRNA sequencing reads to cell cluster plots to replicate a published analysis.
     tutorials:
       - name: scrna-case_alevin
         topic: single-cell
-      - name: name-tags
+      - name: scrna-case_alevin-combine-datasets
+        topic: single-cell
+      - name: scrna-case_basic-pipeline
         topic: single-cell
 
-  - section: "Module 2: Theory of Single-Cell RNA-seq"
+  - section: "Module 2: Inferring trajectories"
     description: |
-      When analysing sequencing data, you should always start with a quality control step to clean your data and make sure your data is good enough to answer your research question. After this step, you will often proceed with a mapping (alignment) or genome assembly step, depending on whether you have a reference genome to work with.
+      This isn't strictly necessary, but if you want to infer trajectories - pseudotime relationships between cells - you can try out these tutorials with the same dataset.  Note that you get two options for inferring trajectories, you can choose either.
     tutorials:
-      - name: scrna-intro
+      - name: scrna-case_trajectories
+        topic: single-cell
+      - name: scrna-case_monocle3-trajectories
         topic: single-cell
 
-  - section: "Module 3: Time to analyse data!"
+  - section: "Module 3: Moving into coding environments"
     description: |
-      It's time to apply your skills! You'll now analyse some clean data from the 10X Chromium platform.
+      Did you know Galaxy can host coding environments? They don't have the same level of computational power as are allocated our tools, but you can still learn how to use these environments to analyse your data. Sometimes, there will be a tool you want to use that's not available in Galaxy, and ([after requesting it!](https://docs.google.com/spreadsheets/d/15hqgqA-RMDhXR-ylKhRF-Dab9Ij2arYSKiEVoPl2df4/edit?usp=sharing)) you can export your data into a coding environment and run the tool there. Let's start with the basics of running these environments in Galaxy.
     tutorials:
-      - name: scrna-preprocessing-tenx
-        topic: single-cell
-      - name: scrna-scanpy-pbmc3k
-        topic: single-cell
+      - name: jupyterlab
+        topic: galaxy-interface
+      - name: galaxy-intro-jupyter
+        topic: galaxy-interface
+      - name: rstudio
+        topic: galaxy-interface
 
   - section: "The End!"
     description: |
-      And now you're done! There are still loads of resources to take you from basic analysis to more difficult decision-making, deconvolution, multiomics, or ingesting from different data sources. See the [Galaxy Single Cell Training page](/training-material/topics/single-cell/index.html) for more!
+      And now you're done! If you are interested in trying out the case study analyses in a coding environment, try out our []"Case study: Reloaded" series](/training-material/topics/single-cell#single-cell-CS) next! Otherwise, you will find more features, tips and tricks in our general [Galaxy Single-cell Training page](/training-material/topics/single-cell/index.html).
 ---
 
 New to Galaxy and/or the field of scRNA-seq? Follow this learning path to get familiar with the basics!

--- a/learning-pathways/beyond_single_cell.md
+++ b/learning-pathways/beyond_single_cell.md
@@ -1,0 +1,54 @@
+---
+layout: learning-pathway
+tags: [beginner]
+cover-image: assets/images/wab-annotatedcells-2.png
+cover-image-alt: "Image of cells in different coloured clusters"
+type: use
+
+editorial_board:
+- nomadscientist
+- pavanvidem
+
+title: Introduction to Galaxy and Single Cell RNA Sequence analysis
+description: |
+  These tutorials take you from raw scRNA sequencing reads to inferred trajectories to replicate a published analysis. The data is messy. The decisions are tough. The interpretation is meaningful. Come here to advance your single cell skills! Note that you get two options for inferring trajectories.
+
+  This learning path aims to teach you the basics of Galaxy and analysis of Single Cell RNA-seq data.
+  You will learn how to use Galaxy for analysis, and an important Galaxy feature for iterative single cell analysis. You'll tbe guided through the general theory of single analysis and then perform a basic analysis of 10X chromium data. For support throughout these tutorials, join our Galaxy [single cell chat group on Matrix](https://matrix.to/#/#Galaxy-Training-Network_galaxy-single-cell:gitter.im) to ask questions!
+
+priority: 9
+
+pathway:
+  - section: "Module 1: Introduction to Galaxy"
+    description: |
+      Get a first look at the Galaxy platform for data analysis. We start with a
+      short introduction (video slides & practical) to familiarize you with the Galaxy
+      interface, and then proceed with a short tutorial of how to tag - and organise! - your history.
+    tutorials:
+      - name: galaxy-intro-short
+        topic: introduction
+      - name: name-tags
+        topic: galaxy-interface
+
+  - section: "Module 2: Theory of Single-Cell RNA-seq"
+    description: |
+      When analysing sequencing data, you should always start with a quality control step to clean your data and make sure your data is good enough to answer your research question. After this step, you will often proceed with a mapping (alignment) or genome assembly step, depending on whether you have a reference genome to work with.
+    tutorials:
+      - name: scrna-intro
+        topic: single-cell
+
+  - section: "Module 3: Time to analyse data!"
+    description: |
+      It's time to apply your skills! You'll now analyse some clean data from the 10X Chromium platform.
+    tutorials:
+      - name: scrna-preprocessing-tenx
+        topic: single-cell
+      - name: scrna-scanpy-pbmc3k
+        topic: single-cell
+
+  - section: "The End!"
+    description: |
+      And now you're done! There are still loads of resources to take you from basic analysis to more difficult decision-making, deconvolution, multiomics, or ingesting from different data sources. See the [Galaxy Single Cell Training page](/training-material/topics/single-cell/index.html) for more!
+---
+
+New to Galaxy and/or the field of scRNA-seq? Follow this learning path to get familiar with the basics!

--- a/learning-pathways/beyond_single_cell.md
+++ b/learning-pathways/beyond_single_cell.md
@@ -52,7 +52,7 @@ pathway:
 
   - section: "The End!"
     description: |
-      And now you're done! If you are interested in trying out the case study analyses in a coding environment, try out our ["Case study: Reloaded" series](/training-material/topics/single-cell#single-cell-CS) next! Otherwise, you will find more features, tips and tricks in our general [Galaxy Single-cell Training page](/training-material/topics/single-cell/index.html).
+      And now you're done! If you are interested in trying out the case study analyses in a coding environment, try out our ["Case study: Reloaded" series](/training-material/topics/single-cell#st-single-cell-cs-code) next! Otherwise, you will find more features, tips and tricks in our general [Galaxy Single-cell Training page](/training-material/topics/single-cell/index.html).
 ---
 
 New to Galaxy and/or the field of scRNA-seq? Follow this learning path to get familiar with the basics!


### PR DESCRIPTION
This is the second batch of training I give my interns when they are upskilling in single-cell analysis. This takes them from the intro towards an intermediate skillset, and points them towards resources for beginning the journey into a coding environment.

PS: I'm happy for this to be a 'hidden' page that we just have links to, so as to now crowd the general learning pathway page, as I know it isn't necessarily set up for a beginner/intermediate evolution. I just don't know how to make an available page hidden.
