### PR TITLE
Fix rendering issue in Filter Plot and Explore (Python) tutorial

### DIFF
--- a/topics/single-cell/tutorials/scrna-case-jupyter_basic-pipeline/tutorial.md
+++ b/topics/single-cell/tutorials/scrna-case-jupyter_basic-pipeline/tutorial.md
@@ -88,7 +88,7 @@ import pandas as pd
 You can import files from your Galaxy history directly using the following code. This will depend on what number in your history the final annotated object is. If your object is dataset #4 in your history, then you import it with the following:
 
 ```python
-mito_counted_anndata = get(4)
+mito_counted_anndata = get(1)
 ```
 
 You now need to read it in as a h5ad object.
@@ -865,15 +865,21 @@ Ultimately, there are quite a lot ways to analyse the data, both within the conf
 
 It’s now time to export your data! First, we need to get Jupyter to see it as a file.
 
-```adata.write('markers_cluster_copy')```
+```python
+adata.write('MarkersCluster.h5ad')
+```
 
 Now you can export it.
 
-```put("MarkersCluster.h5ad")```
+```python
+put("MarkersCluster.h5ad")
+```
 
 To export your notebook to your Galaxy history, you can use the following. Change the text to be your notebook name. Do not use spaces!
 
-```put("yourtitlehere.ipynb")```    
+```python
+put("name_of_jupyter_notebook.ipynb")
+```    
 
 Want to export some plots? Choose any (or all) of the plots you saved as files in the folder at the left and put their titles in the following. You can run multiple exports at the same time.
 

--- a/topics/single-cell/tutorials/scrna-case-jupyter_basic-pipeline/tutorial.md
+++ b/topics/single-cell/tutorials/scrna-case-jupyter_basic-pipeline/tutorial.md
@@ -85,7 +85,7 @@ import pandas as pd
 
 # Load Data
 
-You can import files from your Galaxy history directly using the following code. This will depend on what number in your history the final annotated object is. If your object is dataset #4 in your history, then you import it with the following:
+You can import files from your Galaxy history directly using the following code. This will depend on what number in your history the final annotated object is. If your object is dataset #1 in your history, then you import it with the following:
 
 ```python
 mito_counted_anndata = get(1)

--- a/topics/single-cell/tutorials/scrna-case-jupyter_basic-pipeline/tutorial.md
+++ b/topics/single-cell/tutorials/scrna-case-jupyter_basic-pipeline/tutorial.md
@@ -879,7 +879,7 @@ To export your notebook to your Galaxy history, you can use the following. Chang
 
 ```python
 put("name_of_jupyter_notebook.ipynb")
-```    
+```
 
 Want to export some plots? Choose any (or all) of the plots you saved as files in the folder at the left and put their titles in the following. You can run multiple exports at the same time.
 


### PR DESCRIPTION
Some of the code blocks were not being rendered correctly in the tutorial and generated Jupyter notebook due to some missing python tags and trailing whitespaces after closing one of the code blocks.

Also made some minor updates to some of the code blocks:
- The initial call to ```get()``` should get the first file since that will likely be the position of the required file if following the tutorial
- Fixed the name of the file saved at the end using ```adata.write()``` not matching the name of the file being saved in the next code block using ```put()``` (MarkersCluster.h5ad)
- Changed the filename of the exported Jupyter notebook file to make it slightly more clear that it needs to be the name of the current Jupyter notebook