### PR TITLE
add certificats to main and assembly introduction

### DIFF
--- a/events/galaxy-academy-2024.md
+++ b/events/galaxy-academy-2024.md
@@ -179,10 +179,15 @@ program:
         topic: fair
 ---
 # Welcome to the Galaxy Training Academy
-Do you want to learn how to use Galaxy, a open source data analysis platform? Then you are at the right place. We offer here a 5-day Global Online and Asynchronous learning event.
+Do you want to learn how to use Galaxy, a open source data analysis platform? Then you are at the right place. We offer here a **5-day Global Online and Asynchronous learning event**.
+
+We provide you with training materials which you can study at your own pace and on your own time throughout the week. Don't worry, asynchronous does not mean that you are alone! If you ever need help, you can contact one of our many trainers worldwide via **Slack**.
+
 
 On the first day you can make yourself familiar with the Galaxy platform. In the next days you can follow different tracks, please go to the program tab for more informaiton.
 
 You can set your own pace on your learning journey using our provided self-learning materials. Next to the program, you will find Slack channels you can join to exchange with the trainers and other participants during the event. Here you will also find help if you have qustions or run into an issue during the training. We try to cover all time zones with helpers for each topic, but please be patient if you do not get an immediat response.
 
 You only need a browser and an account on one of the galaxy instances registered for this event. Please have a look at the setup tab.
+
+**Certificats:** You can earn a certificate for the tracks you attended by answering a short questionnaire to verify your participation.

--- a/events/tracks/gta2024-assembly.md
+++ b/events/tracks/gta2024-assembly.md
@@ -28,6 +28,10 @@ program:
     tutorials:
       - name: get-started-genome-assembly
         topic: assembly
+      - type: custom
+        name: "[Introduction To Genome Assembly](https://docs.google.com/presentation/d/1TPr6yKrnNj4cUb5We-E7SXAL_1h2Cqogq0tDTkgETgQ/edit?usp=sharing)"
+        description: |
+          [Lecture Slides](https://docs.google.com/presentation/d/1TPr6yKrnNj4cUb5We-E7SXAL_1h2Cqogq0tDTkgETgQ/edit?usp=sharing); [Lecture Video](https://youtu.be/9WZe7VGtr-k)
       - name: ERGA-post-assembly-QC
         topic: assembly
 

--- a/events/tracks/gta2024-bycovid.md
+++ b/events/tracks/gta2024-bycovid.md
@@ -27,7 +27,7 @@ program:
       - type: custom
         name: "[Sequencing spectrum viral genomes](https://gallantries.github.io/video-library/videos/virology/sequencing-spectrum-viral-genomes)"
         description: |
-          Lecture Video
+          [Lecture Video](https://gallantries.github.io/video-library/videos/virology/sequencing-spectrum-viral-genomes)
       - name: sars-cov-2
         topic: variant-analysis
       - name: aiv-analysis
@@ -42,7 +42,7 @@ program:
       - type: custom
         name: "[An automated SARS-CoV-2 genome surveillance system built around Galaxy](https://www.infectious-diseases-toolkit.org/showcase/covid19-galaxy)"
         description: |
-          Lecture Video
+          [Lecture Tutorial](https://www.infectious-diseases-toolkit.org/showcase/covid19-galaxy)
       - name: sars-cov-2-variant-discovery
         topic: variant-analysis
       - name: workflow-automation
@@ -50,9 +50,9 @@ program:
       - type: custom
         name: "[The usegalaxy.* SARS-CoV-2 Bot in Action](https://gallantries.github.io/video-library/videos/sars-cov2/usegalaxy-star-bot/)"
         description: |
-          Demo Video
+          [Demo Video](https://gallantries.github.io/video-library/videos/sars-cov2/usegalaxy-star-bot/)
       - type: custom
         name: "[Upload to ENA](https://gallantries.github.io/video-library/videos/sars-cov2/upload-ena)"
         description: |
-          Demo Video
+          [Demo Video](https://gallantries.github.io/video-library/videos/sars-cov2/upload-ena)
 ---


### PR DESCRIPTION
Added 
- descriptions that we will use Slack and give out Certificates to the main GTA page
- links to the by-covid track
- Assembly introduction slides + video
