### PR TITLE
correct visual formatting of step 3

### DIFF
--- a/topics/imaging/tutorials/yolo-segmentation-training/tutorial.md
+++ b/topics/imaging/tutorials/yolo-segmentation-training/tutorial.md
@@ -156,10 +156,11 @@ In this tutorial, we annotate all 22 example images using the tool's `Auto label
 >    - **Important:** The object label must match the content of `class_names.txt`.
 >    - Repeat these steps for each image in the dataset to complete the interactive annotation process.
 >
-> 3. Close the tool 
-> Once you have finished annotating all your images, you can safely close the interactive environment.
-> Click on the small cross at the top-right corner of the AnyLabeling window.
-> ![Closing AnyLabeling](../../images/yolo-train/al_close.png){: width="50%"}
+> 3. Close the tool.
+> 
+> Once you have finished annotating all your images, you can safely close the interactive environment.  
+> Click on the small cross at the top-right corner of the AnyLabeling window.  
+> ![Closing AnyLabeling](../../images/yolo-train/al_close.png){: width="50%"}  
 > Wait a few moments for the interface to close completely and return to the Galaxy workspace.
 {: .hands_on}
 


### PR DESCRIPTION
<img width="1257" height="82" alt="Capture d’écran du 2025-10-14 15-13-23" src="https://github.com/user-attachments/assets/f3a1956f-0f9f-4761-a268-4b6ee3e765f5" />

Fixed visual formatting issue in the “Close the tool” step (numbering correction).