### PR TITLE
ensure contribs/orgs/funders are linted

### DIFF
--- a/.github/workflows/ci-main.yml
+++ b/.github/workflows/ci-main.yml
@@ -15,6 +15,11 @@ on:
       - 'learning-pathways/*'
       - 'faqs/**'
       - 'news/**'
+      - 'events/**'
+      - CONTRIBUTORS.yaml
+      - FUNDERS.yaml
+      - ORGANISATIONS.yaml
+
 
 jobs:
   lint:

--- a/CONTRIBUTORS.yaml
+++ b/CONTRIBUTORS.yaml
@@ -125,7 +125,6 @@ andreacabibbe:
     affiliations:
     - irccs
     github: false
-    photo: Andrea_Cabibbe.jpg
     joined: 2024-06
 
 andreasrichter:


### PR DESCRIPTION
since the change got missed in #4980 and has a key that's causing other PRs to fail.