### PR TITLE
maintainer home page

### DIFF
--- a/_layouts/topic-maintainer.html
+++ b/_layouts/topic-maintainer.html
@@ -1,0 +1,99 @@
+---
+layout: base
+---
+
+{% assign topic = site.data[page.topic_name] | default: page.topic %}
+{% assign topic_material = site | list_materials_structured:topic.name %}
+
+<h1>{{ topic.title }} Editorial Board Home</h1>
+
+This is a new, experimental "Editorial Board Home" for a given topic. It is intended to provide a single place for maintainers and editorial board members to find out key information about their topic and identify action items.
+
+<h2>Editorial Board</h2>
+
+{% assign editorial_board_count = topic.editorial_board | size %}
+
+{% if topic.editorial_board %}
+{% assign editorial_board = topic.editorial_board | shuffle %}
+{% include _includes/contributor-list.html contributors=editorial_board badge=true %}
+{% endif %}
+
+<h2>Action Items</h2>
+
+{% assign funders_list_sorted = topic_material | identify_funders: site %}
+{% assign funders_count  = funders_list_sorted | size %}
+
+<table class="table">
+	<thead>
+		<tr>
+			<th>Item</th>
+			<th>Description</th>
+			<th>Status</th>
+		</tr>
+	</thead>
+	<tbody>
+		<tr>
+			<td>Summary</td>
+			<td>Provide a sufficiently detailed summary of the topic.</td>
+			<td>{% if topic.summary %} Done ✅ {% else %} Pending ❌ {% endif %}</td>
+		</tr>
+		<tr>
+			<td>Sufficient Editorial Board Members</td>
+			<td>Having multiple people sharing the burden of being responsible for a specific topic can reduce board member burn-out in the long term.</td>
+			<td>{% if editorial_board_count > 2 %} Done ✅ ({{ editorial_board_count }} members){% else %} More required ❌ {% endif %}</td>
+		</tr>
+		<tr>
+			<td>Enable Subtopics</td>
+			<td>Subtopics help organize the content and make it easier to navigate.</td>
+			<td>{% if topic.subtopics %} Done ✅ {% else %} Pending ❌ {% endif %}</td>
+		</tr>
+		<tr>
+			<td>Annotate Funders</td>
+			<td>By annotating the funders of your topic's materials, you make it easier to write your grant reports later</td>
+			<td>{% if funders_count > 0 %} Done ✅ ({{ funders_count }} funders){% else %} Pending ❌ {% endif %}</td>
+		</tr>
+		<tr>
+			<td>Learning Pathway CTA</td>
+			<td>By providing a Learning Pathway CTA, we can help guide learners to the best resources for learning about this topic.</td>
+			<td>{% if topic.learning_path_cta %} Done ✅ {% else %} Pending ❌ {% endif %}</td>
+		</tr>
+	</tbody>
+</table>
+
+<h2>Your topic's Workflow Testing Results</h2>
+
+Coming Soon™
+
+<h2>Learning Pathways using materials from this Topic</h2>
+
+{% assign learning_pathways = site | find_learningpaths_including_topic: topic.name %}
+{% assign stats_extra_filters = "" | split: ',' %}
+
+<div class="pathwaylist row">
+{% if learning_pathways %}
+  {% for path in learning_pathways %}
+    {% include _includes/pathway-card.html path=path %}
+    {% assign stat_filter = path.path | replace: "md", "html" %}
+    {% assign stats_extra_filters = stats_extra_filters | push: stat_filter %}
+  {% endfor %}
+{% endif %}
+</div>
+
+<details>
+	<summary>Statistics for your Learning Pathways</summary>
+
+	<iframe plausible-embed src="https://plausible.galaxyproject.eu/training.galaxyproject.org?page=%7E{{stats_extra_filters | join:"|"}}&embed=true&theme=system&background=transparent" scrolling="no" frameborder="0" loading="lazy" style="width: 1px; min-width: 100%; height: 1800px;"></iframe>
+	<div style="font-size: 14px; padding-bottom: 14px;">Stats powered by <a target="_blank" style="color: #4F46E5; text-decoration: underline;" href="https://plausible.io">Plausible Analytics</a></div>
+	<script async src="https://plausible.galaxyproject.eu/js/embed.host.js"></script>
+</details>
+
+<h2>Events using materials from this Topic</h2>
+
+TODO once this is merged:
+https://github.com/galaxyproject/training-material/pull/4963
+
+<h2>Statistics For Your Materials</h2>
+
+<iframe plausible-embed src="https://plausible.galaxyproject.eu/training.galaxyproject.org?page=%7E%2Ftopics%2F{{ topic.name }}%2F&embed=true&theme=system&background=transparent" scrolling="no" frameborder="0" loading="lazy" style="width: 1px; min-width: 100%; height: 1800px;"></iframe>
+<div style="font-size: 14px; padding-bottom: 14px;">Stats powered by <a target="_blank" style="color: #4F46E5; text-decoration: underline;" href="https://plausible.io">Plausible Analytics</a></div>
+<script async src="https://plausible.galaxyproject.eu/js/embed.host.js"></script>

--- a/_plugins/gtn.rb
+++ b/_plugins/gtn.rb
@@ -739,6 +739,30 @@ module Jekyll
     def group_icons(icons)
       icons.group_by { |_k, v| v }.transform_values { |v| v.map { |z| z[0] } }.invert
     end
+
+    def materials_for_pathway(page)
+      if page.is_a?(Jekyll::Page)
+        d = page.data.fetch('pathway', [])
+      else
+        d = page.fetch('pathway', [])
+      end
+
+      d.map do |m|
+        m.fetch('tutorials', [])
+          .select { |t| t.has_key?('name') && t.has_key?('topic') }
+          .map {|t| [t['topic'], t['name']] }
+      end.flatten.compact.sort.uniq
+    end
+
+    def find_learningpaths_including_topic(site, topic_id)
+      site.pages
+        .select{|p| p['layout'] == 'learning-pathway'}
+        .select do |p|
+          materials_for_pathway(p)
+            .map{|topic, _tutorial| topic}
+            .include?(topic_id)
+        end
+    end
     # rubocop:enable Naming/PredicateName
   end
 end

--- a/topics/single-cell/maintainer.md
+++ b/topics/single-cell/maintainer.md
@@ -1,0 +1,5 @@
+---
+layout: topic-maintainer
+topic_name: single-cell
+---
+


### PR DESCRIPTION
for @nomadscientist who wants all of the information she needs as a topic editor to be in one easy-to-find place.

works now:

- only for single cell (waiting feedback from @nomadscientist before scaling up)
- basic checklist of topic maintenance tasks (summary, enough editorial board members, various metadata you might want to annotate)
- statistics for all pages in that topic
- stats for all learning pathways that include materials from that topic.

will use it for someday

- workflow testing results across a topic.
- your idea here.

![Screenshot 2024-06-03 at 12-55-36 Single Cell](https://github.com/galaxyproject/training-material/assets/458683/484ddf43-8e14-4a63-a911-ea0ee99b94ea)
