### PR TITLE
Do not hard-code supported Python version in dev tutorials

### DIFF
--- a/topics/dev/tutorials/core-contributing/tutorial.md
+++ b/topics/dev/tutorials/core-contributing/tutorial.md
@@ -72,7 +72,7 @@ With simplicity in mind, we will implement our proposed extension to Galaxy by a
 >    > ```
 >    {: .code-in}
 >
->    Make sure your Python version is at least 3.7 (you can check your Python version with `python --version`). If your system uses an older version, you may specify an alternative Python interpreter using the `GALAXY_PYTHON` environment variable (`GALAXY_PYTHON=/path/to/alt/python bash scripts/common_startup.sh --dev-wheels`).
+>    {% icon warning %} Make sure you are using a [supported Python version](https://galaxyproject.org/admin/python/) (you can check your Python version with `python --version`). If your system uses an older version, you may specify an alternative Python interpreter using the `GALAXY_PYTHON` environment variable (`GALAXY_PYTHON=/path/to/alt/python bash scripts/common_startup.sh --dev-wheels`).
 >
 > 4. Activate your new virtual environment:
 >

--- a/topics/dev/tutorials/debugging/tutorial.md
+++ b/topics/dev/tutorials/debugging/tutorial.md
@@ -96,7 +96,7 @@ Good news! All of the failing tests are on the same Galaxy branch! That means yo
 >    > ```
 >    {: .code-in}
 >
->    Make sure your Python version is at least 3.6 (you can check your Python version with `python --version`). If your system uses an older version, you may specify an alternative Python interpreter using the `GALAXY_PYTHON` environment variable (`GALAXY_PYTHON=/path/to/alt/python bash scripts/common_startup.sh --dev-wheels`).
+>    {% icon warning %} Make sure you are using a [supported Python version](https://galaxyproject.org/admin/python/) (you can check your Python version with `python --version`). If your system uses an older version, you may specify an alternative Python interpreter using the `GALAXY_PYTHON` environment variable (`GALAXY_PYTHON=/path/to/alt/python bash scripts/common_startup.sh --dev-wheels`).
 >
 > 4. Activate your new virtual environment:
 >

--- a/topics/dev/tutorials/writing_tests/tutorial.md
+++ b/topics/dev/tutorials/writing_tests/tutorial.md
@@ -79,7 +79,7 @@ Finally, nothing can substitute studying Galaxy's test code - we encourage you t
 >    > ```
 >    {: .code-in}
 >
->    Make sure your Python version is at least 3.7 (you can check your Python version with `python --version`). If your system uses an older version, you may specify an alternative Python interpreter using the `GALAXY_PYTHON` environment variable (`GALAXY_PYTHON=/path/to/alt/python bash scripts/common_startup.sh --dev-wheels`).
+>    {% icon warning %} Make sure you are using a [supported Python version](https://galaxyproject.org/admin/python/) (you can check your Python version with `python --version`). If your system uses an older version, you may specify an alternative Python interpreter using the `GALAXY_PYTHON` environment variable (`GALAXY_PYTHON=/path/to/alt/python bash scripts/common_startup.sh --dev-wheels`).
 >
 > 4. Activate your new virtual environment:
 >


### PR DESCRIPTION
Refer to the documentation instead to avoid outdated info.