### PR TITLE
Show relevant learning pathways on topics pages

### DIFF
--- a/_layouts/topic.html
+++ b/_layouts/topic.html
@@ -101,6 +101,21 @@ layout: base
         {% include _includes/tutorial_list.html sub=subtopic %}
     {% endfor %}
 
+    <!-- learning pathways for this topic -->
+    {% assign pathways = site.pages | where: "layout", "learning-pathway" | where_exp: "item", "item.topics contains topic.name" | sort: "priority", "last" %}
+    {% for lp in pathways %}
+      {% if forloop.index == 1 %}
+      <h2> Learning Pathways </h2>
+      Or have a look at one of our learning pathways involving this topic. Learning pathways are sets of tutorials curated for you by community experts to form a coherent set of lessons around a topic, building up knowledge as you go. We always recommend to follow the tutorials in the order they are listed in the pathway.
+
+      <div class="pathwaylist row">
+      {% endif %}
+
+      {% include _includes/pathway-card.html path=lp %}
+
+      {% if forloop.last %}</div>{% endif %}
+    {% endfor %}
+
     {{ content }}
 
     {% unless topic.tag_based %}

--- a/bin/schema-learning-pathway.yaml
+++ b/bin/schema-learning-pathway.yaml
@@ -25,6 +25,44 @@ mapping:
           - use
           - admin-dev
           - instructors
+    topics:
+        type: seq
+        required: true
+        description: name of the GTN topics this learning pathway belongs to. It will be listed on these topic pages.
+        sequence:
+          - type: str
+            enum:
+              - admin
+              - ai4life
+              - assembly
+              - climate
+              - community
+              - computational-chemistry
+              - contributing
+              - data-science
+              - dev
+              - digital-humanities
+              - ecology
+              - epigenetics
+              - evolution
+              - fair
+              - galaxy-interface
+              - genome-annotation
+              - imaging
+              - introduction
+              - materials-science
+              - metabolomics
+              - microbiome
+              - proteomics
+              - sequence-analysis
+              - single-cell
+              - statistics
+              - synthetic-biology
+              - teaching
+              - transcriptomics
+              - variant-analysis
+              - visualisation
+              - example
     cover-image:
         type: str
         description: cover image

--- a/learning-pathways/admin-training.md
+++ b/learning-pathways/admin-training.md
@@ -6,7 +6,8 @@ description: |
   Learn how to setup, configure, and maintain your own Galaxy server. This learning pathway
   will guide you through all the steps required to setup your own Galaxy server with Ansible,
   configuring it, and making it production ready.
-
+topics:
+  - admin
 cover-image: assets/images/gat.png
 cover-image-alt: GTN Logo on a spiral galaxy background with text galaxy admin training
 editorial_board:

--- a/learning-pathways/amr-gene-detection.md
+++ b/learning-pathways/amr-gene-detection.md
@@ -5,7 +5,8 @@ description: |
   This learning path aims to teach you the basic steps to detect and check Antimicrobial resistance (AMR) genes in bacterial genomes using Galaxy.
 type: use
 tags: [amr, bacteria, microgalaxy, one-health, microbiome]
-
+topics:
+  - microbiome
 editorial_board:
 - bebatut
 - clsiguret

--- a/learning-pathways/bacterial-comparative-genomics.md
+++ b/learning-pathways/bacterial-comparative-genomics.md
@@ -6,6 +6,8 @@ description: |
 
 draft: true
 type: use
+topics:
+  - microbiome
 tags: [bacteria, comparative genomics, pangenome, phylogeny, microgalaxy]
 
 editorial_board:

--- a/learning-pathways/beyond_single_cell.md
+++ b/learning-pathways/beyond_single_cell.md
@@ -4,7 +4,8 @@ tags: [intermediate, single-cell]
 cover-image: assets/images/wab-annotatedcells-2.png
 cover-image-alt: "Image of cells in different coloured clusters"
 type: use
-
+topics:
+  - single-cell
 editorial_board:
 - nomadscientist
 - pavanvidem

--- a/learning-pathways/biont-python.md
+++ b/learning-pathways/biont-python.md
@@ -8,7 +8,8 @@ description: |
 
 tags: [python, programming, introduction, beginner]
 type: use
-
+topics:
+  - data-science
 
 cover-image: assets/images/BioNT_Logo.png
 cover-image-alt: BioNT logo a blue had with the text BioNT

--- a/learning-pathways/climate-learning.md
+++ b/learning-pathways/climate-learning.md
@@ -7,6 +7,8 @@ description: |
 cover-image: assets/images/galaxy_climate.png
 cover-image-alt: Image of the earth surrounded by a bar colors representing Earth's increasing temperatures.
 tags: [Climate, Overview]
