### PR TITLE
Add in bioinfo bootcamp details retrospectively

### DIFF
--- a/CONTRIBUTORS.yaml
+++ b/CONTRIBUTORS.yaml
@@ -705,7 +705,7 @@ angiolini:
     joined: 2024-05
     elixir_node: uk
     orcid: 0000-0002-0814-8830
-    
+
 emmaleith:
     name: Emma Leith
     email: leith023@umn.edu
@@ -840,7 +840,7 @@ GabrielaLopez:
     orcid: 0000-0002-0814-8830
     joined: 2023-01
     elixir_node: uk
-    
+
 gallardoalba:
     name: Cristóbal Gallardo
     joined: 2020-11
@@ -950,6 +950,12 @@ hexylena:
       lat: 51.91
       lon: 4.46
 
+hfraser:
+  name: Heather Fraser
+  joined: 2024-09
+  email: heather.fraser@open.ac.uk
+  elixir_node: uk
+
 hmenager:
     name: Hervé Ménager
     joined: 2017-09
@@ -998,7 +1004,7 @@ hujambo-dunia:
 igcbioinformatics:
     name: IGC Bioinformatics Unit
     joined: 2018-12
-    
+
 igormakunin:
     name: Igor Makunin
     joined: 2024-09
@@ -1361,7 +1367,7 @@ LonsBio:
 loraine-gueguen:
     name: Loraine Guéguen
     joined: 2017-09
-    
+
 lybCNU:
     name: Yongbin Li
     joined: 2024-08
@@ -1551,7 +1557,7 @@ Melkeb:
 melpetera:
     name: Mélanie Petera
     joined: 2019-06
-    
+
 meltemktn:
     name: Meltem Kutnu
     joined: 2024-09
@@ -1561,6 +1567,11 @@ mgramm1:
     email: mgramm2@smail.uni-koeln.de
     orcid: 0000-0002-4217-5277
     joined: 2021-03
+
+mhintze:
+    name: Mark Hintze
+    email: mark.hintze@open.ac.uk
+    joined: 2024-09
 
 miaomiaozhou88:
     name: Miaomiao Zhou
@@ -1674,7 +1685,7 @@ nakucher:
     name: Natalie Kucher
     email: nkucher3@jhu.edu
     joined: 2023-06
-    
+
 natalie-wa:
     name: Natalie Whitaker-Allen
     email: nwhitak5@jh.edu
@@ -1884,7 +1895,7 @@ paulzierep:
 
 pavanvidem:
     name: Pavankumar Videm
-    orcid: 0000-0002-5192-126X  
+    orcid: 0000-0002-5192-126X
     joined: 2017-09
     affiliations:
       - uni-freiburg
@@ -2150,7 +2161,7 @@ shwdey:
     name: Shweta Pandey
     email: shwphd@gmail.com
     joined: 2024-06
-    
+
 simonbray:
     name: Simon Bray
     joined: 2019-05
@@ -2344,7 +2355,7 @@ timonschlegel:
     name: Timon Schlegel
     orcid: 0009-0001-3228-105X
     joined: 2024-05
-    
+
 timothygriffin:
     name: Timothy J. Griffin
     email: tgriffin@umn.edu
@@ -2399,7 +2410,7 @@ tsenapathi:
 
 trungN:
     name: Nguyen Vo Minh Trung
-    joined: 2024-09    
+    joined: 2024-09
 
 TKlingstrom:
     name: Tomas Klingström

--- a/events/2024-09-16-bioinfo_bootcamp-2024.md
+++ b/events/2024-09-16-bioinfo_bootcamp-2024.md
@@ -10,6 +10,8 @@ description: |
 
     We will provide full information on registering for Galaxy and other necessary platforms in the last week in August and will have a drop-in session to troubleshoot any problems on these registrations and any questions you have about the Bootcamp on Monday, 2nd, September from 19:30-20:30.  
 
+    We strongly thank the Galaxy-Europe and Galaxy Training Network for their computational and training resources that make this course possible for the first time.
+
 date_start: 2024-09-16
 date_end: 2024-09-20
 contributions:

--- a/events/2024-09-16-bioinfo_bootcamp-2024.md
+++ b/events/2024-09-16-bioinfo_bootcamp-2024.md
@@ -1,0 +1,31 @@
+---
+layout: event-external
+title: 2024 Bioinformatics Bootcamp - The Open University
+description: |
+    The School of Life, Health, and Chemical Sciences (LHCS) at The Open University (OU) is running a free, week-long Bioinformatics Bootcamp from the 16-20th September aimed at level 2 and level 3 OU students who are studying life, health and chemical sciences modules and have already completed 120 credits of level 1 study. This will be a fantastic opportunity to gain hands-on experience of the Galaxy bioinformatics platform and analyse real biological data.  On day 2, you’ll have an option to choose a pathway: an interactive web-based graphical user interface (GUI) pathway to run the bioinformatics analysis, or a coding environment using the Python programming language to perform the analysis. So, if you ever fancied trying computer coding, the second pathway is for you.  You’ll analyse the biological data in exactly the same way in each pathway, and it will be possible to swap between GUI and coding based on your confidence.
+
+    Prior knowledge of bioinformatics or computer coding is not required, and you’ll be supported through your study by a dedicated team of experienced researchers and PhD students. The Bioinformatics Bootcamp will run every day approximately from 09:15-17:30 with a break for lunch from 12-13:00 and afternoon break between 15:00-16:00.   There will be a mix of live online Zoom meetings, lectures, and self-directed Galaxy tutorials with online support available from 09:00-18:00 each day. Each day will end with a Key Points Game to summarize outcomes and answer any questions. On Friday, we’ll aim to end early before 15:00.   
+
+    The Bioinformatics Bootcamp will be “real-time” or synchronous compared to typical OU study, which you can do in your own time, so we request that you ensure you are available to attend all sessions each day.  
+
+    We will provide full information on registering for Galaxy and other necessary platforms in the last week in August and will have a drop-in session to troubleshoot any problems on these registrations and any questions you have about the Bootcamp on Monday, 2nd, September from 19:30-20:30.  
+
+date_start: 2024-09-16
+date_end: 2024-09-20
+contributions:
+  organisers:
+    - nomadscientist
+    - hfraser
+    - mhintze
+  lecturers:
+  trainers:
+    - wee-snufkin
+    - nomadscientist
+    - hexhowells
+    - MarisaJL
+  funding:
+location:
+  name:  The Open University - Online
+  city: Milton Keynes
+  country: United Kingdom
+---


### PR DESCRIPTION
Would you advise adding anything else here? (esp. any information / metadata that helps you in particular)

Do these events get automatically pulled into the TESS/ELIXIR database, or do I need to add it separately?