### PR TITLE
deprecate reports tutorial

### DIFF
--- a/topics/admin/tutorials/reports/tutorial.md
+++ b/topics/admin/tutorials/reports/tutorial.md
@@ -20,7 +20,7 @@ contributions:
   funding:
   - deNBI
   - uni-freiburg
-subtopic: monitoring
+subtopic: deprecated
 tags:
   - ansible
   - monitoring


### PR DESCRIPTION
reports have been removed in dev

this sibtopic works for slides, I guess it works for tutorials too?