### PR TITLE
temporarily hide docker images while they aren't updated

### DIFF
--- a/_includes/instance-dropdown.html
+++ b/_includes/instance-dropdown.html
@@ -4,7 +4,7 @@
 {% assign supported_inexactly = own_material.supported_servers.inexact | size %}
 {% assign supported = supported_exactly | plus: supported_inexactly %}
 
-{% if supported > 0 or include.docker %}
+{% if supported > 0 %}
     <a href="#" class="dropdown-toggle" data-toggle="dropdown" aria-expanded="false" title="Where to run the tutorial">
         {% icon instances %}{% if include.label %}&nbsp;{{ locale['supporting-galaxies'] | default: "Available on these Galaxies" }} {% endif %}
     </a>
@@ -44,6 +44,7 @@
     {% endfor %}
     {% endif %}
 
+    <!--
     {% if include.docker %}
 	<li class="dropdown-header">
 		Containers
@@ -54,5 +55,6 @@
             </a>
         </li>
     {% endif %}
+    -->
     </ul>
 {% endif %}

--- a/_layouts/topic.html
+++ b/_layouts/topic.html
@@ -63,6 +63,7 @@ layout: base
     {{ content }}
 
     {% if topic.type == "use" %}
+    <!--
         <h2 id="docker_image">Galaxy instances</h2>
         <p>You can use a public Galaxy instance which has been tested for the availability of the used tools. They are listed along with the tutorials above.</p>
         {% if topic.docker_image and topic.docker_image != "" %}
@@ -71,6 +72,7 @@ layout: base
             <p>NOTE: Use the -d flag at the end of the command if you want to automatically download all the data-libraries into the container.</p>
             <p>It will launch a flavored Galaxy instance available on <a href="http://localhost:8080">http://localhost:8080</a>. This instance will contain all the tools and workflows to follow the tutorials in this topic. Login as <b>admin</b> with password <b>password</b> to access everything.</p>
         {% endif %}
+    -->
     {% endif %}
 
     {% unless topic.tag_based %}


### PR DESCRIPTION
since the base image unfortunately hasn't been updated in a bit.