### PR TITLE
Add Bioschemas Person property @id to template

### DIFF
--- a/_plugins/jekyll-jsonld.rb
+++ b/_plugins/jekyll-jsonld.rb
@@ -137,6 +137,7 @@ module Jekyll
         }
         if !contributor.nil? && contributor.key?('orcid') && contributor['orcid']
           person['identifier'] = "https://orcid.org/#{contributor['orcid']}"
+          person['@id'] = "https://orcid.org/#{contributor['orcid']}"
         end
 
         person


### PR DESCRIPTION
Work from ELIXIR BioHackathon 2025, project 18 "Mining the potential of knowledge graphs". We are working on an MCP server which will allow people to query multiple training registries such as GTN using LLMs. The knowledge graph we build will be much richer if we can include identifiers for people and organisations. 

We noticed that the [Bioschemas Person profile 0.3](https://bioschemas.org/profiles/Person/0.3-DRAFT) you use in GTN training materials uses the `identifier` property for ORCID which is great. However, there is no `@id` property which Bioschemas specification states is required. 

I have proposed an additional line for Person markup where ORCID is provided, to also give the schema.org property of `@id` where there is one. It is not in the preferred order (should be next after `@type`) but this is not essential, and the `if...end` conditional wrapper makes it difficult to insert another property at that position.
