### PR TITLE
Add CYOA option support for up to 20 repositories and add RSpace repository

### DIFF
--- a/_includes/cyoa-choice-fr.html
+++ b/_includes/cyoa-choice-fr.html
@@ -54,6 +54,38 @@
 		<input id="cyoa-opt12{{ include.disambiguation }}" type="radio" name="cyoa{{ include.disambiguation }}" value="{{ include.option12 | slugify_unsafe }}" onclick="cyoaChoice('{{ include.option12 | slugify_unsafe }}', 'gtn-cyoa{{ include.disambiguation }}')">
 		<label for="cyoa-opt12{{ include.disambiguation }}" class="select btn btn-secondary">{{ include.option12 }}</label>
 	{% endif %}
+	{% if include.option13 %}
+		<input id="cyoa-opt13{{ include.disambiguation }}" type="radio" name="cyoa{{ include.disambiguation }}" value="{{ include.option13 | slugify_unsafe }}" onclick="cyoaChoice('{{ include.option13 | slugify_unsafe }}', 'gtn-cyoa{{ include.disambiguation }}')">
+		<label for="cyoa-opt13{{ include.disambiguation }}" class="select btn btn-secondary">{{ include.option13 }}</label>
+	{% endif %}
+	{% if include.option14 %}
+		<input id="cyoa-opt14{{ include.disambiguation }}" type="radio" name="cyoa{{ include.disambiguation }}" value="{{ include.option14 | slugify_unsafe }}" onclick="cyoaChoice('{{ include.option14 | slugify_unsafe }}', 'gtn-cyoa{{ include.disambiguation }}')">
+		<label for="cyoa-opt14{{ include.disambiguation }}" class="select btn btn-secondary">{{ include.option14 }}</label>
+	{% endif %}
+	{% if include.option15 %}
+		<input id="cyoa-opt15{{ include.disambiguation }}" type="radio" name="cyoa{{ include.disambiguation }}" value="{{ include.option15 | slugify_unsafe }}" onclick="cyoaChoice('{{ include.option15 | slugify_unsafe }}', 'gtn-cyoa{{ include.disambiguation }}')">
+		<label for="cyoa-opt15{{ include.disambiguation }}" class="select btn btn-secondary">{{ include.option15 }}</label>
+	{% endif %}
+	{% if include.option16 %}
+		<input id="cyoa-opt16{{ include.disambiguation }}" type="radio" name="cyoa{{ include.disambiguation }}" value="{{ include.option16 | slugify_unsafe }}" onclick="cyoaChoice('{{ include.option16 | slugify_unsafe }}', 'gtn-cyoa{{ include.disambiguation }}')">
+		<label for="cyoa-opt16{{ include.disambiguation }}" class="select btn btn-secondary">{{ include.option16 }}</label>
+	{% endif %}
+	{% if include.option17 %}
+		<input id="cyoa-opt17{{ include.disambiguation }}" type="radio" name="cyoa{{ include.disambiguation }}" value="{{ include.option17 | slugify_unsafe }}" onclick="cyoaChoice('{{ include.option17 | slugify_unsafe }}', 'gtn-cyoa{{ include.disambiguation }}')">
+		<label for="cyoa-opt17{{ include.disambiguation }}" class="select btn btn-secondary">{{ include.option17 }}</label>
+	{% endif %}
+	{% if include.option18 %}
+		<input id="cyoa-opt18{{ include.disambiguation }}" type="radio" name="cyoa{{ include.disambiguation }}" value="{{ include.option18 | slugify_unsafe }}" onclick="cyoaChoice('{{ include.option18 | slugify_unsafe }}', 'gtn-cyoa{{ include.disambiguation }}')">
+		<label for="cyoa-opt18{{ include.disambiguation }}" class="select btn btn-secondary">{{ include.option18 }}</label>
+	{% endif %}
+	{% if include.option19 %}
+		<input id="cyoa-opt19{{ include.disambiguation }}" type="radio" name="cyoa{{ include.disambiguation }}" value="{{ include.option19 | slugify_unsafe }}" onclick="cyoaChoice('{{ include.option19 | slugify_unsafe }}', 'gtn-cyoa{{ include.disambiguation }}')">
+		<label for="cyoa-opt19{{ include.disambiguation }}" class="select btn btn-secondary">{{ include.option19 }}</label>
+	{% endif %}
+	{% if include.option20 %}
+		<input id="cyoa-opt20{{ include.disambiguation }}" type="radio" name="cyoa{{ include.disambiguation }}" value="{{ include.option20 | slugify_unsafe }}" onclick="cyoaChoice('{{ include.option20 | slugify_unsafe }}', 'gtn-cyoa{{ include.disambiguation }}')">
+		<label for="cyoa-opt20{{ include.disambiguation }}" class="select btn btn-secondary">{{ include.option20 }}</label>
+	{% endif %}
 
 	{% if include.default %}
 	<script>

