### PR TITLE
Remove dead link from DH tutorial.bib

### DIFF
--- a/topics/digital-humanities/tutorials/text_mining_chinese/tutorial.bib
+++ b/topics/digital-humanities/tutorials/text_mining_chinese/tutorial.bib
@@ -19,7 +19,6 @@
  author = {Ng, Michael},
  year = {2022},
  title = {Political Censorship in British Hong Kong},
- keywords = {British Hong Kong;Censorship;colonialism;Hong Kong;Law;Secondary Literature;to read},
  publisher = {{Cambridge University Press}},
  isbn = {9781108830027},
  subtitle = {Freedom of Expression and the Law (1842-1997)},
@@ -46,7 +45,6 @@
  year = {1938-10-16},
  subtitle = {Gao yue junmin shu 告粵軍民書 [Letter to Guangdong Army and Civilians]},
  abstract = {},
- url = {https://mmis.hkpl.gov.hk/coverpage/-/coverpage/view?_coverpage_WAR_mmisportalportlet_hsf=%E5%A4%A7%E5%85%AC%E5%A0%B1&_coverpage_WAR_mmisportalportlet_actual_q=%28%20all_dc.title%3A%28%22%E5%A4%A7%E5%85%AC%E5%A0%B1%22%29%29%20AND+%28%20verbatim_dc.collection%3A%28%22Old%5C%20HK%5C%20Newspapers%22%29%29&_coverpage_WAR_mmisportalportlet_sort_field=dc.publicationdate_bsort&p_r_p_-1078056564_c=QF757YsWv59H%2FuxqfBwEJOZ0KGhRikUw&_coverpage_WAR_mmisportalportlet_o=46&_coverpage_WAR_mmisportalportlet_sort_order=asc&_coverpage_WAR_mmisportalportlet_filter=dc.publicationdate_dt%3A%5B1930-01-01T00%3A00%3A00Z+TO+1939-12-31T15%3A59%3A59Z%5D},
  userd = {5598}
 }
 


### PR DESCRIPTION
The link to the newspaper article mentioned in my tutorial is no longer accessible; therefore, it has been deleted.  unnecessary personal tags from another publication were also removed

Thanks for your help in updating :)