### PR TITLE
Cc2024

### DIFF
--- a/events/2024-11-12-biont-CC2024.md
+++ b/events/2024-11-12-biont-CC2024.md
@@ -1,0 +1,18 @@
+---
+layout: event-external
+title: BioNT Community Event & CarpentryConnect - Heidelberg 2024
+external: "https://biont-training.eu/CarpentryConnect2024.html"
+description: | 
+    Join the BioNT Community Event & CarpentryConnect - Heidelberg 2024. In November, the Carpentries and other learning communities will meet to network and collaborate during this 3-day event. The theme of this year's event is: Community-led Training Beyond Academia.
+date_start: 2024-11-12
+date_end: 2024-11-14
+contributions:
+  organisers:
+    - teresa-m
+  funding:
+    - biont
+location:
+  name:  European Molecular Biology Laboratory (EMBL)
+  city: Heidelberg
+  country: Germany
+---

--- a/news/_posts/2024-07-11-CC2024-registration.md
+++ b/news/_posts/2024-07-11-CC2024-registration.md
@@ -8,8 +8,7 @@ contributions:
 
 Are you interested in training and want to connect with other enthusiastic traineres? Than join the BioNT Community Event & CarpentryConnect - Heidelberg 2024. The Carpentries and other learning communities will meet to network and collaborate during this 3-day event. The GTN will is presten with a Poster, Lightning Talks and a Mini-hackathons. 
 
-[Check out the event](https://biont-training.eu/CarpentryConnect2024.html){:.btn.btn-primary}
-
+[Check out the event](https://biont-training.eu/CarpentryConnect2024.html){:.btn.btn-info}
 You can register to participate remotely or in-person before 15th September.
 
 ### If you would like to learn more about the event please also see the previous Carpentrys post on this topic:

--- a/news/_posts/2024-07-11-CC2024-registration.md
+++ b/news/_posts/2024-07-11-CC2024-registration.md
@@ -11,7 +11,7 @@ Are you interested in training and want to connect with other enthusiastic train
 [Check out the event](https://biont-training.eu/CarpentryConnect2024.html){:.btn.btn-info}
 You can register to participate remotely or in-person before 15th September.
 
-### If you would like to learn more about the event please also see the previous Carpentrys post on this topic:
+If you would like to learn more about the event please also see the previous Carpentrys post on this topic:
 
 1. [Registration Open for CarpentryConnect Heidelberg](https://carpentries.org/blog/2024/06/cchd24-registration-programme/)
 2. [Exciting updates from the CarpentryConnect Heidelberg 2024 organising committee](https://carpentries.org/blog/2024/05/cchd2024-updates-from-the-organising-committee/), where we announced the three keynote speakers: Radhika S Khetani, Yanina Bellini Saibene, and Malvika Sharan.

--- a/news/_posts/2024-07-11-CC2024-registration.md
+++ b/news/_posts/2024-07-11-CC2024-registration.md
@@ -4,12 +4,11 @@ layout: news
 contributions:
   authorship:
     - teresa-m
-link: "https://biont-training.eu/CarpentryConnect2024.html"
 ---
 
 Are you interested in training and want to connect with other enthusiastic traineres? Than join the BioNT Community Event & CarpentryConnect - Heidelberg 2024. The Carpentries and other learning communities will meet to network and collaborate during this 3-day event. The GTN will is presten with a Poster, Lightning Talks and a Mini-hackathons. 
 
-[Check out the event]({{ page.link }}){:.btn.btn-primary}
+[Check out the event](https://biont-training.eu/CarpentryConnect2024.html){:.btn.btn-primary}
 
 You can register to participate remotely or in-person before 15th September.
 

--- a/news/_posts/2024-07-11-CC2024-registration.md
+++ b/news/_posts/2024-07-11-CC2024-registration.md
@@ -6,12 +6,12 @@ contributions:
     - teresa-m
 ---
 
-Are you interested in training and want to connect with other enthusiastic traineres? Than join the BioNT Community Event & CarpentryConnect - Heidelberg 2024. The Carpentries and other learning communities will meet to network and collaborate during this 3-day event. The GTN will is presten with a Poster, Lightning Talks and a Mini-hackathons. 
+Are you interested in training and want to connect with other enthusiastic traineres? Than join the BioNT Community Event & CarpentryConnect - Heidelberg 2024. The Carpentries and other learning communities will meet to network and collaborate during this 3-day event. The GTN will is presten with a Poster, Lightning Talks and a Mini-hackathons.
 
 [Check out the event](https://biont-training.eu/CarpentryConnect2024.html){:.btn.btn-info}
 You can register to participate remotely or in-person before 15th September.
 
-If you would like to learn more about the event please also see the previous Carpentrys post on this topic:
+### If you would like to learn more about the event please also see the previous Carpentries posts on this topic:
 
 1. [Registration Open for CarpentryConnect Heidelberg](https://carpentries.org/blog/2024/06/cchd24-registration-programme/)
 2. [Exciting updates from the CarpentryConnect Heidelberg 2024 organising committee](https://carpentries.org/blog/2024/05/cchd2024-updates-from-the-organising-committee/), where we announced the three keynote speakers: Radhika S Khetani, Yanina Bellini Saibene, and Malvika Sharan.

--- a/news/_posts/2024-07-11-CC2024-registration.md
+++ b/news/_posts/2024-07-11-CC2024-registration.md
@@ -1,0 +1,21 @@
+---
+title: "Registration Open for BioNT Community Event & CarpentryConnect Heidelberg"
+layout: news
+contributions:
+  authorship:
+    - teresa-m
+link: "https://biont-training.eu/CarpentryConnect2024.html"
+---
+
+Are you interested in training and want to connect with other enthusiastic traineres? Than join the BioNT Community Event & CarpentryConnect - Heidelberg 2024. The Carpentries and other learning communities will meet to network and collaborate during this 3-day event. The GTN will is presten with a Poster, Lightning Talks and a Mini-hackathons. 
+
+[Check out the event]({{ page.link }}){:.btn.btn-primary}
+
+You can register to participate remotely or in-person before 15th September.
+
+### If you would like to learn more about the event please also see the previous Carpentrys post on this topic:
+
+1. [Registration Open for CarpentryConnect Heidelberg](https://carpentries.org/blog/2024/06/cchd24-registration-programme/)
+2. [Exciting updates from the CarpentryConnect Heidelberg 2024 organising committee](https://carpentries.org/blog/2024/05/cchd2024-updates-from-the-organising-committee/), where we announced the three keynote speakers: Radhika S Khetani, Yanina Bellini Saibene, and Malvika Sharan.
+3. [Proposal submission opens for CCHD24](https://carpentries.org/blog/2024/02/cchd24-call-for-proposals/), where we provided more information about the theme of the event and the kinds of submissions we were hoping to receive.
+4. [Join us for CarpentryConnect Heidelberg 2024!](https://carpentries.org/blog/2024/01/announcing-cchd24/) The initial announcement post, which presents further information including our motivations for the event.


### PR DESCRIPTION
For the  'BioNT Community Event & CarpentryConnect - Heidelberg 2024' I added a news post and as an external event.

I tried to use a button to go to the event page for the first time in the news post.
However, I was not able to build the gtn page locally to test this feature. 
