### PR TITLE
Change topic-level prerequisite

### DIFF
--- a/topics/galaxy-interface/metadata.yaml
+++ b/topics/galaxy-interface/metadata.yaml
@@ -8,8 +8,6 @@ requirements:
   -
     type: "internal"
     topic_name: introduction
-    tutorials:
-      - galaxy-intro-101
 
 subtopics:
   - id: upload


### PR DESCRIPTION
have the introduction topic as a whole as a prerequisite, not the specific genomics intro tutorial

thanks @Sch-Da for pointing this out 
