### PR TITLE
Update GTN organization Bioschemas markup

### DIFF
--- a/_plugins/jekyll-jsonld.rb
+++ b/_plugins/jekyll-jsonld.rb
@@ -14,12 +14,13 @@ module Jekyll
         '@type': 'Organization',
         'http://purl.org/dc/terms/conformsTo': {
           # Bioschemas profile
-          '@id': 'https://bioschemas.org/profiles/Organization/0.2-DRAFT-2019_07_19',
-          '@type': 'Organization'
+          '@id': 'https://bioschemas.org/profiles/Organization/0.3-DRAFT',
+          '@type': 'CreativeWork'
         },
         id: 'https://training.galaxyproject.org',
         email: 'galaxytrainingnetwork@gmail.com',
         name: 'Galaxy Training Network',
+        description: 'An organization providing a collection of tutorials developed and maintained by the worldwide Galaxy community',
         legalName: 'Galaxy Training Network',
         alternateName: 'GTN',
         url: 'https://training.galaxyproject.org',


### PR DESCRIPTION
Work from ELIXIR BioHackathon 2025, project 18 "Mining the potential of knowledge graphs". We are working on an MCP server which will allow people to query multiple training registries such as GTN using LLMs. The knowledge graph we build will be much richer if we can include identifiers for people and organisations.

We noticed that the Bioschemas Organization profile 0.2 you use in GTN training materials to describe the GTN itself has problems. It uses the incorrect `conformsTo` type. It is missing the required property `description`. It uses the outdated version 0.2 instead of [0.3-DRAFT](https://bioschemas.org/profiles/Organization/0.3-DRAFT). All three of these are correct in the other places you use the Organization Bioschemas profile (when you describe the orgs that trainers are members of).  

I have proposed corrections/updates for the three matters. (There are further required properties missing but I am going to the Bioschemas community to propose a version 0.4 draft profile which makes these properties recommended instead of required. I am also looking to use ROR as the recommended identifier.)