### PR TITLE
Update contributor metadata for climate tutorials

### DIFF
--- a/topics/climate/tutorials/climate-101/tutorial.md
+++ b/topics/climate/tutorials/climate-101/tutorial.md
@@ -15,8 +15,9 @@ key_points:
 - Weather versus Climate
 - Essential Climate Variables
 - Observations, reanalysis, predictions and projections.
-contributors:
-- annefou
+contributions:
+  authorship:
+    - annefou
 
 ---
 

--- a/topics/climate/tutorials/fates-jupyterlab/tutorial.md
+++ b/topics/climate/tutorials/fates-jupyterlab/tutorial.md
@@ -46,8 +46,9 @@ key_points:
 - Model analysis
 tags:
   - interactive-tools
-contributors:
-- annefou
+contributions:
+  authorship:
+    - annefou
 
 ---
 

--- a/topics/climate/tutorials/fates/slides.html
+++ b/topics/climate/tutorials/fates/slides.html
@@ -11,9 +11,10 @@ objectives:
 time_estimation: "30m"
 key_points:
   - FATES is a numerical terrestrial ecosystem model used in climate models
-contributors:
-  - rosiealice
-  - annefou
+contributions:
+  authorship:
+    - rosiealice
+    - annefou
 tags:
   - climate
   - ecology

--- a/topics/climate/tutorials/fates/tutorial.md
+++ b/topics/climate/tutorials/fates/tutorial.md
@@ -36,9 +36,10 @@ key_points:
 - CLM-FATES is a numerical terrestrial ecosystem model used in climate models
 - Panoply is a quick visualization tools for plotting your results
 - Multi-case simulations can be easily developed and shared with a Galaxy workflow
-contributors:
-- annefou
-- huitang-earth
+contributions:
+  authorship:
+    - annefou
+    - huitang-earth
 
 
 recordings:

--- a/topics/climate/tutorials/introduction/slides.html
+++ b/topics/climate/tutorials/introduction/slides.html
@@ -7,9 +7,10 @@ subtopic: introduction
 redirect_from:
 - /topics/climate/slides/introduction
 video: true
-contributors:
-  - annefou
-  - j34ni
+contributions:
+  authorship:
+    - annefou
+    - j34ni
 ---
 
 # What do we mean by "Climate"?

--- a/topics/climate/tutorials/jupytergis_collaboration/tutorial.md
+++ b/topics/climate/tutorials/jupytergis_collaboration/tutorial.md
@@ -12,9 +12,10 @@ objectives:
 - Use follow mode to monitor collaborator activities.
 - Add annotations and comments to provide context, ask questions, or share insights.
 time_estimation: 30M
-contributors:
-- elifsu-simula
-- annefou
+contributions:
+  authorship:
+    - elifsu-simula
+    - annefou
 recordings:
 - youtube_id: l3U6c_VOgnU
   length: 7M

--- a/topics/climate/tutorials/pangeo-notebook/slides.html
+++ b/topics/climate/tutorials/pangeo-notebook/slides.html
@@ -28,10 +28,11 @@ key_points:
   - Pangeo-forge eases the extractionm transformation and loading of Earth Science datasets
   - SpatioTemporal Asset Catalogs helps to provide a unified interface for searching and extracting spatio temporal datasets
   - STAC and pangeo-forge aim at complementing each other
-contributors:
-  - BasileGoussard
-  - rabernat
-  - annefou
+contributions:
+  authorship:
+    - BasileGoussard
+    - rabernat
+    - annefou
 tags:
   - climate
 ---

--- a/topics/climate/tutorials/pangeo-notebook/tutorial.md
+++ b/topics/climate/tutorials/pangeo-notebook/tutorial.md
@@ -58,8 +58,9 @@ key_points:
 tags:
   - pangeo
   - interactive-tools
-contributors:
-- annefou
+contributions:
+  authorship:
+    - annefou
 notebook:
   language: python
   snippet: topics/climate/tutorials/pangeo-notebook/preamble.md

--- a/topics/climate/tutorials/pangeo/slides.html
+++ b/topics/climate/tutorials/pangeo/slides.html
@@ -16,9 +16,10 @@ objectives:
 time_estimation: "15m"
 key_points:
   - Pangeo is an inclusive community promoting open, reproducible and scalable science.
-contributors:
-  - annefou
-  - rabernat
+contributions:
+  authorship:
+    - annefou
+    - rabernat
 tags:
   - climate
 ---

--- a/topics/climate/tutorials/pangeo/tutorial.md
+++ b/topics/climate/tutorials/pangeo/tutorial.md
@@ -26,8 +26,9 @@ key_points:
 - Xarray Tools in Galaxy
 tags:
   - pangeo
-contributors:
-- annefou
+contributions:
+  authorship:
+    - annefou
 
 
 recordings:

--- a/topics/climate/tutorials/panoply/tutorial.md
+++ b/topics/climate/tutorials/panoply/tutorial.md
@@ -19,8 +19,9 @@ key_points:
 - Interact with Galaxy to save your plots
 tags:
 - interactive-tools
-contributors:
-- annefou
+contributions:
+  authorship:
+    - annefou
 
 ---
 


### PR DESCRIPTION
## Summary

- migrate the 11 current tracked climate tutorial/slide source files on `main` that still use the legacy `contributors` key to `contributions.authorship`
- preserve every contributor ID, its capitalization, and its per-file order

No tutorial or slide content, contributor registry entries, schemas, or unrelated front matter are changed. This is a topic-local subset of #5509: it completes the migration only for the matching climate tutorial/slide files currently tracked on `main`, not the repository-wide issue.

Refs #5509.

## Validation

- parsed the front matter for all 11 changed files as YAML
- compared each file with `main` and verified that contributor sequences are unchanged
- verified that tutorial/slide bodies are unchanged and no legacy `contributors` key remains in the current tracked climate tutorial/slide sources
- `git diff --check`

## Automation disclosure

This focused metadata migration was prepared and checked with OpenAI Codex automation. The final diff was reviewed against the repository schema, contribution FAQ, current issue state, and open pull requests.
