### PR TITLE
Created a post in the FAQ section for Job Cache feature (re_use_equivalent_jobs)

### DIFF
--- a/faqs/galaxy/re_use_equivalent_jobs.md
+++ b/faqs/galaxy/re_use_equivalent_jobs.md
@@ -1,30 +1,30 @@
 ---
 title: How do I re-use equivalent jobs in Galaxy (aka Job Cache)?
-area: user preferences
+area: features
 layout: faq
 box_type: tip
 contributors: [dadrasarmin, teresa-m]
 ---
 
-Galaxy instances allow you to retrieve the results of running a tool from the cache (and hence almost immediately) if the tool with the exact same input and parameters has already been executed in your history. 
-This is also true if another user used the same tool and inputs and made their history publicly available.
+We can reuse the reproducibility of Galaxy to detect if a tool has been run with the exact same parameters and inputs before. In this case, we can simply skip the computational step and just reuse the
+data we have previously computed. We call this feature the `job cache`. Part of the `job cache` is all your personal data and all data in public histories. 
 This can be highly helpful, e.g., for training events, if the instructor makes a respective training history public before the event. 
-If the trainee activates this option in their account and uses the same input and parameters, they will immediately receive the results. This feature reduce the waiting time in the training sessions,
-saves energy and computational resources, and therefore reducing environmental impact.
+If the trainee activates this option in their account and uses the same input and parameters, they will immediately receive the results. This feature reduces the waiting time in the training sessions,
+saves energy and computational resources, and therefore reduces environmental impact.
 
 To activate this feature, take the following steps:
 
-1. To activate this option for your account, click on your username in the top right part of the page.
-- Select `Preferences`, which will appear after clicking.
-- In your middle panel search for `Manage Information` and select them.
+1. To activate this option for your account, click on your username at the top right of the page.
+- Select `Preferences` and navigate to your user-references.
+- In your middle panel search for `Manage Information` and select them. You can also navigate to "https://<your-galaxy-server.domain>/user" — for example, https://usegalaxy.eu/user.
 - Find the grey box: `Do you want to be able to re-use equivalent jobs?` 
-- Within the box, change the slider saying `no` to `yes`.
-- Scroll down to the bottom of the middle panel and click the `Save` button.
-2. Now you will notice the option `Attempt to re-use jobs with identical parameters?` for every tool you want to run. To test this:
-- Click on any tool you would like to run
-- If you scroll down to the end of the  `Tool Parameters` section, until you see the `Run tool` button, you will notice the new option `Attempt to re-use jobs with identical parameters?` above the `Run tool` button.
-- You can enable this option by sliding the `No` to `Yes`
- - Once you click on the `Run tool`, Galaxy will check if you have access to a run with identical parameters. If so, the results will be displayed shortly thereafter.
+- Within the box, change the slider from `no` to `yes`.
+- Scroll down to the bottom of the page and click the `Save` button.
 
-At the moment, this feature only works with data stored in your own histories or `datasets` directory.
-This function cannot be used to obtain results if the input files are acquired from the internet (for example, input files from Zenodo).
+2. For every tool you want to run now, you will notice the option `Attempt to re-use jobs with identical parameters?`. To test this:
+- Click on any tool you would like to run
+- If you scroll down to the end of the  `Tool Parameters` section until you see the `Run tool` button, you will notice the new option `Attempt to re-use jobs with identical parameters?` above the `Run tool` button.
+- You can enable this option by sliding the `No` to `Yes`
+- Once you click on the `Run tool`, Galaxy will check if this tool was run before with the exact same parameters and inputs. If so, the results will be retrieved from the `job cache` and **not** be calculated.
+
+⚠️ At the moment, this feature only works with data shared/reused inside Galaxy. If you upload the same file twice, we can not detect that it is the same file.

--- a/faqs/galaxy/re_use_equivalent_jobs.md
+++ b/faqs/galaxy/re_use_equivalent_jobs.md
@@ -15,7 +15,8 @@ saves energy and computational resources, and therefore reducing environmental i
 To activate this feature, take the following steps:
 
 1. To activate this option for your account, click on your username in the top right part of the page.