--- a/_includes/cyoa-choices-ES.html
+++ b/_includes/cyoa-choices-ES.html
@@ -56,6 +56,38 @@
 		<input id="cyoa-opt12{{ include.disambiguation }}" type="radio" name="cyoa{{ include.disambiguation }}" value="{{ include.option12 | slugify_unsafe }}" onclick="cyoaChoice('{{ include.option12 | slugify_unsafe }}', 'gtn-cyoa{{ include.disambiguation }}')">
 		<label for="cyoa-opt12{{ include.disambiguation }}" class="select btn btn-secondary">{{ include.option12 }}</label>
 	{% endif %}
+	{% if include.option13 %}
+		<input id="cyoa-opt13{{ include.disambiguation }}" type="radio" name="cyoa{{ include.disambiguation }}" value="{{ include.option13 | slugify_unsafe }}" onclick="cyoaChoice('{{ include.option13 | slugify_unsafe }}', 'gtn-cyoa{{ include.disambiguation }}')">
+		<label for="cyoa-opt13{{ include.disambiguation }}" class="select btn btn-secondary">{{ include.option13 }}</label>
+	{% endif %}
+	{% if include.option14 %}
+		<input id="cyoa-opt14{{ include.disambiguation }}" type="radio" name="cyoa{{ include.disambiguation }}" value="{{ include.option14 | slugify_unsafe }}" onclick="cyoaChoice('{{ include.option14 | slugify_unsafe }}', 'gtn-cyoa{{ include.disambiguation }}')">
+		<label for="cyoa-opt14{{ include.disambiguation }}" class="select btn btn-secondary">{{ include.option14 }}</label>
+	{% endif %}
+	{% if include.option15 %}
+		<input id="cyoa-opt15{{ include.disambiguation }}" type="radio" name="cyoa{{ include.disambiguation }}" value="{{ include.option15 | slugify_unsafe }}" onclick="cyoaChoice('{{ include.option15 | slugify_unsafe }}', 'gtn-cyoa{{ include.disambiguation }}')">
+		<label for="cyoa-opt15{{ include.disambiguation }}" class="select btn btn-secondary">{{ include.option15 }}</label>
+	{% endif %}
+	{% if include.option16 %}
+		<input id="cyoa-opt16{{ include.disambiguation }}" type="radio" name="cyoa{{ include.disambiguation }}" value="{{ include.option16 | slugify_unsafe }}" onclick="cyoaChoice('{{ include.option16 | slugify_unsafe }}', 'gtn-cyoa{{ include.disambiguation }}')">
+		<label for="cyoa-opt16{{ include.disambiguation }}" class="select btn btn-secondary">{{ include.option16 }}</label>
+	{% endif %}
+	{% if include.option17 %}
+		<input id="cyoa-opt17{{ include.disambiguation }}" type="radio" name="cyoa{{ include.disambiguation }}" value="{{ include.option17 | slugify_unsafe }}" onclick="cyoaChoice('{{ include.option17 | slugify_unsafe }}', 'gtn-cyoa{{ include.disambiguation }}')">
+		<label for="cyoa-opt17{{ include.disambiguation }}" class="select btn btn-secondary">{{ include.option17 }}</label>
+	{% endif %}
+	{% if include.option18 %}
+		<input id="cyoa-opt18{{ include.disambiguation }}" type="radio" name="cyoa{{ include.disambiguation }}" value="{{ include.option18 | slugify_unsafe }}" onclick="cyoaChoice('{{ include.option18 | slugify_unsafe }}', 'gtn-cyoa{{ include.disambiguation }}')">
+		<label for="cyoa-opt18{{ include.disambiguation }}" class="select btn btn-secondary">{{ include.option18 }}</label>
+	{% endif %}
+	{% if include.option19 %}
+		<input id="cyoa-opt19{{ include.disambiguation }}" type="radio" name="cyoa{{ include.disambiguation }}" value="{{ include.option19 | slugify_unsafe }}" onclick="cyoaChoice('{{ include.option19 | slugify_unsafe }}', 'gtn-cyoa{{ include.disambiguation }}')">
+		<label for="cyoa-opt19{{ include.disambiguation }}" class="select btn btn-secondary">{{ include.option19 }}</label>
+	{% endif %}
+	{% if include.option20 %}
+		<input id="cyoa-opt20{{ include.disambiguation }}" type="radio" name="cyoa{{ include.disambiguation }}" value="{{ include.option20 | slugify_unsafe }}" onclick="cyoaChoice('{{ include.option20 | slugify_unsafe }}', 'gtn-cyoa{{ include.disambiguation }}')">
+		<label for="cyoa-opt20{{ include.disambiguation }}" class="select btn btn-secondary">{{ include.option20 }}</label>
+	{% endif %}
 
 	{% if include.default %}
 	<script>

