### PR TITLE
Adding Freiburg Galaxy Workshop Event 2026 03 

### DIFF
--- a/events/2026-03-09-hts-workshop-freiburg.md
+++ b/events/2026-03-09-hts-workshop-freiburg.md
@@ -129,7 +129,7 @@ Please see the Program tab.
 
 The number of places in this workshop is limited. The course is conducted in person only (not online or hybrid). 
 Please note that the tutorials on which this workshop is based are all accessible through Open Educational Resources via the Galaxy Training Material. 
-Please click on the "Program" and the content for the respective day to view more information.
+Please click on the Program tab and the content for the respective day to view more information.
 There are no fees for the workshop; however, you will need to cover your own accommodation, travel costs, and catering expenses.
 
 


### PR DESCRIPTION
I created the event for our next Galaxy workshop.
I 
- updated dates, form link, instructors,
- checked tutorials
- corrected the wrong postcode and some typos
- checked in Codespace
- added passage on availability of material in GTN (final paragraph), as people seem unaware (please improve if you have better ideas)

@teresa-m could you check if this works?

Open questions:
- [ ] What about line 5 - the external link from last time? Can I delete it?
- [ ] Instructors really just are the instructors, and helpers are not included, right?
- [ ] I do not see a good way to add the 2*20 min breaks on days except Monday, when we only mention one tutorial. Help.
- [ ] The tutorial for Thursday in the program tab does not include any tags or difficulty - this is intended, right?

@bgruening 
Before, ESG was mentioned as a funder. Are Dataplant and de.NBI sufficient now, or am I missing further funders?

Thanks so much for your help!