-- Navigate to `Preferences` and then `Manage Information`.
+- Select `Preferences`, which will appear after clicking.
+- In your middle panel search for `Manage Information` and select them.
 - Click `Do you want to be able to re-use equivalent jobs?` and change `no` to `yes`.
 - Scroll down to the bottom of the middle panel and select the `Save` button.
 2. After completing the first step, you will notice a new option for each tool you want to run, above the `Run tool` button and below the `Email notification`. When you activate `Attempt to re-use jobs with identical parameters?`

--- a/faqs/galaxy/re_use_equivalent_jobs.md
+++ b/faqs/galaxy/re_use_equivalent_jobs.md
@@ -8,7 +8,7 @@ contributors: [dadrasarmin]
 
 Galaxy instances allow you to retrieve the results of running a tool from the cache (and hence almost immediately) if the tool with the exact same input and parameters has already been executed in your history. 
 This is also true if another user used the same tool and inputs and made their history publicly available.
-This is highly helpful in situations like training events. In such a case, the instructor might complete the tasks and make their results public. 
+This can be highly helpful, e.g., for training events, if the instructor makes a respective training history public before the event. 
 If the trainee activates this option in their account and uses the same input and parameters, they will immediately receive the results. This feature reduce the waiting time in the training sessions,
 saves energy and computational resources, and therefore reducing environmental impact.
 

--- a/faqs/galaxy/re_use_equivalent_jobs.md
+++ b/faqs/galaxy/re_use_equivalent_jobs.md
@@ -1,0 +1,25 @@
+---
+title: How do I re-use equivalent jobs in Galaxy (aka Job Cache)?
+area: user preferences
+layout: faq
+box_type: tip
+contributors: [dadrasarmin]
+---
+
+Galaxy instances allow you to retrieve the results of running a tool from the cache (and hence almost immediately) if the tool with the exact same input and parameters has already been executed in your history. 
+This is also true if another user used the same tool and inputs and made their history publicly available.
+This is highly helpful in situations like training events. In such a case, the instructor might complete the tasks and make their results public. 
+If the trainee activates this option in their account and uses the same input and parameters, they will immediately receive the results. This feature reduce the waiting time in the training sessions,
+saves energy and computational resources, and therefore reducing environmental impact.
+
+To activate this feature, take the following steps:
+
+1. To activate this option for your account, click on your username in the top right part of the page.
+- Navigate to `Preferences` and then `Manage Information`.
+- Click `Do you want to be able to re-use equivalent jobs?` and change `no` to `yes`.
+- Scroll down to the bottom of the middle panel and select the `Save` button.
+2. After completing the first step, you will notice a new option for each tool you want to run, above the `Run tool` button and below the `Email notification`. When you activate `Attempt to re-use jobs with identical parameters?`
+  and click on the `Run tool`, Galaxy will check if you have access to a run with identical parameters. If so, the results will be displayed shortly thereafter.
+
+At the moment, this feature only works with data stored in your own histories or `datasets` directory.
+This function cannot be used to obtain results if the input files are acquired from the internet (for example, input files from Zenodo).

--- a/faqs/galaxy/re_use_equivalent_jobs.md
+++ b/faqs/galaxy/re_use_equivalent_jobs.md
@@ -20,7 +20,10 @@ To activate this feature, take the following steps:
 - Find the grey box: `Do you want to be able to re-use equivalent jobs?` 
 - Within the box, change the slider saying `no` to `yes`.
 - Scroll down to the bottom of the middle panel and click the `Save` button.
-2. After completing the first step, you will notice a new option for each tool you want to run, above the `Run tool` button and below the `Email notification`. When you activate `Attempt to re-use jobs with identical parameters?`
+2. Now you will notice the option `Attempt to re-use jobs with identical parameters?` for every tool you want to run. To test this:
+- Click on any tool you would like to run
+- If you scroll down to the end of the  `Tool Parameters` section, until you see the `Run tool` button, you will notice the new option `Attempt to re-use jobs with identical parameters?` above the `Run tool` button.
+- You can enable this option by sliding the `No` to `Yes`
   and click on the `Run tool`, Galaxy will check if you have access to a run with identical parameters. If so, the results will be displayed shortly thereafter.
 
 At the moment, this feature only works with data stored in your own histories or `datasets` directory.

