### PR TITLE
Fixed typo in tag 'introcuction'

### DIFF
--- a/learning-pathways/intro-to-galaxy-and-genomics.md
+++ b/learning-pathways/intro-to-galaxy-and-genomics.md
@@ -1,6 +1,6 @@
 ---
 layout: learning-pathway
-tags: [beginner, introcuction, sequence-analysis, assembly]
+tags: [beginner, introduction, sequence-analysis, assembly]
 type: use
 
 editorial_board:


### PR DESCRIPTION
One of the metadata tags was 'introcuction'. I corrected it to 'introduction'.