### PR TITLE
Youtube IDs are 11 characters only

### DIFF
--- a/bin/schema-tutorial.yaml
+++ b/bin/schema-tutorial.yaml
@@ -535,7 +535,7 @@ mapping:
               pattern: /^(?:([0-9]*)[Hh])*(?:([0-9]*)[Mm])*(?:([0-9.]*)[Ss])*$/
             youtube_id:
               type: str
-              pattern: /[A-Za-z0-9_-]{9,13}/
+              pattern: /[A-Za-z0-9_-]{11}/
             type:
               type: str
             archive-id:


### PR DESCRIPTION
xref #5419


thanks @martenson 