### PR TITLE
Updating case study tutorials

### DIFF
--- a/topics/single-cell/tutorials/scrna-case_alevin-combine-datasets/tutorial.md
+++ b/topics/single-cell/tutorials/scrna-case_alevin-combine-datasets/tutorial.md
@@ -168,9 +168,13 @@ You can access the data for this tutorial in multiple ways:
 > 1. {% tool [Manipulate AnnData](toolshed.g2.bx.psu.edu/repos/iuc/anndata_manipulate/anndata_manipulate/0.10.3+galaxy0) %} with the following parameters:
 >    - {% icon param-file %} *"Annotated data matrix"*: `N701-400k`
 >    - *"Function to manipulate the object"*: `Concatenate along the observations axis`
->    - {% icon param-file %} *"Annotated data matrix to add"*: `Select all the other matrix files from bottom to top, N702 to N707` (if you imported files from Zenodo, your history may not be in this order, but you can still select them in order from N702 to N707 using the file names)
->
->    > <warning-title>N701 to N701!</warning-title>
+>    - {% icon param-file %} *"Annotated data matrix to add"*: `Select all the other matrix files from bottom to top, N702 to N707`
+> 
+>    <comment-title></comment-title>
+>     >If you imported files from Zenodo instead of using the input history, yours might not be in the same order as ours. Since the files will be concatenated in the order that you click, it will be helpful if you click them in the same order, from N702 to N707. This will ensure your samples are given the same batch numbers as we got in this tutorial, which will help when we're adding in metadata later!
+    {: .comment}
+> 
+>    > <warning-title>Don't add N701!</warning-title>
 >    > You are adding files to N701, so do not add N701 to itself!
 >    {: .warning}
 >

--- a/topics/single-cell/tutorials/scrna-case_alevin-combine-datasets/tutorial.md
+++ b/topics/single-cell/tutorials/scrna-case_alevin-combine-datasets/tutorial.md
@@ -168,9 +168,9 @@ You can access the data for this tutorial in multiple ways:
 > 1. {% tool [Manipulate AnnData](toolshed.g2.bx.psu.edu/repos/iuc/anndata_manipulate/anndata_manipulate/0.10.3+galaxy0) %} with the following parameters:
 >    - {% icon param-file %} *"Annotated data matrix"*: `N701-400k`
 >    - *"Function to manipulate the object"*: `Concatenate along the observations axis`
->    - {% icon param-file %} *"Annotated data matrix to add"*: `Select all the other matrix files from bottom to top, N707 to N702`
+>    - {% icon param-file %} *"Annotated data matrix to add"*: `Select all the other matrix files from bottom to top, N702 to N707` (if you imported files from Zenodo, your history may not be in this order, but you can still select them in order from N702 to N707 using the file names)
 >
->    > <warning-title>N707 to N702!</warning-title>
+>    > <warning-title>N701 to N701!</warning-title>
 >    > You are adding files to N701, so do not add N701 to itself!
 >    {: .warning}
 >
@@ -187,10 +187,10 @@ Now let's look at what we've done! Unfortunately, AnnData objects are quite comp
 > 1. {% tool [Inspect AnnData](toolshed.g2.bx.psu.edu/repos/iuc/anndata_inspect/anndata_inspect/0.10.3+galaxy0) %} with the following parameters:
 >    - {% icon param-file %} *"Annotated data matrix"*: `Combined object`
 >    - *"What to inspect?"*: `General information about the object`
-> 2. {% tool [Inspect AnnData](toolshed.g2.bx.psu.edu/repos/iuc/anndata_inspect/anndata_inspect/0.7.5+galaxy1) %} with the following parameters:
+> 2. {% tool [Inspect AnnData](toolshed.g2.bx.psu.edu/repos/iuc/anndata_inspect/anndata_inspect/0.10.3+galaxy0) %} with the following parameters:
 >    - {% icon param-file %} *"Annotated data matrix"*: `Combined object`
 >    - *"What to inspect?"*: `Key-indexed observations annotation (obs)`
-> 3. {% tool [Inspect AnnData](toolshed.g2.bx.psu.edu/repos/iuc/anndata_inspect/anndata_inspect/0.7.5+galaxy1) %} with the following parameters:
+> 3. {% tool [Inspect AnnData](toolshed.g2.bx.psu.edu/repos/iuc/anndata_inspect/anndata_inspect/0.10.3+galaxy0) %} with the following parameters:
 >    - {% icon param-file %} *"Annotated data matrix"*: `Combined object`
 >    - *"What to inspect?"*: `Key-indexed annotation of variables/features (var)`
 {: .hands_on}

