### PR TITLE
Fix the PMID regex in GTN:004

### DIFF
--- a/bin/lint.rb
+++ b/bin/lint.rb
@@ -276,8 +276,11 @@ module Gtn
     # Companion function to Gtn::Linter.check_dois
     def self.check_pmids(contents)
       # https://www.ncbi.nlm.nih.gov/pubmed/24678044
-      find_matching_texts(contents,
-                          %r{(\[[^\]]*\]\(https?://www.ncbi.nlm.nih.gov/pubmed//[0-9]*\))}).map do |idx, _text, selected|
+      # https://pubmed.ncbi.nlm.nih.gov/24678044/
+      find_matching_texts(
+        contents,
+        %r{(\[[^\]]*\]\(https?://(?:www\.ncbi\.nlm\.nih\.gov/pubmed|pubmed\.ncbi\.nlm\.nih\.gov)/[0-9]+/?\))}
+      ).map do |idx, _text, selected|
         ReviewDogEmitter.warning(
           path: @path,
           idx: idx,


### PR DESCRIPTION
Fixes #7092.

The `check_pmids` pattern in `bin/lint.rb` requires `pubmed//` — a
doubled slash. Real PubMed links have one, as the comment directly above
the pattern shows (`pubmed/24678044`), and as `check_dois` a few lines
up does correctly.

The check has therefore never fired. Across 23 tutorials it saw 47 PMID
links and flagged none.

The patched pattern was tested against legacy host, modern host, plain
HTTP and trailing-slash variants, plus URLs it must not match: 7/7.