### PR TITLE
card implementation pending future hovercard

### DIFF
--- a/CONTRIBUTORS.yaml
+++ b/CONTRIBUTORS.yaml
@@ -1949,15 +1949,15 @@ hexylena:
     joined: 2017-09
     elixir_node: nl
     affiliations:
-      - erasmusmc
-      - gallantries
-      - by-covid
       - elixir-europe
-      - elixir-converge
     former_affiliations:
       - deNBI
       - avans-atgm
       - uni-freiburg
+      - erasmusmc
+      - gallantries
+      - by-covid
+      - elixir-converge
     contact_for_training: false
     location:
       country: NL

--- a/_layouts/contributor_card.html
+++ b/_layouts/contributor_card.html
@@ -1,0 +1,79 @@
+<!DOCTYPE html>
+<html lang="{% if page.lang %}{{ page.lang }}{% else %}en{% endif %}" dir="auto">
+    <head>
+        <meta charset="utf-8">
+        <meta http-equiv="x-ua-compatible" content="ie=edge">
+        <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
+
+        <title>{{ page.title }}</title>
+        {% if jekyll.environment == 'production' %}
+            {% include _includes/analytics.html %}
+        {% endif %}
+        <link rel="shortcut icon" href="{{ "/favicon.ico" | prepend: site.baseurl }}" type="image/x-icon">
+        <link rel="alternate" type="application/atom+xml" href="{{ "/feed.xml" | prepend: site.baseurl }}">
+        <link rel="canonical" href="{{ site.url }}{{ site.baseurl }}{{ page.url }}">
+        <link rel="license" href="https://spdx.org/licenses/{% if page.license %}{{ page.license }}{% else %}CC-BY-4.0{% endif %}">
+        <link rel="preload" href="{{ site.baseurl }}/assets/fonts/AtkinsonHyperlegible/Atkinson-Hyperlegible-Regular-102a.woff2" as="font" type="font/woff2" crossorigin>
+        <link rel="preload" href="{{ site.baseurl }}/assets/fonts/AtkinsonHyperlegible/Atkinson-Hyperlegible-Bold-102a.woff2" as="font" type="font/woff2" crossorigin>
+        <link rel="preload" href="{{ site.baseurl }}/assets/fonts/AtkinsonHyperlegible/Atkinson-Hyperlegible-Italic-102a.woff2" as="font" type="font/woff2" crossorigin>
+        <link rel="preload" href="{{ site.baseurl }}/assets/css/main.css?v=3" as="style">
+        {{ 'load' | bundle_preloads }}
+        <link rel="stylesheet" href="{{ site.baseurl }}/assets/css/main.css?v=3">
+        <meta name="theme-color" content="#2c3143"/>
+
+        {{ page | generate_dublin_core: site }}
+
+        {%- assign og_desc = page.description | default: page.excerpt | default:topic.summary | default: page.content | default: "Collection of tutorials developed and maintained by the worldwide Galaxy community" | strip_html | regex_replace:'[\n\r\s"]',' ' | truncate: 1000 -%}
+        <meta name="description" content="{{ og_desc }}">
+        <meta property="og:site_name" content="Galaxy Training Network">
+	<meta property="og:title" content="{{ og_title | default: page.title }}">
+        <meta property="og:description" content="{{ og_desc }}">
+
+        {%- if page.cover %}{% assign coverimage = page.cover %}
+        {%- elsif page.tags contains "cofest" %}{% assign coverimage = "assets/images/cofest.png" %}
+        {%- elsif page.tags contains "galaxy" %}{% assign coverimage = "assets/images/GalaxyNews.png" %}
+        {%- elsif page.tags contains "gat" %}{% assign coverimage = "assets/images/gat.png" %}
+        {%- else %}{% assign coverimage = "assets/images/GTNLogo1000.png" %}{% endif %}
+        {% assign og_image = page.og_image | default: page['cover-image'] | default: topic.og_image | default: coverimage | default: "assets/images/GTNLogo1000.png" %}
+	{%- if page.layout == "tutorial_hands_on" or page.layout == "tutorial_slides" or page.layout == "event" or page.layout == "workflow" or page.layout == "faq" or page.layout == "introduction_slides" or page.layout == "learning-pathway"  -%}
+	<meta property="og:image" content="https://galaxy-training.s3.amazonaws.com/social{{ page.url | replace: ".html", ".png" }}">
+	{% elsif page.layout == "topic" or page.layout == "recordings" %}
+	<meta property="og:image" content="https://galaxy-training.s3.amazonaws.com/social{{ page.url }}index.png">
+	{%- else -%}
+	<meta property="og:image" content="{% if og_image contains 'https://' %}{{ og_image }}{% else %}{{ site.url }}{{ site.baseurl }}/{{ og_image }}{% endif %}">
+	{%- endif -%}
+
+        <!-- fontawesome -->
+        <link href="{{site.baseurl}}/assets/fontawesome/css/fontawesome.css" rel="stylesheet" />
+        <link href="{{site.baseurl}}/assets/fontawesome/css/brands.css" rel="stylesheet" />
+        <link href="{{site.baseurl}}/assets/fontawesome/css/solid.css" rel="stylesheet" />
+	</head>
+    <body data-spy="scroll" data-target="#toc" data-brightness="auto" data-contrast="auto">
+        {{ 'theme' | load_bundle }}
+
+
+{% assign contributors = site.data['contributors'] %}
+{% assign entity = site | fetch_contributor: page.contributor %}
+
+<script type="application/ld+json">
+	{{ page.contributor | to_pfo_jsonld: site }}
+</script>
+
+<div style="width: 30em;aspect-ratio: 3/1; display: flex; flex-direction: row; margin: 2em; border: 1px solid red;">
+	<div style="width: 10em">
+		{{ entity | fetch_entity_avatar: page.contributor, 200 }}
+	</div>
+	<div style="width: 20em">
+		<h1 style="font-size:1.5rem; margin:0.1rem">{{ entity.name }}</h1>
+		<i>Since {{ entity.joined }}</i>
+
+		<div>
+		{{ page.counts_fmt }}
+		</div>
+	</div>
+</div>
+
+        {{ 'main' | load_bundle }}
+
+    </body>
+</html>

