### PR TITLE
SnapATAC2 tutorial: update data-library.yaml

### DIFF
--- a/topics/single-cell/tutorials/scatac-standard-processing-snapatac2/data-library.yaml
+++ b/topics/single-cell/tutorials/scatac-standard-processing-snapatac2/data-library.yaml
@@ -5,27 +5,27 @@ destination:
   description: Galaxy Training Network Material
   synopsis: Galaxy Training Network Material. See https://training.galaxyproject.org
 items:
-- name: The new topic
-  description: Summary
+- name: Single-cell
+  description: Training material for single-cell analysis.
   items:
-  - name: scATAC-seq standard processing with SnapATAC2
+  - name: Single-cell ATAC-seq standard processing with SnapATAC2
     items:
-    - name: 'DOI: 10.5281/zenodo.11473531' 
+    - name: 'DOI: 10.5281/zenodo.12707159'
       description: latest
       items:
-      - url: https://zenodo.org/api/records/11473531/files/atac_pbmc_5k_nextgem_fragments.tsv/
+      - url: https://zenodo.org/api/records/12707159/files/atac_pbmc_5k_nextgem_fragments.tsv.gz
         src: url
-        ext: auto
-        info: https://zenodo.org/records/11473531
-      - url: https://zenodo.org/api/records/11473531/files/gencode.v46.annotation.gtf.gz/
+        ext: tsv
+        info: https://zenodo.org/records/12707159
+      - url: https://zenodo.org/api/records/12707159/files/gencode.v46.annotation.gtf.gz
         src: url
-        ext: auto
-        info: https://zenodo.org/records/11473531
-      - url: https://zenodo.org/api/records/11473531/files/chrom_sizes.txt/
+        ext: gtf
+        info: https://zenodo.org/records/12707159
+      - url: https://zenodo.org/api/records/12707159/files/chrom_sizes.txt
         src: url
-        ext: auto
-        info: https://zenodo.org/records/11473531
-      - url: https://zenodo.org/api/records/11473531/files/BAM_500-PBMC.bam/
+        ext: txt
+        info: https://zenodo.org/records/12707159
+      - url: https://zenodo.org/api/records/12707159/files/BAM_500-PBMC.bam
         src: url
-        ext: auto
-        info: https://zenodo.org/records/11473531
+        ext: bam
+        info: https://zenodo.org/records/12707159


### PR DESCRIPTION
The latest version of this  Zenodo record has a compressed fragments file which is 4 times smaller than the old one.