### PR TITLE
fix funder/funding split in json metadata

### DIFF
--- a/_layouts/contributor_index.html
+++ b/_layouts/contributor_index.html
@@ -23,9 +23,9 @@ layout: base
 					<h1>
 						{{ entity.name | default: page.contributor }}
 					</h1>
-				{% if entity.funder_name %}
-					<p>Funded by {{ entity.funder_name }}</p>
-				{% endif %}
+					{% if entity.funder%}
+					<p>The activities listed below were partially funded by this project.</p>
+					{% endif %}
 				</hgroup>
 
 				{% if entity.bio %}
@@ -34,9 +34,6 @@ layout: base
 				</p>
 				{% endif %}
 
-				{% if entity.funder %}
-				<div class="label label-default label-large" style="{{ 'GTN Funder' | colour_tag }}">GTN Funder</div>
-				{% endif %}
 				{% if entity.in_memoriam %}
 				<div class="alert alert-dark" role="alert">
 					<h2 class="alert-heading">In Memoriam</h2>

--- a/_plugins/gtn/contributors.rb
+++ b/_plugins/gtn/contributors.rb
@@ -91,9 +91,26 @@ module Gtn
     # +data+:: +Hash+ of the YAML frontmatter from a material
     # Returns:
     # +Array+ of contributor IDs
-    def self.get_funders(data)
+    def self.get_funders(site, data)
       if data.key?('contributions') && data['contributions'].key?('funding')
-        data['contributions']['funding']
+        # The ones specifically in the Grants table
+        data['contributions']['funding'].reject{ |f| site.data['funders'].key?(f) }
+      else
+        []
+      end
+    end
+
+    ##
+    # Get the funders of a material.
+    # Params:
+    # +site+:: +Jekyll::Site+ object
+    # +data+:: +Hash+ of the YAML frontmatter from a material
+    # Returns:
+    # +Array+ of grant IDs
+    def self.get_grants(site, data)
+      if data.key?('contributions') && data['contributions'].key?('funding')
+        # The ones specifically in the Grants table
+        data['contributions']['funding'].select{ |f| site.data['funders'].key?(f) }
       else
         []
       end

--- a/_plugins/jekyll-jsonld.rb
+++ b/_plugins/jekyll-jsonld.rb
@@ -184,7 +184,7 @@ module Jekyll
         '@context': 'https://schema.org',
         '@type': 'Grant',
         identifier: contributor['funding_id'],
-        url: contributor['url'] || Gtn::Contributors.fetch_funding_url(contributor),
+        url: Gtn::Contributors.fetch_funding_url(contributor) || contributor['url'],
         funder: generate_funder_jsonld(id, contributor, site)
       }
 
@@ -274,10 +274,10 @@ module Jekyll
       instructors = Gtn::Contributors.get_instructors(page.to_h).map do |x|
         to_pfo_jsonld(x, site, json: false)
       end
-      funders = Gtn::Contributors.get_funders(page.to_h).map do |x|
+      funders = Gtn::Contributors.get_funders(site, page.to_h).map do |x|
         to_pfo_jsonld(x, site, json: false)
       end
-      funding = Gtn::Contributors.get_funders(page.to_h).map do |x|
+      funding = Gtn::Contributors.get_grants(site, page.to_h).map do |x|
         generate_funding_jsonld(x, Gtn::Contributors.fetch_contributor(site, x), site)
       end
 
@@ -511,6 +511,18 @@ module Jekyll
         material.fetch('objectives', [])
       end.flatten.compact
 
+      funders = materials.map do |material|
+        Gtn::Contributors.get_funders(site, material).map do |x|
+          to_pfo_jsonld(x, site, json: false)
+        end
+      end.flatten.uniq.compact
+
+      funding = materials.map do |material|
+        Gtn::Contributors.get_grants(site, material).map do |x|
+          generate_funding_jsonld(x, Gtn::Contributors.fetch_contributor(site, x), site)
+        end
+      end.flatten.uniq.compact
+
       # TODO: add topic edam terms too? Not sure.
       parts = []
       materials.each do |material|
@@ -558,8 +570,8 @@ module Jekyll
         # learningResourceType
         # teaches
 
-        # funder: funders, # Org or person
-        # funding: funding, # Grant
+        funder: funders, # Org or person
+        funding: funding, # Grant
         publisher: GTN,
         provider: GTN,
         syllabusSections: syllab,
@@ -652,6 +664,11 @@ module Jekyll
         url: "#{site['url']}#{site['baseurl']}/topics/#{topic['name']}/"
       }
 
+      funding = Gtn::Contributors.get_grants(site, material.to_h).map do |x|
+        generate_funding_jsonld(x, Gtn::Contributors.fetch_contributor(site, x), site)
+      end
+
+
       # aggregate everything
       data = {
         # Properties from Course
@@ -690,7 +707,8 @@ module Jekyll
         # "contentRating":,
         # "contentReferenceTime":,
         # "contributor" described below
-        copyrightHolder: GTN,
+        # copyrightHolder: GTN,
+        # copyrightNotice: m
         # "copyrightYear":,
         # "correction":,
         # "creator":,
@@ -704,7 +722,7 @@ module Jekyll
         # "encodingFormat":,
         # "exampleOfWork":,
         # "expires":,
-        # "funder":,
+        "funder": funding,
         # "genre":,
         # "hasPart" described below
         headline: (material['title']).to_s,
@@ -779,6 +797,24 @@ module Jekyll
           data['datePublished'] = Gtn::PublicationTimes.obtain_time(material['path'])
         end
       end
+
+      if material.key?('copyright')
+        # copyrightHolder: GTN,
+        data['copyrightNotice'] = material['copyright']
+      else
+        # I'm not sure this is accurate.
+        data['copyrightHolder'] = GTN
+      end
+
+      funders = Gtn::Contributors.get_funders(site, material).map do |x|
+        to_pfo_jsonld(x, site, json: false)
+      end
+      funding = Gtn::Contributors.get_grants(site, material).map do |x|
+        generate_funding_jsonld(x, Gtn::Contributors.fetch_contributor(site, x), site)
+      end
+
+      data['funder'] = funders
+      data['funding'] = funding
 
       data['identifier'] = "https://gxy.io/GTN:#{material['short_id']}" if material.key?('short_id')
 

--- a/_plugins/jekyll-jsonld.rb
+++ b/_plugins/jekyll-jsonld.rb
@@ -664,11 +664,6 @@ module Jekyll
         url: "#{site['url']}#{site['baseurl']}/topics/#{topic['name']}/"
       }
 
-      funding = Gtn::Contributors.get_grants(site, material.to_h).map do |x|
-        generate_funding_jsonld(x, Gtn::Contributors.fetch_contributor(site, x), site)
-      end
-
-
       # aggregate everything
       data = {
         # Properties from Course
@@ -722,7 +717,7 @@ module Jekyll
         # "encodingFormat":,
         # "exampleOfWork":,
         # "expires":,
-        "funder": funding,
+        # "funder": funding,
         # "genre":,
         # "hasPart" described below
         headline: (material['title']).to_s,


### PR DESCRIPTION
per discussion with @shiltemann over the precise use of 'organisation' and 'funder'.