--- a/_includes/cyoa-choices.html
+++ b/_includes/cyoa-choices.html
@@ -58,6 +58,38 @@
 		<input id="cyoa-opt12{{ include.disambiguation }}" type="radio" name="cyoa{{ include.disambiguation }}" value="{{ include.option12 | slugify_unsafe }}" onclick="cyoaChoice('{{ include.option12 | slugify_unsafe }}', 'gtn-cyoa{{ include.disambiguation }}')">
 		<label for="cyoa-opt12{{ include.disambiguation }}" class="select btn btn-secondary">{{ include.option12 }}</label>
 	{% endif %}
+	{% if include.option13 %}
+		<input id="cyoa-opt13{{ include.disambiguation }}" type="radio" name="cyoa{{ include.disambiguation }}" value="{{ include.option13 | slugify_unsafe }}" onclick="cyoaChoice('{{ include.option13 | slugify_unsafe }}', 'gtn-cyoa{{ include.disambiguation }}')">
+		<label for="cyoa-opt13{{ include.disambiguation }}" class="select btn btn-secondary">{{ include.option13 }}</label>
+	{% endif %}
+	{% if include.option14 %}
+		<input id="cyoa-opt14{{ include.disambiguation }}" type="radio" name="cyoa{{ include.disambiguation }}" value="{{ include.option14 | slugify_unsafe }}" onclick="cyoaChoice('{{ include.option14 | slugify_unsafe }}', 'gtn-cyoa{{ include.disambiguation }}')">
+		<label for="cyoa-opt14{{ include.disambiguation }}" class="select btn btn-secondary">{{ include.option14 }}</label>
+	{% endif %}
+	{% if include.option15 %}
+		<input id="cyoa-opt15{{ include.disambiguation }}" type="radio" name="cyoa{{ include.disambiguation }}" value="{{ include.option15 | slugify_unsafe }}" onclick="cyoaChoice('{{ include.option15 | slugify_unsafe }}', 'gtn-cyoa{{ include.disambiguation }}')">
+		<label for="cyoa-opt15{{ include.disambiguation }}" class="select btn btn-secondary">{{ include.option15 }}</label>
+	{% endif %}
+	{% if include.option16 %}
+		<input id="cyoa-opt16{{ include.disambiguation }}" type="radio" name="cyoa{{ include.disambiguation }}" value="{{ include.option16 | slugify_unsafe }}" onclick="cyoaChoice('{{ include.option16 | slugify_unsafe }}', 'gtn-cyoa{{ include.disambiguation }}')">
+		<label for="cyoa-opt16{{ include.disambiguation }}" class="select btn btn-secondary">{{ include.option16 }}</label>
+	{% endif %}
+	{% if include.option17 %}
+		<input id="cyoa-opt17{{ include.disambiguation }}" type="radio" name="cyoa{{ include.disambiguation }}" value="{{ include.option17 | slugify_unsafe }}" onclick="cyoaChoice('{{ include.option17 | slugify_unsafe }}', 'gtn-cyoa{{ include.disambiguation }}')">
+		<label for="cyoa-opt17{{ include.disambiguation }}" class="select btn btn-secondary">{{ include.option17 }}</label>
+	{% endif %}
+	{% if include.option18 %}
+		<input id="cyoa-opt18{{ include.disambiguation }}" type="radio" name="cyoa{{ include.disambiguation }}" value="{{ include.option18 | slugify_unsafe }}" onclick="cyoaChoice('{{ include.option18 | slugify_unsafe }}', 'gtn-cyoa{{ include.disambiguation }}')">
+		<label for="cyoa-opt18{{ include.disambiguation }}" class="select btn btn-secondary">{{ include.option18 }}</label>
+	{% endif %}
+	{% if include.option19 %}
+		<input id="cyoa-opt19{{ include.disambiguation }}" type="radio" name="cyoa{{ include.disambiguation }}" value="{{ include.option19 | slugify_unsafe }}" onclick="cyoaChoice('{{ include.option19 | slugify_unsafe }}', 'gtn-cyoa{{ include.disambiguation }}')">
+		<label for="cyoa-opt19{{ include.disambiguation }}" class="select btn btn-secondary">{{ include.option19 }}</label>
+	{% endif %}
+	{% if include.option20 %}
+		<input id="cyoa-opt20{{ include.disambiguation }}" type="radio" name="cyoa{{ include.disambiguation }}" value="{{ include.option20 | slugify_unsafe }}" onclick="cyoaChoice('{{ include.option20 | slugify_unsafe }}', 'gtn-cyoa{{ include.disambiguation }}')">
+		<label for="cyoa-opt20{{ include.disambiguation }}" class="select btn btn-secondary">{{ include.option20 }}</label>
+	{% endif %}
 
 	{% if include.default %}
 	<script>

