### PR TITLE
Add Johannes Nussbaum to CONTRIBUTORS.yaml

### DIFF
--- a/CONTRIBUTORS.yaml
+++ b/CONTRIBUTORS.yaml
@@ -1020,6 +1020,12 @@ jellescholtalbers:
     github: false
     joined: 2026-01
 
+jnussbaum:
+    gtn-halloffame: "no"
+    name: Johannes Nussbaum
+    github: true
+    joined: 2026-01
+
 jyotiprakashmohanty:
     gtn-halloffame: "no"
     name: Jyoti Prakash Mohanty


### PR DESCRIPTION
Adding @jnussbaum for proper author attribution of a co-written blogpost, which is forthcoming.
