### PR TITLE
dont show draft events on HoF page

### DIFF
--- a/_plugins/author-page.rb
+++ b/_plugins/author-page.rb
@@ -93,7 +93,7 @@ module Jekyll
             pusher(t, slides_by_author, false)
           end
 
-          pusher(t, events_by_author, false) if t['layout'] == 'event' or t['layout'] == "event-external"
+          pusher(t, events_by_author, false) if (t['layout'] == 'event' or t['layout'] == "event-external") and not t['draft']
 
           pusher(t, faqs_by_author, false) if t['layout'] == 'faq'
 


### PR DESCRIPTION
Prevent events that are in draft status from being shown on the Hall of Fame pages

fixes https://github.com/galaxyproject/training-material/issues/5470