### PR TITLE
indicate type of editorial role on hall of fame page

### DIFF
--- a/_layouts/contributor_index.html
+++ b/_layouts/contributor_index.html
@@ -94,9 +94,9 @@ layout: base
 				{% for res in page.editors %}
 					<li>
 						{% if res.layout == 'learning-pathway' %}
-						<a href="{{ site.baseurl }}{{ res.url }}">{{ res.title }}</a>
+						Learning Pathway: <a href="{{ site.baseurl }}{{ res.url }}">{{ res.title }}</a>
 						{% else %}
-						<a href="{{ site.baseurl }}/topics/{{ res.name }}">{{ res.title }}</a>
+						Topic: <a href="{{ site.baseurl }}/topics/{{ res.name }}">{{ res.title }}</a>
 						{% endif %}
 					</li>
 				{% endfor %}


### PR DESCRIPTION
fixes https://github.com/galaxyproject/training-material/issues/5838

We were actually including learning pathways (under editorial roles), but not indicating that fact