### PR TITLE
Hotfixes for Machine Learning: Intro to RNN Hands-On tutorial

### DIFF
--- a/topics/statistics/tutorials/RNN/tutorial.md
+++ b/topics/statistics/tutorials/RNN/tutorial.md
@@ -318,6 +318,7 @@ The model builder can be downloaded as a zip file.
 > - {% tool [Deep learning training and evaluation](toolshed.g2.bx.psu.edu/repos/bgruening/keras_train_and_eval/keras_train_and_eval/1.0.10.0) %}
 >    - *"Select a scheme"*: `Train and Validate`
 >    - *"Choose the dataset containing pipeline/estimator object"*: Select the *Keras Model Builder* from the previous step.
+>    - *"Metrics for evaluation - Select the primary metric (scoring)"*: `Classification -- 'f1'`
 >    - *"Select input type:"*: `tabular data`
 >        - *"Training samples dataset"*: Select `X_train` dataset
 >        - *"Choose how to select data by column:"*: `All columns`


### PR DESCRIPTION
@teresa-m @anuprulez please review. Screenshots added for clarity. 

_When following step-by-step tutorial instructions, job error due to `default` parameter value for the tool `Deep learning training and evaluation ( Galaxy version 1.0.10.0)` failure:_
![Greenshot 2025-05-09 11 12 51](https://github.com/user-attachments/assets/909da625-fb04-48e4-8140-a8557f396b5e)

_Wording solution in step-by-step instructions which originated from ["Run Workflow in Galaxy" version](https://training.galaxyproject.org/training-material/topics/statistics/tutorials/RNN/workflows/Intro_To_RNN_v1_0_10_0.html) of tutorial which used `f1` parameter value successfully:_
![Greenshot 2025-05-09 11 15 50](https://github.com/user-attachments/assets/d5fe59ca-2dc0-4bb6-b661-695dac17dac8)

