### PR TITLE
[Fix deploy] Undo symlink of tutorials

### DIFF
--- a/topics/fair/tutorials/bioimage-REMBI/tutorial.md
+++ b/topics/fair/tutorials/bioimage-REMBI/tutorial.md
@@ -2,7 +2,6 @@
 layout: tutorial_hands_on
 title: REMBI - Recommended Metadata for Biological Images – metadata guidelines for bioimaging data
 level: Introductory
-subtopic: introduction
 zenodo_link: ''
 
 questions:

--- a/topics/imaging/tutorials/bioimage-REMBI
+++ b/topics/imaging/tutorials/bioimage-REMBI
@@ -1,1 +1,0 @@
-../../fair/tutorials/bioimage-REMBI

--- a/topics/imaging/tutorials/bioimage-metadata
+++ b/topics/imaging/tutorials/bioimage-metadata
@@ -1,1 +1,0 @@
-../../fair/tutorials/bioimage-metadata


### PR DESCRIPTION
@beatrizserrano @kostrykin undoing the symlinking of FAIR tutorials into the imaging topic for now, will work on a way to support this properly.