### PR TITLE
docs: fix news event date format

### DIFF
--- a/_includes/newslist.html
+++ b/_includes/newslist.html
@@ -5,7 +5,7 @@
  {% assign newsitems = site.categories['news'] | sort: date | reverse | where:"layout", "news" %}
  {% for post in newsitems limit: 5 %}
  <a class="list-group-item" href="{% if post.external %}{{post.link}}{% else %}{{ post.url | prepend: site.baseurl }}{% endif %}">
-   <p class="list-group-item-text">{% if post.start %}{{post.start | date: data_format }}{% if post.end %} - {{post.end | date: date_format}}{% endif %}{% else %}{{ post.date | date: date_format }}{% endif %}</p>
+   <p class="list-group-item-text">{% if post.start %}{{post.start | date: date_format }}{% if post.end %} - {{post.end | date: date_format}}{% endif %}{% else %}{{ post.date | date: date_format }}{% endif %}</p>
    <div class="list-group-item-heading">
    {% if post.tags contains 'event' %}{% icon event aria=false %}{% endif %}
    {% if post.tags contains 'new tutorial' %}{% icon curriculum aria=false %}{% endif %}


### PR DESCRIPTION
## Summary

- fix the misspelled Liquid date-format variable used for event start dates
- use the same defined `date_format` for start, end, and fallback dates

Closes #3226.

## Validation

- confirmed `date_format` is defined, `data_format` is no longer referenced, and all three date branches use `date_format`
- `git diff --check`

A full Jekyll render was not run locally because Ruby and Bundler are unavailable in the current environment.
