### PR TITLE
Fixes bibtex formatting issues in training material bibtex export

### DIFF
--- a/_layouts/tutorial_hands_on.html
+++ b/_layouts/tutorial_hands_on.html
@@ -404,7 +404,7 @@ download.file("{{ site.url }}{{ site.baseurl }}/{{ page.path | replace: ".md", "
 	title = "{{ page.title }} (Galaxy Training Materials)",
 	year = "{{ page.last_modified_at | date: "%Y"}}",
 	month = "{{ page.last_modified_at | date: "%m"}}",
-	day = "{{ page.last_modified_at | date: "%d" }}"
+	day = "{{ page.last_modified_at | date: "%d" }}",
 	url = "{% raw %}\url{{% endraw %}{{ site.url }}{{ site.baseurl }}{{page.url}}{% raw %}}{% endraw %}",
 	note = "[Online; accessed TODAY]"
 }
@@ -420,7 +420,7 @@ download.file("{{ site.url }}{{ site.baseurl }}/{{ page.path | replace: ".md", "
 	author = {Saskia Hiltemann and Helena Rasche and Simon Gladman and Hans-Rudolf Hotz and Delphine Larivi{\`{e}}re and Daniel Blankenberg and Pratik D. Jagtap and Thomas Wollmann and Anthony Bretaudeau and Nadia Gou{\'{e}} and Timothy J. Griffin and Coline Royaux and Yvan Le Bras and Subina Mehta and Anna Syme and Frederik Coppens and Bert Droesbeke and Nicola Soranzo and Wendi Bacon and Fotis Psomopoulos and Crist{\'{o}}bal Gallardo-Alba and John Davis and Melanie Christine Föll and Matthias Fahrner and Maria A. Doyle and Beatriz Serrano-Solano and Anne Claire Fouilloux and Peter van Heusden and Wolfgang Maier and Dave Clements and Florian Heyl and Björn Grüning and B{\'{e}}r{\'{e}}nice Batut and},
 	editor = {Francis Ouellette},
 	title = {Galaxy Training: A powerful framework for teaching!},
-	journal = {PLoS Comput Biol} Computational Biology}
+	journal = {PLoS Comput Biol}
 }
 </code>
                    </pre></div></div>


### PR DESCRIPTION
My bibtex parser failed after copying in the citations for a GTN piece (https://training.galaxyproject.org/training-material/topics/fair/tutorials/ro-crate-in-galaxy/tutorial.html). This PR fixes the two formatting issues.

