### PR TITLE
Fix GTN deployment, remove duplicate subtopic key

### DIFF
--- a/topics/fair/tutorials/bioimage-REMBI/tutorial.md
+++ b/topics/fair/tutorials/bioimage-REMBI/tutorial.md
@@ -2,8 +2,8 @@
 layout: tutorial_hands_on
 title: REMBI - Recommended Metadata for Biological Images – metadata guidelines for bioimaging data
 level: Introductory
-subtopic: introduction
 zenodo_link: ''
+subtopic: fair-data
 
 questions:
 - What is REMBI and why should I use it?
@@ -36,7 +36,6 @@ contributions:
   funding:
     - elixir-uk-dash
     - elixir-europe
-subtopic: fair-data
 
 requirements:
   - type: "internal"


### PR DESCRIPTION
There was already a suboptic key, making the deployment fail: https://github.com/galaxyproject/training-material/actions/runs/19729242391/job/56526481985#step:8:436

The introduction key was added in https://github.com/galaxyproject/training-material/pull/6523