### PR TITLE
Remove duplicated instructions in hands-on box

### DIFF
--- a/topics/evolution/tutorials/mtb_transmission/tutorial.md
+++ b/topics/evolution/tutorials/mtb_transmission/tutorial.md
@@ -783,11 +783,6 @@ The two tables we have generated in the two parts of the tutorial share a sample
 >
 >      The *transmission clusters* report only lists the subset of samples that were assigned to a cluster, while the drug-resistance table has a line for every sample. We want to keep all samples from the second table and indicate missing information from the first with `-` values (see next parameter).
 >    - *"Value to put in unpaired (empty) fields"*: `-`
->        - {% icon param-repeat %} *"Insert Replacement"*
->          - *"Find pattern"*: `Drug-resistance: `
->
->              Note the space at the end of the pattern!
->          - *"Replace with"*: leave this field empty
 >
 {: .hands_on}
 


### PR DESCRIPTION
The removed part doesn't seem to belong to the Join step.
