### PR TITLE
image compress action -- do not create a unique branch each time

### DIFF
--- a/.github/workflows/optimize-images.yml
+++ b/.github/workflows/optimize-images.yml
@@ -44,7 +44,7 @@ jobs:
         uses: peter-evans/create-pull-request@v7
         with:
           title: Auto Compress Images
-          branch-suffix: timestamp
+          branch: action_compress_images
           commit-message: Compress Images
           author: github-actions[bot] <github-actions[bot]@users.noreply.github.com>
           committer: github-actions[bot] <github-actions[bot]@users.noreply.github.com>


### PR DESCRIPTION
@shiltemann I think this should work better for this action, there should always be at most one PR and this achieves that afaik