### PR TITLE
Update request-galaxy-tools-on-a-specific-server.md

### DIFF
--- a/faqs/galaxy/request-galaxy-tools-on-a-specific-server.md
+++ b/faqs/galaxy/request-galaxy-tools-on-a-specific-server.md
@@ -8,8 +8,8 @@ contributors: [nomadscientist]
 ---
 To request tools that already exist in the [Galaxy toolshed](https://toolshed.g2.bx.psu.edu), but not in your server, please raise an issue at:
 
-- *Europe - usegalaxy.eu* \| https://github.com/usegalaxy-eu/usegalaxy-eu-tools
+- *Europe - usegalaxy.eu* \| [https://github.com/usegalaxy-eu/usegalaxy-eu-tools](https://github.com/usegalaxy-eu/usegalaxy-eu-tools)
 
-- *USA - usegalaxy.org* \| https://github.com/galaxyproject/usegalaxy-tools
+- *USA - usegalaxy.org* \| [https://github.com/galaxyproject/usegalaxy-tools](https://github.com/galaxyproject/usegalaxy-tools)
 
 - *Australia - usegalaxy.org.au* \| [https://github.com/usegalaxy-au/usegalaxy-au-tools/tree/master/usegalaxy.org.au](https://site.usegalaxy.org.au/request/tool)


### PR DESCRIPTION
Not sure if there was a reason why the EU and US URLs were not a link? I think it is better if people can just click. 

@nomadscientist: Thanks a lot for the faq.

