### PR TITLE
update CODEOWNERS file

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -16,7 +16,7 @@ _plugins/   @bebatut @hexylena
 topics/introduction/               @jennaj
 topics/admin/                      @hexylena  @natefoo  @bgruening  @martenson
 topics/ai4life/                    @beatrizserrano
-topics/assembly/                   @nekrut  @delphine-l  @gallardoalba
+topics/assembly/                   @nekrut  @delphine-l
 topics/climate/                    @annefou
 topics/community/                  @nomadscientist
 topics/computational-chemistry/    @chrisbarnettster  @tsenapathi  @simonbray  @bgruening

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -26,7 +26,7 @@ topics/data-science/               @hexylena  @shiltemann  @fpsom  @bebatut  @yv
 topics/dev/                        @lecorguille  @bebatut  @hexylena
 topics/ecology/                    @yvanlebras
 topics/elixir/                     @bebatut  @fpsom
-topics/epigenetics/                @lldelisle  @heylf  @joachimwolff  @dpryan79
+topics/epigenetics/                @lldelisle  @heylf  @joachimwolff
 topics/evolution/                  @cstritt  @pvanheus
 topics/fair/                       @simleo  @ilveroluca  @stain  @pauldg  @kkamieniecka  @poterlowicz-lab
 topics/galaxy-interface/           @jennaj  @hexylena

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -23,20 +23,20 @@ topics/computational-chemistry/    @chrisbarnettster  @tsenapathi  @simonbray  @
 topics/contributing/               @bebatut  @bgruening
 topics/covid19/                    @wm75
 topics/data-science/               @hexylena  @shiltemann  @fpsom  @bebatut  @yvanlebras
-topics/dev/                        @lecorguille  @bebatut  @hexylena
+topics/dev/                        @lecorguille  @bebatut
 topics/ecology/                    @yvanlebras
 topics/elixir/                     @bebatut  @fpsom
 topics/epigenetics/                @lldelisle  @heylf  @joachimwolff
 topics/evolution/                  @cstritt  @pvanheus
 topics/fair/                       @simleo  @ilveroluca  @stain  @pauldg  @kkamieniecka  @poterlowicz-lab
-topics/galaxy-interface/           @jennaj  @hexylena
+topics/galaxy-interface/           @jennaj
 topics/genome-annotation/          @hexylena  @abretaud
 topics/gmod/                       @hexylena  @abretaud
 topics/imaging/                    @kostrykin  @beatrizserrano
 topics/materials-science/          @patrick-austin  @leandro-liborio
 topics/metabolomics/               @lecorguille  @melpetera  @foellmelanie
 topics/microbiome/                 @bebatut  @shiltemann  @paulzierep
-topics/one-health/                 @wm75  @pvanheus  @TKlingstrom  @hexylena
+topics/one-health/                 @wm75  @pvanheus  @TKlingstrom
 topics/plants/                     @deeptivarshney  @shiltemann
 topics/proteomics/                 @foellmelanie  @subinamehta  @pratikdjagtap  @bgruening
 topics/sequence-analysis/          @yvanlebras  @bebatut  @joachimwolff

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -11,36 +11,49 @@ _layouts/   @bebatut @shiltemann @hexylena
 _includes/  @bebatut @shiltemann @hexylena
 _plugins/   @bebatut @hexylena
 
-# Topic maintainers are placed in github teams @galaxyproject/training-<topic-name>
-topics/admin/                      @galaxyproject/training-admin
-topics/assembly/                   @galaxyproject/training-assembly
-topics/chip-seq/                   @galaxyproject/training-chip-seq
-topics/computational-chemistry/    @galaxyproject/training-computational-chemistry
-topics/contributing/               @galaxyproject/training-contributing
-topics/dev/                        @galaxyproject/training-dev @abretaud
-topics/ecology/                    @galaxyproject/training-ecology
-topics/epigenetics/                @galaxyproject/training-epigenetics
-topics/galaxy-interface/           @galaxyproject/training-galaxy-ui @galaxyproject/training-galaxy-data-manipulation
-topics/genome-annotation/          @galaxyproject/training-genome-annotation
-topics/teaching/                   @galaxyproject/training-instructors
-topics/introduction/               @galaxyproject/training-introduction
-topics/materials-science/          @galaxyproject/training-materials-science
-topics/metabolomics/               @galaxyproject/training-metabolomics
-topics/microbiome/               @galaxyproject/training-metagenomics
-topics/proteomics/                 @galaxyproject/training-proteomics
-topics/sequence-analysis/          @galaxyproject/training-sequence-analysis
-topics/single-cell/                @galaxyproject/training-single-cell
-topics/statistics/                 @galaxyproject/training-statistics
-topics/transcriptomics/            @galaxyproject/training-transcriptomics
-topics/variant-analysis/           @galaxyproject/training-variant-analysis
-topics/imaging/                    @kostrykin
 