--- a/faqs/galaxy/re_use_equivalent_jobs.md
+++ b/faqs/galaxy/re_use_equivalent_jobs.md
@@ -19,7 +19,7 @@ To activate this feature, take the following steps:
 - In your middle panel search for `Manage Information` and select them.
 - Find the grey box: `Do you want to be able to re-use equivalent jobs?` 
 - Within the box, change the slider saying `no` to `yes`.
-- Scroll down to the bottom of the middle panel and select the `Save` button.
+- Scroll down to the bottom of the middle panel and click the `Save` button.
 2. After completing the first step, you will notice a new option for each tool you want to run, above the `Run tool` button and below the `Email notification`. When you activate `Attempt to re-use jobs with identical parameters?`
   and click on the `Run tool`, Galaxy will check if you have access to a run with identical parameters. If so, the results will be displayed shortly thereafter.
 

--- a/faqs/galaxy/re_use_equivalent_jobs.md
+++ b/faqs/galaxy/re_use_equivalent_jobs.md
@@ -3,7 +3,7 @@ title: How do I re-use equivalent jobs in Galaxy (aka Job Cache)?
 area: user preferences
 layout: faq
 box_type: tip
-contributors: [dadrasarmin]
+contributors: [dadrasarmin, teresa-m]
 ---
 
 Galaxy instances allow you to retrieve the results of running a tool from the cache (and hence almost immediately) if the tool with the exact same input and parameters has already been executed in your history. 

--- a/faqs/galaxy/re_use_equivalent_jobs.md
+++ b/faqs/galaxy/re_use_equivalent_jobs.md
@@ -17,7 +17,8 @@ To activate this feature, take the following steps:
 1. To activate this option for your account, click on your username in the top right part of the page.
 - Select `Preferences`, which will appear after clicking.
 - In your middle panel search for `Manage Information` and select them.
-- Click `Do you want to be able to re-use equivalent jobs?` and change `no` to `yes`.
+- Find the grey box: `Do you want to be able to re-use equivalent jobs?` 
+- Within the box, change the slider saying `no` to `yes`.
 - Scroll down to the bottom of the middle panel and select the `Save` button.
 2. After completing the first step, you will notice a new option for each tool you want to run, above the `Run tool` button and below the `Email notification`. When you activate `Attempt to re-use jobs with identical parameters?`
   and click on the `Run tool`, Galaxy will check if you have access to a run with identical parameters. If so, the results will be displayed shortly thereafter.

--- a/faqs/galaxy/re_use_equivalent_jobs.md
+++ b/faqs/galaxy/re_use_equivalent_jobs.md
@@ -24,7 +24,7 @@ To activate this feature, take the following steps:
 - Click on any tool you would like to run
 - If you scroll down to the end of the  `Tool Parameters` section, until you see the `Run tool` button, you will notice the new option `Attempt to re-use jobs with identical parameters?` above the `Run tool` button.
 - You can enable this option by sliding the `No` to `Yes`
-  and click on the `Run tool`, Galaxy will check if you have access to a run with identical parameters. If so, the results will be displayed shortly thereafter.
+ - Once you click on the `Run tool`, Galaxy will check if you have access to a run with identical parameters. If so, the results will be displayed shortly thereafter.
 
 At the moment, this feature only works with data stored in your own histories or `datasets` directory.
 This function cannot be used to obtain results if the input files are acquired from the internet (for example, input files from Zenodo).


### PR DESCRIPTION
Recently, multiple opportunities for using job cache were discussed and we decided toe prepare a FAQ page for it. This way, maybe we can encourage instructors (and trainee) to use job cache, so they get the results faster, reduce the load on computational resources, and limit carbon footprint.

We would like to test the functionality of this feature in a course next week and potentially during the GTA2025.