### PR TITLE
 **Ready for Review** added upload cloud icon for Teresa

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -101,6 +101,7 @@ slack:
 icon-tag:
   announcement: fas fa-bullhorn
   arrow-keys: fa fa-arrows
+  cloud-upload: fa-solid fa-cloud-arrow-up
   code-in: far fa-keyboard
   code-out: fas fa-laptop-code
   cofest: fas fa-users


### PR DESCRIPTION
@teresa-m asked for a new icon to be added to GTN for Cloud Upload. I added this one: https://fontawesome.com/icons/cloud-arrow-up?f=classic&s=solid to the `_config.yml` file.
It appears as expected in the FAQ titled: "Which icons are available to use in my tutorial?"
<img width="704" height="337" alt="upload-cloud" src="https://github.com/user-attachments/assets/ab01d9b3-f0f4-4479-be2d-794946217d6c" />
