### PR TITLE
Removed the biodiversity tag from the tuto

### DIFF
--- a/topics/genome-annotation/tutorials/genome-annotation/tutorial.md
+++ b/topics/genome-annotation/tutorials/genome-annotation/tutorial.md
@@ -5,7 +5,6 @@ title: "Genome Annotation"
 zenodo_link: "https://doi.org/10.5281/zenodo.1250793"
 tags:
   - prokaryote
-  - biodiversity
 questions:
 draft: true
 objectives:


### PR DESCRIPTION
During the All Hands, a user mentioned that about this tutorial "Very old tutorial, should be updated or removed"

Removing the biodiversity tag will avoid having it in the biodiversity codex, or should we just remove it completely?