### PR TITLE
[CI] return to latest ubuntu since its failing now anyway

### DIFF
--- a/.github/workflows/video.yml
+++ b/.github/workflows/video.yml
@@ -10,7 +10,7 @@ on:
 jobs:
   runner-job:
     if: github.repository_owner == 'galaxyproject'
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     services:
       # Label used to access the service container
       mozillatts:


### PR DESCRIPTION
the automated video deploy started failing due to dependency issues. use ubunut-latest again so we can make it work there