### PR TITLE
Added biodiversity tag to tutorials to generate biodiversity codex

### DIFF
--- a/topics/assembly/tutorials/ERGA-post-assembly-QC/tutorial.md
+++ b/topics/assembly/tutorials/ERGA-post-assembly-QC/tutorial.md
@@ -26,6 +26,7 @@ tags:
 - genome
 - assembly
 - QC
+- biodiversity
 recordings:
 - youtube_id: n4PNTTa2d6U
   length: 44M

--- a/topics/assembly/tutorials/assembly-decontamination/tutorial.md
+++ b/topics/assembly/tutorials/assembly-decontamination/tutorial.md
@@ -15,6 +15,8 @@ key_points:
 contributions:
   authorship:
   - delphine-l
+tags:
+  - biodiversity
 recordings:
 - youtube_id: -5oxfNnNwoA
   length: 29M

--- a/topics/assembly/tutorials/assembly-quality-control/tutorial.md
+++ b/topics/assembly/tutorials/assembly-quality-control/tutorial.md
@@ -6,6 +6,7 @@ zenodo_link: 'https://zenodo.org/record/6947782'
 tags:
   - assembly
   - quality control
+  - biodiversity
 questions:
 - Is my genome assembly ready for annotation and/or scaffolding?
 objectives:

--- a/topics/assembly/tutorials/assembly-with-preprocessing/tutorial.md
+++ b/topics/assembly/tutorials/assembly-with-preprocessing/tutorial.md
@@ -35,6 +35,7 @@ requirements:
       - collections
 tags:
   - covid19
+  - biodiversity
 contributors:
   - wm75
 

--- a/topics/assembly/tutorials/chloroplast-assembly/tutorial.md
+++ b/topics/assembly/tutorials/chloroplast-assembly/tutorial.md
@@ -6,6 +6,7 @@ tags:
 - plants
 - nanopore
 - jbrowse1
+- biodiversity
 questions:
 - How can we assemble a chloroplast genome?
 objectives:

--- a/topics/assembly/tutorials/flye-assembly/tutorial.md
+++ b/topics/assembly/tutorials/flye-assembly/tutorial.md
@@ -6,6 +6,7 @@ zenodo_link: ''
 tags:
   - assembly
   - pacbio
+  - biodiversity
 questions:
 - How to perform a genome assembly with PacBio data ?
 - How to check assembly quality ?

--- a/topics/assembly/tutorials/largegenome/tutorial.md
+++ b/topics/assembly/tutorials/largegenome/tutorial.md
@@ -8,6 +8,7 @@ tags:
   - polishing
   - nanopore
   - plants
+  - biodiversity
 questions:
   - "How can we assemble a large plant or animal genome?"
 objectives:

--- a/topics/assembly/tutorials/mitochondrion-assembly/tutorial.md
+++ b/topics/assembly/tutorials/mitochondrion-assembly/tutorial.md
@@ -13,6 +13,8 @@ key_points:
   a reference sequence.
 contributors:
 - delphine-l
+tags:
+  - biodiversity
 recordings:
 - youtube_id: 0ehAZ0DZsFU
   length: 11M

--- a/topics/assembly/tutorials/unicycler-assembly/tutorial.md
+++ b/topics/assembly/tutorials/unicycler-assembly/tutorial.md
@@ -7,6 +7,7 @@ level: Introductory
 tags:
   - prokaryote
   - microgalaxy
+  - biodiversity
 edam_ontology:
   - topic_0196 # Sequence Assembly
   - topic_0622 # Genomics

--- a/topics/assembly/tutorials/vgp_genome_assembly/tutorial.md
+++ b/topics/assembly/tutorials/vgp_genome_assembly/tutorial.md
@@ -7,6 +7,7 @@ tags:
  - pacbio
  - eukaryote
  - VGP
+ - biodiversity
 questions:
 - "What combination of tools can produce the highest quality assembly of vertebrate genomes?"
 - "How can we evaluate the quality of the assembly in a reference-free way?"

--- a/topics/assembly/tutorials/vgp_workflow_training/tutorial.md
+++ b/topics/assembly/tutorials/vgp_workflow_training/tutorial.md
@@ -8,6 +8,7 @@ tags:
 - pacbio
 - eukaryote
 - VGP
+- biodiversity
 questions:
 - What combination of tools can produce the highest quality assembly of vertebrate
   genomes?

--- a/topics/genome-annotation/tutorials/amr-gene-detection/tutorial.md
+++ b/topics/genome-annotation/tutorials/amr-gene-detection/tutorial.md
@@ -21,6 +21,7 @@ tags:
 - one-health
 - jbrowse1
 - microgalaxy
+- biodiversity
 subtopic: prokaryote
 edam_ontology:
 - topic_3673 # Whole genome sequencing

--- a/topics/genome-annotation/tutorials/annotation-with-maker-short/tutorial.md
+++ b/topics/genome-annotation/tutorials/annotation-with-maker-short/tutorial.md
@@ -8,6 +8,7 @@ tags:
   - eukaryote
   - maker
   - jbrowse1
