### PR TITLE
docs: disable JupyterLite for genomic LLM pretraining

### DIFF
--- a/topics/statistics/tutorials/genomic-llm-pretraining/tutorial.md
+++ b/topics/statistics/tutorials/genomic-llm-pretraining/tutorial.md
@@ -49,7 +49,6 @@ subtopic: gai-llm
 priority: 1
 notebook:
   language: python
-  pyolite: true
 ---
 
 **Generative Artificial Intelligence** (AI) represents a cutting-edge domain within machine learning, focused on creating new, synthetic yet realistic data. This includes generating text, images, music, and even biological sequences. At the heart of many generative AI applications are **Large Language Models** (LLMs), which have revolutionized natural language processing and beyond.


### PR DESCRIPTION
## Summary

- remove the JupyterLite opt-in from the genomic LLM pretraining tutorial
- keep regular Python notebook generation enabled

The tutorial installs packages, invokes system commands, and requires GPU/CUDA facilities that are unavailable in JupyterLite's Emscripten runtime.

Closes #6918.

## Validation

- parsed the tutorial frontmatter with PyYAML and confirmed `notebook.language: python` remains while `notebook.pyolite` is absent
- `git diff --check`
