### PR TITLE
Fix for CYOA videos

### DIFF
--- a/_includes/youtube.html
+++ b/_includes/youtube.html
@@ -5,7 +5,7 @@
     credentialless
     allowfullscreen
     referrerpolicy="no-referrer"
-    sandbox="allow-scripts allow-same-origin"
+    sandbox="allow-scripts allow-same-origin allow-popups"
     allow="accelerometer 'none'; ambient-light-sensor 'none'; autoplay 'none'; battery 'none'; bluetooth 'none'; browsing-topics 'none'; camera 'none'; ch-ua 'none'; display-capture 'none'; domain-agent 'none'; document-domain 'none'; encrypted-media 'none'; execution-while-not-rendered 'none'; execution-while-out-of-viewport 'none'; gamepad 'none'; geolocation 'none'; gyroscope 'none'; hid 'none'; identity-credentials-get 'none'; idle-detection 'none'; keyboard-map 'none'; local-fonts 'none'; magnetometer 'none'; microphone 'none'; midi 'none'; navigation-override 'none'; otp-credentials 'none'; payment 'none'; picture-in-picture 'none'; publickey-credentials-create 'none'; publickey-credentials-get 'none'; screen-wake-lock 'none'; serial 'none'; speaker-selection 'none'; sync-xhr 'none'; usb 'none'; web-share 'none'; window-management 'none'; xr-spatial-tracking 'none'"
     csp="sandbox allow-scripts allow-same-origin;"
     width="{{include.width | default: 560 }}"

--- a/_includes/youtube.html
+++ b/_includes/youtube.html
@@ -10,7 +10,7 @@
     csp="sandbox allow-scripts allow-same-origin;"
     width="{{include.width | default: 560 }}"
     height="{{include.height| default: 315 }}"
-    src="https://www.youtube-nocookie.com/embed/{{ include.id }}{% if include.start %}?start={{ include.start }}{% endif %}"
+    src="https://www.youtube{% unless include.cyoa %}-nocookie{% endunless%}.com/embed/{{ include.id }}{% if include.start %}?start={{ include.start }}{% endif %}"
     title="{{ include.title }}"
     frameborder="0"
     loading="lazy"

--- a/_layouts/recordings.html
+++ b/_layouts/recordings.html
@@ -66,7 +66,7 @@ layout: base
   <div class="row recording">
 
     <div class="col-md-6 recording-video">
-    {% include _includes/youtube.html id=recording.youtube_id width="100%" height="100%" nofigure=true%}
+    {% include _includes/youtube.html id=recording.youtube_id width="100%" height="100%" nofigure=true cyoa=recording.cyoa %}
     </div>
 
     <div class="col-md-6 recording-metadata">
@@ -164,6 +164,13 @@ layout: base
       <td><strong>License</strong></td>
       <td><a href="https://creativecommons.org/licenses/by/4.0/">CC-BY</a></td>
     </tr>
+
+    {% if recording.cyoa %}
+    <tr>
+      <td><strong>Note</strong></td>
+      <td>This is a <b>Choose-your-own-adventure</b> video. This means the recording consists of multiple videos, and you will be able to choose your next video at the end of each segment.</td>
+    </tr>
+    {% endif %}
 
     </tbody>
     </table>

--- a/_layouts/recordings.html
+++ b/_layouts/recordings.html
@@ -17,7 +17,7 @@ layout: base
 
   <p><b>Want to add your own recording?</b> We would love to have it to our library!</p>
 
-  [Add your Recording!]({% link faqs/gtn/recordings_add.md %}){: .btn.btn-info}
+  <a href="{% link faqs/gtn/recordings_add.md %}" class="btn btn-info">Add your recordings!</a>
 
   </div>
 

--- a/bin/schema-tutorial.yaml
+++ b/bin/schema-tutorial.yaml
@@ -540,3 +540,5 @@ mapping:
               type: str
             description:
               type: str
+            cyoa:
+              type: bool

--- a/topics/transcriptomics/tutorials/ref-based/tutorial.md
+++ b/topics/transcriptomics/tutorials/ref-based/tutorial.md
@@ -68,6 +68,7 @@ recordings:
   date: '2023-05-15'
   galaxy_version: '23.01'
   length: 2H50M
+  cyoa: true
 - captioners:
   - hexylena
   - shiltemann
@@ -376,7 +377,7 @@ We will map our reads to the *Drosophila melanogaster* genome using **STAR** ({%
 >           - *"Select reference genome"*: `Fly (Drosophila melanogaster): dm6 Full`
 >           - {% icon param-file %} *"Gene model (gff3,gtf) file for splice junctions"*: the imported `Drosophila_melanogaster.BDGP6.32.109_UCSC.gtf.gz`
 >           - *"Length of the genomic sequence around annotated junctions"*: `36`
->               
+>
 >             This parameter should be length of reads - 1
 >                - *"Per gene/transcript output"*: `Per gene read counts (GeneCounts)`
 >    - *"Compute coverage"*:


### PR DESCRIPTION
The end screens which presented the choice of next video in the CYOA transcriptomics video were not showing up in the embedded videos (due to the youtube-nocookie domain). Added metadata field to indicate whether a video is CYOA.

Fixes the issue we discussed today @teresa-m 
