### PR TITLE
[Microbiome] Add learning pathway for MAGs building and annotation

### DIFF
--- a/learning-pathways/mags.md
+++ b/learning-pathways/mags.md
@@ -9,7 +9,7 @@ editorial_board:
 - paulzierep
 funding:
 - elixir-europe
-- de.NBI
+- deNBI
 
 title: Building and Annotating Metagenome-Assembled Genomes (MAGs) from Metagenomics Reads
 description: |


### PR DESCRIPTION
This PR adds a learning pathway for MAGs building and annotation.
Some modules are currently commented out because the corresponding tutorials are under development. But @paulzierep  and I need this learning pathway for a deliverable due next week.

