### PR TITLE
Update actions

### DIFF
--- a/.github/workflows/ci-main.yml
+++ b/.github/workflows/ci-main.yml
@@ -20,7 +20,7 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 1
 

--- a/.github/workflows/ci-main.yml
+++ b/.github/workflows/ci-main.yml
@@ -29,9 +29,9 @@ jobs:
           reviewdog_version: latest
 
       # BEGIN Dependencies
-      - uses: actions/setup-python@v2
+      - uses: actions/setup-python@v5
         with:
-          python-version: '3.7'
+          python-version: '3.11'
           architecture: 'x64'
       - uses: ruby/setup-ruby@v1
         with:

--- a/.github/workflows/ci-main.yml
+++ b/.github/workflows/ci-main.yml
@@ -35,7 +35,7 @@ jobs:
           architecture: 'x64'
       - uses: ruby/setup-ruby@v1
         with:
-          ruby-version: "3.0"
+          ruby-version: "3.2"
       - uses: actions/cache@v2
         with:
           path: |

--- a/.github/workflows/ci-main.yml
+++ b/.github/workflows/ci-main.yml
@@ -36,7 +36,7 @@ jobs:
       - uses: ruby/setup-ruby@v1
         with:
           ruby-version: "3.2"
-      - uses: actions/cache@v2
+      - uses: actions/cache@v4
         with:
           path: |
             vendor/bundle

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,9 +30,9 @@ jobs:
           fetch-depth: 1
 
       # BEGIN Dependencies
-      - uses: actions/setup-python@v2
+      - uses: actions/setup-python@v5
         with:
-          python-version: '3.7'
+          python-version: '3.11'
           architecture: 'x64'
       - uses: ruby/setup-ruby@v1
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,7 +40,7 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: '19'
-      - uses: actions/cache@v2
+      - uses: actions/cache@v4
         with:
           path: |
             vendor/bundle

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,7 +36,7 @@ jobs:
           architecture: 'x64'
       - uses: ruby/setup-ruby@v1
         with:
-          ruby-version: "3.0"
+          ruby-version: "3.2"
       - uses: actions/setup-node@v2
         with:
           node-version: '19'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,7 @@ jobs:
     runs-on: ubuntu-latest
     if: github.event_name != 'pull_request' || !github.event.pull_request.draft
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 1
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,7 +37,7 @@ jobs:
       - uses: ruby/setup-ruby@v1
         with:
           ruby-version: "3.2"
-      - uses: actions/setup-node@v2
+      - uses: actions/setup-node@v4
         with:
           node-version: '19'
       - uses: actions/cache@v2

--- a/.github/workflows/cron-commit-cache.yml
+++ b/.github/workflows/cron-commit-cache.yml
@@ -12,7 +12,7 @@ jobs:
       (github.event_name != 'pull_request' ||
        github.event.pull_request.head.repo.full_name == github.repository)
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 1000
 

--- a/.github/workflows/cron-commit-cache.yml
+++ b/.github/workflows/cron-commit-cache.yml
@@ -50,7 +50,7 @@ jobs:
           bundle exec ruby bin/commit-cache-update.rb
 
       - name: Update geocoding of events
-        id: generate
+        id: geocode
         run: |
           bundle exec ruby bin/geocode.rb
 

--- a/.github/workflows/cron-commit-cache.yml
+++ b/.github/workflows/cron-commit-cache.yml
@@ -20,7 +20,7 @@ jobs:
       - uses: ruby/setup-ruby@v1
         with:
           ruby-version: "3.2"
-      - uses: actions/cache@v2
+      - uses: actions/cache@v4
         with:
           path: |
             vendor/bundle

--- a/.github/workflows/cron-commit-cache.yml
+++ b/.github/workflows/cron-commit-cache.yml
@@ -19,7 +19,7 @@ jobs:
       # BEGIN Dependencies
       - uses: ruby/setup-ruby@v1
         with:
-          ruby-version: "3.0"
+          ruby-version: "3.2"
       - uses: actions/cache@v2
         with:
           path: |

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     if: github.repository_owner == 'galaxyproject'
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
         with:
           # Avg commits between successive monday:
           #  Min.   :  2.0

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -36,7 +36,7 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: '19'
-      - uses: actions/cache@v2
+      - uses: actions/cache@v4
         with:
           path: |
             vendor/bundle

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -26,9 +26,9 @@ jobs:
           fetch-depth: 400
 
       # BEGIN Dependencies
