### PR TITLE
Improve fallback behaviour of workflow import snippets

### DIFF
--- a/_plugins/snippet.rb
+++ b/_plugins/snippet.rb
@@ -63,10 +63,10 @@ module Jekyll
 
             # Allow overriding the title with an include parameter
             title = if !p.nil? && p['title']
-                         p['title']
-                       else
+                      p['title']
+                    else
                          metadata['title']
-                       end
+                    end
 
             if context.registers[:page]&.key?('lang')
               lang = context.registers[:page].fetch('lang', 'en')

--- a/_plugins/snippet.rb
+++ b/_plugins/snippet.rb
@@ -65,7 +65,7 @@ module Jekyll
             title = if !p.nil? && p['title']
                       p['title']
                     else
-                         metadata['title']
+                      metadata['title']
                     end
 
             if context.registers[:page]&.key?('lang')

--- a/_plugins/snippet.rb
+++ b/_plugins/snippet.rb
@@ -61,13 +61,20 @@ module Jekyll
                          metadata['box_type']
                        end
 
+            # Allow overriding the title with an include parameter
+            title = if !p.nil? && p['title']
+                         p['title']
+                       else
+                         metadata['title']
+                       end
+
             if context.registers[:page]&.key?('lang')
               lang = context.registers[:page].fetch('lang', 'en')
               lang = 'en' if lang.nil?
             end
             lang = 'en' if (lang != 'en') && (lang != 'es')
             if (box_type != 'none') && !box_type.nil?