+  - biodiversity
 questions:
   - How to annotate an eukaryotic genome?
   - How to evaluate and visualize annotated genomic features?

--- a/topics/genome-annotation/tutorials/annotation-with-maker-short/tutorial.md
+++ b/topics/genome-annotation/tutorials/annotation-with-maker-short/tutorial.md
@@ -8,7 +8,6 @@ tags:
   - eukaryote
   - maker
   - jbrowse1
-  - biodiversity
 questions:
   - How to annotate an eukaryotic genome?
   - How to evaluate and visualize annotated genomic features?

--- a/topics/genome-annotation/tutorials/apollo-euk/tutorial.md
+++ b/topics/genome-annotation/tutorials/apollo-euk/tutorial.md
@@ -9,6 +9,7 @@ tags:
   - cyoa
   - jbrowse1
   - apollo2
+  - biodiversity
 questions:
   - How to visualize your genome after automated annotations have been performed?
   - How to manually annotate genome after automated annotations have been performed?

--- a/topics/genome-annotation/tutorials/apollo/tutorial.md
+++ b/topics/genome-annotation/tutorials/apollo/tutorial.md
@@ -8,8 +8,8 @@ tags:
   - prokaryote
   - microgalaxy
   - jbrowse1
-  - apollo2
   - biodiversity
+  - apollo2
 questions:
   - How to visualize your genome after automated annotations have been performed?
   - How to manually annotate genome after automated annotations have been performed?

--- a/topics/genome-annotation/tutorials/apollo/tutorial.md
+++ b/topics/genome-annotation/tutorials/apollo/tutorial.md
@@ -9,6 +9,7 @@ tags:
   - microgalaxy
   - jbrowse1
   - apollo2
+  - biodiversity
 questions:
   - How to visualize your genome after automated annotations have been performed?
   - How to manually annotate genome after automated annotations have been performed?

--- a/topics/genome-annotation/tutorials/braker3/tutorial.md
+++ b/topics/genome-annotation/tutorials/braker3/tutorial.md
@@ -7,6 +7,7 @@ tags:
   - eukaryota
   - Braker3
   - jbrowse1
+  - biodiversity
 
 edam_ontology:
 - topic_0196 # Sequence Assembly

--- a/topics/genome-annotation/tutorials/funannotate/tutorial.md
+++ b/topics/genome-annotation/tutorials/funannotate/tutorial.md
@@ -7,6 +7,7 @@ tags:
   - gmod
   - eukaryote
   - jbrowse1
+  - biodiversity
 questions:
   - How to annotate an eukaryotic genome with Funannotate?
   - How to perform functional annotation?

--- a/topics/genome-annotation/tutorials/functional/tutorial.md
+++ b/topics/genome-annotation/tutorials/functional/tutorial.md
@@ -5,6 +5,7 @@ title: Functional annotation of protein sequences
 zenodo_link: https://zenodo.org/record/6861851
 tags:
   - eukaryote
+  - biodiversity
 questions:
   - How to perform functional annotation on protein sequences?
 objectives:

--- a/topics/genome-annotation/tutorials/gene-centric/tutorial.md
+++ b/topics/genome-annotation/tutorials/gene-centric/tutorial.md
@@ -21,6 +21,7 @@ tags:
 - eukaryote
 - prokaryote
 - microgalaxy
+- biodiversity
 requirements:
   -
     type: "internal"

--- a/topics/genome-annotation/tutorials/genome-annotation/tutorial.md
+++ b/topics/genome-annotation/tutorials/genome-annotation/tutorial.md
@@ -5,6 +5,7 @@ title: "Genome Annotation"
 zenodo_link: "https://doi.org/10.5281/zenodo.1250793"
 tags:
   - prokaryote
+  - biodiversity
 questions:
 draft: true
 objectives:

--- a/topics/genome-annotation/tutorials/helixer/tutorial.md
+++ b/topics/genome-annotation/tutorials/helixer/tutorial.md
@@ -7,6 +7,7 @@ tags:
   - eukaryota
   - helixer
   - jbrowse1
+  - biodiversity
 
 edam_ontology:
 - topic_0362 # Genome annotation

--- a/topics/genome-annotation/tutorials/repeatmasker/tutorial.md
+++ b/topics/genome-annotation/tutorials/repeatmasker/tutorial.md
@@ -5,6 +5,7 @@ title: Masking repeats with RepeatMasker
 zenodo_link: https://zenodo.org/record/7085837
 tags:
   - eukaryote
+  - biodiversity
 questions:
   - How to mask repeats in a genome?
   - What is the difference between hard and soft-masking?


### PR DESCRIPTION
The biodiversity is generating their community codex.
In order to automatically pull the relevant tutorials, the tag "biodiversity" was added in a few of them.

The exact list of tutorials to include will be discussed in a follow-up meeting, so this list will be reviewed and updated. 
