### PR TITLE
Add link to Single Cell track in event details

### DIFF
--- a/events/2026-05-18-galaxy-academy.md
+++ b/events/2026-05-18-galaxy-academy.md
@@ -171,7 +171,8 @@ program:
         link: events/tracks/gta2026-ml.md
       - title: Microbiome
       - title: Proteomics
-      - title: events/tracks/gta2026-single-cell.md
+      - title: Single Cell
+        link: events/tracks/gta2026-single-cell.md
       - title: Transcriptomics
       - title: Variant Analysis
 


### PR DESCRIPTION
In the last  PR https://github.com/galaxyproject/training-material/pull/6826,  I replaced the title with the link.