### PR TITLE
make autocompress PRs drafts

### DIFF
--- a/.github/workflows/optimize-images.yml
+++ b/.github/workflows/optimize-images.yml
@@ -49,3 +49,4 @@ jobs:
           author: github-actions[bot] <github-actions[bot]@users.noreply.github.com>
           committer: github-actions[bot] <github-actions[bot]@users.noreply.github.com>
           body: ${{ steps.calibre.outputs.markdown }}
+          draft: always-true


### PR DESCRIPTION
so they don't assign all codeowners on creation
they will stilll ping when taken out of draft, but that should happen less
