### PR TITLE
Event page gta added Climat track

### DIFF
--- a/CONTRIBUTORS.yaml
+++ b/CONTRIBUTORS.yaml
@@ -891,6 +891,11 @@ ethering:
     orcid: 0000-0002-5003-1425
     joined: 2019-10
 
+evenmm:
+    name: Even Moa Myklebust
+    orcid: 0000-0002-8380-6370
+    joined: 2025-04
+
 Ezichi-Fav:
     name: Ofoezie Ezichi
     email: ezichifavour@gmail.com

--- a/events/2025-05-12-galaxy-academy-2025.md
+++ b/events/2025-05-12-galaxy-academy-2025.md
@@ -51,6 +51,7 @@ contributions:
     instructors:
         - ahmedhamidawan
         - annasyme
+        - annefou
         - anuprulez
         - abretaud
         - bebatut
@@ -60,12 +61,15 @@ contributions:
         - dianichj
         - deeptivarshney
         - delphine-l
+        - elifsu-simula
         - elichad
         - EngyNasr
         - emmaustin20
+        - evenmm
         - GarethPrice-Aus
         - khaled196
         - jdavcs
+        - j34ni
         - bernt-matthias
         - foellmelanie
         - meltemktn
@@ -180,6 +184,8 @@ program:
         link: events/tracks/gta2025-single-cell.md
       - title: Microbiome
         link: events/tracks/gta2025-microbiome.md
+      - title: Climate
+        link: events/tracks/gta2025-climate.md
       #- title: Bacterial Genomics
       #  link: events/tracks/gta2024-bacterial-genomics.md
       #- title: BY-COVID

--- a/events/tracks/gta2025-climate.md
+++ b/events/tracks/gta2025-climate.md
@@ -1,0 +1,36 @@
+---
+layout: event-track
+
+title: Climate
+description: Learn all about Climate on Galaxy. Start with the tutorial at your own pace. If you need support contact us during the event via the  gta_single-cell Slack Channel.
+
+
+contributions:
+    organisers:
+        - annefou
+    instructors:
+        - annasyme
+        - annefou
+        - elifsu-simula
+        - j34ni
+        - evenmm
+
+
+program:
+  - section: "Climate Introduction" 
+    description: |
+      If you encounter any issue please ask us in this Slack channel. 
+    tutorials:
+      - name: climate-101
+        topic: climate
+  - section: "Pangeo ecosystem" 
+    description: |
+      If you encounter any issue please ask us in this Slack channel. 
+    tutorials:
+      - name: pangeo
+        topic: climate
+      - name: pangeo-notebook
+        topic: climate
+      - name: jupytergis_collaboration
+        topic: climate
+---


### PR DESCRIPTION
- Added Climat track program (events/tracks/gta2025-climate.md)
- Linked track in the gta-event page, and added all helpers
- Added Even to Contributors.yaml

ToDo:
@annefou: could you have a look at the program looks ok and add some descriptions to the individual section and a general one on top?
 
![Screenshot from 2025-04-15 18-31-38](https://github.com/user-attachments/assets/888a1fb5-e811-4c6b-b89c-4c9bec8f417e)
