### PR TITLE
Fix ``create-env`` Make command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -43,7 +43,7 @@ install-conda: ## install Miniconda
 .PHONY: install-conda
 
 create-env: ## create conda environment
-	if ${CONDA} env list | grep '^${CONDA_ENV}'; then \
+	if ${CONDA} env list | grep '^\s*${CONDA_ENV}'; then \
 	    ${CONDA} env update -f ${ENV_FILE}; \
 	else \
 	    ${CONDA} env create -f ${ENV_FILE}; \


### PR DESCRIPTION
The output from `mamba env list` now starts with a space. Fix the grep regular expression to allow that, so that the `create-env` Make target doesn't try to recreate the `galaxy_training_material` environment.
