### PR TITLE
Added search by topic following previous format.

### DIFF
--- a/search2.html
+++ b/search2.html
@@ -31,7 +31,7 @@ We are testing a new search experience. It does not do semantic ranking of resul
 	</select>
 	</div>
 	</div>
-	
+
 	<div class="col-md-2">
 	<div class="form-group">
 	<label for="level">Level</label>
@@ -43,13 +43,15 @@ We are testing a new search experience. It does not do semantic ranking of resul
 	</select>
 	</div>
 	</div>
-	
+
 	<div class="col-md-3">
 	<div class="form-group">
 	<label for="topic">Topic</label>
 	<select class="form-control" id="topic">
 		<!-- Manually add a few options -->
 		<option value="Any">Any</option>
+		<option value="GTN FAQ">GTN FAQ</option>
+		<option value="Galaxy FAQ">Galaxy FAQ</option>
 		<!-- Automatically add other topics -->
 		{% assign sorted_topics = site | list_topics_ids | sort %}
 		{% for topic_name in sorted_topics %}


### PR DESCRIPTION
I noticed that I sometimes cannot find the tutorials I am looking for. Specially, there are topics that I know they exist. I thought maybe it would be nice to add a new filter button to narrow down the results of the search to a specific "Topic".

There is nothing novel in this PR. I copy-pasted almost everything from the file and changed the text. The local test works fine on my laptop. I changed the size of buttons and menus slightly so everything stays in the same line (it was all white space that I saved).
