### PR TITLE
Update metadata for single-cell materials

### DIFF
--- a/topics/single-cell/tutorials/pseudobulk-analysis/tutorial.md
+++ b/topics/single-cell/tutorials/pseudobulk-analysis/tutorial.md
@@ -1,7 +1,7 @@
 ---
 layout: tutorial_hands_on
 title: Pseudobulk Analysis with Decoupler and EdgeR
-subtopic: end-to-end
+subtopic: exploratory
 zenodo_link: https://zenodo.org/records/13929549
 questions:
 - How does pseudobulk analysis help in understanding cell-type-specific gene expression changes?
@@ -40,6 +40,13 @@ answer_histories:
   - label: "UseGalaxy.eu"
     history: https://usegalaxy.eu/u/dianitachj24/h/pseudo-bulk-edger-tcells
     date: 2025-02-10
+follow_up_training:
+-
+    type: "internal"
+    topic_name: single-cell
+    tutorials:
+        - EBI-retrieval
+        - GO-enrichment
 ---
 
 Pseudobulk analysis is a powerful technique that bridges the gap between single-cell and bulk RNA-seq data. It involves aggregating gene expression data from groups of cells within the same biological replicate, such as a mouse or patient, typically based on clustering or cell type annotations ({% cite Murphy2022 %}).
@@ -217,7 +224,7 @@ The next steps will help you refine your data for easier handling. We will use s
 >            - *"in column"*: `c2`
 >            - *"Find pattern"*: `^([0-9])(.+)`
 >            - *"Replace with"*: `GG_\\1\\2`
-> 
+>
 > In the previous steps, the following modifications were made to the files:
 >
 > 1. **Replace Text**: Replaces special characters (`[ --+*^]+`) with underscores (`_`) in the `count_matrix` file.

--- a/topics/single-cell/tutorials/scrna-intro/slides.html
+++ b/topics/single-cell/tutorials/scrna-intro/slides.html
@@ -7,7 +7,6 @@ subtopic: scintroduction
 priority: 1
 level: Intermediate
 video: yes
-zenodo_link: ""
 redirect_from:
 - /topics/transcriptomics/tutorials/scrna-intro/slides
 tags:

--- a/topics/single-cell/tutorials/scrna-plates-batches-barcodes/slides.html
+++ b/topics/single-cell/tutorials/scrna-plates-batches-barcodes/slides.html
@@ -10,7 +10,6 @@ redirect_from:
 - /topics/transcriptomics/tutorials/scrna-plates-batches-barcodes/slides
 
 video: yes
-zenodo_link: ""
 tags:
 questions:
   - "What is a batch when it comes to single cells?"


### PR DESCRIPTION
There were a couple remaining X on the maintainer page. I *think* if you remove the zenodo line from a slide deck, it no longer is 'missing' zenodo.