### PR TITLE
Delete markdown CSS style on EU co-funding image

### DIFF
--- a/GRANTS.yaml
+++ b/GRANTS.yaml
@@ -141,7 +141,7 @@ biont:
 
       **Disclaimer:** Views and opinions expressed on this page are however those of the author(s) only and do not necessarily reflect those of the European Union or European Health and Digital Executive Agency. Neither the European Union nor the granting authority can be held responsible for them.
 
-      ![Cofunded by the EU](https://training.galaxyproject.org/training-material/assets/images/eu-cofunded.png){: style="width:50%"}
+      ![Cofunded by the EU](https://training.galaxyproject.org/training-material/assets/images/eu-cofunded.png)
 
 by-covid:
     name: BeYond-COVID


### PR DESCRIPTION
Removed inline style from EU co-funding image that is not understood by the template at https://galaxyproject.org/hall-of-fame/biont/

@bgruening we patched the URL yesterday but the CSS annotation doesn't seem to render either - https://galaxyproject.org/hall-of-fame/biont/