### PR TITLE
[CodeSpaces] free up some disk space in preview command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -89,9 +89,13 @@ serve-quick: api/swagger.json ## run a local server (faster, some plugins disabl
 preview: serve-codespaces
 .PHONY: serve-codespaces
 
-serve-codespaces: bundle-install bundle-update
+serve-codespaces: codespace-clean bundle-install bundle-update
 	bundle exec jekyll serve --config _config.yml,_config-dev.yml --incremental
 .PHONY: serve-codespaces
+
+codespace-clean:
+	rm -rf /workspaces/.codespaces/shared/editors/jetbrains;
+.PHONY: codespace-clean
 
 serve-gitpod: bundle-install  ## run a server on a gitpod.io environment
 	bundle exec jekyll serve --config _config.yml --incremental


### PR DESCRIPTION
The onCreateCommand or onStartCommand directive wasnt always working, so just do it as part of the startup command to make sure its really gone.

Free accounts cannot use the 64GB storage machines, so we have to make it work with 32GB machines
