### PR TITLE
Drop help@galaxyproject.org from US help

### DIFF
--- a/faqs/galaxy/support_admins.md
+++ b/faqs/galaxy/support_admins.md
@@ -10,7 +10,7 @@ If you suspect there is something wrong with the server, or would like to reques
 
 - **Tool error?** Please follow these [troubleshooting steps]({% link faqs/galaxy/analysis_troubleshooting.md %})
 - Each Galaxy server has different contact procedures, here are the contact options for the 3 biggest servers:
-  - **Galaxy US:** [Email](mailto:help@galaxyproject.org), [Gitter channel](https://gitter.im/galaxyproject/Lobby)
+  - **Galaxy US:** [Gitter channel](https://gitter.im/galaxyproject/Lobby)
   - **Galaxy EU:** [Gitter channel](https://gitter.im/usegalaxy-eu/Lobby), [Request TIaaS](https://usegalaxy.eu/tiaas/)
   - **Galaxy AU:** [Email](mail:help@genome.edu.au), [Request a tool](https://request.usegalaxy.org.au/), [Request Data Quota](https://docs.google.com/forms/d/e/1FAIpQLSeiw6ajmkezLCwbXc3OFQEU3Ai9hGnBd967u9YbQ8ANPgvatA/viewform)
   - **Galaxy FR:** [Request TIaaS](https://usegalaxy.fr/tiaas/)


### PR DESCRIPTION
The email doesn't exist and I think we ideally want everything to go through the help forum.