-      - uses: actions/setup-python@v2
+      - uses: actions/setup-python@v5
         with:
-          python-version: '3.7'
+          python-version: '3.11'
           architecture: 'x64'
       - uses: ruby/setup-ruby@v1
         with:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -33,7 +33,7 @@ jobs:
       - uses: ruby/setup-ruby@v1
         with:
           ruby-version: "3.2"
-      - uses: actions/setup-node@v2
+      - uses: actions/setup-node@v4
         with:
           node-version: '19'
       - uses: actions/cache@v2

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -32,7 +32,7 @@ jobs:
           architecture: 'x64'
       - uses: ruby/setup-ruby@v1
         with:
-          ruby-version: "3.0"
+          ruby-version: "3.2"
       - uses: actions/setup-node@v2
         with:
           node-version: '19'

--- a/.github/workflows/docker-build.yaml
+++ b/.github/workflows/docker-build.yaml
@@ -7,7 +7,7 @@ jobs:
   admin-docker:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: Build and push to Docker Hub
       uses: docker/build-push-action@v1
       with:
@@ -20,7 +20,7 @@ jobs:
   assembly-docker:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: Build and push to Docker Hub
       uses: docker/build-push-action@v1
       with:
@@ -33,7 +33,7 @@ jobs:
   climate-docker:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: Build and push to Docker Hub
       uses: docker/build-push-action@v1
       with:
@@ -46,7 +46,7 @@ jobs:
   computational-chemistry-docker:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: Build and push to Docker Hub
       uses: docker/build-push-action@v1
       with:
@@ -59,7 +59,7 @@ jobs:
   contributing-docker:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: Build and push to Docker Hub
       uses: docker/build-push-action@v1
       with:
@@ -72,7 +72,7 @@ jobs:
   dev-docker:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: Build and push to Docker Hub
       uses: docker/build-push-action@v1
       with:
@@ -85,7 +85,7 @@ jobs:
   ecology-docker:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: Build and push to Docker Hub
       uses: docker/build-push-action@v1
       with:
@@ -98,7 +98,7 @@ jobs:
   epigenetics-docker:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: Build and push to Docker Hub
       uses: docker/build-push-action@v1
       with:
@@ -111,7 +111,7 @@ jobs:
   genome-annotation-docker:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: Build and push to Docker Hub
       uses: docker/build-push-action@v1
       with:
@@ -124,7 +124,7 @@ jobs:
   imaging-docker:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: Build and push to Docker Hub
       uses: docker/build-push-action@v1
       with:
@@ -137,7 +137,7 @@ jobs:
   introduction-docker:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: Build and push to Docker Hub
       uses: docker/build-push-action@v1
       with:
@@ -150,7 +150,7 @@ jobs:
   materials-science-docker:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: Build and push to Docker Hub
       uses: docker/build-push-action@v1
       with:
@@ -163,7 +163,7 @@ jobs:
   metabolomics-docker:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: Build and push to Docker Hub
       uses: docker/build-push-action@v1
       with:
@@ -176,7 +176,7 @@ jobs:
   # metagenomics-docker:
   #   runs-on: ubuntu-latest
   #   steps:
-  #   - uses: actions/checkout@v2
+  #   - uses: actions/checkout@v4
   #   - name: Build and push to Docker Hub
   #     uses: docker/build-push-action@v1
   #     with:
@@ -189,7 +189,7 @@ jobs:
   # proteomics-docker:
   #   runs-on: ubuntu-latest
   #   steps:
-  #   - uses: actions/checkout@v2
+  #   - uses: actions/checkout@v4
   #   - name: Build and push to Docker Hub
   #     uses: docker/build-push-action@v1
   #     with:
@@ -202,7 +202,7 @@ jobs:
   sequence-analysis-docker:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: Build and push to Docker Hub
       uses: docker/build-push-action@v1
       with:
@@ -215,7 +215,7 @@ jobs:
   statistics-docker:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: Build and push to Docker Hub
       uses: docker/build-push-action@v1
       with:
@@ -228,7 +228,7 @@ jobs:
   # transcriptomics-docker:
   #   runs-on: ubuntu-latest
   #   steps:
-  #   - uses: actions/checkout@v2
+  #   - uses: actions/checkout@v4
   #   - name: Build and push to Docker Hub
   #     uses: docker/build-push-action@v1
   #     with:
