### PR TITLE
Remove external link from workshop description

### DIFF
--- a/events/2026-03-09-hts-workshop-freiburg.md
+++ b/events/2026-03-09-hts-workshop-freiburg.md
@@ -2,8 +2,6 @@
 layout: event
 title: "Workshop on high-throughput sequencing data analysis with Galaxy"
 
-# external: "https://galaxyproject.org/events/2025-03-10-galaxy-workshop-freiburg/"
-
 description: |
     This course introduces scientists to the data analysis platform Galaxy. The course is designed for beginners; no prior programming skills are required.
 


### PR DESCRIPTION
Removed external link from the event markdown file.

to avoid later confusion

@teresa-m can you approve this?