--- a/faqs/galaxy/manage_your_repositories.md
+++ b/faqs/galaxy/manage_your_repositories.md
@@ -17,7 +17,7 @@ For all of the possible repositories, you should fill the following fields:
 - In the `Name` section, give a name to your repository. This name will be used to choose the repository on Galaxy for importing or exporting datasets.
 - Optionally, you can provide a `Description` for this repository. This is a note for yourself.
 
-{% include _includes/cyoa-choices.html option1="Onedata" option2="Amazon Web Services Private Bucket" option3="Amazon Web Services Public Bucket" option4="Azure Blob" option5="Dropbox" option6="eLabFTW" option7="An FTP Server" option8="Export to Google Drive" option9="InvenioRDM" option10="S3 Compatible Storage with Credentials" option11="WebDAV" option12="Zenodo" default="Onedata" text="Select the repository you like to add to your Galaxy account." disambiguation="BYOD" %}
+{% include _includes/cyoa-choices.html option1="Onedata" option2="Amazon Web Services Private Bucket" option3="Amazon Web Services Public Bucket" option4="Azure Blob" option5="Dropbox" option6="eLabFTW" option7="An FTP Server" option8="Export to Google Drive" option9="InvenioRDM" option10="S3 Compatible Storage with Credentials" option11="WebDAV" option12="Zenodo" option13="RSpace" default="Onedata" text="Select the repository you like to add to your Galaxy account." disambiguation="BYOD" %}
 
 <div class="Onedata" markdown="1">
 If you have an [Onedata](https://onedata.org/) account, you can use this repository to import and/or export your data directly from and to Onedata. The minimal supported Onezone version is 21.02.4. More information on Onedata can be found on [Onedata's website](https://onedata.org/#/home).
@@ -115,6 +115,15 @@ In some cases, you may need to activate some features on your ownCloud or nextCl
 - Provide a name for the "creator" metadata of your records on Zenodo using the `Publication Name` field.  You can always change this value later by editing the records in Zenodo. If left blank, an anonymous user will be used as the creator.
 - You have to provide a `Personal Access Token` from your Zenodo account to Galaxy. To do so, you need to log into your account. Then, visit this site: https://zenodo.org/account/settings/applications/. Alternatively, you can click on your username on top right and then click on "Applications". Here, you need to create a "Personal Access Token". This will allow Galaxy to display your draft records and upload files to them. If you enabled the option to export data from Galaxy to Zenodo, make sure to enable the **deposit:write** scope when creating the token.
 - Click on `Create`.
+</div>
+<div class="RSpace" markdown="1">
+[RSpace](https://www.researchspace.com/) is an electronic laboratory notebook (ELN) - comparable to eLabFTW - for documenting experiments, protocols, observations, data, and research results in a structured and collaborative environment. RSpace is now open source, and RSpace Community is free to use, while managed Team and Enterprise versions are paid. A use can get an idea about its features by using the [community server](https://community.researchspace.com).
+- RSpace has its own [Galaxy integration](https://documentation.researchspace.com/l/en/article/zzsl46jo5y-galaxy) and can send data to Galaxy and track invocations using this data.
+- Add a name like community.researchspace
+- Optional description
+- Add the RSpace instance endpoint e.g.: https://community.researchspace.com
+- Add the `RSpace API Key`. You get it on the RSpace server, when you click on profile, then on regenerate key. Store it you will not see it again.
+- Click `Create`.
 </div>
 
 > <tip-title>What can you do after you connected a repository</tip-title>


### PR DESCRIPTION
Extend the cyoa-choices include to support up to 20 options across the main, French, and Spanish versions. Add the RSpace option to the Manage Your Repositories FAQ.