@@ -241,7 +241,7 @@ jobs:
   # variant-analysis-docker:
   #   runs-on: ubuntu-latest
   #   steps:
-  #   - uses: actions/checkout@v2
+  #   - uses: actions/checkout@v4
   #   - name: Build and push to Docker Hub
   #     uses: docker/build-push-action@v1
   #     with:

--- a/.github/workflows/git-gat.yml
+++ b/.github/workflows/git-gat.yml
@@ -17,7 +17,7 @@ jobs:
   run:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 1
       - uses: actions/setup-python@v2

--- a/.github/workflows/git-gat.yml
+++ b/.github/workflows/git-gat.yml
@@ -20,9 +20,9 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 1
-      - uses: actions/setup-python@v2
+      - uses: actions/setup-python@v5
         with:
-          python-version: '3.7'
+          python-version: '3.11'
           architecture: 'x64'
 
       - name: Export commits

--- a/.github/workflows/google-form.yml
+++ b/.github/workflows/google-form.yml
@@ -12,7 +12,7 @@ jobs:
       (github.event_name != 'pull_request' ||
        github.event.pull_request.head.repo.full_name == github.repository)
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 1
 

--- a/.github/workflows/google-form.yml
+++ b/.github/workflows/google-form.yml
@@ -20,7 +20,7 @@ jobs:
       - uses: ruby/setup-ruby@v1
         with:
           ruby-version: "3.2"
-      - uses: actions/cache@v2
+      - uses: actions/cache@v4
         with:
           path: |
             vendor/bundle

--- a/.github/workflows/google-form.yml
+++ b/.github/workflows/google-form.yml
@@ -19,7 +19,7 @@ jobs:
       # BEGIN Dependencies
       - uses: ruby/setup-ruby@v1
         with:
-          ruby-version: "3.0"
+          ruby-version: "3.2"
       - uses: actions/cache@v2
         with:
           path: |

--- a/.github/workflows/matrix.yml
+++ b/.github/workflows/matrix.yml
@@ -20,7 +20,7 @@ jobs:
       # BEGIN Dependencies
       - uses: ruby/setup-ruby@v1
         with:
-          ruby-version: "3.0"
+          ruby-version: "3.2"
       - uses: actions/cache@v2
         with:
           path: |

--- a/.github/workflows/matrix.yml
+++ b/.github/workflows/matrix.yml
@@ -21,7 +21,7 @@ jobs:
       - uses: ruby/setup-ruby@v1
         with:
           ruby-version: "3.2"
-      - uses: actions/cache@v2
+      - uses: actions/cache@v4
         with:
           path: |
             vendor/bundle

--- a/.github/workflows/matrix.yml
+++ b/.github/workflows/matrix.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 200
 

--- a/.github/workflows/monthly-release-backfill.yml
+++ b/.github/workflows/monthly-release-backfill.yml
@@ -29,7 +29,7 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: '19'
-      - uses: actions/cache@v2
+      - uses: actions/cache@v4
         with:
           path: |
             vendor/bundle

--- a/.github/workflows/monthly-release-backfill.yml
+++ b/.github/workflows/monthly-release-backfill.yml
@@ -25,7 +25,7 @@ jobs:
           architecture: 'x64'
       - uses: ruby/setup-ruby@v1
         with:
-          ruby-version: "3.0"
+          ruby-version: "3.2"
       - uses: actions/setup-node@v2
         with:
           node-version: '19'

--- a/.github/workflows/monthly-release-backfill.yml
+++ b/.github/workflows/monthly-release-backfill.yml
@@ -13,7 +13,7 @@ jobs:
     if: github.repository_owner == 'galaxyproject'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
         with:
           ref: "${{ github.event.inputs.selected_tag }}"
           fetch-depth: 0

--- a/.github/workflows/monthly-release-backfill.yml
+++ b/.github/workflows/monthly-release-backfill.yml
@@ -19,7 +19,7 @@ jobs:
           fetch-depth: 0
 
       # BEGIN Dependencies
-      - uses: actions/setup-python@v2
+      - uses: actions/setup-python@v5
         with:
           python-version: '3.11'
           architecture: 'x64'

--- a/.github/workflows/monthly-release-backfill.yml
+++ b/.github/workflows/monthly-release-backfill.yml
@@ -26,7 +26,7 @@ jobs:
       - uses: ruby/setup-ruby@v1
         with:
           ruby-version: "3.2"
