### PR TITLE
Fix tags of tutorials

### DIFF
--- a/topics/single-cell/tutorials/scrna-case-jupyter_basic-pipeline/tutorial.md
+++ b/topics/single-cell/tutorials/scrna-case-jupyter_basic-pipeline/tutorial.md
@@ -37,9 +37,7 @@ answer_histories:
     history: https://colab.research.google.com/drive/1DkCysA77iaFAWoKJ1vwE5_qYV8Su7UsX?usp=sharing
     date: 2024-09-09
 tags:
-- 10x
 - paper-replication
-- Python
 - MIGHTS
 contributions:
   authorship:

--- a/topics/single-cell/tutorials/scrna-case_FilterPlotandExploreRStudio/tutorial.md
+++ b/topics/single-cell/tutorials/scrna-case_FilterPlotandExploreRStudio/tutorial.md
@@ -42,9 +42,7 @@ follow_up_training:
         - GO-enrichment
 
 tags:
-- 10x
 - paper-replication
-- R
 - MIGHTS
 
 contributions:

--- a/topics/single-cell/tutorials/scrna-case_FilterPlotandExplore_SeuratTools/tutorial.md
+++ b/topics/single-cell/tutorials/scrna-case_FilterPlotandExplore_SeuratTools/tutorial.md
@@ -37,7 +37,6 @@ follow_up_training:
         - GO-enrichment
 
 tags:
-- 10x
 - paper-replication
 - MIGHTS
 

--- a/topics/single-cell/tutorials/scrna-case_JUPYTER-trajectories/tutorial.md
+++ b/topics/single-cell/tutorials/scrna-case_JUPYTER-trajectories/tutorial.md
@@ -52,9 +52,7 @@ follow_up_training:
         - EBI-retrieval
 
 tags:
-- 10x
 - paper-replication
-- Python
 - MIGHTS
 
 contributions:

--- a/topics/single-cell/tutorials/scrna-case_alevin-combine-datasets/tutorial.md
+++ b/topics/single-cell/tutorials/scrna-case_alevin-combine-datasets/tutorial.md
@@ -44,7 +44,6 @@ key_points:
   - Retreive partially analysed data from a public repository
 
 tags:
-  - 10x
   - paper-replication
   - MIGHTS
 

--- a/topics/single-cell/tutorials/scrna-case_alevin/tutorial.md
+++ b/topics/single-cell/tutorials/scrna-case_alevin/tutorial.md
@@ -33,7 +33,6 @@ key_points:
 - Create a scanpy-accessible AnnData object from FASTQ files, including relevant gene
   metadata
 tags:
-- 10x
 - paper-replication
 - MIGHTS
 contributions:

--- a/topics/single-cell/tutorials/scrna-case_basic-pipeline/tutorial.md
+++ b/topics/single-cell/tutorials/scrna-case_basic-pipeline/tutorial.md
@@ -48,7 +48,6 @@ requirements:
         - scrna-case_alevin
         - scrna-case_alevin-combine-datasets
 tags:
-- 10x
 - paper-replication
 - MIGHTS
 

--- a/topics/single-cell/tutorials/scrna-case_cell-cycle/tutorial.md
+++ b/topics/single-cell/tutorials/scrna-case_cell-cycle/tutorial.md
@@ -36,7 +36,6 @@ key_points:
 - Cell cycle genes can conceal what is happening in your data if cells are grouping together according to their stage in the cycle
 - Identifying the cell cycle genes and using them to regress out the effects of the cell cycle can reveal underlying patterns in the data
 tags:
-- 10x
 
 contributions:
   authorship:

--- a/topics/single-cell/tutorials/scrna-case_monocle3-rstudio/tutorial.md
+++ b/topics/single-cell/tutorials/scrna-case_monocle3-rstudio/tutorial.md
@@ -45,9 +45,7 @@ follow_up_training:
         - GO-enrichment
 
 tags:
-- 10x
 - paper-replication
-- R
 - MIGHTS
 
 contributions:

--- a/topics/single-cell/tutorials/scrna-case_monocle3-trajectories/tutorial.md
+++ b/topics/single-cell/tutorials/scrna-case_monocle3-trajectories/tutorial.md
@@ -57,7 +57,6 @@ follow_up_training:
         - GO-enrichment
 
 tags:
-- 10x
 - paper-replication
 - MIGHTS
 

--- a/topics/single-cell/tutorials/scrna-case_trajectories/tutorial.md
+++ b/topics/single-cell/tutorials/scrna-case_trajectories/tutorial.md
@@ -47,7 +47,6 @@ follow_up_training:
 
 
 tags:
-- 10x
 - paper-replication
 - MIGHTS
 


### PR DESCRIPTION
While the Case Study works for 10x data, it actually uses Drop-Seq data, so that's an unnecessary tag.

Also, no point in labelling both R and markdown notebook; same for jupyter-notebook

Basically, we had too many tags