### PR TITLE
lint cyoa branches

### DIFF
--- a/_plugins/gtn.rb
+++ b/_plugins/gtn.rb
@@ -111,7 +111,7 @@ module Jekyll
     #  slugify_unsafe("Hello, World!") # => "Hello-World"
     def slugify_unsafe(text)
       # Gets rid of *most* things without making it completely unusable?
-      text.gsub(%r{["'\\/;:,.!@#$%^&*()]}, '').gsub(/\s/, '-').gsub(/-+/, '-')
+      unsafe_slugify(text)
     end
 
     ##

--- a/_plugins/util.rb
+++ b/_plugins/util.rb
@@ -52,3 +52,7 @@ def markdownify(site, text)
     Jekyll::Converters::Markdown
   ).convert(text.to_s)
 end
+
+def unsafe_slugify(text)
+  text.gsub(%r{["'\\/;:,.!@#$%^&*()]}, '').gsub(/\s/, '-').gsub(/-+/, '-')
+end

--- a/topics/contributing/tutorials/create-new-tutorial-content/tutorial.md
+++ b/topics/contributing/tutorials/create-new-tutorial-content/tutorial.md
@@ -1186,6 +1186,8 @@ Sometimes you're writing a large tutorial and at one small step there are multip
 
 Include this markdown where you want your user to choose between the multiple paths:
 
+<!-- GTN:IGNORE:041 we cannot tell code samples from text so we get dupe warnings here. -->
+
 > <code-in-title>Markdown</code-in-title>
 > {% raw %}
 > ```

--- a/topics/contributing/tutorials/create-new-tutorial-content/tutorial.md
+++ b/topics/contributing/tutorials/create-new-tutorial-content/tutorial.md
@@ -1238,6 +1238,18 @@ And then they can wrap the relevant sections with a `div` block with the relevan
 > {: .code-out}
 {: .code-2col}
 
+> <tip-title>Why ananas-of-course? Name munging</tip-title>
+> CYOAs work by filtering the content based on the class name. Class names cannot contain spaces, so, we need to replace all whitespace with `-`.
+> The exact algorithm we use to create 'safe' IDs is:
+>
+> 1. Remove the following character `"`, `'`, `/`, `;`, `:`, `,`, `.`, `!`, `@`, `#`, `$`, `%`, `^`, `&`, `*`, `(`, `)` from the text.
+> 2. Replace all whitespace with `-`
+> 3. Replace multiple `-`s with a single `-`
+>
+> This results in retaining capitalisation. Hence, `Ananas of course` becomes `Ananas-of-course`.
+> For a more complicated example `(RNA) inhibitors` would become `RNA-inhibitors`.
+{: .tip}
+
 This can also be used inline: My favourite fruit is an <span class="Ananas-of-course">🍍</span><span class="Avocados">🥑</span>.
 
 > <tip-title>Multiple, Disconnected CYOAs</tip-title>
@@ -1258,6 +1270,26 @@ This can also be used inline: My favourite fruit is an <span class="Ananas-of-co
 > ```
 {: .tip}
 
+> <tip-title>Using every branch</tip-title>
+> We, the GTN, don't always know if you *intend* to have not used a specific branch. As such we recommend that if you have a branch that has no steps, you should include a `div` block with the class name of that branch, just so we know for sure you meant it to be empty.
+>
+> E.g. 
+>
+> ```
+> {% raw %}
+> {% include _includes/cyoa-choices.html option1="Yes, they don't pass QC" option2="No" text="Do you think your samples need to be filtered?" %}
+> 
+> <div class="Yes-they-dont-pass-QC" markdown="1">
+> Some content here!
+> </div>
+> 
+> <div class="No" markdown="1">
+> <!-- intentionally empty. This comment itself isn't necessary, but we recommend adding the div. -->
+> </div>
+> 
+> {% endraw %}
+> ```
+{: .tip}
 
 ### URL Parameter
 

--- a/topics/galaxy-interface/tutorials/workflow-posters/tutorial.md
+++ b/topics/galaxy-interface/tutorials/workflow-posters/tutorial.md
@@ -35,7 +35,7 @@ There are third party tools which can help us in making high resolution screensh
 and produce pictures which are suitable for printing and sharing.
 
 {% include _includes/cyoa-choices.html option1="Print" option2="Web" default="Print"
-       text="If you want to print your Galaxy Workflow on a poster, choose \"Print\", otherwise \"Web\" is the better option." %}
+       text="If you want to print your Galaxy Workflow on a poster, choose Print, otherwise Web is the better option." %}
 
 > <agenda-title></agenda-title>
 >

--- a/topics/single-cell/tutorials/scrna-case_FilterPlotandExplore_SeuratTools/tutorial.md
+++ b/topics/single-cell/tutorials/scrna-case_FilterPlotandExplore_SeuratTools/tutorial.md
@@ -70,7 +70,7 @@ We’ll provided you with experimental data to analyse from a mouse dataset of f
 ## Get Data onto Galaxy
 To start, let's get our dataset loaded into Galaxy.
 
-{% include _includes/cyoa-choices.html option1='EBI Data Retrieval' option2='Importing from a history' option3='Uploading from Zenodo' default='EBI-Data-Retrieval' text="There are multiple ways in which to collect the data for this tutorial. I find it easiest to do so via the EBI Data Retrieval." %}
+{% include _includes/cyoa-choices.html option1="EBI Data Retrieval" option2="Importing from a history" option3="Uploading from Zenodo" default="EBI-Data-Retrieval" text="There are multiple ways in which to collect the data for this tutorial. I find it easiest to do so via the EBI Data Retrieval." %}
 
 <div class='EBI-Data-Retrieval' markdown='1'>
 > <hands-on-title>EBI Data Retrieval</hands-on-title>


### PR DESCRIPTION
for @lldelisle, xref https://github.com/galaxyproject/training-material/pull/5529  featuring a number of new warnings:


```
$ ruby bin/lint.rb --limit GTN:041
./topics/climate/tutorials/ocean-variables/tutorial.md:1:1:1:1:GTN041 You have non-unique options in your Choose Your Own Adventure. Please ensure that each option is unique in its text. Unfortunately we do not currently support re-using the same option text across differently disambiguated CYOA branches, so, please inform us if this is a requirement for you.We identified the following duplicate options in your CYOA: Options xview, xview became the key: xview; Options png, png became the key: png
$ ruby bin/lint.rb --limit GTN:042
./topics/contributing/tutorials/create-new-tutorial-content/tutorial.md:1:1:1:1:GTN042 We recommend specifying a default for every branch
./topics/ecology/tutorials/marine_omics_bgc/tutorial.md:1:1:1:1:GTN042 We recommend specifying a default for every branch
$ ruby bin/lint.rb --limit GTN:043
./topics/genome-annotation/tutorials/apollo-euk/tutorial.md:1:1:1:1:GTN043 We did not see a corresponding option# for the default: _Create your own organism"_, but this could have been written before we automatically slugified the options. If you like, please consider making your default option match the option text exactly.
$ ruby bin/lint.rb --limit GTN:044
./topics/climate/tutorials/ocean-variables/tutorial.md:1:1:1:1:GTN044 We did not see a corresponding option# for the default: «tools», please ensure the text matches one of the branches.
$ ruby bin/lint.rb --limit GTN:045
./topics/assembly/tutorials/mrsa-nanopore/tutorial.md:1:1:1:1:GTN045 We did not see a branch for Without Illumina MiSeq data (Without-Illumina-MiSeq-data) in the file. Please consider ensuring that all options are used.
```

I think there are valid use cases for GTN:045, but, maybe people should be adding an explicit 'no' branch anyway, even if it is just an empty div?

the linting is not as nice as it could be, it reports the error as being on the first line of the file. But due to needing to use multi-line matches, we don't have a good way to know where the real start is...