### PR TITLE
Add a FAQ to guide users to IWC guidelines

### DIFF
--- a/faqs/galaxy/contribute_IWC.md
+++ b/faqs/galaxy/contribute_IWC.md
@@ -1,0 +1,13 @@
+---
+title: Publish your workflow in IWC
+area: workflows
+box_type: tip
+layout: faq
+contributors: [lldelisle]
+---
+
+IWC stands for Intergalactic Workflow Commission.
+
+The IWC maintains high-quality Galaxy Workflows. These production workflows target at users that want to analyze their own data. As such, the workflow should be sufficiently generic that users can provide their own data. These workflows usually use workflow parameter explained in [this tutorial]({% link topics/galaxy-interface/tutorials/workflow-parameters/tutorial.md %}).
+
+The steps to get a workflow in IWC are described in the [README of the IWC github repository](https://github.com/galaxyproject/iwc/blob/main/workflows/README.md).


### PR DESCRIPTION
Hi,
I added a FAQ to guide the users to the IWC guidelines. We decided not to write a proper tutorial about it as it seems that this way we won't have issues in case we change the guidelines.