### PR TITLE
adding the link for the instructor google form

### DIFF
--- a/events/2025-05-18-galaxy-academy.md
+++ b/events/2025-05-18-galaxy-academy.md
@@ -178,5 +178,5 @@ You will be able to obtain a certificate by the end of the event. To ensure you 
 
 
 ## Do you want to join the GTA as a trainer?
-Please fill out our [Google Form](https://training.galaxyproject.org/training-material/events/2025-05-18-galaxy-academy.html#do-you-want-to-join-the-gta-as-a-trainer) to indicate in what capacity you would like to help.
+Please fill out our [Google Form](https://docs.google.com/forms/d/e/1FAIpQLSdyNhUhWtk2W6nxDwpxao4aRgV9921_PGGyQpGIaRbZynHnAQ/viewform?usp=header) to indicate in what capacity you would like to help.
 


### PR DESCRIPTION
Updated the GTA 2026 page to include a link to a google form for prospective instructors

<!-- Contributor Checklist

1. Give your pull request a descriptive title
2. Describe your changes in detail at the top of this text box
3. List anything you still need some help with or things that are still TODO
4. Check that your images are allowed to be re-hosted by the GTN!
5. Not ready for review yet? Make it a **Draft** pull request
   - Once you are done making changes, choose **Ready for Review**
   - Then the automated tests will run and we will know to review and merge it

-->