+# Topic Editorial Board members
+topics/introduction/               @jennaj
+topics/admin/                      @hexylena  @natefoo  @bgruening  @martenson
+topics/ai4life/                    @beatrizserrano
+topics/assembly/                   @nekrut  @delphine-l  @gallardoalba
+topics/climate/                    @annefou
+topics/community/                  @nomadscientist
+topics/computational-chemistry/    @chrisbarnettster  @tsenapathi  @simonbray  @bgruening
+topics/contributing/               @bebatut  @bgruening
+topics/covid19/                    @wm75
+topics/data-science/               @hexylena  @shiltemann  @fpsom  @bebatut  @yvanlebras
+topics/dev/                        @lecorguille  @bebatut  @hexylena
+topics/ecology/                    @yvanlebras
+topics/elixir/                     @bebatut  @fpsom
+topics/epigenetics/                @lldelisle  @heylf  @joachimwolff  @dpryan79
+topics/evolution/                  @cstritt  @pvanheus
+topics/fair/                       @simleo  @ilveroluca  @stain  @pauldg  @kkamieniecka  @poterlowicz-lab
+topics/galaxy-interface/           @jennaj  @hexylena
+topics/genome-annotation/          @hexylena  @abretaud
+topics/gmod/                       @hexylena  @abretaud
+topics/imaging/                    @kostrykin  @beatrizserrano
+topics/materials-science/          @patrick-austin  @leandro-liborio
+topics/metabolomics/               @lecorguille  @melpetera  @foellmelanie
+topics/microbiome/                 @bebatut  @shiltemann  @paulzierep
+topics/one-health/                 @wm75  @pvanheus  @TKlingstrom  @hexylena
+topics/plants/                     @deeptivarshney  @shiltemann
+topics/proteomics/                 @foellmelanie  @subinamehta  @pratikdjagtap  @bgruening
+topics/sequence-analysis/          @yvanlebras  @bebatut  @joachimwolff
+topics/single-cell/                @nomadscientist  @mtekman  @pavanvidem  @hexhowells  @MarisaJL  @heylf
+topics/statistics/                 @marziacremona  @cumbof  @anuprulez
+topics/synthetic-biology/          @kenza12  @tduigou  @breakthewall  @guillaume-gricourt
+topics/teaching/                   @bebatut
+topics/transcriptomics/            @bebatut  @mblue9  @heylf
+topics/variant-analysis/           @bebatut  @wm75  @bgruening  @nekrut
+topics/visualisation/              @shiltemann  @hexylena
 
 # Spanish tutorials
-topics/introduction/tutorials/galaxy-intro-short/                          @galaxyproject/training-spanish @galaxyproject/training-introduction
-topics/transcriptomics/tutorials/scrna-case_alevin/     @galaxyproject/training-spanish @galaxyproject/training-transcriptomics
-topics/transcriptomics/tutorials/scrna-intro/                              @galaxyproject/training-spanish @galaxyproject/training-transcriptomics
-topics/transcriptomics/tutorials/scrna_case_basic-pipeline/                 @galaxyproject/training-spanish @galaxyproject/training-transcriptomics
+# Notify both the spanish team (@beatrizserrano @nomadscientist @davelopez) as the topic team
+topics/introduction/tutorials/galaxy-intro-short/             @beatrizserrano @nomadscientist @davelopez    @jennaj
+topics/single-cell/tutorials/scrna-case_alevin/               @beatrizserrano @nomadscientist @davelopez    @mtekman  @pavanvidem  @hexhowells  @MarisaJL  @heylf
+topics/single-cell/tutorials/scrna-intro/                     @beatrizserrano @nomadscientist @davelopez    @mtekman  @pavanvidem  @hexhowells  @MarisaJL  @heylf
+topics/single-cell/tutorials/scrna_case_basic-pipeline/       @beatrizserrano @nomadscientist @davelopez    @mtekman  @pavanvidem  @hexhowells  @MarisaJL  @heylf
 
 # Lines starting with '#' are comments.
 # # Order is important. The last matching pattern has the most precedence.

--- a/editorial-board.md
+++ b/editorial-board.md
@@ -20,3 +20,25 @@ title: GTN Editorial Board
 {% endfor %}
 
 </section>
+
+<h2> Codeowners</h2>
+
+Automatic CODEOWNERS file (just to make it easier to keep updated)
+
+
+<!-- autogenerate a codeowners file based on this info -->
+
+```
+assets/     @bebatut @shiltemann @hexylena
+bin/        @bebatut @shiltemann @hexylena
+metadata/   @bebatut @shiltemann @hexylena
+badges/     @hexylena
+_layouts/   @bebatut @shiltemann @hexylena
+_includes/  @bebatut @shiltemann @hexylena
+_plugins/   @bebatut @hexylena
+
+{% for t in sorted_topics %}{% assign topic = site.data[t] %}
+topics/{{t}}/               {% for member in topic.editorial_board %} @{{member}} {% endfor %}{% endfor%}
+```
+
+

--- a/metadata/one-health.yaml
+++ b/metadata/one-health.yaml
@@ -12,4 +12,3 @@ editorial_board:
   - wm75
   - pvanheus
   - TKlingstrom
-  - hexylena

--- a/topics/assembly/metadata.yaml
+++ b/topics/assembly/metadata.yaml
@@ -20,4 +20,3 @@ requirements:
 editorial_board:
   - nekrut
   - delphine-l
-  - gallardoalba

--- a/topics/dev/metadata.yaml
+++ b/topics/dev/metadata.yaml
@@ -9,7 +9,6 @@ requirements:
 editorial_board:
   - lecorguille
   - bebatut
-  - hexylena
 
 gitter: galaxyproject/dev
 

--- a/topics/epigenetics/metadata.yaml
+++ b/topics/epigenetics/metadata.yaml
@@ -22,4 +22,3 @@ editorial_board:
   - lldelisle
   - heylf
   - joachimwolff
-  - dpryan79

--- a/topics/galaxy-interface/metadata.yaml
+++ b/topics/galaxy-interface/metadata.yaml
@@ -33,4 +33,3 @@ subtopics:
 
 editorial_board:
   - jennaj
-  - hexylena


### PR DESCRIPTION
I realized our CODEOWNERS file was very outdated (missing/renamed topics etc)

The team based approach was not working for us, so I've written down all editorial board members individually. 

So all editorial board members should get notified about any PRs concerning their topic.

Everybody is free to add/remove themselves to parts of this file as they want

I also made a section on the editorial-board page that autogenerates the codeowners from metadata, so that it is easy to update in the future.