### PR TITLE
Add kMetaShot as optional tool in  mags building training

### DIFF
--- a/topics/microbiome/tutorials/mags-building/tutorial.bib
+++ b/topics/microbiome/tutorials/mags-building/tutorial.bib
@@ -546,3 +546,17 @@ Publisher: Nature Publishing Group},
     volume = {32},
     doi={10.1093/bioinformatics/btv638}
 }
+
+
+@article{defazio2025,
+    author = {Defazio, Giuseppe and Tangaro, Marco Antonio and Pesole, Graziano and Fosso, Bruno},
+    journal = {Briefings in Bioinformatics},
+    number = {1},
+    year = {2025},
+    month = {1},
+    pages = {1--12},
+    publisher = {Oxford University Press (OUP)},
+    title = {kMetaShot: a fast and reliable taxonomy classifier for metagenome-assembled genomes},
+    volume = {26},
+    doi={10.1093/bib/bbae680}
+}

--- a/topics/microbiome/tutorials/mags-building/tutorial.md
+++ b/topics/microbiome/tutorials/mags-building/tutorial.md
@@ -1272,6 +1272,18 @@ Let's add the relative abundance values.
 Taxonomic assignment using **GTDB-Tk** provides a **robust and standardized** approach to classifying MAGs, enabling researchers to **explore microbial diversity, compare communities, and interpret ecological roles**. By leveraging the **Genome Taxonomy Database**, GTDB-Tk ensures that taxonomic classifications are **accurate, reproducible, and up-to-date**, making it an indispensable tool in metagenomic analysis.
 Accurate taxonomic classification of MAGs is essential for understanding the microbial diversity and functional potential within your metagenomic samples. By assigning taxonomic labels to your MAGs, we can explore their evolutionary relationships, ecological roles, and potential functions.
 
+<optional-title>Optional: taxonomic assignment with ***kMetaShot***<optional-title>
+> Taxonomic assignment of MAGs can be also performed by usign other tools such as **kMetaShot** ({% cite defazio2025 %}). This is an alignment-free and k-mer/minimizer based tool relying on NCBI taxonomy. Comparison of results from different tools can improve the reliability of MAGs taxonomic assignment
+>
+>> <hands-on-title>kMetaShot assignment</hands-on-title>
+>> 1. {% tool [kMetaShot](toolshed.g2.bx.psu.edu/repos/bgruening/kmetashot/kmetashot/2.0+galaxy2) %} with following parameters:
+>>    - *"Input type"*: select `bin(s)/MAG(s)`
+>>    - {% icon param-collection %} *"Bin(s)/MAG(s) FASTA file(s)"*: collection of .fasta or .fasta.gz files
+>>    - *"Select a reference database"*: it is suggested to select the latest
+>>    - *"Set ass2ref parameter"*: float from 0 to 1
+> {: .hands_on}
+{: .optional}
+
 ## Functional Annotation of MAGs
 
 Functional annotation is a **critical step** in MAGs analysis, enabling us to **identify and characterize the genes** present in Metagenome-Assembled Genomes (MAGs). By assigning functional roles to these genes, we can uncover the **biological potential** of microbial communities, including their involvement in **metabolic pathways, environmental interactions, and host associations**. Functional annotation provides insights into the **ecological roles** of microbes and helps identify genes associated with **pathogenicity, antibiotic resistance, or beneficial functions** such as nutrient cycling and symbiosis.


### PR DESCRIPTION
In this PR I propose to add an optional square that user can optionally open in which is briefly described kMetaShot as optional taxonomic assignment tool of MAGs and the beneficial to use multiple tools for results comparison.