+topics:
+  - climate
 
 editorial_board:
 - Marie59

--- a/learning-pathways/clinical-metaproteomics.md
+++ b/learning-pathways/clinical-metaproteomics.md
@@ -2,7 +2,8 @@
 layout: learning-pathway
 tags: [beginner, proteomics]
 type: use
-
+topics:
+  - proteomics
 
 title: Clinical metaproteomics workflows within Galaxy
 description: |

--- a/learning-pathways/data-driven-biology.md
+++ b/learning-pathways/data-driven-biology.md
@@ -4,6 +4,9 @@ cover-image: /assets/images/genomics_intro.png
 cover-image-alt: "Genomics intro"
 tags: [introduction, real-course, data-science]
 type: use
+topics:
+  - data-science
+
 editorial_board:
 - nekrut
 

--- a/learning-pathways/deconvolution_projects.md
+++ b/learning-pathways/deconvolution_projects.md
@@ -4,6 +4,8 @@ tags: [advanced, single-cell]
 cover-image: assets/images/wab-lp-deconvolution.png
 cover-image-alt: "XY plot of actual versus inferred proportions, with coloured dots representing clusters and largely falling in a 1-1 slope"
 type: use
+topics:
+  - single-cell
 
 editorial_board:
 - nomadscientist

--- a/learning-pathways/dev_tools_training.md
+++ b/learning-pathways/dev_tools_training.md
@@ -2,6 +2,9 @@
 layout: learning-pathway
 title: Tool development for a nice & shiny subdomain
 type: admin-dev
+topics:
+  - dev
+
 description: |
   Discover Galaxy's communities and learn how to  create your subdomain and enrich it by writing, testing and submiting your tools on Galaxy. This learning pathway
   will guide you through all the steps required to build a tool for Galaxy with Planemo for batch tools and how write an interactive tool.

--- a/learning-pathways/epigenetics-from-zero.md
+++ b/learning-pathways/epigenetics-from-zero.md
@@ -4,6 +4,8 @@ tags: [beginner, genomic-intervals, epigenetics]
 cover-image: assets/images/chipseq-viz.png
 cover-image-alt: "Plot of ChIP-Seq signal from multiple samples across a genome region"
 type: use
+topics:
+  - epigenetics
 
 editorial_board:
 - wm75

--- a/learning-pathways/fair-training.md
+++ b/learning-pathways/fair-training.md
@@ -6,6 +6,8 @@ description: |
   The FAIR data management training learning pathway teaches you how to organise, describe, and store research data according to the FAIR principles (Findable, Accessible, Interoperable, Reusable).
 tags: [fair, dmp, data management, data stewardship]
 type: use
+topics:
+  - fair
 
 editorial_board:
   - simleo

--- a/learning-pathways/genome-annotation-eukaryote.md
+++ b/learning-pathways/genome-annotation-eukaryote.md
@@ -5,6 +5,8 @@ description: |
   Learn how to annotate an eukaryotic genome sequence: identify repeated regions, find the position and function of genes, and even set up a manual curation environment with Apollo.
 type: use
 tags: [genome-annotation, eukaryote]
+topics:
+  - genome-annotation
 
 cover-image: assets/images/gga.png
 cover-image-alt: "Galaxy Genome Annotation logo"

--- a/learning-pathways/genome-annotation-prokaryote.md
+++ b/learning-pathways/genome-annotation-prokaryote.md
@@ -5,6 +5,8 @@ description: |
   Learn how to annotate a prokaryotic genome sequence: find the position and function of genes, and even set up a manual curation environment with Apollo.
 type: use
 tags: [genome-annotation, prokaryote]
+topics:
+  - genome-annotation
 
 cover-image: assets/images/gga.png
 cover-image-alt: "Galaxy Genome Annotation logo"

--- a/learning-pathways/intro-to-galaxy-and-ecology.md
+++ b/learning-pathways/intro-to-galaxy-and-ecology.md
@@ -8,6 +8,8 @@ description: |
   You will learn how to use Galaxy for analysis, and will be guided through the common
   steps of biodiversity data analysis: download, check, filter and explore biodiversity data and analyze abundance data through modeling.
 
+topics:
+  - ecology
 
 tags: [beginner, ecology]
 cover-image: assets/images/galaxy-e-logo.png

