### PR TITLE
Simplify requirements display, fix duplicated hands-on

### DIFF
--- a/_includes/display_extra_training.md
+++ b/_includes/display_extra_training.md
@@ -1,37 +1,42 @@
 {% for training in include.extra_trainings %}
-    <li>
     {% if training.type == "internal" %}
         {% assign extra_topic_metadata = site.data[training.topic_name] %}
         {% assign extra_topic = site | topic_filter:training.topic_name %}
-        <a href="{{ site.baseurl }}/topics/{{ training.topic_name }}">{{ extra_topic_metadata.title }}</a>
-        {% if training.tutorials %}
-            <ul>
-                {% for extra_tuto in training.tutorials %}
-                    {% for topic_tuto in extra_topic %}
-                        {% if extra_tuto == topic_tuto.tutorial_name %}
-                            {% assign sep = "" %}
-                            <li> {{ topic_tuto.title }}:
-                            {% if topic_tuto.slides %}
-                                <a href="{{ site.baseurl }}/topics/{{ training.topic_name }}/tutorials/{{ topic_tuto.tutorial_name }}/slides.html">{% icon slides %} slides</a>
-                                {% assign sep = "-" %}
-                            {% endif %}
-                            {% if topic_tuto.hands_on %}
-                                {% if topic_tuto.hands_on_url %}
-                                    {{ sep }} <a href="{{ topic_tuto.hands_on_url }}">{% icon tutorial %} hands-on</a>
-                                {% else %}
-                                    {{ sep }} <a href="{{ site.baseurl }}/topics/{{ training.topic_name }}/tutorials/{{ topic_tuto.tutorial_name }}/tutorial.html">{% icon tutorial %} hands-on</a>
-                                {% endif %}
-                            {% endif %}
+        {% unless training.tutorials %}
+        <li>
+          <a href="{{ site.baseurl }}/topics/{{ training.topic_name }}">{{ extra_topic_metadata.title }}</a>
+        </li>
+        {% else training.tutorials %}
+            {% for extra_tuto in training.tutorials %}
+                {% for topic_tuto in extra_topic %}
+                    {% if extra_tuto == topic_tuto.tutorial_name %}
+                        {% if topic_tuto.slides %}
+                            <li>
+                              <a href="{{ site.baseurl }}/topics/{{ training.topic_name }}/tutorials/{{ topic_tuto.tutorial_name }}/slides.html">{% icon slides %} Slides: {{ topic_tuto.title }}</a>
                             </li>
                         {% endif %}
-                    {% endfor %}
+                        {% if topic_tuto.hands_on %}
+                            {% if topic_tuto.hands_on_url %}
+                                <li>
+                                  <a href="{{ topic_tuto.hands_on_url }}">{% icon tutorial %} Hands-on: {{ topic_tuto.title }}</a>
+                                </li>
+                            {% else %}
+                                <li>
+                                  <a href="{{ site.baseurl }}/topics/{{ training.topic_name }}/tutorials/{{ topic_tuto.tutorial_name }}/tutorial.html">{% icon tutorial %} Hands-on: {{ topic_tuto.title }}</a>
+                                </li>
+                            {% endif %}
+                        {% endif %}
+                    {% endif %}
                 {% endfor %}
-            </ul>
-        {% endif %}
+            {% endfor %}
+        {% endunless %}
     {% elsif training.type == "none" %}
+      <li>
         {{ training.title }}
+      </li>
     {% else %}
+      <li>
         <a href="{{ training.link }}">{{ training.title }}</a>
+      </li>
     {% endif %}
-    </li>
 {% endfor %}

--- a/_plugins/gtn.rb
+++ b/_plugins/gtn.rb
@@ -668,7 +668,7 @@ module Jekyll
 
       if site.data.key?(topic_id)
         if site.data[topic_id].is_a?(Hash) && site.data[topic_id].key?('title')
-          og_title = [site.data[topic_id]['title']]
+          og_title = [site.data[topic_id]['title'].clone]
         else
           Jekyll.logger.warn "Missing title for #{topic_id}"
         end
@@ -701,9 +701,9 @@ module Jekyll
       when 'learning-pathway'
         og_title.push "Learning Pathway: #{page['title']}"
       when 'tutorial_hands_on'
-        og_title[-1]&.prepend 'Hands-on: '
+        og_title.push "Hands-on: #{page['title']}"
       when /slides/
-        og_title[-1]&.prepend 'Slide Deck: '
+        og_title.push "Slides: #{page['title']}"
       else
         og_title.push page['title']
       end

--- a/_plugins/search.rb
+++ b/_plugins/search.rb
@@ -18,6 +18,10 @@ module Jekyll
     end
 
     def render(context)
+      if Jekyll.env != 'production'
+        Jekyll.logger.info '[GTN/Search] Skipping search generation in development'
+        return
+      end
       Jekyll.logger.info '[GTN/Search]'
 
       site = context.registers[:site]


### PR DESCRIPTION
xref #4956 

Screenshot | Comments
--- | ---
![Screenshot 2024-05-29 at 10-39-35 Galaxy Server administration _ Hands-on Galaxy Installation with Ansible](https://github.com/galaxyproject/training-material/assets/458683/889ec7ba-1368-4094-8b5b-85d9d8abdf5d) | The current display. Users probably do *not* need to go to the topic, they're being directed to a specific tutorial, the topic link is a bit of a red herring. There is not much 'paint' for the small buttons. Are both materials mandatory? Unknown!
![Screenshot 2024-05-29 at 10-39-30 Single Cell _ Inferring single cell trajectories (Monocle3) _ Hands-on Inferring single cell trajectories (Monocle3)](https://github.com/galaxyproject/training-material/assets/458683/10de7cc4-19a4-43b4-8ed9-1f5ad95408d7) | New display, every material listed sequentially. Considered prefixing all with "Single Cell / ..." but this was very redundant and not interesting or useful I think?
![Screenshot 2024-05-29 at 10-39-26 Galaxy Server administration _ Galaxy Installation with Ansible _ Hands-on Galaxy Installation with Ansible](https://github.com/galaxyproject/training-material/assets/458683/fcf82fd5-5170-4180-8c2d-1581decd332b) | Now slides + hands on are listed sequentially showing that you should follow these in this order.
![Screenshot 2024-05-29 at 10-39-20 Statistics and machine learning _ Deep Learning (Part 2) - Recurrent neural networks (RNN) _ Hands-on Deep Learning (Part 2) - Recurrent neural networks (RNN)](https://github.com/galaxyproject/training-material/assets/458683/fda0e13c-2392-43b6-a5c3-fd337133f71a) | makes me think we need a topic icon.
