### PR TITLE
Ensure event page content is shown on small screens as well

### DIFF
--- a/_includes/tutorial_list.html
+++ b/_includes/tutorial_list.html
@@ -44,7 +44,12 @@
           {% endif %}
 
           {% if material.layout == 'custom' %} <!-- e.g. for events -->
-            <td> {{material.title | markdownify }} </td>
+            <td>
+              {{material.title | markdownify }} 
+              <div class="duplicate" style="display: none;">
+                {{material.description | markdownify }}
+              </div>
+            </td>
             <td colspan="3"> {{material.description | markdownify }}</td>
           {% else %}
           <td class="tutorial_title">


### PR DESCRIPTION
The information hierarchy is kinda sub-optimal, but, not something I think we should fix now, so last minute.

![Screenshot 2024-10-02 at 10-23-25 BeYond-COVID](https://github.com/user-attachments/assets/efefece7-26a2-4288-89a4-043e78505884)