-              _box_id, box_title = Gtn::Boxify.generate_title(box_type, metadata['title'], lang,
+              _box_id, box_title = Gtn::Boxify.generate_title(box_type, title, lang,
                                                               context.registers[:page]['path'])
               box_start = "> #{box_title}"
               box_end = "\n{: .#{box_type}}"

--- a/_plugins/snippet.rb
+++ b/_plugins/snippet.rb
@@ -62,8 +62,8 @@ module Jekyll
                        end
 
             # Allow overriding the title with an include parameter
-            title = if !p.nil? && p['title']
-                      p['title']
+            title = if !p.nil? && p['override_title']
+                      p['override_title']
                     else
                       metadata['title']
                     end

--- a/assets/css/main.scss
+++ b/assets/css/main.scss
@@ -1343,6 +1343,10 @@ body {
 		display: none;
 	}
 
+	.hide-when-galaxy-proxy-active {
+		display: unset;
+	}
+
 	span.tool, span.workflow {
 		border: 1px solid #999;
 		padding: 2px;
@@ -1358,6 +1362,7 @@ body {
 body.galaxy-proxy-active {
 	.show-when-galaxy-proxy-active {
 		cursor: pointer;
+		display: unset;
 	}
 
 	.hide-when-galaxy-proxy-active {

--- a/faqs/galaxy/workflows_import.md
+++ b/faqs/galaxy/workflows_import.md
@@ -8,12 +8,11 @@ contributors: [shiltemann,mblue9,hexylena]
 
 - Click on *Workflow* on the top menu bar of Galaxy. You will see a list of all your workflows.
 - Click on {% icon galaxy-upload %} **Import** at the top-right of the screen
-- Provide your workflow
+- {% if include.import_url %}Paste the following URL into the box labelled *"Archived Workflow URL"*: `{{ include.import_url }}`{% else %}Provide your workflow
   - Option 1: Paste the URL of the workflow into the box labelled *"Archived Workflow URL"*
-  - Option 2: Upload the workflow file in the box labelled *"Archived Workflow File"*
+  - Option 2: Upload the workflow file in the box labelled *"Archived Workflow File"*{% endif %}
 - Click the **Import workflow** button
 
 Below is a short video demonstrating how to import a workflow from GitHub using this procedure:
 
-<p align="center"><iframe width="560" height="315" src="https://www.youtube-nocookie.com/embed/hoP36Te5wko" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe></p>
-
+{% include _includes/youtube.html id="hoP36Te5wko" title="Importing a workflow from URL" %}

--- a/faqs/galaxy/workflows_import_from_dockstore.md
+++ b/faqs/galaxy/workflows_import_from_dockstore.md
@@ -8,19 +8,15 @@ contributors: [nekrut]
 
 [Dockstore](https://dockstore.org/) is a free and open source platform for sharing reusable and scalable analytical tools and workflows.
 
-1. Go to [DockStore](https://dockstore.org).
-2. Select any Galaxy workflow you want to import.
+1. Ensure that you are logged in to your Galaxy account.
+1. {% unless include.dockstore_id %}Go to [DockStore](https://dockstore.org).
+2. Select any Galaxy workflow you want to import.{% else %}Go to [DockStore](https://dockstore.org/workflows/{{ include.dockstore_id }}){% endunless %}
 3. Click on "Galaxy" dropdown within the "Launch with" panel located in the upper right corner.
 4. Select a galaxy instance you want to launch this workflow with.
 5. You will be redirected to Galaxy and presented with a list of workflow versions.
 6. Click the version you want (usually the latest labelled as "main")
 7. You are done!
 
-> <warning-title>Make sure you are logged in!</warning-title>
-> Ensure that you are logged in into your Galaxy account!
-{: .warning}
-
 The following short video walks you through this uncomplicated procedure:
 
-<p align="center"><iframe width="560" height="315" src="https://www.youtube-nocookie.com/embed/K2wFrSLFpa0" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe></p>
-{: .hands_on}
+{% include _includes/youtube.html id="K2wFrSLFpa0" title="Importing from Dockstore" %}

--- a/faqs/galaxy/workflows_import_from_workflowhub.md
+++ b/faqs/galaxy/workflows_import_from_workflowhub.md
@@ -8,10 +8,7 @@ contributors: [gallardoalba, abueg, nekrut]
 
 [WorkflowHub](https://workflowhub.eu/) is a workflow management system which allows workflows to be FAIR (Findable, Accessible, Interoperable, and Reusable), citable, have managed metadata profiles, and be openly available for review and analytics.
 
-> <warning-title>Make sure you are logged in!</warning-title>
-> Ensure that you are logged in into your Galaxy account!
-{: .warning}
-
+1. Ensure that you are logged in to your Galaxy account.
 1. Click on the **Workflow** menu, located in the top bar.
 2. Click on the **Import** button, located in the right corner.
 3. In the section "Import a Workflow from Configured GA4GH Tool Registry Servers (e.g. Dockstore)", click on **Search form**.
@@ -23,5 +20,4 @@ After that, the imported workflows will appear in the main workflow menu. In ord
 
 Below is a short video showing this uncomplicated procedure:
 
-<p align="center"><iframe width="560" height="315" src="https://www.youtube-nocookie.com/embed/hoP36Te5wko" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe></p>
-{: .hands_on}
+{% include _includes/youtube.html id="hoP36Te5wko" title="Importing from WorkflowHub" %}

--- a/faqs/galaxy/workflows_run_ds.md
+++ b/faqs/galaxy/workflows_run_ds.md
@@ -10,7 +10,7 @@ contributors: [hexylena]
 
 <div class="show-when-galaxy-proxy-active">
 
-<span class="workflow" data-workflow="https://dockstore.org/api/ga4gh/trs/v2/tools/#{{ include.dockstore_id }}">Launch <strong>{{ include.title }}</strong> <i class="fas fa-share-alt" aria-hidden="true"></i></span>
+<span class="workflow" data-workflow="https://dockstore.org/api/ga4gh/trs/v2/tools/#workflow/{{ include.dockstore_id }}">Launch <strong>{{ include.title }}</strong> <i class="fas fa-share-alt" aria-hidden="true"></i></span>
 (<a href="https://dockstore.org/workflows/{{ include.dockstore_id }}">View on Dockstore</a>)
 
 
@@ -18,10 +18,12 @@ contributors: [hexylena]
 
 <div class="hide-when-galaxy-proxy-active">
 
-<a href="https://my.galaxy.training/?path=/workflows/trs_import%3ftrs_server=dockstore.org%26run_form=true%26trs_id=%2523{{ include.dockstore_id }}">Launch <strong>{{ include.title }}</strong> <i class="fas fa-share-alt" aria-hidden="true"></i></a>
+<a href="https://my.galaxy.training/?path=/workflows/trs_import%3ftrs_server=dockstore.org%26run_form=true%26trs_id=%2523workflow/{{ include.dockstore_id }}">Launch <strong>{{ include.title }}</strong> <i class="fas fa-share-alt" aria-hidden="true"></i></a>
 (<a href="https://dockstore.org/workflows/{{ include.dockstore_id }}">View on Dockstore</a>)
 
 </div>
+
+{% snippet faqs/galaxy/workflows_import_from_dockstore.md title="If this does not work" dockstore_id=include.dockstore_id %}
 
 {% else %}
 

--- a/faqs/galaxy/workflows_run_ds.md
+++ b/faqs/galaxy/workflows_run_ds.md
@@ -23,7 +23,7 @@ contributors: [hexylena]
 
 </div>
 
-{% snippet faqs/galaxy/workflows_import_from_dockstore.md title="If this does not work" dockstore_id=include.dockstore_id %}
+{% snippet faqs/galaxy/workflows_import_from_dockstore.md override_title="If this does not work" dockstore_id=include.dockstore_id %}
 
 {% else %}
 

--- a/faqs/galaxy/workflows_run_trs.md
+++ b/faqs/galaxy/workflows_run_trs.md
@@ -10,6 +10,7 @@ contributors: [hexylena]
 
 <div class="show-when-galaxy-proxy-active">
 <span class="workflow" data-workflow="{{ site.url }}{{ site.baseurl }}{{ include.path | convert_workflow_path_to_trs }}">Launch <strong>{{ include.title }}</strong> <i class="fas fa-share-alt" aria-hidden="true"></i></span>
+(<a href="https://github.com/galaxyproject/training-material/blob/main/{{ include.path }}">View on GitHub</a>, <a href="https://training.galaxyproject.org/training-material/{{ include.path }}">Download workflow</a>)
 workflow.
 </div>
 
@@ -19,8 +20,11 @@ Click to
 <a href="https://my.galaxy.training/?path=/workflows/trs_import%3Frun_form=true%26trs_url={{ site.url }}{{ site.baseurl }}{{ include.path | convert_workflow_path_to_trs }}">
     Launch <strong>{{ include.title }}</strong> {% icon workflow aria=false %}
 </a>
+(<a href="https://github.com/galaxyproject/training-material/blob/main/{{ include.path }}">View on GitHub</a>, <a href="https://training.galaxyproject.org/training-material/{{ include.path }}">Download workflow</a>)
 
 </div>
+{% capture import_url %}https://training.galaxyproject.org/training-material/{{ include.path }}{% endcapture %}
+{% snippet faqs/galaxy/workflows_import.md title="If this does not work" import_url=import_url %}
 
 {% else %}
 

--- a/faqs/galaxy/workflows_run_trs.md
+++ b/faqs/galaxy/workflows_run_trs.md
@@ -23,8 +23,9 @@ Click to
 (<a href="https://github.com/galaxyproject/training-material/blob/main/{{ include.path }}">View on GitHub</a>, <a href="https://training.galaxyproject.org/training-material/{{ include.path }}">Download workflow</a>)
 
 </div>
+
 {% capture import_url %}https://training.galaxyproject.org/training-material/{{ include.path }}{% endcapture %}
-{% snippet faqs/galaxy/workflows_import.md title="If this does not work" import_url=import_url %}
+{% snippet faqs/galaxy/workflows_import.md override_title="If this does not work" import_url=import_url %}
 
 {% else %}
 

--- a/faqs/galaxy/workflows_run_wfh.md
+++ b/faqs/galaxy/workflows_run_wfh.md
@@ -23,7 +23,7 @@ contributors: [hexylena]
 </div>
 
 {% capture filter %}name:"{{ include.title }}"{% endcapture %}
-{% snippet faqs/galaxy/workflows_import_from_workflowhub.md title="If this does not work" filter=filter %}
+{% snippet faqs/galaxy/workflows_import_from_workflowhub.md override_title="If this does not work" filter=filter %}
 
 {% else %}
 

--- a/faqs/galaxy/workflows_run_wfh.md
+++ b/faqs/galaxy/workflows_run_wfh.md
@@ -22,6 +22,9 @@ contributors: [hexylena]
 
 </div>
 
+{% capture filter %}name:"{{ include.title }}"{% endcapture %}
+{% snippet faqs/galaxy/workflows_import_from_workflowhub.md title="If this does not work" filter=filter %}
+
 {% else %}
 
 1. Go to [Workflow → Import](https://my.galaxy.training/?path=/workflows/import) in your Galaxy

--- a/news/_posts/2023-12-12-tutorial-run-wfh-ds.md
+++ b/news/_posts/2023-12-12-tutorial-run-wfh-ds.md
@@ -15,6 +15,10 @@ We've added two snippets which make that easier than ever:
 
 And one for Dockstore:
 
-{% snippet faqs/galaxy/workflows_run_ds.md title="My Cool Workflow" dockstore_id="workflow/github.com/jmchilton/galaxy-workflow-dockstore-example-1/mycoolworkflow" %}
+{% snippet faqs/galaxy/workflows_run_ds.md title="My Cool Workflow" dockstore_id="github.com/jmchilton/galaxy-workflow-dockstore-example-1/mycoolworkflow" %}
+
+And one for workflows hosted natively in the GTN:
+
+{% snippet faqs/galaxy/workflows_run_trs.md path="topics/assembly/tutorials/largegenome/workflows/Galaxy-Workflow-Data_QC.ga" title="Galaxy Workflow Data QC" %}
 
 You can read more about these snippets and how to use them yourself in your tutorials in the [GTN Contribution Guide section on Workflows]({% link topics/contributing/tutorials/create-new-tutorial-content/tutorial.md %}#workflows).

--- a/news/_posts/2024-03-28-by-covid-pathways.md
+++ b/news/_posts/2024-03-28-by-covid-pathways.md
@@ -25,8 +25,9 @@ As part of the work of [BeYond COVID](https://by-covid.org/), we have developed 
 
 This work generated a number of brand new WorkflowHub Workflows, which can now be launched more easily than ever in the GTN:
 
-- {% snippet faqs/galaxy/workflows_run_wfh.md title="mRNA-Seq BY-COVID Pipeline: Counts" wfhub_id="688" box_type="none" %}
-- {% snippet faqs/galaxy/workflows_run_wfh.md title="mRNA-Seq BY-COVID Pipeline: Analysis" wfhub_id="689" box_type="none" %}
+{% snippet faqs/galaxy/workflows_run_wfh.md title="mRNA-Seq BY-COVID Pipeline: Counts" wfhub_id="688" %}
+
+{% snippet faqs/galaxy/workflows_run_wfh.md title="mRNA-Seq BY-COVID Pipeline: Analysis" wfhub_id="689" %}
 
 And a few new GTN features like the ability to embed a workflow visualisation directly into a tutorial.
 Go check it out!

--- a/topics/contributing/tutorials/create-new-tutorial-content/tutorial.md
+++ b/topics/contributing/tutorials/create-new-tutorial-content/tutorial.md
@@ -947,6 +947,25 @@ If you have example input histories for your tutorial, perhaps for specific serv
 
 In some tutorials you aren't as interested in teaching users the individual steps for analysing data, but rather want to focus on some downstream aspects of analysis, or to showcase the best practice workflows that are already available for a user to use! In those cases it can be useful to have a nicer way of inviting the user to execute those steps.
 
+If you are accessing these in tutorial mode, they should function as button that, when clicked, launch the workflow directly. Outside of tutorial mode, they will link to our redirection service which will let you supply which Galaxy you plan to use.
+
+Note that if for some reason the 'fancy' method doesn't work, there are fallback tip boxes to help a user execute a similar procedure manually.
+
+### GTN Workflows
+
+If you've included the workflow in the GTN but haven't uploaded to a repository yet:
+
+{% raw %}
+```markdown
+{% snippet faqs/galaxy/workflows_run_trs.md path="topics/assembly/tutorials/largegenome/workflows/Galaxy-Workflow-Data_QC.ga" title="Galaxy Workflow Data QC" %}
+```
+{% endraw %}
+
+Rendered:
+
+{% snippet faqs/galaxy/workflows_run_trs.md path="topics/assembly/tutorials/largegenome/workflows/Galaxy-Workflow-Data_QC.ga" title="Galaxy Workflow Data QC" %}
+
+
 ### WorkflowHub
 
 You can use a dedicated snippet to invite users to run a WorkflowHub workflow:
@@ -969,13 +988,13 @@ Please note that the dockstore ID should be provided without the `#` character.
 
 {% raw %}
 ```markdown
-{% snippet faqs/galaxy/workflows_run_ds.md title="My Cool Workflow" dockstore_id="workflow/github.com/jmchilton/galaxy-workflow-dockstore-example-1/mycoolworkflow" %}
+{% snippet faqs/galaxy/workflows_run_ds.md title="My Cool Workflow" dockstore_id="github.com/jmchilton/galaxy-workflow-dockstore-example-1/mycoolworkflow" %}
 ```
 {% endraw %}
 
 Rendered:
 
-{% snippet faqs/galaxy/workflows_run_ds.md title="My Cool Workflow" dockstore_id="workflow/github.com/jmchilton/galaxy-workflow-dockstore-example-1/mycoolworkflow" %}
+{% snippet faqs/galaxy/workflows_run_ds.md title="My Cool Workflow" dockstore_id="github.com/jmchilton/galaxy-workflow-dockstore-example-1/mycoolworkflow" %}
 
 This snippet has the same behaviour, it will use my.galaxy.training links to make them server independent, but in Tutorial Mode it will open on the current server.
 

--- a/topics/transcriptomics/tutorials/minerva-pathways/tutorial.md
+++ b/topics/transcriptomics/tutorials/minerva-pathways/tutorial.md
@@ -119,7 +119,7 @@ We'll start by downloading our FASTQ files from the [GEO Dataset GSE182152](http
 >
 > 1. **Import the workflow** into Galaxy
 >
->    {% snippet faqs/galaxy/workflows_run_trs.md path="topics/transcriptomics/tutorials/minerva-pathways/workflows/Galaxy-Workflow-BY-COVID__Data_Download.ga" title="Trim and Filter reads" box_type="none" %}
+>    {% snippet faqs/galaxy/workflows_run_trs.md path="topics/transcriptomics/tutorials/minerva-pathways/workflows/Galaxy-Workflow-BY-COVID__Data_Download.ga" title="Trim and Filter reads" %}
 >
 > 1. **Run the workflow** with the following parameters:
 >
@@ -149,9 +149,7 @@ This workflow produces a set of featureCounts tables, a set of featureLengths (n
 
 > <hands-on-title>Run the Workflow</hands-on-title>
 >
-> 1. **Import the workflow** into Galaxy
->
->    {% snippet faqs/galaxy/workflows_run_wfh.md title="mRNA-Seq BY-COVID Pipeline" wfhub_id="688" box_type="none" %}
+> {% snippet faqs/galaxy/workflows_run_wfh.md title="mRNA-Seq BY-COVID Pipeline" wfhub_id="688" %}
 >
 > 1. **Run the workflow** with the following parameters:
 >
@@ -281,7 +279,7 @@ Goseq is a tool for gene ontology enrichment analysis, and the MINERVA Platform 
 >
 > 1. Run the workflow with the Factor Data from the first Hands-on, and the datasets from the workflow or Zenodo download, depending on your path:
 >
->    {% snippet faqs/galaxy/workflows_run_wfh.md title="mRNA-Seq BY-COVID Pipeline" wfhub_id="689" box_type="none" %}
+>    {% snippet faqs/galaxy/workflows_run_wfh.md title="mRNA-Seq BY-COVID Pipeline" wfhub_id="689" %}
 >
 {: .hands_on}
 

--- a/topics/transcriptomics/tutorials/minerva-pathways/workflows/Galaxy-Workflow-BY-COVID__Data_Download.ga
+++ b/topics/transcriptomics/tutorials/minerva-pathways/workflows/Galaxy-Workflow-BY-COVID__Data_Download.ga
@@ -1,0 +1,205 @@
+{
+    "a_galaxy_workflow": "true",
+    "annotation": "Downloads data from NCBI assuming the correct data input format. (I.e. it should be two columns, with a header, Run and Group, where Run is an SRR identifier.)",
+    "comments": [],
+    "creator": [
+        {
+            "class": "Person",
+            "identifier": "0000-0001-9760-8992",
+            "name": "Helena Rasche"
+        }
+    ],
+    "format-version": "0.1",
+    "license": "AGPL-3.0-or-later",
+    "name": "BY-COVID: Data Download",
+    "steps": {
+        "0": {
+            "annotation": "This should be a two column sample table that looks like:\n\n```\nRun\tGroup\nSRR16681566\thealthy\nSRR16681565\thealthy\nSRR16681564\thealthy\n```",
+            "content_id": null,
+            "errors": null,
+            "id": 0,
+            "input_connections": {},
+            "inputs": [
+                {
+                    "description": "This should be a two column sample table that looks like:\n\n```\nRun\tGroup\nSRR16681566\thealthy\nSRR16681565\thealthy\nSRR16681564\thealthy\n```",
+                    "name": "Sample Table"
+                }
+            ],
+            "label": "Sample Table",
+            "name": "Input dataset",
+            "outputs": [],
+            "position": {
+                "left": 0,
+                "top": 6
+            },
+            "tool_id": null,
+            "tool_state": "{\"optional\": false, \"format\": [\"tabular\"], \"tag\": null}",
+            "tool_version": null,
+            "type": "data_input",
+            "uuid": "0db27234-a5f7-4177-8de5-f461765a00b8",
+            "when": null,
+            "workflow_outputs": []
+        },
+        "1": {
+            "annotation": "",
+            "content_id": "Cut1",
+            "errors": null,
+            "id": 1,
+            "input_connections": {
+                "input": {
+                    "id": 0,
+                    "output_name": "output"
+                }
+            },
+            "inputs": [],
+            "label": null,
+            "name": "Cut",
+            "outputs": [
+                {
+                    "name": "out_file1",
+                    "type": "tabular"
+                }
+            ],
+            "position": {
+                "left": 280,
+                "top": 0
+            },
+            "post_job_actions": {
+                "HideDatasetActionout_file1": {
+                    "action_arguments": {},
+                    "action_type": "HideDatasetAction",
+                    "output_name": "out_file1"
+                }
+            },
+            "tool_id": "Cut1",
+            "tool_state": "{\"__input_ext\": \"tabular\", \"chromInfo\": \"/opt/galaxy/tool-data/shared/ucsc/chrom/?.len\", \"columnList\": \"c1\", \"delimiter\": \"T\", \"input\": {\"__class__\": \"ConnectedValue\"}, \"__page__\": null, \"__rerun_remap_job_id__\": null}",
+            "tool_version": "1.0.2",
+            "type": "tool",
+            "uuid": "078accd8-6164-4e40-9c54-650034f5e91f",
+            "when": null,
+            "workflow_outputs": []
+        },
+        "2": {
+            "annotation": "",
+            "content_id": "Grep1",
+            "errors": null,
+            "id": 2,
+            "input_connections": {
+                "input": {
+                    "id": 1,
+                    "output_name": "out_file1"
+                }
+            },
+            "inputs": [],
+            "label": null,
+            "name": "Select",
+            "outputs": [
+                {
+                    "name": "out_file1",
+                    "type": "input"
+                }
+            ],
+            "position": {
+                "left": 560,
+                "top": 0
+            },
+            "post_job_actions": {
+                "HideDatasetActionout_file1": {
+                    "action_arguments": {},
+                    "action_type": "HideDatasetAction",
+                    "output_name": "out_file1"
+                }
+            },
+            "tool_id": "Grep1",
+            "tool_state": "{\"__input_ext\": \"input\", \"chromInfo\": \"/opt/galaxy/tool-data/shared/ucsc/chrom/?.len\", \"input\": {\"__class__\": \"ConnectedValue\"}, \"invert\": \"-v\", \"keep_header\": false, \"pattern\": \"Run\", \"__page__\": null, \"__rerun_remap_job_id__\": null}",
+            "tool_version": "1.0.4",
+            "type": "tool",
+            "uuid": "7e6b8476-bf1d-4fbf-ab55-b6ee872d528b",
+            "when": null,
+            "workflow_outputs": []
+        },
+        "3": {
+            "annotation": "",
+            "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/sra_tools/fasterq_dump/3.0.8+galaxy1",
+            "errors": null,
+            "id": 3,
+            "input_connections": {
+                "input|file_list": {
+                    "id": 2,
+                    "output_name": "out_file1"
+                }
+            },
+            "inputs": [
+                {
+                    "description": "runtime parameter for tool Faster Download and Extract Reads in FASTQ",
+                    "name": "input"
+                }
+            ],
+            "label": null,
+            "name": "Faster Download and Extract Reads in FASTQ",
+            "outputs": [
+                {
+                    "name": "list_paired",
+                    "type": "input"
+                },
+                {
+                    "name": "output_collection",
+                    "type": "input"
+                },
+                {
+                    "name": "output_collection_other",
+                    "type": "input"
+                },
+                {
+                    "name": "log",
+                    "type": "txt"
+                }
+            ],
+            "position": {
+                "left": 840,
+                "top": 6
+            },
+            "post_job_actions": {
+                "HideDatasetActionlist_paired": {
+                    "action_arguments": {},
+                    "action_type": "HideDatasetAction",
+                    "output_name": "list_paired"
+                },
+                "HideDatasetActionlog": {
+                    "action_arguments": {},
+                    "action_type": "HideDatasetAction",
+                    "output_name": "log"
+                },
+                "HideDatasetActionoutput_collection_other": {
+                    "action_arguments": {},
+                    "action_type": "HideDatasetAction",
+                    "output_name": "output_collection_other"
+                }
+            },
+            "tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/sra_tools/fasterq_dump/3.0.8+galaxy1",
+            "tool_shed_repository": {
+                "changeset_revision": "e407b9da183a",
+                "name": "sra_tools",
+                "owner": "iuc",
+                "tool_shed": "toolshed.g2.bx.psu.edu"
+            },
+            "tool_state": "{\"__input_ext\": \"input\", \"adv\": {\"seq_defline\": \"@$sn/$ri\", \"minlen\": null, \"split\": \"--split-3\", \"skip_technical\": true}, \"chromInfo\": \"/opt/galaxy/tool-data/shared/ucsc/chrom/?.len\", \"input\": {\"input_select\": \"file_list\", \"__current_case__\": 2, \"file_list\": {\"__class__\": \"ConnectedValue\"}}, \"__page__\": null, \"__rerun_remap_job_id__\": null}",
+            "tool_version": "3.0.8+galaxy1",
+            "type": "tool",
+            "uuid": "4e6c90ae-68d6-4e80-b63a-8c5b5adff338",
+            "when": null,
+            "workflow_outputs": [
+                {
+                    "label": "output_collection",
+                    "output_name": "output_collection",
+                    "uuid": "b7c7e59d-6a78-41af-ae59-e52fcc1fe2f6"
+                }
+            ]
+        }
+    },
+    "tags": [
+        "name:BY-COVID"
+    ],
+    "uuid": "c7c92451-c1f4-4319-830a-667020d04f6c",
+    "version": 7
+}


### PR DESCRIPTION
For @pvanheus. Each of the "if this does not work" includes diretions specific to the defined workflow (e.g. the gtn workflow's instructions in the snippet include the URL you must copy and paste

![Screenshot 2024-06-11 at 11-30-45 Contributing to the Galaxy Training Material _ Creating content in Markdown _ Hands-on Creating content in Markdown](https://github.com/galaxyproject/training-material/assets/458683/a2b40d42-3e45-4c86-8fe0-ee031d51d891)
