### PR TITLE
Ensure pages without short IDs are part of search results

### DIFF
--- a/_plugins/generator-workflows.rb
+++ b/_plugins/generator-workflows.rb
@@ -44,11 +44,13 @@ module Jekyll
           page2 = PageWithoutAFile.new(site, '', '', "#{workflow['path'].gsub(/.ga$/, '.html')}")
           path = File.join('/', workflow['path'].gsub(/.ga$/, '.html'))
           page2.content = nil
+          page2.data['title'] = workflow['title']
           page2.data['layout'] = 'workflow'
           page2.data['material'] = material
           page2.data['workflow'] = workflow
           page2.data['js_requirements'] = {'mathjax' => false, 'mermaid' => true}
           page2.data['short_id'] = shortlinks[path]
+          page2.data['redirect_from'] = ["/short/#{shortlinks[path]}"]
           site.pages << page2
         end
       end

--- a/_plugins/gtn.rb
+++ b/_plugins/gtn.rb
@@ -399,7 +399,7 @@ module Jekyll
 
     def layout_to_human(layout)
       case layout
-      when /slides/
+      when /_slides/ # excludes slides-plain
         'Slides'
       when /tutorial_hands_on/
         'Hands-on'
@@ -407,6 +407,8 @@ module Jekyll
         'FAQs'
       when 'news'
         'News'
+      when 'workflow'
+        'Workflow'
       end
     end
 
@@ -569,6 +571,10 @@ module Jekyll
     def topic_name_from_page(page, site)
       if page.key? 'topic_name'
         site.data[page['topic_name']]['title']
+      elsif page['url'] =~ /^\/faqs\/gtn/
+        'GTN FAQ'
+      elsif page['url'] =~ /^\/faqs\/galaxy/
+        'Galaxy FAQ'
       else
         site.data.fetch(page['url'].split('/')[2], { 'title' => '' })['title']
       end
@@ -937,6 +943,13 @@ Jekyll::Hooks.register :site, :post_read do |site|
 
   site.pages.each do |page|
     page.data['short_id'] = shortlinks_reversed[page.url]
+  end
+
+  # Annotate symlinks
+  site.pages.each do |page|
+    page.data['symlink'] = File.symlink?(page.path) 
+    # Elsewhere we checked more levels deep, maybe enable if needed.
+    # || File.symlink?(File.dirname(page.path)) || File.symlink?(File.dirname(File.dirname(page.path)))
   end
 
   Jekyll.logger.info '[GTN] Annotating events'

--- a/search2.html
+++ b/search2.html
@@ -27,6 +27,7 @@ We are testing a new search experience. It does not do semantic ranking of resul
 		<option value="Slides">Slides</option>
 		<option value="FAQs">FAQs</option>
 		<option value="News">News</option>
+		<option value="Workflow">Workflows</option>
 	</select>
 	</div>
 	</div>
@@ -74,10 +75,12 @@ We are testing a new search experience. It does not do semantic ranking of resul
 			</tr>
 		{%- endfor -%}
 		{%- for page in site.pages -%}
-			{%- if page.short_id -%}
+			{%- assign layout = page.layout | layout_to_human -%}
+			{%- unless page.symlink %}
+			{%- if layout -%}
 			{%- if page.short_id != 'F00001' -%}
 			<tr id="{{ page.short_id }}">
-				<td><a class="badge badge-info" href="https://gxy.io/GTN:{{ page.short_id }}">{%- icon purl -%} GTN:{{ page.short_id }}</a></td>
+				<td>{% if page.short_id %}<a class="badge badge-info" href="https://gxy.io/GTN:{{ page.short_id }}">{%- icon purl -%} GTN:{{ page.short_id }}</a>{% else %}<abbr title="To Be Assigned">TBA</a>{% endif %}</td>
 				<td>{{ page.layout | layout_to_human }}</td>
 				<td><a href="{{ site.baseurl }}{{ page.url }}">{{ page.title }}</a><br/>
 					{%- for tag in page.tags -%}
@@ -90,6 +93,7 @@ We are testing a new search experience. It does not do semantic ranking of resul
 			</tr>
 			{%- endif -%}
 			{%- endif -%}
+			{%- endunless -%}
 		{%- endfor -%}
 	</tbody>
 </table>


### PR DESCRIPTION
per request from @sujaikumar, now tutorials without short IDs will show up in search results. Additionally workflows are now included as well.