### PR TITLE
fix reports nginx config to avoid localhost issues

### DIFF
--- a/topics/admin/tutorials/beacon/tutorial.md
+++ b/topics/admin/tutorials/beacon/tutorial.md
@@ -330,7 +330,7 @@ Now that our beacon is running, we need to get data from Galaxy to the Beacon
 >    ```diff
 >    --- a/templates/nginx/galaxy.j2
 >    +++ b/templates/nginx/galaxy.j2
->    @@ -115,4 +115,14 @@ server {
+>    @@ -117,4 +117,14 @@ server {
 >     
 >     	{{ tiaas_nginx_routes }}
 >     

--- a/topics/admin/tutorials/connect-to-compute-cluster/tutorial.md
+++ b/topics/admin/tutorials/connect-to-compute-cluster/tutorial.md
@@ -148,7 +148,7 @@ be taken into consideration when choosing where to run jobs and what parameters 
 >    @@ -194,6 +194,16 @@ nginx_ssl_role: usegalaxy_eu.certbot
 >     nginx_conf_ssl_certificate: /etc/ssl/certs/fullchain.pem
 >     nginx_conf_ssl_certificate_key: /etc/ssl/user/privkey-www-data.pem
->
+>     
 >    +# Slurm
 >    +slurm_roles: ['controller', 'exec'] # Which roles should the machine play? exec are execution hosts.
 >    +slurm_nodes:

--- a/topics/admin/tutorials/monitoring/tutorial.md
+++ b/topics/admin/tutorials/monitoring/tutorial.md
@@ -535,15 +535,15 @@ There are some nice examples of dashboards available from the public Galaxies, w
 >    ```diff
 >    --- a/templates/nginx/galaxy.j2
 >    +++ b/templates/nginx/galaxy.j2
->    @@ -108,4 +108,9 @@ server {
->     		proxy_pass http://{{ galaxy_config.gravity.reports.bind }}:/;
+>    @@ -109,4 +109,9 @@ server {
+>     		proxy_set_header X-Forwarded-Host $host;
+>     		proxy_set_header X-Forwarded-Proto $scheme;
 >     	}
->     
+>    +
 >    +	location /grafana/ {
 >    +		proxy_pass http://127.0.0.1:3000/;
 >    +		proxy_set_header Host $http_host;
 >    +	}
->    +
 >     }
 >    {% endraw %}
 >    ```

--- a/topics/admin/tutorials/reports/tutorial.md
+++ b/topics/admin/tutorials/reports/tutorial.md
@@ -32,17 +32,6 @@ requirements:
 
 The reports application gives some pre-configured analytics screens. These are very easy to setup and can help with debugging issues in Galaxy.
 
-> <warning-title>Currently Broken, Requires Separate Domain</warning-title>
-> Reports does not work, under a path prefix (the default setup that most
-> people will use.) It is completely broken and the developers have no plans to fix it in the near term.
-> See
-> [galaxyproject/galaxy#15966](https://github.com/galaxyproject/galaxy/issues/15966) for more details.
->
-> However, it should still function with a separate domain, if that is possible
-> for your setup. Otherwise, it **will not work.** If you wish to follow this
-> tutorial, please be aware of this.
-{: .warning}
-
 > <agenda-title></agenda-title>
 >
 > 1. TOC
@@ -121,6 +110,8 @@ The reports application is included with the Galaxy codebase and this tutorial a
 >    +
 >    +	location /reports/ {
 >    +		proxy_pass http://{{ galaxy_config.gravity.reports.bind }}:/;
+>    +      proxy_set_header X-Forwarded-Host $host;
+>    +      proxy_set_header X-Forwarded-Proto $scheme;
 >    +	}
 >    +
 >     }

--- a/topics/admin/tutorials/reports/tutorial.md
+++ b/topics/admin/tutorials/reports/tutorial.md
@@ -103,17 +103,16 @@ The reports application is included with the Galaxy codebase and this tutorial a
 >    ```diff
 >    --- a/templates/nginx/galaxy.j2
 >    +++ b/templates/nginx/galaxy.j2
->    @@ -103,4 +103,9 @@ server {
+>    @@ -103,4 +103,10 @@ server {
 >     		proxy_set_header Upgrade $http_upgrade;
 >     		proxy_set_header Connection "upgrade";
 >     	}
 >    +
 >    +	location /reports/ {
 >    +		proxy_pass http://{{ galaxy_config.gravity.reports.bind }}:/;
->    +      proxy_set_header X-Forwarded-Host $host;
->    +      proxy_set_header X-Forwarded-Proto $scheme;
+>    +		proxy_set_header X-Forwarded-Host $host;
+>    +		proxy_set_header X-Forwarded-Proto $scheme;
 >    +	}
->    +
 >     }
 >    {% endraw %}
 >    ```

--- a/topics/admin/tutorials/tiaas/tutorial.md
+++ b/topics/admin/tutorials/tiaas/tutorial.md
@@ -200,10 +200,11 @@ This tutorial will go cover how to set up such a service on your own Galaxy serv
 >    ```diff
 >    --- a/templates/nginx/galaxy.j2
 >    +++ b/templates/nginx/galaxy.j2
->    @@ -113,4 +113,6 @@ server {
+>    @@ -114,4 +114,7 @@ server {
+>     		proxy_pass http://127.0.0.1:3000/;
 >     		proxy_set_header Host $http_host;
 >     	}
->     
+>    +
 >    +	{{ tiaas_nginx_routes }}
 >    +
 >     }


### PR DESCRIPTION
fixes https://github.com/galaxyproject/galaxy/issues/15966 by applying patch from @jdwhatsup from
https://github.com/jdwhatsup/training-material/commit/c88b7561e36ae8c4c467e0b96d6e41216eed4da5

I tested this on a fairly standard instance with reports under `/reports` and it loads jobs fine