### PR TITLE
add Anup to tutorial metadata under infrastructure

### DIFF
--- a/topics/imaging/tutorials/process-image-bioimageio/tutorial.md
+++ b/topics/imaging/tutorials/process-image-bioimageio/tutorial.md
@@ -32,6 +32,8 @@ contributions:
     - annefou
   editing:
     - kostrykin
+  infrastructure:
+    - anuprulez
   funding:
     - nfdi4bioimage
     - deNBI


### PR DESCRIPTION
Adding Anup to tutorial metadata based on https://training.galaxyproject.org/training-material/topics/contributing/faqs/new-contributions.html 