### PR TITLE
[GAT] Update celery tutorial bump flower to `2.0.1`

### DIFF
--- a/topics/admin/tutorials/celery/tutorial.md
+++ b/topics/admin/tutorials/celery/tutorial.md
@@ -117,7 +117,7 @@ First we need to add our new Ansible Roles to the `requirements.yml`:
 >    +- name: geerlingguy.redis
 >    +  version: 1.8.0
 >    +- name: usegalaxy_eu.flower
->    +  version: 1.0.2
+>    +  version: 2.1.0
 >    {% endraw %}
 >    ```
 >    {: data-commit="Add requirement" data-ref="add-req"}
@@ -428,7 +428,7 @@ Now that everything is running, we want to test celery and watch it processing t
 We can simply do that by starting an upload to our Galaxy.
 
 > <hands-on-title>Test Celery and monitor tasks with Flower</hands-on-title>
-> 1. First, open a new tab and enter your machines hostname followed by `/flower/dashboard` then log in with `username: admin` and you password.
+> 1. First, open a new tab and enter your machines hostname followed by `/flower/dashboard` then log in with `username: admin` and your password.
 >    You should see an overview with active workers.  
 >    Keep that tab open
 > 2. In split view, open a second browser window and open your Galaxy page.

--- a/topics/admin/tutorials/monitoring/tutorial.md
+++ b/topics/admin/tutorials/monitoring/tutorial.md
@@ -93,7 +93,7 @@ The available Ansible roles for InfluxDB unfortunately do not support configurin
 >    @@ -42,3 +42,5 @@
 >       version: 1.8.0
 >     - name: usegalaxy_eu.flower
->       version: 1.0.2
+>       version: 2.1.0
 >    +- src: usegalaxy_eu.influxdb
 >    +  version: v6.0.7
 >    {% endraw %}
@@ -297,7 +297,7 @@ Setting up Telegraf is again very simple. We just add a single role to our playb
 >    --- a/requirements.yml
 >    +++ b/requirements.yml
 >    @@ -44,3 +44,7 @@
->       version: 1.0.2
+>       version: 2.1.0
 >     - src: usegalaxy_eu.influxdb
 >       version: v6.0.7
 >    +# Monitoring


### PR DESCRIPTION
Flower role updated to 2.1.0
this means:
 - `pip install virtualenv` is removed
 - flower is updated `1.2.0` → `2.0.1`
