### PR TITLE
Remove incorrectly configured names

### DIFF
--- a/topics/genome-annotation/tutorials/amr-gene-detection/data/trackList.json
+++ b/topics/genome-annotation/tutorials/amr-gene-detection/data/trackList.json
@@ -1,10 +1,6 @@
 {
    "formatVersion" : 1,
    "hideGenomeOptions" : false,
-   "names" : {
-      "type" : "Hash",
-      "url" : "names/"
-   },
    "plugins" : [
       {
          "location" : "https://cdn.jsdelivr.net/gh/TAMU-CPT/blastview@97572a21b7f011c2b4d9a0b5af40e292d694cbef/",

--- a/topics/genome-annotation/tutorials/bacterial-genome-annotation/data/trackList.json
+++ b/topics/genome-annotation/tutorials/bacterial-genome-annotation/data/trackList.json
@@ -2,10 +2,6 @@
    "defaultTracks" : "e1c36f2c4382e60836c6c4b4d8026fa5_0",
    "formatVersion" : 1,
    "hideGenomeOptions" : false,
-   "names" : {
-      "type" : "Hash",
-      "url" : "names/"
-   },
    "plugins" : [
       {
          "location" : "https://cdn.jsdelivr.net/gh/TAMU-CPT/blastview@97572a21b7f011c2b4d9a0b5af40e292d694cbef/",


### PR DESCRIPTION
@jennaj reported in GTN chat that a name popup was triggering a page scroll. This didn't happen in the past but it does now, not sure when that changed. @scottcain explained the root cause of jbrowse doing this. Not sure how these were generated by the tool.

As the browser level policy isn't implemented yet, we cannot prevent this happening in the future: https://github.com/w3c/csswg-drafts/issues/7134 so we need to fix them individually.