--- a/_layouts/contributor_index.html
+++ b/_layouts/contributor_index.html
@@ -262,7 +262,7 @@ layout: base
         {% if maintains_num > 0 %}<p class="card-text">Editorial board member for {% for res in maintains %}{{res.title}}{% unless forloop.last %}, {% endunless %}{% endfor %}</p>{% endif %}
         <p class="card-text">{{ page.counts_fmt }}</p>
         <p class="card-text"><small class="text-muted">GTN contributor since {{ entity.joined }}</small></p>
-        <img src="{{site.baseurl}}/assets/images/GTN-60px.png" style="width: 2em; position: absolute; bottom: 0; right: 0.5em;"/>
+        <img src="{{site.baseurl}}/assets/images/GTN-60px.png" style="width: 2em; position: absolute; bottom: 0; right: 0.5em;" alt="GTN logo"/>
       </div>
     </div>
   </div>

--- a/_layouts/contributor_index.html
+++ b/_layouts/contributor_index.html
@@ -87,8 +87,28 @@ layout: base
 					The following list includes only slides and tutorials where the individual or organisation has been added to the contributor list. This may not include the sum total of their contributions to the training materials (e.g. GTN css or design, tutorial datasets, workflow development, etc.) unless described by a news post.
 
                 </p>
+
+<div style="width: 30em;aspect-ratio: 3/1; display: flex; flex-direction: row; border: 1px solid grey;  border: 1px solid var(--border);  box-shadow: 5px 5px 0 var(--color-primary);">
+	<div style="width: 10em">
+		{{ entity | fetch_entity_avatar: page.contributor, 200 }}
+	</div>
+	<div style="width: 20em">
+		<div style="font-size:1.5rem; margin:0.1rem">
+			{% if entity.orcid %}
+			{% icon orcid %}
+			{% endif %}
+			{{ entity.short_name | default: entity.name }}
+		</div>
+
+		<div>
+			Contributed to
+			{{ page.counts_fmt }}
+			<i>since {{ entity.joined }}</i>
+		</div>
+	</div>
+</div>
 				{% if page.editor_count > 0 %}
-				<h3>Editorial Roles</h3>
+				<h3 id="editorial-role">{{ page.editor_count }} Editorial Role{% if page.editor_count > 1%}s{% endif %}</h3>
 				<p>This contributor has taken on additional responsibilities as an editor for the following topics. They are responsible for ensuring that the content is up to date, accurate, and follows GTN best practices.</p>
 				<ul>
 				{% for res in page.editors %}
@@ -104,7 +124,7 @@ layout: base
 				{% endif %}
 
 				{% if page.tutorials_count > 0 %}
