### PR TITLE
Add contributions categories to feeds

### DIFF
--- a/_plugins/feeds.rb
+++ b/_plugins/feeds.rb
@@ -182,6 +182,14 @@ def generate_topic_feeds(site, topic, bucket)
               end
             end
           end
+
+          if page.data.key?('contributions')
+            page.data['contributions'].each do |role, ids|
+              Array(ids).each do |id|
+                xml.category(term: "contributions:#{role}:#{id}")
+              end
+            end
+          end
         end
       end
     end
@@ -348,6 +356,14 @@ def generate_matrix_feed_itemized(site, mats, group_by: 'day', filter_by: nil)
                     xml.name(Gtn::Contributors.fetch_name(site, c, warn:false))
                     if c !~ / /
                       xml.uri("#{site.config['url']}#{site.baseurl}/hall-of-fame/#{c}/")
+                    end
+                  end
+                end
+
+                if page.data.key?('contributions')
+                  page.data['contributions'].each do |role, ids|
+                    Array(ids).each do |id|
+                      xml.category(term: "contributions:#{role}:#{id}")
                     end
                   end
                 end
@@ -573,6 +589,14 @@ def generate_event_feeds(site)
             xml.contributor do
               xml.name(Gtn::Contributors.fetch_name(site, c, warn:false))
               xml.uri("#{site.config['url']}#{site.baseurl}/hall-of-fame/#{c}/")
+            end
+          end
+
+          if page.data.key?('contributions')
+            page.data['contributions'].each do |role, ids|
+              Array(ids).each do |id|
+                xml.category(term: "contributions:#{role}:#{id}")
+              end
             end
           end
         end

--- a/_plugins/feeds.rb
+++ b/_plugins/feeds.rb
@@ -189,6 +189,10 @@ def generate_topic_feeds(site, topic, bucket)
                 xml.category(term: "contributions:#{role}:#{id}")
               end
             end
+          elsif page.data.key?('contributors')
+            Array(page.data['contributors']).each do |id|
+              xml.category(term: "contributions:authorship:#{id}")
+            end
           end
         end
       end
@@ -365,6 +369,10 @@ def generate_matrix_feed_itemized(site, mats, group_by: 'day', filter_by: nil)
                     Array(ids).each do |id|
                       xml.category(term: "contributions:#{role}:#{id}")
                     end
+                  end
+                elsif page.data.key?('contributors')
+                  Array(page.data['contributors']).each do |id|
+                    xml.category(term: "contributions:authorship:#{id}")
                   end
                 end
 
@@ -597,6 +605,10 @@ def generate_event_feeds(site)
               Array(ids).each do |id|
                 xml.category(term: "contributions:#{role}:#{id}")
               end
+            end
+          elsif page.data.key?('contributors')
+            Array(page.data['contributors']).each do |id|
+              xml.category(term: "contributions:authorship:#{id}")
             end
           end
         end


### PR DESCRIPTION
Adds `contributions:<role>:<id>` categories to topic feeds, matrix itemized feeds, and event feeds, mirroring the existing block already present in `generate_matrix_feed`.

<!-- Contributor Checklist

1. Give your pull request a descriptive title
2. Describe your changes in detail at the top of this text box
3. List anything you still need some help with or things that are still TODO
4. Check that your images are allowed to be re-hosted by the GTN!
5. Not ready for review yet? Make it a **Draft** pull request
   - Once you are done making changes, choose **Ready for Review**
   - Then the automated tests will run and we will know to review and merge it

-->