--- a/learning-pathways/intro-to-galaxy-and-genomics.md
+++ b/learning-pathways/intro-to-galaxy-and-genomics.md
@@ -2,6 +2,9 @@
 layout: learning-pathway
 tags: [beginner, introduction, sequence-analysis, assembly]
 type: use
+topics:
+  - sequence-analysis
+  - introduction
 
 editorial_board:
 - shiltemann

--- a/learning-pathways/intro-to-r-and-ml.md
+++ b/learning-pathways/intro-to-r-and-ml.md
@@ -2,6 +2,9 @@
 layout: learning-pathway
 tags: [beginner, statistics, data-science]
 type: use
+topics:
+  - data-science
+  - statistics
 
 editorial_board:
 - fpsom

--- a/learning-pathways/intro_single_cell.md
+++ b/learning-pathways/intro_single_cell.md
@@ -4,6 +4,8 @@ tags: [beginner, single-cell]
 cover-image: assets/images/wab-annotatedcells-2.png
 cover-image-alt: "Image of cells in different coloured clusters"
 type: use
+topics:
+  - single-cell
 
 editorial_board:
 - nomadscientist

--- a/learning-pathways/io1.md
+++ b/learning-pathways/io1.md
@@ -2,6 +2,9 @@
 layout: learning-pathway
 tags: [beginner, data-science, contributing, sequence-analysis, transcriptomics]
 type: use
+topics:
+  - data-science
+  - sequence-analysis
 
 editorial_board:
 - fpsom
@@ -10,7 +13,7 @@ editorial_board:
 funding:
 - gallantries
 
-title: Gallantries Grant - Intellectual Output 1 - Introduction to data analysis and -management, statistics, and coding
+title: Introduction to data analysis and -management, statistics, and coding
 
 description: |
   This Learning Pathway collects the results of Intellectual Output 1 in the Gallantries Project

--- a/learning-pathways/io2.md
+++ b/learning-pathways/io2.md
@@ -2,6 +2,12 @@
 layout: learning-pathway
 tags: [beginner, galaxy-interface, microbiome, visualisation, data-science, variant-analysis ]
 type: use
+topics:
+  - data-science
+  - microbiome
+  - galaxy-interface
+  - variant-analysis
+
 
 editorial_board:
 - shiltemann
@@ -10,7 +16,7 @@ editorial_board:
 funding:
 - gallantries
 
-title: Gallantries Grant - Intellectual Output 2 - Large-scale data analysis, and introduction to visualisation and data modelling
+title: Large-scale data analysis, and introduction to visualisation and data modelling
 
 
 description: |

--- a/learning-pathways/io3.md
+++ b/learning-pathways/io3.md
@@ -2,6 +2,9 @@
 layout: learning-pathway
 tags: [beginner, genome-annotation]
 type: use
+topics:
+  - genome-annotation
+  - fair
 
 editorial_board:
 - abretaud
@@ -10,7 +13,7 @@ editorial_board:
 funding:
 - gallantries
 
-title: Gallantries Grant - Intellectual Output 3 - Data stewardship, federation, standardisation, and collaboration
+title: Data stewardship, federation, standardisation, and collaboration
 
 description: |
   This Learning Pathway collects the results of Intellectual Output 3 in the Gallantries Project

--- a/learning-pathways/io4.md
+++ b/learning-pathways/io4.md
@@ -2,6 +2,8 @@
 layout: learning-pathway
 tags: [beginner, ecology]
 type: use
+topics:
+  - ecology
 
 editorial_board:
 - yvanlebras
@@ -9,7 +11,7 @@ editorial_board:
 funding:
 - gallantries
 
-title: Gallantries Grant - Intellectual Output 4 - Data analysis and modelling for evidence and hypothesis generation and knowledge discovery
+title: Data analysis and modelling for evidence and hypothesis generation and knowledge discovery
 
 description: |
   This Learning Pathway collects the results of Intellectual Output 4 in the Gallantries Project

--- a/learning-pathways/io5.md
+++ b/learning-pathways/io5.md
@@ -2,6 +2,9 @@
 layout: learning-pathway
 tags: [beginner, contributing, teaching]
 type: use
+topics:
+  - contributing
+  - teaching
 
 editorial_board:
 - bebatut
@@ -9,7 +12,7 @@ editorial_board:
 funding:
 - gallantries
 
-title: Gallantries Grant - Intellectual Output 5 - Train-the-Trainer and mentoring programme
+title: Train-the-Trainer and mentoring programme
 
 description: |
   This Learning Pathway collects the results of Intellectual Output 5 in the Gallantries Project

