### PR TITLE
Tweak Gitpod settings for faster build

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,6 +1,6 @@
 tasks:
   - init: make bundle-install
-    command: make bundle-install
+    command: make serve-gitpod
 
 ports:
   - port: 4000


### PR DESCRIPTION
I think the build was timing out waiting for content to be served on port 4000, this should save about 15 minutes of build time