-				<h3>Tutorials</h3>
+				<h3 id="tutorials">{{ page.tutorials_count }} Tutorial{% if page.tutorials_count > 1%}s{% endif %}</h3>
 				<ul>
 				{% for res in page.tutorials %}
 					{% assign stats_filters = stats_filters | push: res[0].url %}
@@ -130,7 +150,7 @@ layout: base
 				{% endif %}
 
 				{% if page.slides_count > 0 %}
-				<h3>Slides</h3>
+				<h3 id="slides">{{ page.slides_count  }} Slide{% if page.slides_count  > 1%}s{% endif %}</h3>
 				<ul>
 				{% for res in page.slides %}
 					{% assign stats_filters = stats_filters | push: res[0].url %}
@@ -156,7 +176,7 @@ layout: base
 				{% endif %}
 
 				{% if page.learning_pathways_count > 0 %}
-				<h3>Learning Pathways</h3>
+				<h3 id="learning-pathways">{{ page.learning_pathways_count  }}  Learning Pathway{% if page.learning_pathways_count  > 1%}s{% endif %}</h3>
 				<ul>
 				{% for res in page.learning_pathways %}
 					{% assign stats_filters = stats_filters | push: res[0].url %}
@@ -176,7 +196,7 @@ layout: base
 				{% endif %}
 
 				{% if page.faqs_count > 0 %}
-				<h3>FAQs</h3>
+				<h3 id="faqs">{{ page.faqs_count }} FAQ{% if page.faqs_count > 1%}s{% endif %}</h3>
 				<ul>
 				{% for res in page.faqs %}
 					{% assign stats_filters = stats_filters | push: res[0].url %}
@@ -196,7 +216,7 @@ layout: base
 				{% endif %}
 
 				{% if page.videos_count > 0 %}
-				<h3>Video Recordings</h3>
+				<h3 id="video-recordings">{{ page.videos_count }} Video Recording{% if page.videos_count > 1%}s{% endif %}</h3>
 				<ul>
 				{% for res in page.videos %}
 					<li>
@@ -221,7 +241,7 @@ layout: base
 				{% endif %}
 
 				{% if page.events_count > 0 %}
-				<h3>Events</h3>
+				<h3 id="events">{{ page.events_count }} Event{% if page.events_count > 1%}s{% endif %}</h3>
 				<ul>
 				{% for res in page.events %}
 					{% assign stats_filters = stats_filters | push: res[0].url %}
@@ -318,6 +338,10 @@ layout: base
 			<div class="col-md-3">
 				<div>
 					{{ entity | fetch_entity_avatar: page.contributor, 200 }}
+				</div>
+
+				<div class="contact-items text-muted">
+					<i>GTN contributor since {{ entity.joined }}</i>
 				</div>
 
 				<h2>External Links</h2>

--- a/_layouts/contributor_index.html
+++ b/_layouts/contributor_index.html
@@ -88,26 +88,8 @@ layout: base
 
                 </p>
 
-<div style="width: 30em;aspect-ratio: 3/1; display: flex; flex-direction: row; border: 1px solid grey;  border: 1px solid var(--border);  box-shadow: 5px 5px 0 var(--color-primary);">
-	<div style="width: 10em">
-		{{ entity | fetch_entity_avatar: page.contributor, 200 }}
-	</div>
-	<div style="width: 20em">
-		<div style="font-size:1.5rem; margin:0.1rem">
-			{% if entity.orcid %}
-			{% icon orcid %}
-			{% endif %}
-			{{ entity.short_name | default: entity.name }}
-		</div>
 
-		<div>
-			Contributed to
-			{{ page.counts_fmt }}
-			<i>since {{ entity.joined }}</i>
-		</div>
-	</div>
-</div>
-				{% if page.editor_count > 0 %}
+  				{% if page.editor_count > 0 %}
 				<h3 id="editorial-role">{{ page.editor_count }} Editorial Role{% if page.editor_count > 1%}s{% endif %}</h3>
 				<p>This contributor has taken on additional responsibilities as an editor for the following topics. They are responsible for ensuring that the content is up to date, accurate, and follows GTN best practices.</p>
 				<ul>
@@ -263,6 +245,30 @@ layout: base
                 {% unless entity.github == false %}
                 <br><br>
 		{% unless entity.funder %}