--- a/topics/single-cell/tutorials/scrna-case_alevin/tutorial.md
+++ b/topics/single-cell/tutorials/scrna-case_alevin/tutorial.md
@@ -528,7 +528,10 @@ We will nevertheless proceed with your majestic annotated expression matrix of 3
 >
 > 1. {% tool [SCEasy Converter](toolshed.g2.bx.psu.edu/repos/iuc/sceasy_convert/sceasy_convert/0.0.7+galaxy2) %} with the following parameters:
 >    - *"Convert From / To"*: `SingleCellExperiment to AnnData`
->    - {% icon param-file %} *"Input object in sce,rds,rdata.sce format"*: `Emptied-Object` (if the dataset does not show up in the corresponding input field or displays as 'unavailable', don't worry - try dragging the dataset from the history panel and dropping it into the input field. If this still doesn't work, then you can change the datatype to rdata.sce)
+>    - {% icon param-file %} *"Input object in sce,rds,rdata.sce format"*: `Emptied-Object`
+>
+> If the dataset does not show up in the corresponding input field or displays as 'unavailable', don't worry - try dragging the dataset from the history panel and dropping it into the input field. If this still doesn't work, then you can change the datatype to rdata.sce.
+> 
 > {% snippet faqs/galaxy/datasets_change_datatype.md %}
 >
 > 2. Rename {% icon galaxy-pencil %} output `N701-400k-AnnData`

--- a/topics/single-cell/tutorials/scrna-case_alevin/tutorial.md
+++ b/topics/single-cell/tutorials/scrna-case_alevin/tutorial.md
@@ -232,7 +232,7 @@ We now have:
 * transcript/ gene mapping
 * filtered FASTA
 
-We can now run Alevin. In some public instances, Alevin won't show up if you search for it. Instead, you may have to click the Single Cell tab at the left and scroll down to the Alevin tool. Alternatively, use Tutorial Mode as described above and you'll easily navigate to all the tools, and their versions will all be the tried and tested ones of this tutorial. It's often a good idea to check your tool versions. To identify which version of a tool you are using, select {% icon tool-versions %} 'Versions' and choose the appropriate version. In this case the tutorial was built with Alevin Galaxy Version 1.9.0+galaxy2.
+We can now run Alevin. In some public instances, Alevin won't show up if you search for it. Instead, you may have to click the Single Cell tab at the left and scroll down to the Alevin tool. Alternatively, use Tutorial Mode as described above and you'll easily navigate to all the tools, and their versions will all be the tried and tested ones of this tutorial. It's often a good idea to check your tool versions. To identify which version of a tool you are using, select {% icon tool-versions %} 'Versions' and choose the appropriate version. In this case the tutorial was built with Alevin Galaxy Version 1.9.0+galaxy2, but will also work with the versions named in the Hands-on sections.
 
 
 > <hands-on-title>Running Alevin</hands-on-title>
@@ -528,7 +528,8 @@ We will nevertheless proceed with your majestic annotated expression matrix of 3
 >
 > 1. {% tool [SCEasy Converter](toolshed.g2.bx.psu.edu/repos/iuc/sceasy_convert/sceasy_convert/0.0.7+galaxy2) %} with the following parameters:
 >    - *"Convert From / To"*: `SingleCellExperiment to AnnData`
