### PR TITLE
Fix "access_type is too permissive" on WorkflowHub submission

### DIFF
--- a/bin/wfh-upload.py
+++ b/bin/wfh-upload.py
@@ -115,6 +115,9 @@ def doUpload(crate_path):
     #
     push = False
     if updated_policy:
+        # Prevents "access_type is too permissive" error if the policy already had public "download" permissions, 
+        #  but the GTN project permission required changes:
+        updated_policy['access'] = 'download'
         push = True
         permissions_update['data']['attributes']['policy'] = updated_policy
 


### PR DESCRIPTION
Fixes this issue: https://github.com/galaxyproject/training-material/actions/runs/15389089921/job/43294210078#step:8:1030

which was due to WorkflowHub not handling partial updates of the policy very well. The submission script tried to add a "manage" permission for members of the GTN Team on WorkflowHub, but the WorkflowHub API also requires the public access type to be declared in the request.

(FYI I fixed the policies of the GTN workflows server-side, so future submissions should succeed regardless of this PR)