### PR TITLE
Fixed a "import with link" snippet that was using the wrong format

### DIFF
--- a/topics/assembly/tutorials/vgp_genome_assembly/tutorial.md
+++ b/topics/assembly/tutorials/vgp_genome_assembly/tutorial.md
@@ -1332,7 +1332,6 @@ Before we begin, we need to upload BioNano data:
 >**Step 2**: Upload datasets into Galaxy
 >    - set the datatype to `cmap`
 >
->The box below explains how to upload data if you forgot. Just make sure you set dataset type to `cmap`.
 >
 > {% snippet faqs/galaxy/datasets_import_via_link.md format="cmap" %}
 >

--- a/topics/assembly/tutorials/vgp_genome_assembly/tutorial.md
+++ b/topics/assembly/tutorials/vgp_genome_assembly/tutorial.md
@@ -1334,7 +1334,7 @@ Before we begin, we need to upload BioNano data:
 >
 >The box below explains how to upload data if you forgot. Just make sure you set dataset type to `cmap`.
 >
-> {% snippet faqs/galaxy/datasets_import_via_link.md format="fasta" %}
+> {% snippet faqs/galaxy/datasets_import_via_link.md format="cmap" %}
 >
 {: .hands_on}
 


### PR DESCRIPTION
The snippet was pointing to fasta instead of cmap. 
Also removed the line "in case you forgot" above it since we don't use similar ones for the other snippets.  