### PR TITLE
Add external events to eventstable on homepage

### DIFF
--- a/_layouts/home.html
+++ b/_layouts/home.html
@@ -234,7 +234,7 @@ layout: base
 
                 <div class="newstable">
                 <div class="list-group">
-                 {% assign events = site.pages |  where: "layout", "event" | where: "not_started", true %}
+                 {% assign events = site.pages |  where_exp: "item", "item.layout == 'event' or item.layout == 'event-external' " | where: "not_started", true | sort: 'date_start' %}
                  {% assign events_length = events | size %}
                  {% if events_length == 0 %}
                  <p>No known upcoming events.</p>


### PR DESCRIPTION
External events were not yet included in the events-list shown on the homepage

ping @hexylena
