### PR TITLE
Update image link for EU co-funding in GRANTS.yaml used by Galaxy Community Hub

### DIFF
--- a/GRANTS.yaml
+++ b/GRANTS.yaml
@@ -141,7 +141,7 @@ biont:
 
       **Disclaimer:** Views and opinions expressed on this page are however those of the author(s) only and do not necessarily reflect those of the European Union or European Health and Digital Executive Agency. Neither the European Union nor the granting authority can be held responsible for them.
 
-      ![Cofunded by the EU]({% link /assets/images/eu-cofunded.png %}){: style="width:50%"}
+      ![Cofunded by the EU](https://training.galaxyproject.org/training-material/assets/images/eu-cofunded.png){: style="width:50%"}
 
 by-covid:
     name: BeYond-COVID


### PR DESCRIPTION
Related to https://github.com/galaxyproject/galaxy-hub/issues/3899#issuecomment-4237588646

If using a full link to the GTN project is considered bad practice, we can also remove the line altogether.

@bgruening @shiltemann 