### PR TITLE
Reorder tutorrials in Contributing topic

### DIFF
--- a/topics/contributing/metadata.yaml
+++ b/topics/contributing/metadata.yaml
@@ -15,11 +15,14 @@ docker_image: "quay.io/galaxy/contributing-training"
 
 subtopics:
   - id: pedagogy
-    title: "Pedagogical aspects"
-    description: "These will guide you on the pedagogy to create impactful training material"
+    title: "Before you start: Designing your lessons"
+    description: "These tutorials will guide you on the pedagogy to create impactful training material"
+  - id: getting-started
+    title: "Getting Started with the GTN"
+    description: "These tutorials will get you started with the basics needed to contribute to the GTN. First we will show you how you can build the GTN website on GitPod or locally, and then the basics of creating tutorials and slides."
   - id: writing
-    title: "Writing Tutorials in GTN"
-    description: "These will take you from zero to hero in writing Galaxy Training Materials."
+    title: "Advanced GTN Materials writing"
+    description: "Tutorials showing you how to use some advanced GTN features in your training materials."
   - id: contribute
     title: "Contributing through GitHub"
     description: "How to collaborate with the GTN"

--- a/topics/contributing/tutorials/create-new-topic/tutorial.md
+++ b/topics/contributing/tutorials/create-new-topic/tutorial.md
@@ -9,6 +9,7 @@ objectives:
   - "Create a new topic"
   - "Set up the metadata for a topic"
 time_estimation: "30m"
+subtopic: writing
 key_points:
   - "A new topic can be easily added for new tutorials"
 contributions:

--- a/topics/contributing/tutorials/create-new-tutorial-content/tutorial.md
+++ b/topics/contributing/tutorials/create-new-tutorial-content/tutorial.md
@@ -13,7 +13,8 @@ time_estimation: "15m"
 key_points:
   - "You can highlight questions, tools and hints with a special syntax"
   - "Self-learning can be done by questions and hidden answers"
-subtopic: writing
+subtopic: getting-started
+priority: 4
 contributions:
   authorship:
   - bebatut

--- a/topics/contributing/tutorials/create-new-tutorial-slides/slides.html
+++ b/topics/contributing/tutorials/create-new-tutorial-slides/slides.html
@@ -13,7 +13,8 @@ objectives:
   - "Create a new set of slides"
   - "Add presenter comments"
 time_estimation:
-subtopic: writing
+subtopic: getting-started
+priority: 5
 key_points:
   - "Slides are often presented before the hands-on portion, provide relevant background information"
   - "Provide examples that are relevant to your audience"

--- a/topics/contributing/tutorials/create-new-tutorial/tutorial.md
+++ b/topics/contributing/tutorials/create-new-tutorial/tutorial.md
@@ -14,7 +14,8 @@ time_estimation: "15m"
 key_points:
   - "Finding good training datasets is hard!"
   - "Creating a new tutorial involves several steps: some are mandatory, some can be skipped even if they are recommended"
-subtopic: writing
+subtopic: getting-started
+priority: 3
 contributors:
   - bebatut
   - hexylena

--- a/topics/contributing/tutorials/gitpod/tutorial.md
+++ b/topics/contributing/tutorials/gitpod/tutorial.md
@@ -8,7 +8,8 @@ objectives:
   - "Preview the GTN website online via GitPod"
   - "Make changes to the GTN website and preview those changes"
 time_estimation: "15m"
-subtopic: writing
+subtopic: getting-started
+priority: 1
 key_points:
   - "GitPod can be used to serve the GTN training materials"
 contributors:

--- a/topics/contributing/tutorials/running-jekyll/tutorial.md
+++ b/topics/contributing/tutorials/running-jekyll/tutorial.md
@@ -1,7 +1,7 @@
 ---
 layout: tutorial_hands_on
 
-title: "Running the GTN website locally"
+title: "Running the GTN website locally using the command line"
 questions:
   - "How to setup the infrastructure to build training webpages?"
 objectives:
@@ -9,7 +9,8 @@ objectives:
   - "Running the GTN material website locally"
   - "Tracking changes to the content live in the webbrowser"
 time_estimation: "15m"
-subtopic: writing
+subtopic: getting-started
+priority: 2
 key_points:
   - "Checking the generated website can be done locally"
 contributors:


### PR DESCRIPTION
Reorder the tutorials on the contributing page to make it easier for people to know where to start

Tutorials in the "Getting Started" section can/should be followed in order

![image](https://github.com/user-attachments/assets/e4620c89-97ec-46df-b848-bb7801c60cff)

