### PR TITLE
Remove spaces in front of zenodo file names in VGP tutorial

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,6 +76,10 @@ jobs:
         run: |
           ! fgrep -R 'lt;blockquote' _site
 
+      - name: Ensure no poorly indented code blocks
+        run: |
+          bundle exec ruby bin/check-indent.rb
+
       - name: Ensure no unexpected jekyll in output
         run: |
           ! fgrep -R 'site.pages' _site

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -64,3 +64,7 @@ Lint/DuplicateBranch:
 # We keep having bugs, so, disable this for now.
 Style/FrozenStringLiteralComment:
   Enabled: false
+
+# Unnecessary
+Style/IfUnlessModifier:
+  Enabled: false

--- a/bin/check-indent.rb
+++ b/bin/check-indent.rb
@@ -6,6 +6,7 @@ def check_indent(file)
   doc = Nokogiri::HTML(File.open(file))
   # Find all <pre> tags
   # <div class="language-plaintext highlighter-rouge"><div class="highlight"><pre class="highlight"><code>
+  ec = false
   doc.css('div.language-plaintext.highlighter-rouge div.highlight pre.highlight code').each do |pre|
     # Get the text content of the <pre> tag
     content = pre.text
@@ -18,16 +19,25 @@ def check_indent(file)
       lines.each do |line|
         if line =~ /^\s+/
           puts "#{file}: Indentation error: #{line}"
+          ec = true
         end
       end
     end
   end
+  ec
 end
 
+should_exit = false
 Find.find('./_site/training-material/topics/') do |path|
   if path =~ /tutorial.*\.html$/
-    check_indent(path)
+    if check_indent(path)
+      should_exit = true
+    end
   end
+end
+
+if should_exit
+  exit 1
 end
 #
 # check_indent(ARGV[0])

