### PR TITLE
updating tutorial with new bam file

### DIFF
--- a/topics/genome-annotation/tutorials/lncrna/data-library.yaml
+++ b/topics/genome-annotation/tutorials/lncrna/data-library.yaml
@@ -10,18 +10,18 @@ items:
   items:
   - name: Long non-coding RNAs (lncRNAs) annotation with FEELnc
     items:
-    - name: 'DOI: 10.5281/zenodo.7107050'
+    - name: 'DOI: 10.5281/zenodo.11367439'
       description: latest
       items:
-      - url: https://zenodo.org/api/files/0f8d27c5-8c8d-4379-90c4-c3cd950de391/genome_assembly.fasta
+      - url: https://zenodo.org/api/records/11367439/files/genome_assembly.fasta/content
         src: url
         ext: fasta
-        info: https://zenodo.org/record/7107050
-      - url: https://zenodo.org/api/files/0f8d27c5-8c8d-4379-90c4-c3cd950de391/genome_annotation.gff3
+        info: https://zenodo.org/record/11367439
+      - url: https://zenodo.org/api/records/11367439/files/genome_annotation.gff3/content
         src: url
         ext: gff3
-        info: https://zenodo.org/record/7107050
-      - url: https://zenodo.org/api/files/0f8d27c5-8c8d-4379-90c4-c3cd950de391/all_RNA_mapped.bam
+        info: https://zenodo.org/record/11367439
+      - url: https://zenodo.org/api/records/11367439/files/SRR8534859_RNASeq_mapped.bam/content
         src: url
         ext: bam
-        info: https://zenodo.org/record/7107050
+        info: https://zenodo.org/record/11367439

--- a/topics/genome-annotation/tutorials/lncrna/tutorial.md
+++ b/topics/genome-annotation/tutorials/lncrna/tutorial.md
@@ -2,7 +2,7 @@
 layout: tutorial_hands_on
 
 title: Long non-coding RNAs (lncRNAs) annotation with FEELnc
-zenodo_link: https://zenodo.org/record/7107050
+zenodo_link: https://zenodo.org/records/11367439
 tags:
   - eukaryote
 questions:
@@ -89,9 +89,9 @@ To assemble transcriptome with StringTie and annotate {lncRNAs} with FEELnc, we 
 >     -> `{{ page.title }}`):
 >
 >    ```
->    https://zenodo.org/record/7107050/files/genome_assembly.fasta
->    https://zenodo.org/record/7107050/files/genome_annotation.gff3
->    https://zenodo.org/record/7107050/files/all_RNA_mapped.bam
+>    https://zenodo.org/records/11367439/files/genome_assembly.fasta
+>    https://zenodo.org/records/11367439/files/genome_annotation.gff3
+>    https://zenodo.org/records/11367439/files/SRR8534859_RNASeq_mapped.bam
 >    ```
 >
 >    {% snippet faqs/galaxy/datasets_import_via_link.md %}
@@ -111,7 +111,7 @@ A reference annotation file in GTF or GFF3 format can be provided to StringTie w
 >
 > {% tool [StringTie](toolshed.g2.bx.psu.edu/repos/iuc/stringtie/stringtie/2.1.7+galaxy1) %} with the following parameters:
 >    - *"Input options"*: `Short reads`
->    - {% icon param-file %} *"Input short mapped reads"*: `all_RNA_mapped.bam`
+>    - {% icon param-file %} *"Input short mapped reads"*: `SRR8534859_RNASeq_mapped.bam`
 >    - *"Specify strand information"*: Unstranded
 >    - *"Use a reference file to guide assembly?"*: Use reference GTF/GFF3
 >    - *"Reference file"*: Use a file from history
@@ -172,11 +172,11 @@ FEELnc provides also summary file in stdout.
 >
 > > <solution-title></solution-title>
 > >
-> > The summary file indicates 104 {lncRNAs} and 0 new {mRNAs} were annotated by FEELnc. The initial annotation contains 13,795 {mRNAs} annotated. Therefore, a total of 13,898 RNAs are currently annotated.
+> > The summary file indicates 268 {lncRNAs} and 0 new {mRNAs} were annotated by FEELnc. The initial annotation contains 13,795 {mRNAs} annotated. Therefore, a total of 14,063 RNAs are currently annotated.
 > >
-> > The summary file indicates 652 interactions between {lncRNAs} and {mRNAs}. These interactions are described in the Classifier output file.
+> > The summary file indicates 772 interactions between {lncRNAs} and {mRNAs}. These interactions are described in the Classifier output file.
 > >
-> > The different types of {lncRNAs} (intergenic (sense and antisense), intragenic (sense)) are described in the Classifier output file. We observe that the majority of the {lncRNAs} are intergenic. These {lncRNAs} can each have interactions with several {mRNAs}. Only 7 {lncRNAs} are genic. These {lncRNAs} have only one interaction with the mRNA that contains it.
+> > The different types of {lncRNAs} (intergenic (sense and antisense), intragenic (sense)) are described in the Classifier output file. We observe that the majority of the {lncRNAs} are intergenic. These {lncRNAs} can each have interactions with several {mRNAs}. Only 5 {lncRNAs} are genic. These {lncRNAs} have only one interaction with the mRNA that contains it.
 > >
 > {: .solution}
 >


### PR DESCRIPTION
Changes for "Long non-coding RNAs (lncRNAs) annotation with FEELnc)" tutorial :

- The input dataset all_RNA_mapped.bam was replaced by SRR8534859_RNASeq_mapped.bam

- This dataset was added in a new version (v2) of the data repository Zenodo :
https://zenodo.org/records/11367439

- Solution of the last question was also corrected because new results were obtained with this new dataset

Thanks in advance for the review :-)