### PR TITLE
Add external link to event feeds

### DIFF
--- a/_plugins/feeds.rb
+++ b/_plugins/feeds.rb
@@ -544,6 +544,9 @@ def generate_event_feeds(site)
           xml.category(term: "starts:#{page.data['date_start'].to_datetime.rfc3339}")
           xml.category(term: "ends:#{(page.data['date_end'] || page.data['date_start']).to_datetime.rfc3339}")
           xml.category(term: "days:#{page.data['duration']}")
+          if page.data['external']
+            xml.category(term: "external_link:#{page.data['external']}")
+          end
 
           # xml.path(page.path)
           xml.category(term: "new #{page['layout']}")

--- a/_plugins/feeds.rb
+++ b/_plugins/feeds.rb
@@ -545,7 +545,7 @@ def generate_event_feeds(site)
           xml.category(term: "ends:#{(page.data['date_end'] || page.data['date_start']).to_datetime.rfc3339}")
           xml.category(term: "days:#{page.data['duration']}")
           if page.data['external']
-            xml.category(term: "external_link:#{page.data['external']}")
+            xml.link(href: page.data['external'])
           end
 
           # xml.path(page.path)


### PR DESCRIPTION
Introduce a new category for external links in the event feeds generation process.
This could be used in Galaxy Hub to link directly to the external link.
Related to https://github.com/galaxyproject/galaxy-hub/issues/3124