### PR TITLE
link a SC tutorial from the proteomics topic to single cell topic

### DIFF
--- a/topics/single-cell/metadata.yaml
+++ b/topics/single-cell/metadata.yaml
@@ -86,6 +86,10 @@ subtopics:
   - id: scmultiomics
     title: "Multiomic Analyses"
     description: "This section lets you build on mere scRNA analyses into a multiomic future!"
+    crosstopic_tutorials:
+      - topic: proteomics
+        tutorial: bioconductor-scp
+        priority: 4
   - id: tricks
     title: "Tips, tricks & other hints"
     description: "These tutorials cover helpful skills for scRNA-seq analysis"
@@ -102,13 +106,13 @@ subtopics:
 
 references:
 
-  - 
+  -
     authors: "Loach, Marisa; Naghsh Nilchi, Amirhossein; Chiang, Diana; Howells, Morgan; Heyl, Florian; Rasche, Helena; Jakiela, Julia; Tekman, Mehmet; Gamal, Menna; Moreno, Pablo; Hiltemann, Saskia; Schlegel, Timon; Grüning, Björn; Backofen, Rolf; Videm, Pavankumar; Bacon, Wendi"
     title: "Galaxy single-cell & spatial omics community update: Navigating new frontiers in 2025"
     link: "https://doi.org/10.1016/j.xgen.2025.101005"
     summary: ""
 
-  - 
+  -
     authors: "Tekman, Mehmet and Batut, Bérénice; Ostrovsky, Alexander; Antoniewski, Christophe; Clements, Dave; Ramirez, Fidel; Etherington, Graham J; Hotz, Hans-Rudolf; Scholtalbers, Jelle; Manning, Jonathan R; Bellenger, Lea; Doyle, Maria A; Heydarian, Mohammad; Huang, Ni; Soranzo, Nicola; Moreno, Pablo; Mautner, Stefan; Papatheodorou, Irene; Nekrutenko, Anton; Taylor, James; Blankenberg, Daniel; Backofen, Rolf; Grüning, Björn;"
     title: "A single-cell RNA-sequencing training and analysis suite using the Galaxy framework"
     link: "https://doi.org/10.1093/gigascience/giaa102"


### PR DESCRIPTION
As requested by @nomadscientist ages ago in https://github.com/galaxyproject/training-material/issues/5762 I've linked a Single Cell tutorial from the Proteomics topic into the Single Cell topic.

@pavanvidem @dianichj @MarisaJL I didn't know what the best place was to put this, so I put it in the multiomics subtopic, but please let me know if you think somewhere else is better