--- a/learning-pathways/machine-learning.md
+++ b/learning-pathways/machine-learning.md
@@ -2,7 +2,8 @@
 layout: learning-pathway
 tags: [beginner, machine learning]
 type: use
-
+topics:
+  - statistics
 editorial_board:
 - anuprulez
 
@@ -20,7 +21,7 @@ pathway:
 
   - section: "Module 2: Classification and Regression"
     description:  |
-      Regression and classification 
+      Regression and classification
     tutorials:
       - topic: statistics
         name: classification_machinelearning

--- a/learning-pathways/mags.md
+++ b/learning-pathways/mags.md
@@ -3,6 +3,8 @@ layout: learning-pathway  # (uncomment this line to activate it)
 type: use
 cover-image: assets/images/microgalaxy-logo.png
 cover-image-alt: "microgalaxy logo"
+topics:
+  - microbiome
 
 editorial_board:
 - bebatut
@@ -119,7 +121,7 @@ pathway:
 #
 #        By the end of this module, you'll be able to confidently assign taxonomic identities to your MAGs, enabling deeper insights into microbial diversity and function.
 #    tutorials:
-#      - name: 
+#      - name:
 #        topic: microbiome
 
   - section: "Module 6: Functional Annotation of MAGs – Applying Genomic Approaches to Metagenome-Assembled Genomes"
@@ -143,7 +145,7 @@ pathway:
 
   - section: "Recommended follow-up tutorial"
     description: |
-        While this learning pathway goes into detail about all steps required for MAGs generation, a full end-to-end training was developed, which executes all workflows for MAGs generation and annotation instead of running individual steps. This tutorial can be used as a guide to execute the workflows on your own data. It explains how you can perform quality control, remove host contamination, and run the main MAGs workflow to obtain quality-controlled, taxonomically and functionally annotated MAGs. 
+        While this learning pathway goes into detail about all steps required for MAGs generation, a full end-to-end training was developed, which executes all workflows for MAGs generation and annotation instead of running individual steps. This tutorial can be used as a guide to execute the workflows on your own data. It explains how you can perform quality control, remove host contamination, and run the main MAGs workflow to obtain quality-controlled, taxonomically and functionally annotated MAGs.
     tutorials:
       - name: mags-building
         topic: microbiome

--- a/learning-pathways/metagenomics.md
+++ b/learning-pathways/metagenomics.md
@@ -3,6 +3,8 @@ layout: learning-pathway  # (uncomment this line to activate it)
 type: use
 cover-image: assets/images/microgalaxy-logo.png
 cover-image-alt: "microgalaxy logo"
+topics:
+  - microbiome
 
 editorial_board:
 - bebatut

--- a/learning-pathways/ml-using-python.md
+++ b/learning-pathways/ml-using-python.md
@@ -3,6 +3,8 @@ layout: learning-pathway
 type: use
 cover-image: shared/images/elixir.png
 cover-image-alt: ELIXIR logo
+topics:
+  - statistics
 
 editorial_board:
 - bebatut
@@ -13,61 +15,61 @@ description: |
 tags: [elixir, ai, ml]
 
 pathway:
-- 
+-
     section: "Module 0: Python warm-up"
     description: Python warm-up for statistics and Machine Learning
     tutorials:
-    - 
+    -
         name: python-basics
         topic: data-science
-    - 
+    -
         name: python-warmup-stat-ml
         topic: data-science
-- 
+-
     section: "Module 1: Foundational Aspects of Machine Learning"
     description: Foundational Aspects of Machine Learning
     tutorials:
-    - 
+    -
         name: intro-to-ml-with-python
         topic: statistics
-- 
+-
     section: "Module 2: Neural networks"
     description: Neural networks
     tutorials:
-    - 
+    -
         name: neural-networks-with-python
         topic: statistics
-- 
+-
     section: "Module 3: Deep Learning (without Generative Artificial Intelligence)"
     description: Deep Learning (without Generative Artificial Intelligence)
     tutorials:
-    - 
+    -
         name: deep-learning-without-gai-with-python
         topic: statistics
-- 
+-
     section: "Module 4: Generative Artificial Intelligence and Large Langage Model for Genomics using Python"
     description: This tutorial series provides a comprehensive guide to leveraging large language models for genomics, covering pretraining, fine-tuning, mutation impact prediction, sequence generation, and optimization.
     tutorials:
-    - 
+    -
         name: genomic-llm-pretraining
         topic: statistics
-    - 
+    -
         name: genomic-llm-finetuning
         topic: statistics
-    - 
+    -
         name: genomic-llm-zeroshot-prediction
         topic: statistics
