### PR TITLE
Revert "Add CNAME file"

### DIFF
--- a/CNAME
+++ b/CNAME
@@ -1,1 +1,0 @@
-training.galaxyproject.org


### PR DESCRIPTION
This reverts commit 28be59be613e52e50ffaa8b5ee9e504fd58fb65d.

Having the GH Pages custom domain configured creates an infinite redirect loop between http://training.galaxyproject.org and https://training.galaxyproject.org.