### PR TITLE
Add 'new_fave_extract' to the plugin list

### DIFF
--- a/_plugins/util.rb
+++ b/_plugins/util.rb
@@ -101,6 +101,7 @@ ALLOWED_SHORT_IDS = [
   'mousemine',
   'ncbi_datasets_source',
   'netcdf2zarr',
+  'new_fave_extract',
   'omicsdi',
   'param_value_from_file',
   'Paste1',


### PR DESCRIPTION
Adding new fave's short tool ID to enable using it in GTN: https://github.com/galaxyproject/training-material/pull/7049