-    - 
+    -
         name: genomic-llm-sequence-generation
         topic: statistics
-    - 
+    -
         name: genomic-llm-sequence-optimization
         topic: statistics
-- 
+-
     section: "Module 5: Regulations/standards for AI using DOME"
     description: Regulations/standards for AI using DOME
     tutorials:
-    - 
+    -
         name: dome
         topic: statistics
 ---

--- a/learning-pathways/neoantigen.md
+++ b/learning-pathways/neoantigen.md
@@ -2,7 +2,8 @@
 layout: learning-pathway
 tags: [intermediate, immunopeptidomics, cancer, proteogenomics, label-free]
 type: use
-
+topics:
+  - proteomics
 
 
 title: Neoantigen discovery using the iPepGen pipeline

--- a/learning-pathways/onboarding-contributing.md
+++ b/learning-pathways/onboarding-contributing.md
@@ -2,6 +2,8 @@
 layout: learning-pathway
 tags: [introduction, contributing, cofest]
 type: instructors
+topics:
+  - contributing
 
 priority: 1
 

--- a/learning-pathways/pathway-example.md
+++ b/learning-pathways/pathway-example.md
@@ -9,6 +9,9 @@ description: |
 
 type: use  # 'use' for science topics, or admin-dev or instructors
 tags: [some, keywords, here, gtn-topic-id ]
+topics:  # list the relevant GTN topics here, e.g. single-cell, proteomics, .. The learning pathway will be shown on those topic pages
+  - example
+
 editorial_board:
 - shiltemann
 

--- a/learning-pathways/proteogenomics.md
+++ b/learning-pathways/proteogenomics.md
@@ -2,7 +2,8 @@
 layout: learning-pathway
 tags: [beginner, proteomics]
 type: use
-
+topics:
+  - proteomics
 
 title: Proteogenomics
 description: |

--- a/learning-pathways/python.md
+++ b/learning-pathways/python.md
@@ -4,6 +4,8 @@ title: Introductory Python
 type: use
 description: |
   This is an introductory course of Python, as it was taught in [Avans Hogeschool](https://www.avans.nl/) in the Netherlands.
+topics:
+  - data-science
 
 editorial_board:
 - hexylena

--- a/learning-pathways/reloaded_single_cell.md
+++ b/learning-pathways/reloaded_single_cell.md
@@ -4,6 +4,8 @@ tags: [advanced, single-cell]
 cover-image: assets/images/wab-annotatedcells-2.png
 cover-image-alt: "Image of cells in different coloured clusters"
 type: use
+topics:
+  - single-cell
 
 editorial_board:
 - nomadscientist

--- a/learning-pathways/sig-and-codex-creation.md
+++ b/learning-pathways/sig-and-codex-creation.md
@@ -2,6 +2,9 @@
 layout: learning-pathway
 title: Creation of a Community CoDex and lab (and optionally of a Special Interest Group (SIG))
 type: instructors
+topics:
+  - community
+
 description: |
   The Galaxy Communities Dock or **Galaxy CoDex** is a centralized repository that ensures the versioning and documentation of the community components (Batut et al., 2024; Nasr et al., 2024).
 

--- a/learning-pathways/sql.md
+++ b/learning-pathways/sql.md
@@ -4,6 +4,8 @@ title: Introductory SQL
 type: use
 description: |
   This is an introductory course of SQL, as it was taught in [Avans Hogeschool](https://www.avans.nl/) in the Netherlands.
+topics:
+  - data-science
 
 editorial_board:
 - hexylena

--- a/learning-pathways/train-the-trainers.md
+++ b/learning-pathways/train-the-trainers.md
@@ -1,6 +1,8 @@
 ---
 layout: learning-pathway  # (uncomment this line to activate it)
 type: instructors
+topics:
+  - teaching
 
 title: Train the Trainers
 description: |


### PR DESCRIPTION
In order to make learning pathways a bit more visible, I added `topics:` metadata to learning pathways. 

```
layout: learning-pathway
title: "My pathway"
topics:
  - single-cell
  - transcriptomics
```

The learning pathways will be shown on those topic pages, below the list of tutorials:

<img width="1214" height="864" alt="image" src="https://github.com/user-attachments/assets/04230cd3-1672-465a-858a-adca1db24168" />

To topic maintainers: feel free to remove your topic from a learning pathway if it is not helpful to show on your topic page, or add your topic to a learning pathway you do wish to show.

I did not automatically determine the topics based on the tutorials used in the learning pathway, because sometimes a single tutorial from a topic is included as intro/background but that is not really the topic of the pathway.