+
+<h3> Your Contributor Card </h3>
+
+<!-- contributor card -->
+<div class="card mb-3" style="max-width: 540px;">
+  <div class="row g-0">
+    <div class="col-md-4" style="padding-right: 0;">
+      {{ entity | fetch_entity_avatar: page.contributor, 200 }}
+    </div>
+    <div class="col-md-8" style="padding-left: 0;">
+      <div class="card-body">
+        <h5 class="card-title">{% if entity.orcid %}<a href="https://orcid.org/{{entity.orcid}}" style="color: white">{% icon orcid %}</a>{% endif %} {{ entity.short_name | default: entity.name }}</h5>
+        {% assign maintains = page.editors | where_exp: "item", "item.layout != 'learning-pathway'" %}
+        {% assign maintains_num = maintains | size %}
+        {% if maintains_num > 0 %}<p class="card-text">Editorial board member for {% for res in maintains %}{{res.title}}{% unless forloop.last %}, {% endunless %}{% endfor %}</p>{% endif %}
+        <p class="card-text">{{ page.counts_fmt }}</p>
+        <p class="card-text"><small class="text-muted">GTN contributor since {{ entity.joined }}</small></p>
+        <img src="{{site.baseurl}}/assets/images/GTN-60px.png" style="width: 2em; position: absolute; bottom: 0; right: 0.5em;"/>
+      </div>
+    </div>
+  </div>
+</div>
+<!-- end contributor card -->
+
                 <h3> GitHub Activity</h4>
                 <a href="https://github.com/galaxyproject/training-material/issues?q=+is%3Aissue+author%3A{{page.contributor}}">{% icon github %} Issues Reported</a>
 

--- a/_plugins/author-page.rb
+++ b/_plugins/author-page.rb
@@ -1,7 +1,9 @@
 # frozen_string_literal: true
 
 require './_plugins/gtn/mod'
+require './_plugins/colour-tags'
 require './_plugins/gtn'
+require './_plugins/util'
 
 module Jekyll
   module Generators
@@ -154,6 +156,22 @@ module Jekyll
           end
           page2.data['editor_count'] = page2.data['editors'].length
 
+          page2.data['counts_fmt'] = page2.data
+            .select{|k| k =~ /_count/}
+            .select{|_, v| v > 0}
+            .sort_by{|_, v| -v}
+            .map{|k, v|
+              k_fixed = k.gsub(/_count/,'').gsub(/_/, ' ').gsub(/faqs/i, 'FAQs')
+              k_fixed[/^\W*\w/] = k_fixed[/^\W*\w/].upcase
+
+              style = Gtn::HashedColours.colour_tag(k)
+              if k == "editor_count"
+                %Q(<span class="label" style="#{style}">Editorial Board</span>)
+              else
+                %Q(<span class="label" style="#{style}">#{v} #{k_fixed}</span>)
+              end
+            }.join(' ') # ·
+
           page2.data['has_philosophy'] = has_philosophy[contributor]
 
           countable_reviews = reviews_by_author[contributor]
@@ -170,6 +188,15 @@ module Jekyll
             .map{|x| x[0]}
 
           site.pages << page2
+
+          # and their hovercard
+          page3 = PageWithoutAFile.new(site, '', File.join(dir, contributor), 'card.html')
+          page3.content = nil
+          page3.data = page2.data.clone
+          page3.data['layout'] = 'contributor_card'
+          site.pages << page3
+
+
         end
       end
     end

--- a/stats/index.md
+++ b/stats/index.md
@@ -15,7 +15,7 @@ description: Some useful statistics about the GTN. We're a growing community!
 {% assign topics_technical = site | list_topics_by_category: "technical" | to_vals %}
 
 <!-- contributors stats -->
-{% assign contributors = site.data['contributors'] | where_exp: "item", "item.halloffame != 'no'" | sort: "joined" %}
+{% assign contributors = site.data['contributors'] | where_exp: "item", "item.gtn-halloffame != 'no'" | sort: "joined" %}
 {% assign contributors_by_month = contributors | group_by: "joined" %}
 {% assign contributors_over_time = "" | split: ',' %}
 {% assign contributors_over_time_labels = "" | split: ',' %}


### PR DESCRIPTION
while I was again perusing my HoF page in order to write a useful summary for a grant application I noticed the counts were missing and for some of us, it isn't trivial to count contributions by hand so they're now in the section titles properly, and we also added a 'card' representing an entity. in a future update one could imagine this being a hover card like github does. 

discussed with @shiltemann 