### PR TITLE
fix bug for curated translations display

### DIFF
--- a/_includes/resource-handson.html
+++ b/_includes/resource-handson.html
@@ -25,7 +25,7 @@
            {% for lang in include.material.translations.tutorial %}
             <li class="dropdown-item">
             <a class="dropdown-item" hreflang="{{ lang }}" href="{{ site.baseurl }}/topics/{{ include.material.topic_name }}/tutorials/{{ include.material.tutorial_name }}/tutorial_{{lang | upcase }}.html" title="{{ lang }}">
-                {{language[lang]}}
+                {{ site.other_languages[lang] }}
             </a>
             </li>
         {% endfor %}

--- a/_includes/resource-slides.html
+++ b/_includes/resource-slides.html
@@ -18,7 +18,7 @@
            {% for lang in include.material.translations.slides %}
 		   <li class="dropdown-item">
             <a class="dropdown-item" hreflang="{{ lang }}" href="{{ site.baseurl }}/topics/{{ include.material.topic_name }}/{{subfolder}}/{{ include.material.tutorial_name }}/slides_{{lang | upcase }}.html" title="{{ lang }}">
-                {{language[lang]}}
+                {{ site.other_languages[lang] }}
             </a>
 			</li>
            {% endfor %}


### PR DESCRIPTION
On GTN，when checking the **Curated translations** of Slides and Hands-on，will see blank content, like this:

<img width="1159" alt="image" src="https://github.com/galaxyproject/training-material/assets/7628861/6f626aab-bbce-4509-b27d-a287811c1c25">

this pull request fixes the bugs.

