### PR TITLE
[Events] added location field to Google Form

### DIFF
--- a/bin/google-form-event.rb
+++ b/bin/google-form-event.rb
@@ -54,6 +54,9 @@ data.each do |row|
     'contributions' => {
        'organisers' => row['Organizers already in the GTN CONTRIBUTORS file'].split(',').map(&:strip)
     },
+    'location' => {
+        'name' => row['Location of the event']
+    },
     'date_start' => event_date.to_date,
   }
 


### PR DESCRIPTION
Just a freetext field to keep it simple on the submitter's side, reviewers can split it into name/city/country properly if needed