-      - uses: actions/setup-node@v2
+      - uses: actions/setup-node@v4
         with:
           node-version: '19'
       - uses: actions/cache@v2

--- a/.github/workflows/monthly-release.yml
+++ b/.github/workflows/monthly-release.yml
@@ -23,7 +23,7 @@ jobs:
           fetch-depth: 1200
 
       # BEGIN Dependencies
-      - uses: actions/setup-python@v2
+      - uses: actions/setup-python@v5
         with:
           python-version: '3.11'
           architecture: 'x64'

--- a/.github/workflows/monthly-release.yml
+++ b/.github/workflows/monthly-release.yml
@@ -17,19 +17,6 @@ jobs:
           echo "release_title=$(LC_ALL=C date '+%Y %B %d')" >> $GITHUB_ENV
           echo "release_tag=$(LC_ALL=C date -I)" >> $GITHUB_ENV
 
-      - name: Create Release
-        id: create_release
-        uses: actions/create-release@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          tag_name: ${{ env.release_tag }}
-          commitish: main
-          release_name: Release ${{ env.release_title }}
-          body: "Monthly release of the GTN materials"
-          draft: false
-          prerelease: false
-
       - uses: actions/checkout@v2
         with:
           # Based on logic in deploy.yml
@@ -101,3 +88,16 @@ jobs:
           ./bin/publish-archive
         env:
           SOURCE_TAG: ${{ env.release_tag }}
+
+      - name: Create Release
+        id: create_release
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ env.release_tag }}
+          target_commitish: main
+          release_name: Release ${{ env.release_title }}
+          body: "Monthly release of the GTN materials"
+          draft: false
+          prerelease: false
+          make_latest: true
+          token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/monthly-release.yml
+++ b/.github/workflows/monthly-release.yml
@@ -6,6 +6,9 @@ on:
     - cron:  '0 4 1 * *'
   workflow_dispatch:
 
+permissions:
+  contents: write
+
 jobs:
   setup:
     if: github.repository_owner == 'galaxyproject'

--- a/.github/workflows/monthly-release.yml
+++ b/.github/workflows/monthly-release.yml
@@ -96,7 +96,8 @@ jobs:
           tag_name: ${{ env.release_tag }}
           target_commitish: main
           release_name: Release ${{ env.release_title }}
