### PR TITLE
Tool IDs tweak

### DIFF
--- a/_plugins/util.rb
+++ b/_plugins/util.rb
@@ -143,8 +143,8 @@ ALLOWED_SHORT_IDS = [
   'ucsc_table_direct_archaea1',
   'upload1',
   'vcf_to_maf_customtrack1',
-  'velvetg',
-  'velveth',
+  #'velvetg',  # velvet has a toolshed alternative, discourage using built-in version
+  #'velveth',  # velvet has a toolshed alternative, discourage using built-in version
   'visualize_icenet_forecast',
   'wc_gnu',
   'wiggle2simple1',


### PR DESCRIPTION
Just a small follow up to @dadrasarmin's PR regarding tool IDs

- converters and interactive tools already had a general exception further down in the code, so remove those from the list
- one tool had been commented out because the tool button to open it directly in Galaxy did not work for some reason
- I commented out the velvet built-in tools because there are toolshed alternatives that should be encouraged for use in tutorials

