### PR TITLE
Update organization names for clarity and consistency

### DIFF
--- a/ORGANISATIONS.yaml
+++ b/ORGANISATIONS.yaml
@@ -245,7 +245,7 @@ uni-bremen:
     avatar: "/training-material/shared/images/logos/uni-bremen.png"
 
 deNBI:
-    name: "German Network for Bioinformatics Infrastructure Service, Training, Cooperations & Cloud Computing"
+    name: "de.NBI - German Network for Bioinformatics Infrastructure Service, Training, Cooperations & Cloud Computing"
     short_name: "de.NBI"
     joined: 2015-01
     github: false
@@ -255,7 +255,7 @@ deNBI:
     ror: "01vmpm840"
 
 deKCD:
-    name: German Competence Center Cloud Technologies for Data Management and Processing
+    name: "de.KCD - German Competence Center Cloud Technologies for Data Management and Processing"
     short_name: "de.KCD"
     bio: "The German Competence Center Cloud Technologies for Data Management and Processing (de.KCD) is a cross-location and cross-domain contact point for teaching skills in handling data using cloud-based technologies, resources and methods for institutions and networked centers as well as for researchers at all career levels."
     joined: 2025-03
@@ -504,7 +504,7 @@ MPIIE:
     ror: "058xzat49"
 
 mwk:
-    name: Ministry of Science, Research and Arts
+    name: "MWK - Ministry of Science, Research and Arts"
     short_name: MWK
     joined: 2024-08
     bio: "The [MWK](https://mwk.baden-wuerttemberg.de/en) serves as Baden-Württemberg's highest state authority for all public universities, the majority of non-university research institutions, academic libraries and archives as well as important art institutions in the state."


### PR DESCRIPTION
I hereby suggest adding popular German shortcuts in front of organisation names to show those instead of the currently used less common English translations on the HUB.

For example:
deNBI
deKCD
and MWK are more common than their English translations and will more likely be searched under the German acronyms. 