-          body: "Monthly release of the GTN materials"
+          body: |
+            Monthly release of the GTN materials is now [available on the archive](https://training.galaxyproject.org/archive/${{ env.release_tag }}/).
           draft: false
           prerelease: false
           make_latest: true

--- a/.github/workflows/monthly-release.yml
+++ b/.github/workflows/monthly-release.yml
@@ -91,14 +91,5 @@ jobs:
 
       - name: Create Release
         id: create_release
-        uses: softprops/action-gh-release@v2
-        with:
-          tag_name: ${{ env.release_tag }}
-          target_commitish: main
-          release_name: Release ${{ env.release_title }}
-          body: |
-            Monthly release of the GTN materials is now [available on the archive](https://training.galaxyproject.org/archive/${{ env.release_tag }}/).
-          draft: false
-          prerelease: false
-          make_latest: true
-          token: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh release create ${{ env.release_tag }} --title "Release ${{ env.release_title }}" --notes "Monthly release of the GTN materials is now [available on the archive](https://training.galaxyproject.org/archive/${{ env.release_tag }}/)." --target main --latest

--- a/.github/workflows/monthly-release.yml
+++ b/.github/workflows/monthly-release.yml
@@ -30,7 +30,7 @@ jobs:
       - uses: ruby/setup-ruby@v1
         with:
           ruby-version: "3.2"
-      - uses: actions/setup-node@v2
+      - uses: actions/setup-node@v4
         with:
           node-version: '19'
       - uses: actions/cache@v2

--- a/.github/workflows/monthly-release.yml
+++ b/.github/workflows/monthly-release.yml
@@ -33,7 +33,7 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: '19'
-      - uses: actions/cache@v2
+      - uses: actions/cache@v4
         with:
           path: |
             vendor/bundle

--- a/.github/workflows/monthly-release.yml
+++ b/.github/workflows/monthly-release.yml
@@ -17,7 +17,7 @@ jobs:
           echo "release_title=$(LC_ALL=C date '+%Y %B %d')" >> $GITHUB_ENV
           echo "release_tag=$(LC_ALL=C date -I)" >> $GITHUB_ENV
 
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
         with:
           # Based on logic in deploy.yml
           fetch-depth: 1200

--- a/.github/workflows/monthly-release.yml
+++ b/.github/workflows/monthly-release.yml
@@ -67,10 +67,12 @@ jobs:
           bundle pristine ffi
       # END Dependencies
 
-      - name: Build Site
+      - name: List Tags
         run: |
           git tag -l
-          git checkout ${SOURCE_TAG}
+
+      - name: Build Site
+        run: |
           gem install bundler
           bundle config path vendor/bundle
           sed -i s"|^baseurl: .*|baseurl: '/archive/${SOURCE_TAG}'|g" _config.yml

--- a/.github/workflows/monthly-release.yml
+++ b/.github/workflows/monthly-release.yml
@@ -29,7 +29,7 @@ jobs:
           architecture: 'x64'
       - uses: ruby/setup-ruby@v1
         with:
-          ruby-version: "3.0"
+          ruby-version: "3.2"
       - uses: actions/setup-node@v2
         with:
           node-version: '19'

--- a/.github/workflows/optimize-images.yml
+++ b/.github/workflows/optimize-images.yml
@@ -21,7 +21,7 @@ jobs:
        github.event.pull_request.head.repo.full_name == github.repository)
     steps:
       - name: Checkout Branch
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       - name: Compress Images
         id: calibre
         uses: calibreapp/image-actions@main

--- a/.github/workflows/shortlinks.yaml
+++ b/.github/workflows/shortlinks.yaml
@@ -44,7 +44,7 @@ jobs:
         # If it's not a Pull Request then commit any changes as a new PR.
         if: |
           github.event_name != 'pull_request' &&
-          steps.generate.outputs.new_ids != ''
+          steps.generate.outputs.new_ids != '0'
         uses: peter-evans/create-pull-request@v3
         with:
           title: Update Persistent uniform resource locators

--- a/.github/workflows/shortlinks.yaml
+++ b/.github/workflows/shortlinks.yaml
@@ -12,7 +12,7 @@ jobs:
       (github.event_name != 'pull_request' ||
        github.event.pull_request.head.repo.full_name == github.repository)
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 10
 

--- a/.github/workflows/shortlinks.yaml
+++ b/.github/workflows/shortlinks.yaml
@@ -20,7 +20,7 @@ jobs:
       - uses: ruby/setup-ruby@v1
         with:
           ruby-version: "3.2"
-      - uses: actions/cache@v2
+      - uses: actions/cache@v4
         with:
           path: |
             vendor/bundle

--- a/.github/workflows/shortlinks.yaml
+++ b/.github/workflows/shortlinks.yaml
@@ -19,7 +19,7 @@ jobs:
       # BEGIN Dependencies
       - uses: ruby/setup-ruby@v1
         with:
-          ruby-version: "3.0"
+          ruby-version: "3.2"
       - uses: actions/cache@v2
         with:
           path: |

--- a/.github/workflows/update-libraries.yaml
+++ b/.github/workflows/update-libraries.yaml
@@ -12,7 +12,7 @@ jobs:
       (github.event_name != 'pull_request' ||
        github.event.pull_request.head.repo.full_name == github.repository)
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 1
 

--- a/.github/workflows/update-libraries.yaml
+++ b/.github/workflows/update-libraries.yaml
@@ -20,7 +20,7 @@ jobs:
       - uses: ruby/setup-ruby@v1
         with:
           ruby-version: "3.2"
-      - uses: actions/cache@v2
+      - uses: actions/cache@v4
         with:
           path: |
             vendor/bundle

--- a/.github/workflows/update-libraries.yaml
+++ b/.github/workflows/update-libraries.yaml
@@ -19,7 +19,7 @@ jobs:
       # BEGIN Dependencies
       - uses: ruby/setup-ruby@v1
         with:
-          ruby-version: "3.0"
+          ruby-version: "3.2"
       - uses: actions/cache@v2
         with:
           path: |

--- a/.github/workflows/video-dry.yml
+++ b/.github/workflows/video-dry.yml
@@ -18,7 +18,7 @@ jobs:
       #     - 5002:5002
     steps:
       # Shallow should be fine for video
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 1
 

--- a/.github/workflows/video-dry.yml
+++ b/.github/workflows/video-dry.yml
@@ -30,7 +30,7 @@ jobs:
       - uses: ruby/setup-ruby@v1
         with:
           ruby-version: "3.2"
-      - uses: actions/setup-node@v2
+      - uses: actions/setup-node@v4
         with:
           node-version: '19'
       - uses: actions/cache@v2

--- a/.github/workflows/video-dry.yml
+++ b/.github/workflows/video-dry.yml
@@ -33,7 +33,7 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: '19'
-      - uses: actions/cache@v2
+      - uses: actions/cache@v4
         with:
           path: |
             vendor/bundle

--- a/.github/workflows/video-dry.yml
+++ b/.github/workflows/video-dry.yml
@@ -29,7 +29,7 @@ jobs:
           architecture: 'x64'
       - uses: ruby/setup-ruby@v1
         with:
-          ruby-version: "3.0"
+          ruby-version: "3.2"
       - uses: actions/setup-node@v2
         with:
           node-version: '19'

--- a/.github/workflows/video-dry.yml
+++ b/.github/workflows/video-dry.yml
@@ -23,9 +23,9 @@ jobs:
           fetch-depth: 1
 
       # BEGIN Dependencies
-      - uses: actions/setup-python@v2
+      - uses: actions/setup-python@v5
         with:
-          python-version: '3.7'
+          python-version: '3.11'
           architecture: 'x64'
       - uses: ruby/setup-ruby@v1
         with:

--- a/.github/workflows/video.yml
+++ b/.github/workflows/video.yml
@@ -34,7 +34,7 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: '19'
-      - uses: actions/cache@v2
+      - uses: actions/cache@v4
         with:
           path: |
             vendor/bundle

--- a/.github/workflows/video.yml
+++ b/.github/workflows/video.yml
@@ -30,7 +30,7 @@ jobs:
           architecture: 'x64'
       - uses: ruby/setup-ruby@v1
         with:
-          ruby-version: "3.0"
+          ruby-version: "3.2"
       - uses: actions/setup-node@v2
         with:
           node-version: '19'

--- a/.github/workflows/video.yml
+++ b/.github/workflows/video.yml
@@ -31,7 +31,7 @@ jobs:
       - uses: ruby/setup-ruby@v1
         with:
           ruby-version: "3.2"
-      - uses: actions/setup-node@v2
+      - uses: actions/setup-node@v4
         with:
           node-version: '19'
       - uses: actions/cache@v2

--- a/.github/workflows/video.yml
+++ b/.github/workflows/video.yml
@@ -24,9 +24,9 @@ jobs:
           fetch-depth: 5000
 
       # BEGIN Dependencies
-      - uses: actions/setup-python@v2
+      - uses: actions/setup-python@v5
         with:
-          python-version: '3.7'
+          python-version: '3.11'
           architecture: 'x64'
       - uses: ruby/setup-ruby@v1
         with:

--- a/.github/workflows/video.yml
+++ b/.github/workflows/video.yml
@@ -19,7 +19,7 @@ jobs:
           - 5002:5002
     steps:
       # Shallow should be fine for video
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 5000
 

--- a/bin/news.rb
+++ b/bin/news.rb
@@ -101,6 +101,7 @@ def fixEvents(n)
   # news/_posts/2021-11-10-api.html => news/2021/11/10/api.html
   meta = safe_load_yaml(n[:path])
   n[:md] += " (#{collapse_event_date_pretty(meta)})"
+  n
 end
 
 def isDraft(n)
@@ -125,6 +126,7 @@ data = {
     events: addedfiles
        .grep(%r{events/.*\.md})
        .reject { |n| isDraft(n) }
+       .reject { |n| n =~ /index.md/ }
        .map { |x| printableMaterial(x) }
        .map { |n| fixEvents(n) },
   },
@@ -201,7 +203,7 @@ def build_news(data, filter: nil, updates: true, only_news: false)
   end
 
   o = format_events(
-    data[:added][:events].select { |n| filter.nil? || safe_load_yaml(n[:path])['tags'].include?(filter) }
+    data[:added][:events].select { |n| filter.nil? || safe_load_yaml(n[:path]).fetch('tags',[]).include?(filter) }
   )
   output += o
   newsworthy |= o.length.positive?


### PR DESCRIPTION
> Node.js 16 actions are deprecated. Please update the following actions to use Node.js 20: actions/create-release@v1, actions/checkout@v2, actions/setup-python@v2, actions/setup-node@v2, actions/cache@v2. For more information see: https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/.
