### PR TITLE
[News From] fix key names for cover image metadata

### DIFF
--- a/bin/google-form-news.rb
+++ b/bin/google-form-news.rb
@@ -51,8 +51,8 @@ data.each do |row|
   end
 
   if row['Optional Cover Image']
-    post_metadata['cover_image'] = row['Optional Cover Image']
-    post_metadata['cover_image_alt'] = row['Cover Image Alternative Text']
+    post_metadata['cover'] = row['Optional Cover Image']
+    post_metadata['coveralt'] = row['Cover Image Alternative Text']
   end
 
   if row['Link to a specific tutorial you wish to push people to view']


### PR DESCRIPTION
we are terribly inconsistent with these metadata keys between news, learning pathways, events etc, but for news it should be `cover` and `coveralt` currently