->    - {% icon param-file %} *"Input object in sce,rds,rdata.sce format"*: `Emptied-Object` (if the dataset does not show up in the corresponding input field or displays as 'unavailable', don't worry - just drag the dataset from the history panel and drop into the input field)
+>    - {% icon param-file %} *"Input object in sce,rds,rdata.sce format"*: `Emptied-Object` (if the dataset does not show up in the corresponding input field or displays as 'unavailable', don't worry - try dragging the dataset from the history panel and dropping it into the input field. If this still doesn't work, then you can change the datatype to rdata.sce)
+> {% snippet faqs/galaxy/datasets_change_datatype.md %}
 >
 > 2. Rename {% icon galaxy-pencil %} output `N701-400k-AnnData`
 >

--- a/topics/single-cell/tutorials/scrna-case_basic-pipeline/tutorial.md
+++ b/topics/single-cell/tutorials/scrna-case_basic-pipeline/tutorial.md
@@ -19,7 +19,9 @@ answer_histories:
     date: 2024-02-28
 
 input_histories:
-  - label: "UseGalaxy.eu"
+  - label: "UseGalaxy.eu 1"
+    history:  https://usegalaxy.eu/published/history?id=67ff4cea2adc574d
+  - label: "UseGalaxy.eu 2"
     history: https://usegalaxy.eu/u/j.jakiela/h/filter-plot-explore-tutorial-input
 
 questions:

--- a/topics/single-cell/tutorials/scrna-case_basic-pipeline/tutorial.md
+++ b/topics/single-cell/tutorials/scrna-case_basic-pipeline/tutorial.md
@@ -19,10 +19,8 @@ answer_histories:
     date: 2024-02-28
 
 input_histories:
-  - label: "UseGalaxy.eu 1"
+  - label: "UseGalaxy.eu"
     history:  https://usegalaxy.eu/published/history?id=67ff4cea2adc574d
-  - label: "UseGalaxy.eu 2"
-    history: https://usegalaxy.eu/u/j.jakiela/h/filter-plot-explore-tutorial-input
 
 questions:
 - Is my single cell dataset a quality dataset?

--- a/topics/single-cell/tutorials/scrna-case_trajectories/tutorial.bib
+++ b/topics/single-cell/tutorials/scrna-case_trajectories/tutorial.bib
@@ -92,7 +92,7 @@
 @article{scanpytutorialsTrajectoryInference,
 	author = {Alex Wolf, Fidel Ramirez, Sergei Rybakov},
 	title = {{T}rajectory inference for hematopoiesis in mouse \&#x2014; scanpy-tutorials 1.4.7.dev38+g3e4e434 documentation --- scanpy-tutorials.readthedocs.io},
-	url = {https://scanpy-tutorials.readthedocs.io/en/latest/paga-paul15.html},
+	url = {https://scanpy.readthedocs.io/en/stable/tutorials/trajectories/paga-paul15.html},
 	year = {2023},
-	note = {[Accessed 15-12-2023]},
+	note = {[Accessed 11-09-2024]},
 }

--- a/topics/single-cell/tutorials/scrna-case_trajectories/tutorial.md
+++ b/topics/single-cell/tutorials/scrna-case_trajectories/tutorial.md
@@ -218,6 +218,10 @@ Now that we have our diffusion map, we need to re-calculate neighbors using the 
 >
 {: .hands_on}
 
+> <comment-title></comment-title>
+> If you're using the latest versions of these tools (e.g. {% tool [Scanpy ComputeGraph](https://usegalaxy.eu/root?tool_id=toolshed.g2.bx.psu.edu/repos/ebi-gxa/scanpy_compute_graph/scanpy_compute_graph/1.9.3+galaxy0) %}, rather than the ones suggested in the tutorial (e.g. {% tool [Scanpy ComputeGraph](toolshed.g2.bx.psu.edu/repos/ebi-gxa/scanpy_compute_graph/scanpy_compute_graph/1.8.1+galaxy9) %} then you may need to change one more parameter here to set the `Number of PCs to use` to 15. These are the 15 diffusion components we just calculated, rather than actual PCs.
+{: .comment}
+
 ## Re-draw the FDG
 
 Now that we've re-calculated the nearest neighbours, we can use these new neighbours to re-draw the FDG to see how this changes the plot.

--- a/topics/single-cell/tutorials/scrna-case_trajectories/tutorial.md
+++ b/topics/single-cell/tutorials/scrna-case_trajectories/tutorial.md
@@ -53,12 +53,12 @@ contributions:
 
 You've done all the hard work of preparing a single-cell matrix, processing it, plotting it, interpreting it, and finding lots of lovely genes. Now you want to infer trajectories, or relationships between cells... you can do that here, using the Galaxy interface, or head over to the [Jupyter notebook version of this tutorial]({% link topics/single-cell/tutorials/scrna-case_JUPYTER-trajectories/tutorial.md %}) to learn how to perform the same analysis using Python.
 
-Traditionally, we thought that differentiating or changing cells jumped between discrete states, so 'Cell A' became 'Cell B' as part of its maturation. However, most data shows otherwise. Generally, there is a spectrum (a 'trajectory', if you will...) of small, subtle changes along a pathway of that differentiation. Trying to analyse cells every 10 seconds can be pretty tricky, so 'pseudotime' analysis takes a single sample and assumes that those cells are all on slightly different points along a path of differentiation. Some cells might be slightly more mature and others slightly less, all captured at the same 'time'.  These cells are sorted accordingly along these pseudotime paths of differentiation to build a continuum of cells from one state to the next.  We therefore 'assume' or 'infer' relationships between from this continuum of cells.
+Traditionally, we thought that differentiating or changing cells jumped between discrete states, so 'Cell A' became 'Cell B' as part of its maturation. However, most data shows otherwise. Generally, there is a spectrum (a 'trajectory', if you will...) of small, subtle changes along a pathway of that differentiation. Trying to analyse cells every 10 seconds can be pretty tricky, so 'pseudotime' analysis takes a single sample and assumes that those cells are all on slightly different points along a path of differentiation. Some cells might be slightly more mature and others slightly less, all captured at the same 'time'.  These cells are sorted accordingly along these pseudotime paths of differentiation to build a continuum of cells from one state to the next.  We therefore 'assume' or 'infer' relationships from this continuum of cells.
 
 We will use the same sample from the previous three tutorials, which contains largely T-cells in the thymus. We know T-cells differentiate in the thymus, so we would assume that we would capture cells at slightly different time points within the same sample. Furthermore, our cluster analysis alone showed different states of T-cells. Now it's time to look further!
 
 > <comment-title>Tutorial from Scanpy</comment-title>
-> Please note, this tutorial is largely based on the trajectories tutorial found [on the Scanpy site itself](https://scanpy-tutorials.readthedocs.io/en/latest/paga-paul15.html) ({% cite scanpytutorialsTrajectoryInference %}).
+> Please note, this tutorial is largely based on the trajectories tutorial found [on the Scanpy site itself](https://scanpy.readthedocs.io/en/stable/tutorials/trajectories/paga-paul15.html) ({% cite scanpytutorialsTrajectoryInference %}).
 {: .comment}
 
 > <agenda-title></agenda-title>
@@ -168,7 +168,7 @@ And now time to plot it!
 >    - {% icon param-file %} *"Input object in AnnData/Loom format"*: `FDG object Anndata` (output of **Scanpy RunFDG** {% icon tool %})
 >    - *"name of the embedding to plot"*: `draw_graph_fa`
 >    - *"color by attributes, comma separated texts"*: `cell_type`
->    - *"Use raw attributes if present"*: {% icon galaxy-toggle %} `No`
+>    - *"Use raw attributes"*: {% icon galaxy-toggle %} `No`
 >    - *"Location of legend"*: `On data`
 {: .hands_on}
 
@@ -234,7 +234,7 @@ Now that we've re-calculated the nearest neighbours, we can use these new neighb
 >    - {% icon param-file %} *"Input object in AnnData/Loom format"*: `FDG object Anndata` (output of **Scanpy RunFDG** {% icon tool %})
 >    - *"name of the embedding to plot"*: `draw_graph_fa`
 >    - *"color by attributes, comma separated texts"*: `cell_type`
->    - *"Use raw attributes if present"*: `No`
+>    - *"Use raw attributes"*: `No`
 >    - *"Location of legend"*: `On data`
 >
 {: .hands_on}
@@ -257,10 +257,9 @@ Now that we've re-calculated the nearest neighbours, we can use these new neighb
 > - Control
 >   - Go straight to the [Partition-based Graph Abstraction (PAGA) section](#partition-based-graph-abstraction-paga)
 > - Everyone else:
->   - you could recluster your cells using {% tool [Scanpy FindCluster](toolshed.g2.bx.psu.edu/repos/ebi-gxa/scanpy_find_cluster/scanpy_find_cluster/1.8.1+galaxy0) %} at a different resolution, perhaps lower than the 0.6 we used before (Take a look at the Cell clusters step in the [Filter, Plot and Explore]({% link topics/single-cell/tutorials/scrna-case_basic-pipeline/tutorial.md %}) tutorial if you need help with this.)
-> - Please note that in this case, you will want to change the PAGA step **Scanpy PAGA** to group by `louvain` rather than `cell_type`. You can certainly still plot both, we only didn't because with using our old Louvain calls, the `cell_type` and `louvain` categories are identical.
+>   - you could recluster your cells using {% tool [Scanpy FindCluster](toolshed.g2.bx.psu.edu/repos/ebi-gxa/scanpy_find_cluster/scanpy_find_cluster/1.8.1+galaxy0) %} at a different resolution, perhaps lower than the 0.6 we used before (Take a look at the Cell clusters step in the [Filter, Plot and Explore]({% link topics/single-cell/tutorials/scrna-case_basic-pipeline/tutorial.md %}) tutorial if you need help with this.) Please note that in this case, you will want to change the PAGA step **Scanpy PAGA** to group by `louvain` rather than `cell_type`. You can certainly still plot both, we only didn't because with using our old Louvain calls, the `cell_type` and `louvain` categories are identical.
 >   - you could undo the optional diffusion map step by recalculating the neighbours again using `X_pca` instead of `X_diffmap`
->   - you could also try changing the number of neighbors used in that step
+>   - you could also try changing the number of neighbors used in that step when running {% tool [Scanpy ComputeGraph](toolshed.g2.bx.psu.edu/repos/ebi-gxa/scanpy_compute_graph/scanpy_compute_graph/1.8.1+galaxy9) %}
 >
 > - Everyone else: You will want to compare FREQUENTLY with your control team member.
 {: .details}
@@ -326,7 +325,7 @@ Force-directed graphs can be initialised randomly, or we can prod it in the righ
 >    - {% icon param-file %} *"Input object in AnnData/Loom format"*: `FDG object Anndata` (output of **Scanpy RunFDG** {% icon tool %})
 >    - *"name of the embedding to plot"*: `draw_graph_fa`
 >    - *"color by attributes, comma separated texts"*: `cell_type`
->    - *"Use raw attributes if present"*: `No`
+>    - *"Use raw attributes"*: `No`
 >    - *"Location of legend"*: `On data`
 >
 {: .hands_on}
@@ -358,8 +357,8 @@ The easiest way to do this is just to rerun {% icon galaxy-refresh %} the previo
 >    - {% icon param-file %} *"Input object in AnnData/Loom format"*: `FDG object Anndata` (output of **Scanpy RunFDG** {% icon tool %})
 >    - *"name of the embedding to plot"*: `draw_graph_fa`
 >    - *"color by attributes, comma separated texts"*: `genotype`
->    - *"Use raw attributes if present"*: `No`
->    - *"Location of legend"*: `On data`
+>    - *"Use raw attributes"*: `No`
+>    - *"Location of legend"*: `Right margin`
 >
 {: .hands_on}
 
@@ -386,7 +385,7 @@ We're also interested in the expression of the two genes that are known to be ma
 >    - {% icon param-file %} *"Input object in AnnData/Loom format"*: `FDG object Anndata` (output of **Scanpy RunFDG** {% icon tool %})
 >    - *"name of the embedding to plot"*: `draw_graph_fa`
 >    - *"color by attributes, comma separated texts"*: `ENSMUSG00000023274,ENSMUSG00000053977`
->    - *"Use raw attributes if present"*: `No`
+>    - *"Use raw attributes"*: `No`
 >    - *"Location of legend"*: `On data`
 >
 >    > <comment-title> Gene Symbols </comment-title>
@@ -420,7 +419,7 @@ We know that our cells are initialising at DN. We can feed that information into
 > If you called new clusters using {% tool [Scanpy FindCluster](toolshed.g2.bx.psu.edu/repos/ebi-gxa/scanpy_find_cluster/scanpy_find_cluster/1.8.1+galaxy0) %}, you might want to choose one of those clusters to be your root cell instead, so change the `cell_type` for `louvain` and then name the cluster number. Use the plots you created to help you pick the number!
 {: .details}
 
-Onto the [diffusion pseudotime](https://scanpy.readthedocs.io/en/stable/api/scanpy.tl.dpt.html), where we infer multiple time points within the same piece of data!
+On to the [diffusion pseudotime](https://scanpy.readthedocs.io/en/stable/api/scanpy.tl.dpt.html), where we infer multiple time points within the same piece of data!
 
 > <hands-on-title> DPT Plot </hands-on-title>
 >
@@ -434,7 +433,7 @@ Onto the [diffusion pseudotime](https://scanpy.readthedocs.io/en/stable/api/scan
 >    - {% icon param-file %} *"Input object in AnnData/Loom format"*: `Diffusion pseudotime inference Anndata` (output of **Scanpy DPT** {% icon tool %})
 >    - *"name of the embedding to plot"*: `draw_graph_fa`
 >    - *"color by attributes, comma separated texts"*: `cell_type,dpt_pseudotime`
->    - *"Use raw attributes if present"*: `No`
+>    - *"Use raw attributes"*: `No`
 >    - *"Location of legend"*: `On data`
 >
 {: .hands_on}


### PR DESCRIPTION
- Some minor updates to tool names, links 
- Also changed the bit on the order in which Anndata are concatenated in the combining datasets tutorial - the first one you click is the first one added, so they should click N702 to N707 not 7 to 2

New changes:
-  The Filter, Plot, Explore tutorial has also been checked now - only change is that we need to include the older input history as the new one doesn't work for the current tool versions/workflow - I'm not sure if we should have both available for now or just have the older one until we update the tools?
- Also added a note for people using the newer tools on the trajectories tutorial as they need to change n-pcs (again, we can improve this when we update the tool versions)
