### PR TITLE
Bioimaging tutorial typo fixed

### DIFF
--- a/topics/fair/tutorials/bioimage-REMBI/tutorial.md
+++ b/topics/fair/tutorials/bioimage-REMBI/tutorial.md
@@ -287,7 +287,7 @@ Start with the details of the equipment for the Instrument Attributes. If this i
 >   </tr>
 >   <tr>
 >     <th>Objective</th>
->     <td>Cos-7 cells cultured in DMEM medium, and then plated on #1 coverslips and imaged live in L-15 medium</td>
+>     <td>20x</td>
 >   </tr>
 >   <tr>
 >     <th>Excitation Wavelength</th>


### PR DESCRIPTION
A small mistake found in preparations for the training event. 

Objective value fixed in image acquisition section.

@kkamieniecka 