### PR TITLE
[WorkflowHub action] update cache action to v4

### DIFF
--- a/.github/workflows/workflowhub.yml
+++ b/.github/workflows/workflowhub.yml
@@ -31,7 +31,7 @@ jobs:
       - uses: ruby/setup-ruby@v1
         with:
           ruby-version: "3.1"
-      - uses: actions/cache@v2
+      - uses: actions/cache@v4
         with:
           path: |
             vendor/bundle


### PR DESCRIPTION
The action has been broken for the past while it turns out because we used an outdated version of the cache action, update to v4, which hopefully should work out of the box