### PR TITLE
Fix tag parsing for optional filename suffixes

### DIFF
--- a/topics/transcriptomics/tutorials/ref-based/tutorial.md
+++ b/topics/transcriptomics/tutorials/ref-based/tutorial.md
@@ -1621,8 +1621,8 @@ DESeq2 requires to provide for each factor, counts of samples in each category. 
 >      - {% icon param-file %} *"File to process"*: output of **Extract element identifiers** {% icon tool %}
 >      - In *"Replacement"*:
 >         - In *"1: Replacement"*
->            - *"Find pattern"*: `(.*)_(.*)_(.*)_(.*)`
->            - *"Replace with"*: `\1_\2_\3_\4\tgroup:\2\tgroup:\3`
+>            - *"Find pattern"*: `^([^_]+)_([^_]+)_([^_]+)(_.+)?$`
+>            - *"Replace with"*: `\1_\2_\3\4\tgroup:\2\tgroup:\3`
 >
 >     This step creates 2 additional columns with the type of treatment and sequencing that can be used with the {% tool [Tag elements](__TAG_FROM_FILE__) %} tool
 >

--- a/topics/transcriptomics/tutorials/ref-based/tutorial_DE.md
+++ b/topics/transcriptomics/tutorials/ref-based/tutorial_DE.md
@@ -1523,8 +1523,8 @@ DESeq2 verlangt, dass für jeden Faktor die Anzahl der Proben in jeder Kategorie
 >      - {% icon param-file %} *"Zu verarbeitende Datei "*: Ausgabe von **Elementbezeichner extrahieren** {% icon tool %}
 >      - In *"Replacement "*:
 >         - In *"1: Ersetzung "*
->            - *"Muster finden "*: `(.*)_(.*)_(.*)`
->            - *"Ersetzen durch "*: `\1_\2_\3\tgroup:\2\tgroup:\3`
+>            - *"Muster finden "*: `^([^_]+)_([^_]+)_([^_]+)(_.+)?$`
+>            - *"Ersetzen durch "*: `\1_\2_\3\4\tgroup:\2\tgroup:\3`
 >
 >     Dieser Schritt erstellt 2 zusätzliche Spalten mit der Art der Behandlung und der Sequenzierung, die mit dem {% tool [Tag elements](__TAG_FROM_FILE__) %} tool verwendet werden können
 >

--- a/topics/transcriptomics/tutorials/ref-based/tutorial_ES.md
+++ b/topics/transcriptomics/tutorials/ref-based/tutorial_ES.md
@@ -1530,8 +1530,8 @@ DESeq2 requiere proporcionar para cada factor, recuentos de muestras en cada cat
 >      - {% icon param-file %} *"Fichero a procesar "*: salida de **Extraer identificadores de elementos** {% icon tool %}
 >      - En *"Replacement "*:
 >         - En *"1: Replacement "*
->            - *"Find pattern "*: `(.*)_(.*)_(.*)`
->            - *"Replace with "*: `\1_\2_\3\tgroup:\2\tgroup:\3`
+>            - *"Find pattern "*: `^([^_]+)_([^_]+)_([^_]+)(_.+)?$`
+>            - *"Replace with "*: `\1_\2_\3\4\tgroup:\2\tgroup:\3`
 > 
 >    Este paso crea 2 columnas adicionales con el tipo de tratamiento y secuenciación que pueden utilizarse con la herramienta {% tool [Tag elements](__TAG_FROM_FILE__) %} tool
 > 

--- a/topics/transcriptomics/tutorials/ref-based/tutorial_IT.md
+++ b/topics/transcriptomics/tutorials/ref-based/tutorial_IT.md
@@ -1517,8 +1517,8 @@ DESeq2 richiede di specificare, per ciascun fattore sperimentale, i conteggi dei
 >      - {% icon param-file %} *"File to process"*: output di **Extract element identifiers** {% icon tool %}
 >      - In *"Replacement "*:
 >         - In *"1: Replacement "*
->            - *"Find pattern"*: `(.*)_(.*)_(.*)`
->            - *"Replace with"*: `\1_\2_\3\tgroup:\2\tgroup:\3`
+>            - *"Find pattern"*: `^([^_]+)_([^_]+)_([^_]+)(_.+)?$`
+>            - *"Replace with"*: `\1_\2_\3\4\tgroup:\2\tgroup:\3`
 > 
 >    Questo passaggio crea 2 colonne aggiuntive con il tipo di trattamento e di sequenziamento che possono essere utilizzate con lo strumento {% tool [Elementi tag](__TAG_FROM_FILE__) %}
 > 


### PR DESCRIPTION
Make the tag-based hands-on instructions accept both the three-component collection identifiers they ask learners to create and the four-component filenames reported in #6180.

The English regex added in #6181 only matches identifiers that retain the `_featureCounts.counts` suffix, while the preceding instruction uses names such as `GSM461176_untreat_single`. The anchored expression now treats any suffix as optional, preserves it when present, and consistently tags treatment and sequencing from capture groups 2 and 3. The same technical literals are synchronized across the German, Spanish, and Italian translations.

The workflow is intentionally unchanged: its tests use three-component collection element identifiers without the `_featureCounts.counts` suffix.

Refs #6180. Follow-up to #6181.

## Testing

- `git diff --check`
- `python bin/lint-diffs.py` for each changed tutorial
- GNU sed 4.9 behavior checks for both `GSM461176_untreat_single` and `GSM461176_untreat_single_featureCounts.counts`
- Regex checks for all seven collection identifiers in the workflow test data

## Automation disclosure

This focused documentation fix was prepared and checked with OpenAI Codex automation. The final expression was reviewed against the official Galaxy tool wrappers and validated with GNU sed 4.9.
