### PR TITLE
Update main Galaxy Project citation to latest 2026 NAR paper

### DIFF
--- a/topics/introduction/tutorials/galaxy-cite/tutorial.md
+++ b/topics/introduction/tutorials/galaxy-cite/tutorial.md
@@ -53,8 +53,8 @@ Citing Galaxy comes in two main actions:
 ## Citing Galaxy Project
 Please cite Galaxy Project’s primary publication: 
 
-- ***The Galaxy platform for accessible, reproducible, and collaborative data analyses: 2024 update***
-  - Nucleic Acids Research, Volume 52, Issue W1, 5 July 2024, Pages W83–W94, [https://doi.org/10.1093/nar/gkae410](https://doi.org/10.1093/nar/gkae410)
+- ***Galaxy for accessible, reproducible, and collaborative data analyses: 2026 update***
+  - Nucleic Acids Research, gkag469, [https://doi.org/10.1093/nar/gkag469](https://doi.org/10.1093/nar/gkag469)
 
 This is also found on the Galaxy Project Hub with more specific examples of how to cite individual aspects of Galaxy Project - [https://galaxyproject.org/citing-galaxy/](https://galaxyproject.org/citing-galaxy/)
 


### PR DESCRIPTION
After a request from one of our users to cite Galaxy, I noticed the main citation for the Galaxy Project has not yeet been updated to the one from this year (2026). 

This seems to be the only relevant place in the GTN where it should be updated, however on Galaxy level there are other places where it also still mentions to cite the 2024 edition where I will create a separate issue for so nothing is missed. 

Let me know if this was put on hold deliberately, but I could not find anything back by searching the repo.