--- a/bin/check-indent.rb
+++ b/bin/check-indent.rb
@@ -1,0 +1,33 @@
+#!/usr/bin/env ruby
+require 'find'
+require 'nokogiri'
+
+def check_indent(file)
+  doc = Nokogiri::HTML(File.open(file))
+  # Find all <pre> tags
+  # <div class="language-plaintext highlighter-rouge"><div class="highlight"><pre class="highlight"><code>
+  doc.css('div.language-plaintext.highlighter-rouge div.highlight pre.highlight code').each do |pre|
+    # Get the text content of the <pre> tag
+    content = pre.text
+    # Split the content by newlines
+    lines = content.split("\n")
+
+    # If all lines look like URLs:
+    if lines.all? { |line| line =~ /:\/\// }
+      # If any are space indented
+      lines.each do |line|
+        if line =~ /^\s+/
+          puts "#{file}: Indentation error: #{line}"
+        end
+      end
+    end
+  end
+end
+
+Find.find('./_site/training-material/topics/') do |path|
+  if path =~ /tutorial.*\.html$/
+    check_indent(path)
+  end
+end
+#
+# check_indent(ARGV[0])

--- a/bin/check-indent.rb
+++ b/bin/check-indent.rb
@@ -14,7 +14,7 @@ def check_indent(file)
     lines = content.split("\n")
 
     # If all lines look like URLs:
-    if lines.all? { |line| line =~ /:\/\// }
+    if lines.all? { |line| line =~ %r{://} }
       # If any are space indented
       lines.each do |line|
         if line =~ /^\s+/
@@ -29,10 +29,8 @@ end
 
 should_exit = false
 Find.find('./_site/training-material/topics/') do |path|
-  if path =~ /tutorial.*\.html$/
-    if check_indent(path)
-      should_exit = true
-    end
+  if path =~ (/tutorial.*\.html$/) && check_indent(path)
+    should_exit = true
   end
 end
 

--- a/bin/lint.rb
+++ b/bin/lint.rb
@@ -763,6 +763,22 @@ module GtnLinter
     end
   end
 
+  def self.nonsemantic_list(contents)
+    find_matching_texts(contents, />\s*(\*\*\s*[Ss]tep)/)
+      .map do |idx, _text, selected|
+      ReviewDogEmitter.error(
+        path: @path,
+        idx: idx,
+        match_start: selected.begin(1),
+        match_end: selected.end(1) + 1,
+        replacement: nil,
+        message: 'This is a non-semantic list which is bad for accessibility and bad for screenreaders. ' \
+                 'It results in poorly structured HTML and as a result is not allowed.',
+        code: 'GTN:035'
+      )
+    end
+  end
+
   def self.fix_md(contents)
     [
       *fix_notoc(contents),
@@ -789,7 +805,8 @@ module GtnLinter
       *check_bolded_heading(contents),
       *snippets_too_close_together(contents),
       *zenodo_api(contents),
-      *empty_alt_text(contents)
+      *empty_alt_text(contents),
+      *nonsemantic_list(contents)
     ]
   end
 

--- a/topics/assembly/tutorials/vgp_genome_assembly/tutorial.md
+++ b/topics/assembly/tutorials/vgp_genome_assembly/tutorial.md
@@ -179,9 +179,9 @@ The following two steps demonstrate how to upload three PacBio {HiFi} datasets i
 >    - you can do this by clicking on {% icon copy %} button in the right upper corner of the box below. It will appear if you mouse over the box.
 >
 >    ```
->    https://zenodo.org/record/6098306/files/HiFi_synthetic_50x_01.fasta
->    https://zenodo.org/record/6098306/files/HiFi_synthetic_50x_02.fasta
->    https://zenodo.org/record/6098306/files/HiFi_synthetic_50x_03.fasta
+>https://zenodo.org/record/6098306/files/HiFi_synthetic_50x_01.fasta
+>https://zenodo.org/record/6098306/files/HiFi_synthetic_50x_02.fasta
+>https://zenodo.org/record/6098306/files/HiFi_synthetic_50x_03.fasta
 >    ```
 >
 >**Step 3**: Upload datasets into Galaxy.
@@ -206,8 +206,8 @@ Illumina {Hi-C} data is uploaded in essentially the same way as shown in the fol
 >**Step 1**: Copy the following URLs into the clipboard. You can do this by clicking on {% icon copy %} button in the right upper corner of the box below. It will appear if you mouse over the box.
 >
 >    ```
->    https://zenodo.org/record/5550653/files/SRR7126301_1.fastq.gz
->    https://zenodo.org/record/5550653/files/SRR7126301_2.fastq.gz
+>https://zenodo.org/record/5550653/files/SRR7126301_1.fastq.gz
+>https://zenodo.org/record/5550653/files/SRR7126301_2.fastq.gz
 >    ```
 >
 >**Step 2**: Upload datasets into Galaxy and set the datatype to `fastqsanger.gz`
@@ -1326,7 +1326,7 @@ Before we begin, we need to upload BioNano data:
 >**Step 1**: Copy the following URLs into clipboard. You can do this by clicking on {% icon copy %} button in the right upper corner of the box below. It will appear if you mouse over the box.
 >
 >    ```
->    https://zenodo.org/records/5887339/files/bionano.cmap
+>https://zenodo.org/records/5887339/files/bionano.cmap
 >    ```
 >
 >**Step 2**: Upload datasets into Galaxy

--- a/topics/assembly/tutorials/vgp_genome_assembly/tutorial.md
+++ b/topics/assembly/tutorials/vgp_genome_assembly/tutorial.md
@@ -171,20 +171,20 @@ The following two steps demonstrate how to upload three PacBio {HiFi} datasets i
 
 > <hands-on-title><b>Uploading <tt>FASTA</tt> datasets from Zenodo</b></hands-on-title>
 >
->**Step 1**: Create a new history for this tutorial
+> 1. Create a new history for this tutorial
 >
-> {% snippet faqs/galaxy/histories_create_new.md %}
+>    {% snippet faqs/galaxy/histories_create_new.md %}
 >
->**Step 2**: Copy the following URLs into the clipboard.
+> 2. Copy the following URLs into the clipboard.
 >    - you can do this by clicking on {% icon copy %} button in the right upper corner of the box below. It will appear if you mouse over the box.
 >
 >    ```
->https://zenodo.org/record/6098306/files/HiFi_synthetic_50x_01.fasta
->https://zenodo.org/record/6098306/files/HiFi_synthetic_50x_02.fasta
->https://zenodo.org/record/6098306/files/HiFi_synthetic_50x_03.fasta
+>    https://zenodo.org/record/6098306/files/HiFi_synthetic_50x_01.fasta
+>    https://zenodo.org/record/6098306/files/HiFi_synthetic_50x_02.fasta
+>    https://zenodo.org/record/6098306/files/HiFi_synthetic_50x_03.fasta
 >    ```
 >
->**Step 3**: Upload datasets into Galaxy.
+> 3. Upload datasets into Galaxy.
 >    - set the datatype to `fasta`
 >
 > {% snippet faqs/galaxy/datasets_import_via_link.md format="fasta" %}
@@ -203,18 +203,18 @@ Illumina {Hi-C} data is uploaded in essentially the same way as shown in the fol
 
 > <hands-on-title><b>Uploading <tt>fastqsanger.gz</tt> datasets from Zenodo</b></hands-on-title>
 >
->**Step 1**: Copy the following URLs into the clipboard. You can do this by clicking on {% icon copy %} button in the right upper corner of the box below. It will appear if you mouse over the box.
+> 1. Copy the following URLs into the clipboard. You can do this by clicking on {% icon copy %} button in the right upper corner of the box below. It will appear if you mouse over the box.
 >
 >    ```
->https://zenodo.org/record/5550653/files/SRR7126301_1.fastq.gz
->https://zenodo.org/record/5550653/files/SRR7126301_2.fastq.gz
+>    https://zenodo.org/record/5550653/files/SRR7126301_1.fastq.gz
+>    https://zenodo.org/record/5550653/files/SRR7126301_2.fastq.gz
 >    ```
 >
->**Step 2**: Upload datasets into Galaxy and set the datatype to `fastqsanger.gz`
+> 2. Upload datasets into Galaxy and set the datatype to `fastqsanger.gz`
 >
-> {% snippet faqs/galaxy/datasets_import_via_link.md format="fastqsanger.gz" %}
->
-> {% snippet topics/assembly/tutorials/vgp_genome_assembly/faqs/dataset_upload_fastqsanger_via_urls.md %}
+>   {% snippet faqs/galaxy/datasets_import_via_link.md format="fastqsanger.gz" %}
+>  
+>   {% snippet topics/assembly/tutorials/vgp_genome_assembly/faqs/dataset_upload_fastqsanger_via_urls.md %}
 >
 {: .hands_on}
 

--- a/topics/assembly/tutorials/vgp_genome_assembly/tutorial.md
+++ b/topics/assembly/tutorials/vgp_genome_assembly/tutorial.md
@@ -212,9 +212,9 @@ Illumina {Hi-C} data is uploaded in essentially the same way as shown in the fol
 >
 > 2. Upload datasets into Galaxy and set the datatype to `fastqsanger.gz`
 >
->   {% snippet faqs/galaxy/datasets_import_via_link.md format="fastqsanger.gz" %}
->  
->   {% snippet topics/assembly/tutorials/vgp_genome_assembly/faqs/dataset_upload_fastqsanger_via_urls.md %}
+>    {% snippet faqs/galaxy/datasets_import_via_link.md format="fastqsanger.gz" %}
+>
+>    {% snippet topics/assembly/tutorials/vgp_genome_assembly/faqs/dataset_upload_fastqsanger_via_urls.md %}
 >
 {: .hands_on}
 

--- a/topics/assembly/tutorials/vgp_workflow_training/tutorial.md
+++ b/topics/assembly/tutorials/vgp_workflow_training/tutorial.md
@@ -107,13 +107,14 @@ The following two steps demonstrate how to upload three PacBio {HiFi} datasets i
 >    {% snippet faqs/galaxy/histories_create_new.md %}
 >
 > 2. Copy the following URLs into clipboard.
->    - you can do this by clicking on {% icon copy %} button in the right upper corner of the box below. It will appear if you mouse over the box.)
 >
->     ```
->     https://zenodo.org/record/6098306/files/HiFi_synthetic_50x_01.fasta
->     https://zenodo.org/record/6098306/files/HiFi_synthetic_50x_02.fasta
->     https://zenodo.org/record/6098306/files/HiFi_synthetic_50x_03.fasta
->     ```
+>    you can do this by clicking on {% icon copy %} button in the right upper corner of the box below. It will appear if you mouse over the box.)
+>
+>    ```
+>    https://zenodo.org/record/6098306/files/HiFi_synthetic_50x_01.fasta
+>    https://zenodo.org/record/6098306/files/HiFi_synthetic_50x_02.fasta
+>    https://zenodo.org/record/6098306/files/HiFi_synthetic_50x_03.fasta
+>    ```
 >
 > 3. Upload datasets into Galaxy.
 >    - set the datatype to `fasta`
@@ -179,10 +180,9 @@ Once we have imported the datasets, the next step is to import the workflows nec
 
 All analyses described in this tutorial are performed using *workflows*--chains of tools--shown in [Fig. 1](#figure-1). Specifically, we will use four workflows corresponding to analysis trajectory **B**: 1, 4, 6, and 8. To use these four workflows you need to import them into your Galaxy account following the steps below:
 
-> <hands-on-title><b>Importing workflows from GitHub</b></hands-on-title>
+> <hands-on-title>Importing workflows from GitHub</hands-on-title>
 >
 > Links to the four workflows that will be used in this tutorial are listed in the table. Follow the procedure described below the table to import each of them into your Galaxy account.
-> <br>
 >
 > | Workflow | Link |
 > |---------|---------|
@@ -191,26 +191,22 @@ All analyses described in this tutorial are performed using *workflows*--chains 
 > | Purge duplicate contigs workflow (WF6) | [https://raw.githubusercontent.com/iwc-workflows/Purge-duplicate-contigs-VGP6/v0.3.2/Purge-duplicate-contigs-VGP6.ga](https://raw.githubusercontent.com/iwc-workflows/Purge-duplicate-contigs-VGP6/v0.3.2/Purge-duplicate-contigs-VGP6.ga) |
 > | Scaffolding with Hi-C workflow (WF8) | [https://raw.githubusercontent.com/iwc-workflows/Scaffolding-HiC-VGP8/v0.2/Scaffolding-HiC-VGP8.ga](https://raw.githubusercontent.com/iwc-workflows/Scaffolding-HiC-VGP8/v0.2/Scaffolding-HiC-VGP8.ga)|
 >
-> <br>
+> 1. Copy the workflow URL into clipboard
 >
-> **Step 1: Copy the workflow URL into clipboard**
+>    1. Right click on a URL in the table above.
+>    2. Select "Copy link address" option in the dropdown menu that appears.
+>    3. Go to Galaxy
 >
-> 1. Right click on a URL in the table above.
-> 2. Select "Copy link address" option in the dropdown menu that appears.
-> 3. Go to Galaxy
+>    > <warning-title>Make sure you are logged in!</warning-title>
+>    > Ensure that you are logged in into your Galaxy account!
+>    {: .warning}
 >
->> <warning-title>Make sure you are logged in!</warning-title>
->> Ensure that you are logged in into your Galaxy account!
-> {: .warning}
+> 2. Import the workflow
 >
-> <br>
->
-> **Step 2: Import the workflow**
->
-> 1. Click "Workflow" on top of the Galaxy interface.
-> 2. On top-right of the middle pane click "{% icon galaxy-upload %} Import" button.
-> 3. Paste the URL you copied into the clipboard at Step 1 above to "Archived Workflow URL" box.
-> 4. Click "Import workflow" button.
+>    1. Click "Workflow" on top of the Galaxy interface.
+>    2. On top-right of the middle pane click "{% icon galaxy-upload %} Import" button.
+>    3. Paste the URL you copied into the clipboard at Step 1 above to "Archived Workflow URL" box.
+>    4. Click "Import workflow" button.
 >
 > This entire procedure is shown in the animated figure below. {% icon warning %} **You need to repeat this process for all four workflows**
 >
@@ -247,39 +243,37 @@ Now that our data and workflows are imported, we can run our first workflow. Bef
 
 > <hands-on-title><b>Launching <i>K</i>-mer profile analysis workflow</b></hands-on-title>
 >
-> **Step 1: Identify inputs**
+> 1. Identify inputs
 >
-> The profiling workflow takes the following inputs:
+>    The profiling workflow takes the following inputs:
+>   
+>    1. {HiFi} reads as a collection
+>    2. *K*-mer length
+>    3. Ploidy
 >
-> 1. {HiFi} reads as a collection
-> 2. *K*-mer length
-> 3. Ploidy
+> 2. Launch *k*-mer profiling workflow
 >
-> **Step 2: Launch *k*-mer profiling workflow**
+>    1. Click in the **Workflow** menu, located in the top bar
+>    2. Click in the {% icon workflow-run %} **Run workflow** buttom corresponding to `K-mer profiling and QC (WF1)`
+>    3. In the **Workflow: VGP genome profile analysis** menu:
+>     - {% icon param-collection %} "*Collection of Pacbio Data*": `7: HiFi_collection`
+>     - "*K-mer length*": `31`
+>     - "*Ploidy*": `2`
+>    4. Click on the <kbd>Run workflow</kbd> buttom
+>   
+>    This should like this:
 >
-> 1. Click in the **Workflow** menu, located in the top bar
-> 2. Click in the {% icon workflow-run %} **Run workflow** buttom corresponding to `K-mer profiling and QC (WF1)`
-> 3. In the **Workflow: VGP genome profile analysis** menu:
->  - {% icon param-collection %} "*Collection of Pacbio Data*": `7: HiFi_collection`
->  - "*K-mer length*": `31`
->  - "*Ploidy*": `2`
-> 4. Click on the <kbd>Run workflow</kbd> buttom
+>    ![Parameters of *k*-mer profiling workflow](../../images/vgp_assembly/wf1_launch_ui.png  "Workflow main menu. The workflow menu lists all the workflows that have been imported. It provides useful information for organizing the workflows, such as last update and the tags. The worklows can be run by clicking in the play icon, marked in red in the image.")
 >
-> This should like this:
->
->
->![Parameters of *k*-mer profiling workflow](../../images/vgp_assembly/wf1_launch_ui.png  "Workflow main menu. The workflow menu lists all the workflows that have been imported. It provides useful information for organizing the workflows, such as last update and the tags. The worklows can be run by clicking in the play icon, marked in red in the image.")
->
->
->> <comment-title>K-mer length</comment-title>
->> In this tutorial, we are using a *k*-mer length of 31. This can vary, but the VGP pipeline tends to use a *k*-mer length of 21, which tends to work well for most mammalian-size genomes. There is more discussion about *k*-mer length trade-offs in the extended VGP pipeline tutorial.
-> {: .comment}
+>    > <comment-title>K-mer length</comment-title>
+>    > In this tutorial, we are using a *k*-mer length of 31. This can vary, but the VGP pipeline tends to use a *k*-mer length of 21, which tends to work well for most mammalian-size genomes. There is more discussion about *k*-mer length trade-offs in the extended VGP pipeline tutorial.
+>    {: .comment}
 >
 ><br>
 >
-> **Step 3: Refill your coffee**
+> 3. Refill your coffee
 >
-> Assembly is not exactly an instantaneous type of analysis - this workflow will take approx 15 minutes to complete. The same is true for all analyses in tutorial.
+>    Assembly is not exactly an instantaneous type of analysis - this workflow will take approx 15 minutes to complete. The same is true for all analyses in tutorial.
 {: .hands_on}
 
 ### Interpreting the results

--- a/topics/computational-chemistry/tutorials/zauberkugel/tutorial.md
+++ b/topics/computational-chemistry/tutorials/zauberkugel/tutorial.md
@@ -123,9 +123,9 @@ In this step, we will manually create an SMI file containing the SMILES of staur
 > >
 > > A SMILES string can automatically be generated from a ligand name or 2D structure with a desktop molecule editor such [ChemDraw®](https://perkinelmerinformatics.com/products/research/chemdraw/) and [Marvin®](https://chemaxon.com/products/marvin), or with web-based molecule editors such as [PubChem Sketcher](https://pubchem.ncbi.nlm.nih.gov//edit3/index.html) and [ChemDraw® JS](https://chemdrawdirect.perkinelmer.cloud/js/sample/index.html). Moreover, the pre-computed SMILES strings of a large number of bioactive compounds can be retrieved from chemical databases such as [PubChem](https://pubchem.ncbi.nlm.nih.gov/). e.g.
 > >
-> >    ```
-> >    https://pubchem.ncbi.nlm.nih.gov/compound/44259#section=Isomeric-SMILES&fullscreen=true
-> >    ```
+> > ```
+> > https://pubchem.ncbi.nlm.nih.gov/compound/44259#section=Isomeric-SMILES&fullscreen=true
+> > ```
 > >
 > {: .tip}
 >

--- a/topics/ecology/tutorials/regionalGAM/tutorial.md
+++ b/topics/ecology/tutorials/regionalGAM/tutorial.md
@@ -178,9 +178,9 @@ As the dataset is quite big and may contain heterogeneous information, we need t
 >
 > To test these steps, you can use the following dataset:
 >
->   ```
->   https://zenodo.org/record/1324204/files/Dataset%20multispecies%20Regional%20GAM.csv
->   ```
+> ```
+> https://zenodo.org/record/1324204/files/Dataset%20multispecies%20Regional%20GAM.csv
+> ```
 >
 > > <question-title></question-title>
 > >

--- a/topics/ecology/tutorials/x-array-map-plot/tutorial.md
+++ b/topics/ecology/tutorials/x-array-map-plot/tutorial.md
@@ -78,9 +78,9 @@ It is beginner friendly and does not require much knowledge about the tool.
 >
 >    **or**, if this is not available, you can import from [Zenodo]({{page.zenodo_link}}):
 >
->     ```
->     https://zenodo.org/record/6621460/files/air_temperature_at_2_metres.netcdf
->     ```
+>    ```
+>    https://zenodo.org/record/6621460/files/air_temperature_at_2_metres.netcdf
+>    ```
 >
 >    {% snippet faqs/galaxy/datasets_import_via_link.md %}
 >

--- a/topics/introduction/tutorials/galaxy-intro-short/tutorial_ES.md
+++ b/topics/introduction/tutorials/galaxy-intro-short/tutorial_ES.md
@@ -81,7 +81,7 @@ Tu “Historial” está en el panel de la derecha.
 > 1. Ve al panel **History** (a la derecha)
 > 2. Haz clic en el nombre del historial (que por defecto es "Unnamed history")
 >
->	![name history](../../../../shared/images/rename_history.png){:width="320px"}
+>    ![name history](../../../../shared/images/rename_history.png){:width="320px"}
 >
 > 3. Teclea el nuevo nombre, por ejemplo, "Mi-Analisis"
 > 4. Presiona <kbd>Enter</kbd> en tu teclado para guardar
@@ -99,18 +99,18 @@ Tus herramientas están en el panel de la izquierda.
 > <hands-on-title>Cargar un archivo desde una dirección URL</hands-on-title>
 > 1. En la parte superior del panel **Tools** (a la derecha), haz clic en {% icon galaxy-upload %} **Upload**
 >
->	![upload button](../../images/upload-data.png)
+>    ![upload button](../../images/upload-data.png)
 >
->	Se desplegará el siguiente cuadro:
+>    Se desplegará el siguiente cuadro:
 >
->	![filebox](../../images/upload-box.png){:width="500px"}
+>    ![filebox](../../images/upload-box.png){:width="500px"}
 >
 > 3. Haz clic en **Paste/Fetch data**
 > 4. Pega la dirección de un archivo:
 >
->	```
->	https://zenodo.org/record/582600/files/mutant_R1.fastq
->	````
+>    ```
+>    https://zenodo.org/record/582600/files/mutant_R1.fastq
+>    ````
 >
 > 5. Haz clic en **Start**
 > 6. Haz clic en **Close**
@@ -130,7 +130,7 @@ Cuando el archivo se haya cargado en Galaxy, aparecerá en color verde.
 > <hands-on-title>Visualizar el contenido de un conjunto de datos</hands-on-title>
 > 1. Haz clic en el icono {% icon galaxy-eye %} (ojo) junto al nombre del conjunto de datos para visualizar su contenido
 >
->	![eye](../../images/eye-icon.png){:width="320px"}
+>    ![eye](../../images/eye-icon.png){:width="320px"}
 {: .hands_on}
 
 El contenido del archivo se desplegará en el panel central de Galaxy.
@@ -147,11 +147,11 @@ Echemos un vistazo a la calidad de las lecturas de este archivo
 > 1. Teclea **FastQC** en el cuadro de búsqueda del panel de herramientas (parte superior)
 > 2. Haz clic en la herramienta {% tool [FastQC](toolshed.g2.bx.psu.edu/repos/devteam/fastqc/fastqc/0.72) %}
 >
->	La herramienta se desplegará en el panel central de Galaxy.
+>    La herramienta se desplegará en el panel central de Galaxy.
 >
 > 3. Selecciona los siguientes parámetros:
->	- {% icon param-file %} *"Short read data from your current history"*: el archivo en formato FASTQ que cargamos
->	- Deja sin cambios el resto de los parámetros
+>    - {% icon param-file %} *"Short read data from your current history"*: el archivo en formato FASTQ que cargamos
+>    - Deja sin cambios el resto de los parámetros
 > 4. Haz clic en **Execute**
 >
 {: .hands_on}
@@ -172,9 +172,9 @@ Vamos a ver el archivo de salida llamado *FastQC on data 1: Webpage*.
 > <hands-on-title>Visualización de resultados</hands-on-title>
 > * Haz clic en el icono {% icon galaxy-eye %} (ojo) junto a la salida "Webpage".
 >
->	La información se desplegará en el panel central
+>    La información se desplegará en el panel central
 >
->	![fastqc-out](../../images/fastqc-out.png){:width="620px"}
+>    ![fastqc-out](../../images/fastqc-out.png){:width="620px"}
 {: .hands_on}
 
 Esta herramienta resume la información de calidad de todas las lecturas en nuestro archivo FASTQ.
@@ -200,9 +200,9 @@ Vamos a ejecutar otra herramienta para filtrar las lecturas de baja calidad de n
 > 1. Teclea **Filter by quality** en el cuadro de búsqueda del panel de herramientas (parte superior)
 > 2. Haz clic en la herramienta {% tool [Filter by quality](toolshed.g2.bx.psu.edu/repos/devteam/fastq_quality_filter/cshl_fastq_quality_filter/1.0.1) %}
 > 3. Selecciona los siguientes parámetros:
->	- {% icon param-file %} *"Input FASTQ file"*: Nuestro archivo inicial el formato FASTQ
->	- *"Quality cut-off"*: valor de corte de calidad = 35
->	- *"Minimum percentage"*:  Porcentaje de bases en la secuencia que debe tener calidad mayor o igual al valor de corte de calidad = 80
+>    - {% icon param-file %} *"Input FASTQ file"*: Nuestro archivo inicial el formato FASTQ
+>    - *"Quality cut-off"*: valor de corte de calidad = 35
+>    - *"Minimum percentage"*:  Porcentaje de bases en la secuencia que debe tener calidad mayor o igual al valor de corte de calidad = 80
 > 4. Haz clic en **Execute**
 {: .hands_on}
 
@@ -219,9 +219,9 @@ Podríamos hacer clic en el icono del ojo para ver el contenido de este archivo 
 > <hands-on-title>Obtener metadatos de un archivo</hands-on-title>
 > 1. Haz clic en el nombre de un conjunto de datos de salida en el panel de historial.
 >
->	Esta acción expandirá la información que se tenga sobre el archivo.
+>    Esta acción expandirá la información que se tenga sobre el archivo.
 >
->	![filter1](../../images/filter-fastq1.png)
+>    ![filter1](../../images/filter-fastq1.png)
 >
 {: .hands_on}
 
@@ -241,13 +241,13 @@ Ahora hemos decidido que nuestro conjunto de datos de entrada tiene que ser filt
 > <hands-on-title>Volver a ejecutar la herramienta</hands-on-title>
 > 1. Haz clic en el icono {% icon galaxy-refresh %} (**Run this job again**) para el set de datos de salida **Filter by quality** {% icon tool %}
 >
->	![rerun](../../images/rerun.png)
+>    ![rerun](../../images/rerun.png)
 >
->	La interfaz de la herramienta aparecerá en el panel central con los valores de parámetros que utilizamos previamente para generar este set de datos
+>    La interfaz de la herramienta aparecerá en el panel central con los valores de parámetros que utilizamos previamente para generar este set de datos
 >
 > 2. Cambia los parámetros para un filtrado más estricto
 >
->	Por ejemplo, podrías decidir que el 80 por ciento de las bases tengan una calidad de 36 o superior, en lugar de 35.
+>    Por ejemplo, podrías decidir que el 80 por ciento de las bases tengan una calidad de 36 o superior, en lugar de 35.
 >
 > 3. Haz clic en **Execute**
 > 4. Visualiza los resultados: Haz clic en el nombre del conjunto de datos de salida para expandir la información. (*Nota*: No uses el icono {% icon galaxy-eye %} (ojo))
@@ -285,15 +285,15 @@ Este nuevo historial todavía no tiene datos.
 > <hands-on-title>Visualizar historiales</hands-on-title>
 > 1. Haz clic en el icono **View all histories** ({% icon galaxy-columns %}) en la parte superior derecha de tu historial
 >
->	![view-hist](../../images/galaxy_interface_history_switch.png){:width="320px"}
+>    ![view-hist](../../images/galaxy_interface_history_switch.png){:width="320px"}
 >
->	Aparecerá una nueva página donde se desplegarán todos tus historiales.
+>    Aparecerá una nueva página donde se desplegarán todos tus historiales.
 >
 > 2. Copia un conjunto de datos a tu historial nuevo
->	1. Haz clic en el archivo FASTQ en el historial "Mi-Analisis"
->	2. Arrastralo al historial "Nuevo-Analisis"
+>    1. Haz clic en el archivo FASTQ en el historial "Mi-Analisis"
+>    2. Arrastralo al historial "Nuevo-Analisis"
 >
->	Esto generará una copia del conjunto de datos en tu historial nuevo (sin utilizar espacio de disco adicional)
+>    Esto generará una copia del conjunto de datos en tu historial nuevo (sin utilizar espacio de disco adicional)
 >
 > 3. Haz clic en el icono {% icon galaxy-home %} (o en **Analyze Data** en versiones anteriores de Galaxy) en la parte superior para regresar a la ventana de análisis
 >

--- a/topics/single-cell/tutorials/scrna-data-ingest/tutorial.md
+++ b/topics/single-cell/tutorials/scrna-data-ingest/tutorial.md
@@ -792,7 +792,7 @@ We will continue working on previously used dataset, so you can copy it from you
 > 
 >    {% snippet faqs/galaxy/histories_copy_dataset.md %}
 >
-> Or, alternatively, download the dataset from [Zenodo]({{ page.zenodo_link }})
+>    Or, alternatively, download the dataset from [Zenodo]({{ page.zenodo_link }})
 >
 >    ```
 >    https://zenodo.org/record/10391629/files/Downsampled_annotated_AnnData.h5ad

--- a/topics/single-cell/tutorials/scrna-ncbi-anndata/tutorial.md
+++ b/topics/single-cell/tutorials/scrna-ncbi-anndata/tutorial.md
@@ -59,9 +59,9 @@ The first step is the obtain the data. For this tutorial, we will use data from 
 > <hands-on-title>Download and extract the data from GEO</hands-on-title>
 >
 > 1. Using a web browser navigate to the GEO repository for the paper
->     ```
->     https://www.ncbi.nlm.nih.gov/geo/query/acc.cgi?acc=GSE176031
->     ```
+>    ```
+>    https://www.ncbi.nlm.nih.gov/geo/query/acc.cgi?acc=GSE176031
+>    ```
 > 2. Copy the ```(http)``` link located in the supplemental materials section of the page
 >
 > 3. Import the data into Galaxy

--- a/topics/transcriptomics/tutorials/rna-seq-counts-to-genes/tutorial.md
+++ b/topics/transcriptomics/tutorials/rna-seq-counts-to-genes/tutorial.md
@@ -99,17 +99,17 @@ We will use three files for this analysis:
 > 2. Import the mammary gland counts table and the associated sample information file.
 >
 >    To import the files, there are two options:
->     - Option 1: From a shared data library if available (`GTN - Material -> {{ page.topic_name }} -> {{ page.title }}`)
->     - Option 2: From [Zenodo](https://zenodo.org/record/4273218)
+>    - Option 1: From a shared data library if available (`GTN - Material -> {{ page.topic_name }} -> {{ page.title }}`)
+>    - Option 2: From [Zenodo](https://zenodo.org/record/4273218)
 >
->       {% snippet faqs/galaxy/datasets_import_via_link.md %}
+>      {% snippet faqs/galaxy/datasets_import_via_link.md %}
 >
->     - You can paste both links below into the **Paste/Fetch** box:
+>    - You can paste both links below into the **Paste/Fetch** box:
 >
->     ```
->     https://zenodo.org/record/4273218/files/countdata.tsv
->     https://zenodo.org/record/4273218/files/factordata.tsv
->     ```
+>    ```
+>    https://zenodo.org/record/4273218/files/countdata.tsv
+>    https://zenodo.org/record/4273218/files/factordata.tsv
+>    ```
 >
 > 2. Rename the counts dataset as `countdata` and the sample information dataset as `factordata` using the {% icon galaxy-pencil %} (pencil) icon.
 > 3. Check that the datatype is `tabular`.
@@ -131,14 +131,14 @@ The `factordata` file contains basic information about the samples that we will 
 
 > <details-title>Formatting the data</details-title>
 >
->The files above have been formatted for you. If you are interested to know how they were formatted the information is below.
+> The files above have been formatted for you. If you are interested to know how they were formatted the information is below.
 >
 > The original files are available at
 >
->     ```
->     https://zenodo.org/record/4273218/files/GSE60450_Lactation-GenewiseCounts.txt
->     https://zenodo.org/record/4273218/files/SampleInfo.txt
->     ```
+> ```
+> https://zenodo.org/record/4273218/files/GSE60450_Lactation-GenewiseCounts.txt
+> https://zenodo.org/record/4273218/files/SampleInfo.txt
+> ```
 >
 >![seqdata file](../../images/rna-seq-counts-to-genes/seqdata.png "Count file (before formatting)")
 >


### PR DESCRIPTION
Remove spaces in front of zenodo file names, because if not, the files may not upload correctly in Galaxy. 
I think this formatting still looks ok in the preview but could someone else also check, thanks. 