### PR TITLE
Add Dmitrijs Sizovs to CONTRIBUTORS.yaml

### DIFF
--- a/CONTRIBUTORS.yaml
+++ b/CONTRIBUTORS.yaml
@@ -4430,3 +4430,11 @@ kevinrue:
         country: UK
         lat: 51.764301
         lon: -1.2178922
+
+dSizovs:
+    name: Dmitrijs Sizovs
+    email: dmitrijs.sizovs@gmail.com
+    matrix: 'dmitrijs.sizovs:matrix.org'
+    joined: 2026-06
+    bio: Master's student at the University of Freiburg
+    linkedin: dmitrijssizovs


### PR DESCRIPTION
Adds myself to CONTRIBUTORS.yaml ahead of my first contribution to the
Galaxy Community Hub (a news post about connecting the bwForCluster NEMO
to usegalaxy.eu via Pulsar relay mode).

Contributor ID matches my GitHub username (dSizovs).