### PR TITLE
Switch to production WorkflowHub

### DIFF
--- a/.github/workflows/workflowhub.yml
+++ b/.github/workflows/workflowhub.yml
@@ -1,4 +1,4 @@
-name: "[Cron] Upload workflows to (DEV)WorkflowHub"
+name: "[Cron] Upload workflows to WorkflowHub"
 
 concurrency:
   group: wfh-${{ github.head_ref }}
@@ -57,9 +57,9 @@ jobs:
 
       - name: Upload workflows
         run: |
-          python bin/wfh-upload.py
+          python bin/wfh-upload.py --prod
         env:
-          WFH_TOKEN: ${{ secrets.DEV_WFH_TOKEN }}
+          WFH_TOKEN: ${{ secrets.PROD_WFH_TOKEN }}
 
       - name: Any changes?
         run: |


### PR DESCRIPTION
The GTN workflows are currently automatically pushed to the development instance of WorkflowHub, this changes that to target production WFH