### PR TITLE
Update GTA ML track

### DIFF
--- a/events/tracks/gta2025-ml.md
+++ b/events/tracks/gta2025-ml.md
@@ -33,9 +33,11 @@ program:
         topic: statistics
       - name: classification_machinelearning
         topic: statistics
-      - name: CNN
+      - name: FNN
         topic: statistics
       - name: RNN
+        topic: statistics
+      - name: CNN
         topic: statistics
       - name: fine_tuning_protTrans
         topic: statistics


### PR DESCRIPTION
Adds the missing FNN tutorial, and fixes order of RNN/CNN