### PR TITLE
Set test to fail if one part of the pipe fails

### DIFF
--- a/.github/workflows/ci-main.yml
+++ b/.github/workflows/ci-main.yml
@@ -68,6 +68,8 @@ jobs:
       - name: Check Tutorial Formatting
         run: |
           find topics/ -name tutorial.md | xargs -n 1 python bin/check-broken-boxes.py | reviewdog -efm="%f:%l: %m" -filter-mode=file -reporter=github-pr-review -fail-level=any
+          set -e
+          set -o pipefail
           bundle exec ruby bin/lint.rb --format rdjson | reviewdog -filter-mode=file -reporter=github-pr-review -f=rdjsonl -fail-level=any
         env:
             REVIEWDOG_GITHUB_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Because of the pipes, error exit codes were being ignored