### PR TITLE
Update Helixer tutorial.md - gffread inputs

### DIFF
--- a/topics/genome-annotation/tutorials/helixer/tutorial.md
+++ b/topics/genome-annotation/tutorials/helixer/tutorial.md
@@ -170,7 +170,7 @@ We want to run BUSCO on the protein sequences predicted from gene sequences of t
 >    - {% icon param-file %} *"Input GFF3 or GTF feature file"*: output of {% tool [Helixer](toolshed.g2.bx.psu.edu/repos/genouest/helixer/helixer/0.3.3+galaxy1)) %}
 >    - In *"Reference Genome"* select: `From your history` (Input dataset)
 >    - *"Genome Reference Fasta"*: `masked genome` (Input dataset)
->    - In *"Select fasta outputs"* select: `fasta file with spliced exons for each GFF transcript (-y)`
+>    - In *"Select fasta outputs"* select: `protein fasta file with the translation of CDS for each record (-y)`
 >    - *"full GFF attribute preservation (all attributes are shown)"*: `Yes`
 >    - *"decode url encoded characters within attributes"*: `Yes`
 >    - *"warn about duplicate transcript IDs and other potential problems with the given GFF/GTF records"*: `Yes`


### PR DESCRIPTION
In the tutorial, for the tool gffread, for `select fasta outputs`, I think the wrong item is specified. 

I have changed it from `fasta file with spliced exons` to `protein fasta file`, because the next step in the tutorial (using Busco) needs this protein fasta file.

