### PR TITLE
first draft of GTA 2026 event page

### DIFF
--- a/events/2025-05-18-galaxy-academy.md
+++ b/events/2025-05-18-galaxy-academy.md
@@ -1,0 +1,182 @@
+---
+layout: event
+
+title: Galaxy Training Academy 2026
+description: |
+  The Galaxy Training Academy is a self-paced online training event for beginners and advanced learners who want to improve their Galaxy data analysis skills.
+  Over the course of one week, we offer a diverse selection of learning track for you.
+
+# <button id="program-button" class="btn btn-info" onclick="$('#program-tab').tab('show');">Start the Course!</button>
+
+#cover-image: <div style="background:white">
+#              <img src="./events/images/Galaxy_GTA2025_Transparent.png">
+#              </div>
+#cover-image: events/images/Galaxy_GTA2025.png
+#cover-image-alt: logo for the Galaxy Training Academy Event 2025
+
+#registration:
+#  link: https://forms.gle/vSfms7xDVk4r7dhx8
+#  deadline: 2025-05-16
+#  open: true
+
+date_start: 2026-05-18
+date_end: 2026-05-22
+
+cost: free
+audience: Everyone who would like to get to know Galaxy and learn bioinformatics data analysis, whether you want to master a specific analysis or learn a new skill.
+contact_email: academy@galaxyproject.org
+
+async: true
+mode: online
+
+tags:
+- microbiome
+- single-cell
+- proteomics
+- introduction
+- galaxy-interface
+- assembly
+- statistics
+- variant-analysis
+- climate
+- humanities
+
+contributions:
+    organisers:
+        - delphine-l
+        - teresa-m
+        - scottcain
+        - natalie-wa
+        - shiltemann
+        - dianichj
+        - dadrasarmin
+#    instructors:
+#        - ahmedhamidawan
+#        - annasyme
+#        - annefou
+#        - anuprulez
+#        - abretaud
+#        - nekrut
+#        - dadrasarmin
+#        - Nilchia
+#        - bebatut
+#        - bgruening
+#        - clsiguret
+#        - Sch-Da
+#        - dannon
+#        - dianichj
+#        - deeptivarshney
+#        - delphine-l
+#        - elifsu-simula
+#        - elichad
+#        - EngyNasr
+#        - emmaustin20
+#        - evenmm
+#        - GarethPrice-Aus
+#        - hrhotz
+#        - hvelab
+#        - igormakunin
+#        - khaled196
+#        - jdavcs
+#        - j34ni
+#        - jennaj
+#        - jhahnfeld
+#        - jochenblom
+#        - lisanna
+#        - lfenske-93
+#        - bernt-matthias
+#        - PfisterMaxJLU
+#        - foellmelanie
+#        - meltemktn
+#        - mschatz
+#        - hujambo-dunia
+#        - mirandaembl
+#        - natalie-wa
+#        - natefoo
+#        - Oliver_Rupp
+#        - oschwengers
+#        - pauldg
+#        - paulzierep
+#        - pavanvidem
+#        - plushz
+#        - poterlowicz-lab
+#        - pratikdjagtap
+#        - RZ9082
+#        - rlibouba
+#        - reytakop
+#        - SaimMomin12
+#        - sanjaysrikakulam
+#        - scottcain
+#        - silviadg87
+#        - stephanierobin
+#        - subinamehta
+#        - teresa-m
+#        - timothygriffin
+#        - tcollins2011
+#        - nomadscientist
+#        - wm75
+#    funding:
+#        - eurosciencegateway
+#        - biont
+#        - nfdi4plants
+#        - deNBI
+#        - elixir-europe
+#        - mwk
+#        - abromics
+#        - ifb
+#        - FAIR2Adapt
+
+location:
+  name: online
+
+infrastructure:
+  tiaas: true
+  servers:
+    - server: https://usegalaxy.eu
+      name: Galaxy EU
+      # tiaas_link:
+    - server: https://usegalaxy.org
+      name: Galaxy Main
+    - server: https://usegalaxy.org.au/
+      name: Galaxy AU
+    - server: https://usegalaxy.fr
+      name: Galaxy FR
+      tiaas_link: https://usegalaxy.fr/join-training/gta2025
+  support:
+    platform: Slack
+
+---
+# Welcome to the Galaxy Training Academy 2026
+Do you want to learn how to use Galaxy, an open source data analysis platform? Then you are at the right place. We offer here a **5-day Global Online and Asynchronous learning event**.
+
+**Content of the event**
+
+We provide you with training materials which you can study at your own pace and on your own time throughout the week. A program will be posted here closer to the event start.
+
+On the first day, you can make yourself familiar with the Galaxy platform. In the next days, you can learn about Proteomics, Assembly, Transcriptomics, Single Cell, Microbiome or Machine Learning data analysis in Galaxy. On the last day, the Friday we additionally offer a ***FAIR training*** program to you.
+
+**Course format**
+
+The event is asynchronous which means you can set your own pace on your learning journey using our provided self-learning materials. You will start the event by yourself at your preferred time.
+Don't worry, asynchronous does not mean that you are alone! If you ever need help, you can contact one of our many trainers worldwide via **Slack chat**.
+
+**How to participate**
+
+First, you will need to register. **We will open registrations soon.**
+You only need a browser and an account on one of the Galaxy instances registered for this event.
+
+
+**How to get help**
+
+You will not be alone! If you ever need help, you can contact one of our many trainers worldwide via **Slack chat**. Next to the program, you will find Slack channels you can join to exchange with the trainers and other participants during the event. Here you will also find help if you have questions or run into an issue during the training. We try to cover all time zones with helpers for each topic, but please be patient if you do not get an immediate response.
+
+
+**Certificates**
+
+You will be able to obtain a certificate by the end of the event. More information is coming soon.
+
+
+
+## Do you want to join the GTA as a trainer?
+Please fill out our `link to come` to indicate in what capacity you would like to help.
+


### PR DESCRIPTION
Basically, I took the 2025 GTA event and copied it. I removed the section for the logos and program, commented out the instructors and funders and removed links that were specific to the 2025 event (which will be needed for 2026 but don't exist yet). Assuming this is ok as an event as a "more info soon" sort of thing, I'd like to get it up on the site soon so that I can refer to it in contacts with users.

<!-- Contributor Checklist

1. Give your pull request a descriptive title
2. Describe your changes in detail at the top of this text box
3. List anything you still need some help with or things that are still TODO
4. Check that your images are allowed to be re-hosted by the GTN!
5. Not ready for review yet? Make it a **Draft** pull request
   - Once you are done making changes, choose **Ready for Review**
   - Then the automated tests will run and we will know to review and merge it

-->
