### PR TITLE
Fix js loading in dev environments

### DIFF
--- a/_plugins/jekyll-bundler.rb
+++ b/_plugins/jekyll-bundler.rb
@@ -5,17 +5,19 @@ require 'digest'
 # so we can use that as a cache buster
 Jekyll::Hooks.register :site, :post_read do |site|
   site.config['javascript_bundles'].each do |name, resources|
-    # Get the maximum last file modified time to use as the bundle timestamp
-    bundle_timestamp = resources['resources'].map { |f| File.mtime(f).to_i }.max
-    site.config['javascript_bundles'][name]['timestamp'] = bundle_timestamp
+    if Jekyll.env == 'production'
+      # Get the maximum last file modified time to use as the bundle timestamp
+      bundle_timestamp = resources['resources'].map { |f| File.mtime(f).to_i }.max
+      site.config['javascript_bundles'][name]['timestamp'] = bundle_timestamp
 
-    # This is inefficient since we read twice but it's also not that expensive.
-    bundle = resources['resources'].map { |f| File.read(f) }.join("\n")
-    hash = Digest::MD5.hexdigest(bundle)[0..7]
-    site.config['javascript_bundles'][name]['hash'] = hash
-    site.config['javascript_bundles'][name]['path'] = "/assets/js/bundle.#{name}.#{hash}.js"
+      # This is inefficient since we read twice but it's also not that expensive.
+      bundle = resources['resources'].map { |f| File.read(f) }.join("\n")
+      hash = Digest::MD5.hexdigest(bundle)[0..7]
+      site.config['javascript_bundles'][name]['hash'] = hash
+      site.config['javascript_bundles'][name]['path'] = "/assets/js/bundle.#{name}.#{hash}.js"
 
-    Jekyll.logger.info "Analysing JS Bundle #{name} => #{bundle_timestamp} / #{hash}"
+      Jekyll.logger.info "Analysing JS Bundle #{name} => #{bundle_timestamp} / #{hash}"
+    end
   end
 end
 
@@ -25,14 +27,16 @@ end
 # gzip probably does enough, everything else is pre-minified.
 Jekyll::Hooks.register :site, :post_write do |site|
   site.config['javascript_bundles'].each do |name, resources|
-    bundle_path = "#{site.dest}#{resources['path']}"
-    Jekyll.logger.info "Building JS bundle #{name} => #{bundle_path}"
+    if Jekyll.env == 'production'
+      bundle_path = "#{site.dest}#{resources['path']}"
+      Jekyll.logger.info "Building JS bundle #{name} => #{bundle_path}"
 
-    # Just concatenate them all together
-    bundle = resources['resources'].map { |f| File.read(f) }.join("\n")
+      # Just concatenate them all together
+      bundle = resources['resources'].map { |f| File.read(f) }.join("\n")
 
-    # Write the bundle to the output directory
-    File.write(bundle_path, bundle)
+      # Write the bundle to the output directory
+      File.write(bundle_path, bundle)
+    end
   end
 end
 

--- a/_plugins/jekyll-bundler.rb
+++ b/_plugins/jekyll-bundler.rb
@@ -93,12 +93,8 @@ module Jekyll
 
       baseurl = @context.registers[:site].config['baseurl']
 
-      attrs = ""
-      attrs += " async" if bundle['async']
-      attrs += " defer" if bundle['defer']
-
       bundle['resources'].map do |f|
-        "<script #{attrs} src='#{baseurl}/#{f}'></script>"
+        "<script src='#{baseurl}/#{f}'></script>"
       end.join("\n")
     end
 

--- a/_plugins/jekyll-webfinger.rb
+++ b/_plugins/jekyll-webfinger.rb
@@ -3,6 +3,11 @@
 require './_plugins/gtn'
 
 Jekyll::Hooks.register :site, :post_write do |site|
+  if Jekyll.env != 'production'
+    Jekyll.logger.info '[GTN/Webfinger] Skipping webfinger generation in development'
+    next
+  end
+
   # Make the directory
   Jekyll.logger.info '[GTN/Webfinger] Generating webfinger files'
   FileUtils.mkdir_p "#{site.dest}/api/fedi"

--- a/_plugins/sitemap.rb
+++ b/_plugins/sitemap.rb
@@ -2,7 +2,7 @@
 
 module Jekyll
   # Generate a sitemap like Jekyll::Sitemap
-  class SitemapGenerator < Generator
+  class SitemapGenerator2 < Generator
     safe true
 
     ##
@@ -14,11 +14,14 @@ module Jekyll
     # Params:
     # +site+:: The +Jekyll::Site+ object
     def generate(site)
-      if Jekyll.env == 'development'
+      if Jekyll.env == 'production'
+        _build(site)
+      else
         Jekyll.logger.info '[GTN/Sitemap] Skipping in development mode'
-        return
       end
+    end
 
+    def _build(site)
       # We import later in case we don't need to bother importing in the first place.
       require 'date'
       require './_plugins/gtn'


### PR DESCRIPTION
This cherry-picks a commit from #4896 which moved some more bundling functionality to prod-only, But still in dev environments we need the JS loading properly. Which means bundling, or, synchronous loading. So we opt for that.

Fixes https://github.com/galaxyproject/training-material/issues/4897